### PR TITLE
fix(npu): bind arithmetic ACLNN symbols from libopapi

### DIFF
--- a/src/candle/_backends/npu/aclnn.py
+++ b/src/candle/_backends/npu/aclnn.py
@@ -4075,6 +4075,25 @@ def _create_scalar(bindings, value, dtype):
 
 
 def _bind_symbol(libs, name, restype, argtypes):
+    preferred = None
+    if name in {
+        "aclnnAdd", "aclnnAddGetWorkspaceSize",
+        "aclnnSub", "aclnnSubGetWorkspaceSize",
+        "aclnnMul", "aclnnMulGetWorkspaceSize",
+        "aclnnDiv", "aclnnDivGetWorkspaceSize",
+        "aclnnAdds", "aclnnAddsGetWorkspaceSize",
+        "aclnnSubs", "aclnnSubsGetWorkspaceSize",
+    }:
+        for lib in libs:
+            path = getattr(lib, "_name", "") or ""
+            if path.endswith("libopapi.so") and hasattr(lib, name):
+                preferred = lib
+                break
+    if preferred is not None:
+        func = getattr(preferred, name)
+        func.restype = restype
+        func.argtypes = argtypes
+        return func
     for lib in libs:
         if hasattr(lib, name):
             func = getattr(lib, name)

--- a/src/candle/_backends/npu/ops.py
+++ b/src/candle/_backends/npu/ops.py
@@ -325,17 +325,7 @@ def add(a, b):
 def mul(a, b):
     if isinstance(b, (int, float)):
         b = _scalar_to_npu_tensor(b, a)
-    try:
-        return _binary_op(a, b, aclnn.mul, "mul")
-    except RuntimeError as exc:
-        # On some Ascend runtime builds, aclnnMul intermittently fails for
-        # scalar-like paths. Fall back to div(a, reciprocal(b)) semantics to
-        # keep training-critical execution stable for 0.1 scope.
-        if a.device.type != "npu" or getattr(b, "device", None) is None or b.device.type != "npu":
-            raise
-        one = _scalar_to_npu_tensor(1.0, b)
-        recip = div(one, b)
-        return div(a, recip)
+    return _binary_op(a, b, aclnn.mul, "mul")
 
 
 

--- a/tests/npu/test_mul_scalar_regression_npu.py
+++ b/tests/npu/test_mul_scalar_regression_npu.py
@@ -1,6 +1,8 @@
 import pytest
 
 import candle as torch
+from candle._backends.npu import aclnn
+from candle._backends.npu import ops as npu_ops
 
 
 @pytest.mark.skipif(not torch.npu.is_available(), reason="NPU not available")
@@ -13,3 +15,49 @@ def test_mul_scalar_after_randn_on_npu():
     y = torch.mul(x, scale)
     assert y.device.type == "npu"
     assert y.shape == x.shape
+    expected = x.to("cpu").numpy() * 3.0
+    assert y.to("cpu").shape == x.to("cpu").shape
+    assert pytest.approx(expected, rel=1e-6, abs=1e-6) == y.to("cpu").numpy()
+
+
+@pytest.mark.skipif(not torch.npu.is_available(), reason="NPU not available")
+def test_mul_supports_zero_dim_npu_tensors_without_fallback():
+    a = torch.tensor(2.0, device="npu")
+    b = torch.tensor(3.0, device="npu")
+
+    y = torch.mul(a, b)
+    assert y.device.type == "npu"
+    assert y.shape == ()
+    assert y.item() == pytest.approx(6.0)
+
+
+@pytest.mark.skipif(not torch.npu.is_available(), reason="NPU not available")
+def test_mul_zero_dim_npu_parameter_keeps_gradients():
+    x = torch.randn(16, device="npu")
+    weight = torch.tensor(3.0, device="npu", requires_grad=True)
+
+    y = torch.mul(x, weight).sum()
+    y.backward()
+
+    assert weight.grad is not None
+    assert weight.grad.shape == ()
+    assert weight.grad.device.type == "npu"
+    assert weight.grad.item() == pytest.approx(x.to("cpu").sum().item(), rel=1e-5, abs=1e-5)
+
+
+@pytest.mark.skipif(not torch.npu.is_available(), reason="NPU not available")
+def test_mul_propagates_kernel_error_instead_of_falling_back(monkeypatch):
+    x = torch.tensor([2.0, 3.0], device="npu")
+    y = torch.tensor([4.0, 5.0], device="npu")
+
+    def fail_mul(*args, **kwargs):
+        raise RuntimeError("sentinel mul failure")
+
+    def fail_div(*args, **kwargs):
+        raise AssertionError("mul should not fall back to div")
+
+    monkeypatch.setattr(aclnn, "mul", fail_mul)
+    monkeypatch.setattr(npu_ops, "div", fail_div)
+
+    with pytest.raises(RuntimeError, match="sentinel mul failure"):
+        torch.mul(x, y)


### PR DESCRIPTION
## Summary
- prefer `libopapi.so` for duplicated ACLNN arithmetic symbols so NPU `add/sub/mul/div` and scalar `adds/subs` bind to the working implementation
- remove the temporary NPU `mul -> div(reciprocal)` fallback so `mul` stays NPU-only and surfaces real kernel failures
- add NPU regressions for scalar mul correctness, zero-dim gradient flow, and explicit no-fallback behavior

## Root Cause
- both `libaclnn_math.so` and `libopapi.so` export `aclnnMul` and related arithmetic symbols
- Candle was binding `aclnnMul*` from `libaclnn_math.so`
- on this CANN build, `randn(128, device="npu") * tensor(3.0, device="npu")` fails there with `aclnnMul failed: 561000`
- rebinding those arithmetic symbols to `libopapi.so` fixes the raw ACLNN path and the high-level NPU path without any CPU fallback

## Validation
- `PYTHONPATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:src python -m pytest tests/npu/test_mul_scalar_regression_npu.py -q`
- `PYTHONPATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:src python -m pytest tests/npu/test_no_cpu_fallback_npu.py tests/npu/test_npu_golden_training_loop.py tests/npu/test_npu_training_checkpoint_continuity.py -q`
- raw/high-level probe: `randn(128, device="npu") * tensor(3.0, device="npu")` now passes both through `aclnn.mul` and `torch.mul`
