### PR TITLE
Add GPU/NPU kernel fallback policy for Claude and Codex

### DIFF
--- a/.codex/skills/gpu-kernel-fallback-policy/SKILL.md
+++ b/.codex/skills/gpu-kernel-fallback-policy/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: gpu-kernel-fallback-policy
+description: "Mandatory policy for all GPU/NPU backend work: never fall back to CPU, use on-device composite workarounds, preserve native kernel entry points, and document issues in docs/known-kernel-issues.md."
+---
+
+# GPU/NPU Kernel Fallback Policy
+
+## Scope
+
+This policy applies to ALL changes under:
+- `src/candle/_backends/mps/`
+- `src/candle/_backends/cuda/`
+- `src/candle/_backends/npu/`
+
+## Mandatory Rules
+
+### Rule 1: NEVER Fall Back to CPU
+
+- **NEVER** move computation from GPU/NPU to CPU (numpy) to work around a kernel bug or missing op.
+- CPU fallback hides real problems, breaks device-placement guarantees, and will not be accepted in review.
+- This includes: converting tensors to numpy for computation, calling CPU ops from GPU kernels, or using `.cpu()` round-trips inside op implementations.
+
+### Rule 2: Composite On-Device Workarounds ARE Allowed
+
+When a native kernel (Metal shader, ACLNN large kernel, CUDA kernel) has a bug:
+
+1. You MAY reimplement the op as a **composite of smaller on-device ops** that already work correctly.
+2. Every op in the composite must execute on the **same device** — no CPU round-trips.
+3. Example: if `aten.baddbmm` crashes on MPS Metal, reimplement using `bmm` + `add` + `mul` — all staying on MPS.
+
+### Rule 3: Preserve Native Kernel Entry Points
+
+- Do NOT delete broken native kernel code.
+- Keep it in the codebase behind a clear guard so it can be re-enabled and tested when the underlying platform is updated.
+- Mark with comment: `# TODO: re-enable native kernel when <platform> fixes <issue>`
+- This enables automated regression testing after CANN SDK / CUDA toolkit / macOS updates.
+
+### Rule 4: Document Every Known Kernel Issue
+
+Record every known kernel issue in `docs/known-kernel-issues.md` with:
+
+| Field | Description |
+|-------|-------------|
+| Op name | e.g., `aten.baddbmm` |
+| Backend | `mps` / `cuda` / `npu` |
+| Error description | What happens when the native kernel runs |
+| Composite workaround | What smaller ops replace it |
+| Platform version | e.g., `macOS 15.3 / Metal 3`, `CANN 8.0` |
+| Status | `open` (workaround active) or `resolved` (native kernel re-enabled) |
+
+This document is the checklist for regression testing after platform upgrades.
+
+## Verification Checklist
+
+Before opening a PR that touches GPU/NPU backend code:
+
+- [ ] No CPU fallback introduced (grep for `.numpy()`, `.cpu()`, `np.` in device backend code)
+- [ ] Broken native kernels are preserved, not deleted
+- [ ] `docs/known-kernel-issues.md` updated if a new workaround was added
+- [ ] All composite ops run on the same device as the original op

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,3 +67,28 @@ pytest tests/mps/ -v --tb=short
 git checkout main && git pull upstream main
 git checkout -b feat/<name>
 ```
+
+## GPU/NPU Kernel Fallback Policy (Mandatory)
+
+This rule applies to all MPS, CUDA, and NPU backend code. Violations will block PR merge.
+
+### NEVER fall back to CPU
+
+- **NEVER** move computation from GPU/NPU to CPU (numpy) to work around a kernel bug or missing op.
+- CPU fallback hides real problems, breaks device-placement guarantees, and will not be accepted in review.
+
+### Composite workarounds ARE allowed
+
+- When a native kernel (Metal shader, ACLNN large kernel, CUDA kernel) has a bug, you MAY reimplement the op as a **composite of smaller on-device ops** that already work.
+- Every op in the composite must execute on the **same device** — no CPU round-trips.
+
+### Preserve native kernel entry points
+
+- Do NOT delete broken native kernel code. Keep it guarded so it can be re-enabled when the underlying platform is updated (CANN SDK, CUDA toolkit, macOS/Metal).
+- Mark with: `# TODO: re-enable native kernel when <platform> fixes <issue>`
+
+### Document every known issue
+
+- Record every known kernel issue in `docs/known-kernel-issues.md`.
+- Each entry must include: op name, backend, error description, composite workaround used, and the platform version that exhibits the bug.
+- This document is the checklist for regression testing after platform upgrades.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,14 +80,21 @@ Candle does NOT depend on PyTorch at runtime. PyTorch is only used in tests for 
 - All computation must be implemented via the internal dispatch mechanism and backend-specific kernels
 - Allowed dependencies: `numpy`, `scipy`, `ctypes`, and the Python standard library
 
-### Core Design Principle: No Fallback to Numpy on GPU/NPU
+### Core Design Principle: No Fallback to CPU on GPU/NPU
 
-For MPS/CUDA/NPU devices, **NEVER** fall back to numpy for computation.
+For MPS/CUDA/NPU devices, **NEVER** fall back to CPU (numpy) to work around kernel bugs or missing functionality.
 
-- MPS ops should stay on the Metal GPU path
-- NPU ops should use ACLNN kernels via ctypes
-- CUDA ops should use CUDA kernels
+- MPS ops must stay on the Metal GPU path
+- NPU ops must use ACLNN kernels via ctypes
+- CUDA ops must use CUDA kernels
 - NumPy is ONLY acceptable for the CPU backend
+
+**When a native kernel has a bug or limitation:**
+
+1. **Composite workaround allowed**: You MAY reimplement the op as a composition of smaller on-device ops that already work correctly. All computation must remain on the same device.
+2. **Preserve the native kernel entry point**: Do NOT delete the broken native kernel call. Keep it in the code behind a clear guard (e.g., a flag or commented-out block) so it can be re-enabled and tested when the underlying platform (CANN SDK / CUDA toolkit / macOS) is updated.
+3. **Document the issue**: Record every known kernel issue in `docs/known-kernel-issues.md` with: op name, backend, error description, workaround used, and the platform version that exhibits the bug.
+4. **Never silently degrade**: Moving computation to CPU is never an acceptable workaround — it hides the real problem and breaks device-placement guarantees.
 
 ### Core Design Principle: Schema Validation is Intentional
 
@@ -102,8 +109,13 @@ For each backend, follow this priority order:
 
 1. **Native device kernels** (Metal shaders for MPS, ACLNN for NPU, CUDA kernels) — always preferred
 2. **Accelerate BLAS** (for MPS matmul) or equivalent hardware-accelerated libraries
-3. **Composite of existing dispatched ops** — build complex ops from simpler ones
-4. **NumPy fallback** — ONLY for CPU backend
+3. **Composite of existing dispatched ops** — build complex ops from smaller on-device ops that already work. This is the **only acceptable workaround** when a native kernel has a bug. All ops in the composite must run on the same device.
+4. **NumPy fallback** — ONLY for CPU backend, NEVER for MPS/CUDA/NPU
+
+When using option 3 as a workaround for a broken native kernel:
+- Keep the native kernel code in place (guarded, not deleted)
+- Add an entry to `docs/known-kernel-issues.md`
+- Add a `# TODO: re-enable native kernel when <platform> fixes <issue>` comment
 
 ### For Bug Fixes
 

--- a/docs/known-kernel-issues.md
+++ b/docs/known-kernel-issues.md
@@ -1,0 +1,19 @@
+# Known Kernel Issues
+
+This document tracks native kernel bugs and their on-device composite workarounds across GPU/NPU backends. It serves as the regression testing checklist after platform upgrades (CANN SDK, CUDA toolkit, macOS/Metal).
+
+## How to Use This Document
+
+- **After a platform upgrade**: Test each `open` entry by re-enabling the native kernel and running the associated test. If the native kernel works, mark the entry as `resolved` and remove the composite workaround.
+- **When adding a workaround**: Add a new entry here with all required fields.
+
+## Issue Table
+
+| Op | Backend | Error Description | Composite Workaround | Platform Version | Status |
+|----|---------|-------------------|----------------------|------------------|--------|
+| — | — | No known issues yet | — | — | — |
+
+<!--
+Entry template:
+| `aten.op_name` | mps/cuda/npu | Brief error description | `op_a` + `op_b` composite | macOS XX.X / CANN X.X / CUDA XX.X | open/resolved |
+-->


### PR DESCRIPTION
## Summary
- Enforce mandatory rule: MPS/CUDA/NPU ops must **never** fall back to CPU to work around kernel bugs
- On-device composite workarounds (smaller ops on the same device) are explicitly allowed
- Native kernel entry points must be **preserved** (not deleted) so they can be re-tested after CANN/CUDA/macOS platform upgrades
- Add `docs/known-kernel-issues.md` as the tracking document for all known kernel issues and their workarounds

## Files changed
- `CLAUDE.md` — expanded "No Fallback" and "Kernel Implementation Priority" sections
- `AGENTS.md` — added "GPU/NPU Kernel Fallback Policy" mandatory section
- `.codex/skills/gpu-kernel-fallback-policy/SKILL.md` — Codex skill for the same policy
- `docs/known-kernel-issues.md` — issue tracking template for kernel bugs

## Test plan
- [ ] Documentation-only change, no code affected
- [ ] Verify policy text is consistent across CLAUDE.md, AGENTS.md, and Codex skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)