### PR TITLE
feat(cpu): close p1 nn.functional pooling and inplace parity gaps

### DIFF
--- a/docs/plans/2026-03-09-cpu-parity-p1-implementation.md
+++ b/docs/plans/2026-03-09-cpu-parity-p1-implementation.md
@@ -1,0 +1,166 @@
+# CPU Parity P1 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Close high-impact nn.functional API parity gaps for CPU by adding missing torch-compatible wrappers and behavior for pooling-with-indices, adaptive max pooling variants, max unpooling, and inplace activation wrappers.
+
+**Architecture:** Keep backend kernels as source of truth and extend `candle.nn.functional` wrappers first, only adding minimal kernel logic where missing (for max_unpool ops). Drive all behavior through torch-comparison tests in CPU suite and preserve existing dispatch architecture. Scope is intentionally constrained to high-frequency training/inference entry points.
+
+**Tech Stack:** Python, numpy-backed CPU kernels, candle dispatch, pytest
+
+---
+
+### Task 1: Add failing nn.functional parity tests for P1 target APIs
+
+**Files:**
+- Modify: `tests/cpu/test_nn_functional.py`
+- Reference: `src/candle/nn/functional.py`
+
+**Step 1: Write failing tests for wrappers that should exist**
+
+Add tests for:
+- `F.relu_`, `F.elu_`, `F.hardtanh_`, `F.rrelu_`, `F.threshold_`, `F.selu_`, `F.celu_`
+- `F.max_pool1d_with_indices`, `F.max_pool2d_with_indices`
+- `F.adaptive_max_pool1d`, `F.adaptive_max_pool2d(..., return_indices=True)`
+
+Example test style:
+
+```python
+def test_relu_inplace_wrapper_matches_torch_shape_and_mutation():
+    x = torch.tensor([-1.0, 2.0])
+    out = F.relu_(x)
+    assert out is x
+    assert x.tolist() == [0.0, 2.0]
+```
+
+**Step 2: Run target tests and verify failure**
+
+Run: `PYTHONPATH=src pytest tests/cpu/test_nn_functional.py -k "inplace_wrapper or with_indices or adaptive_max_pool" -v`
+Expected: FAIL with missing attributes/wrappers.
+
+**Step 3: Commit test-only red phase**
+
+```bash
+git add tests/cpu/test_nn_functional.py
+git commit -m "test(cpu): add failing P1 nn.functional parity coverage"
+```
+
+---
+
+### Task 2: Implement missing nn.functional wrappers for existing CPU kernels
+
+**Files:**
+- Modify: `src/candle/nn/functional.py`
+
+**Step 1: Add minimal wrappers for inplace activations**
+
+Implement wrappers:
+- `relu_`, `elu_`, `hardtanh_`, `rrelu_`, `threshold_`, `selu_`, `celu_`
+
+Implementation should delegate to existing non-inplace functions or tensor in-place methods with minimal semantics.
+
+**Step 2: Add wrappers for pooling with indices**
+
+Implement wrappers:
+- `max_pool1d_with_indices`
+- `max_pool2d_with_indices`
+
+Return tuple `(output, indices)` with torch-compatible argument signatures.
+
+**Step 3: Add/adjust adaptive max pool wrappers**
+
+Implement wrappers:
+- `adaptive_max_pool1d`
+- `adaptive_max_pool2d` path for `return_indices=True`
+
+**Step 4: Run target tests and verify green**
+
+Run: `PYTHONPATH=src pytest tests/cpu/test_nn_functional.py -k "inplace_wrapper or with_indices or adaptive_max_pool" -v`
+Expected: PASS.
+
+**Step 5: Commit wrapper implementation**
+
+```bash
+git add src/candle/nn/functional.py
+git commit -m "feat(nn.functional): add P1 wrappers for inplace activations and pooling with indices"
+```
+
+---
+
+### Task 3: Add max_unpool CPU support (minimal, torch-aligned behavior)
+
+**Files:**
+- Modify: `src/candle/nn/functional.py`
+- Modify: `src/candle/_backends/cpu/ops.py`
+- Modify: `src/candle/_backends/cpu/__init__.py`
+- Modify: `src/candle/_dispatch/schemas.py`
+- Test: `tests/cpu/test_nn_functional.py`
+
+**Step 1: Add failing tests for max unpool**
+
+Add tests for:
+- `F.max_unpool1d`
+- `F.max_unpool2d`
+
+Minimum behavior:
+- correct output shape
+- values scattered back by indices
+- invalid index raises
+
+**Step 2: Run tests and confirm failure**
+
+Run: `PYTHONPATH=src pytest tests/cpu/test_nn_functional.py -k "max_unpool" -v`
+Expected: FAIL.
+
+**Step 3: Implement minimal CPU kernels and registration**
+
+- Add CPU ops for `max_unpool1d` and `max_unpool2d` in `ops.py`.
+- Register kernels in `_backends/cpu/__init__.py`.
+- Add schemas in `_dispatch/schemas.py`.
+- Add `nn.functional` wrappers.
+
+**Step 4: Re-run max_unpool tests**
+
+Run: `PYTHONPATH=src pytest tests/cpu/test_nn_functional.py -k "max_unpool" -v`
+Expected: PASS.
+
+**Step 5: Commit max_unpool batch**
+
+```bash
+git add src/candle/_backends/cpu/ops.py src/candle/_backends/cpu/__init__.py src/candle/_dispatch/schemas.py src/candle/nn/functional.py tests/cpu/test_nn_functional.py
+git commit -m "feat(cpu): add max_unpool1d/2d parity support"
+```
+
+---
+
+### Task 4: Regression verification and parity smoke
+
+**Files:**
+- Reuse touched files only
+
+**Step 1: Run focused suites**
+
+```bash
+PYTHONPATH=src pytest tests/cpu/test_nn_functional.py tests/cpu/test_top_level_ops.py -v
+```
+
+**Step 2: Run broader safety smoke**
+
+```bash
+PYTHONPATH=src pytest tests/cpu/test_ops_cpu.py tests/cpu/test_autograd_ops.py -q
+```
+
+**Step 3: Commit any test stabilization changes**
+
+```bash
+git add -A
+git commit -m "test(cpu): stabilize P1 parity and regression coverage"
+```
+
+---
+
+### Non-goals
+
+- No long-tail torch nn.functional parity (fractional pools, grouped_mm, etc.)
+- No new linalg/fft/special expansion in this batch
+- No cross-backend behavior changes unless shared wrapper paths require it

--- a/src/candle/_backends/cpu/__init__.py
+++ b/src/candle/_backends/cpu/__init__.py
@@ -798,10 +798,12 @@ registry.register("upsample_bilinear2d", "cpu", upsample_bilinear2d)
 registry.register("upsample_bicubic2d", "cpu", upsample_bicubic2d)
 
 # 1D pooling ops
-from .ops import max_pool1d, avg_pool1d, adaptive_avg_pool1d
+from .ops import max_pool1d, avg_pool1d, adaptive_avg_pool1d, max_unpool1d, max_unpool2d
 registry.register("max_pool1d", "cpu", max_pool1d)
 registry.register("avg_pool1d", "cpu", avg_pool1d)
 registry.register("adaptive_avg_pool1d", "cpu", adaptive_avg_pool1d)
+registry.register("max_unpool1d", "cpu", max_unpool1d)
+registry.register("max_unpool2d", "cpu", max_unpool2d)
 
 # 3D conv/pool ops
 from .ops import conv_transpose3d, max_pool3d, avg_pool3d, adaptive_avg_pool3d, conv3d

--- a/src/candle/_backends/cpu/ops.py
+++ b/src/candle/_backends/cpu/ops.py
@@ -2080,6 +2080,8 @@ def max_pool2d(input, kernel_size, stride, padding=0, dilation=1, ceil_mode=Fals
                      mode='constant', constant_values=-np.inf)
 
     out = np.full((N, C, H_out, W_out), -np.inf, dtype=inp.dtype)
+    if return_indices:
+        out_indices = np.zeros((N, C, H_out, W_out), dtype=np.int64)
     for oh in range(H_out):
         for ow in range(W_out):
             for kh in range(kH):
@@ -2087,9 +2089,21 @@ def max_pool2d(input, kernel_size, stride, padding=0, dilation=1, ceil_mode=Fals
                     ih = oh * sH + kh * dH
                     iw = ow * sW + kw * dW
                     if ih < inp.shape[2] and iw < inp.shape[3]:
-                        out[:, :, oh, ow] = np.maximum(out[:, :, oh, ow], inp[:, :, ih, iw])
+                        cand = inp[:, :, ih, iw]
+                        mask = cand > out[:, :, oh, ow]
+                        out[:, :, oh, ow] = np.where(mask, cand, out[:, :, oh, ow])
+                        if return_indices:
+                            in_h = ih - pH
+                            in_w = iw - pW
+                            if 0 <= in_h < H and 0 <= in_w < W:
+                                flat_idx = in_h * W + in_w
+                                out_indices[:, :, oh, ow] = np.where(mask, flat_idx, out_indices[:, :, oh, ow])
 
-    return _from_numpy(np.ascontiguousarray(out), input.dtype, input.device)
+    out_t = _from_numpy(np.ascontiguousarray(out), input.dtype, input.device)
+    if return_indices:
+        idx_t = _from_numpy(np.ascontiguousarray(out_indices), int64_dtype, input.device)
+        return out_t, idx_t
+    return out_t
 
 
 def avg_pool2d(input, kernel_size, stride, padding=0, ceil_mode=False,
@@ -4003,13 +4017,28 @@ def max_pool1d(input, kernel_size, stride, padding, dilation, ceil_mode=False, r
     else:
         oW = int(np.floor((W_padded - dW * (kW - 1) - 1) / sW + 1))
 
-    out = np.empty((N, C, oW), dtype=a.dtype)
+    out = np.full((N, C, oW), -np.inf, dtype=a.dtype)
+    if return_indices:
+        out_indices = np.zeros((N, C, oW), dtype=np.int64)
     for ow in range(oW):
         w_start = ow * sW
-        vals = [a[:, :, w_start + k * dW] for k in range(kW) if w_start + k * dW < W_padded]
-        out[:, :, ow] = np.maximum.reduce(vals)
+        for k in range(kW):
+            wi = w_start + k * dW
+            if wi >= W_padded:
+                continue
+            cand = a[:, :, wi]
+            mask = cand > out[:, :, ow]
+            out[:, :, ow] = np.where(mask, cand, out[:, :, ow])
+            if return_indices:
+                in_w = wi - pW
+                if 0 <= in_w < W:
+                    out_indices[:, :, ow] = np.where(mask, in_w, out_indices[:, :, ow])
 
-    return _from_numpy(out, input.dtype, input.device)
+    out_t = _from_numpy(np.ascontiguousarray(out), input.dtype, input.device)
+    if return_indices:
+        idx_t = _from_numpy(np.ascontiguousarray(out_indices), int64_dtype, input.device)
+        return out_t, idx_t
+    return out_t
 
 
 def avg_pool1d(input, kernel_size, stride, padding, ceil_mode=False, count_include_pad=True):
@@ -4367,6 +4396,90 @@ def adaptive_max_pool1d(input, output_size, return_indices=False):
         out[:, :, ol] = region.max(axis=2)
 
     return _from_numpy(out, input.dtype, input.device)
+
+
+def max_unpool1d(input, indices, kernel_size, stride, padding, output_size=None):
+    """Max unpooling 1D by scattering pooled values back using flattened indices."""
+    in_np = _to_numpy(input)
+    idx_np = _ensure_integer_indices(_to_numpy(indices), "indices").astype(np.int64, copy=False)
+    if in_np.shape != idx_np.shape:
+        raise ValueError("input and indices must have the same shape")
+
+    if input.ndim != 3:
+        raise ValueError(f"Expected 3D input, got {input.ndim}D")
+
+    N, C, L_in = in_np.shape
+    kW = kernel_size[0]
+    sW = stride[0]
+    pW = padding[0]
+
+    if output_size is not None:
+        if len(output_size) == 3:
+            out_shape = tuple(int(v) for v in output_size)
+        elif len(output_size) == 1:
+            out_shape = (N, C, int(output_size[0]))
+        else:
+            raise ValueError("output_size must have length 1 or 3 for max_unpool1d")
+        if out_shape[0] != N or out_shape[1] != C:
+            raise ValueError("output_size batch/channel dimensions must match input")
+        L_out = out_shape[2]
+    else:
+        L_out = (L_in - 1) * sW - 2 * pW + kW
+        out_shape = (N, C, L_out)
+
+    out = np.zeros(out_shape, dtype=in_np.dtype)
+    if (idx_np < 0).any() or (idx_np >= L_out).any():
+        raise IndexError("index out of range")
+
+    for n in range(N):
+        for c in range(C):
+            out[n, c, idx_np[n, c]] = in_np[n, c]
+
+    return _from_numpy(np.ascontiguousarray(out), input.dtype, input.device)
+
+
+def max_unpool2d(input, indices, kernel_size, stride, padding, output_size=None):
+    """Max unpooling 2D by scattering pooled values back using flattened HW indices."""
+    in_np = _to_numpy(input)
+    idx_np = _ensure_integer_indices(_to_numpy(indices), "indices").astype(np.int64, copy=False)
+    if in_np.shape != idx_np.shape:
+        raise ValueError("input and indices must have the same shape")
+
+    if input.ndim != 4:
+        raise ValueError(f"Expected 4D input, got {input.ndim}D")
+
+    N, C, H_in, W_in = in_np.shape
+    kH, kW = kernel_size
+    sH, sW = stride
+    pH, pW = padding
+
+    if output_size is not None:
+        if len(output_size) == 4:
+            out_shape = tuple(int(v) for v in output_size)
+        elif len(output_size) == 2:
+            out_shape = (N, C, int(output_size[0]), int(output_size[1]))
+        else:
+            raise ValueError("output_size must have length 2 or 4 for max_unpool2d")
+        if out_shape[0] != N or out_shape[1] != C:
+            raise ValueError("output_size batch/channel dimensions must match input")
+        H_out, W_out = out_shape[2], out_shape[3]
+    else:
+        H_out = (H_in - 1) * sH - 2 * pH + kH
+        W_out = (W_in - 1) * sW - 2 * pW + kW
+        out_shape = (N, C, H_out, W_out)
+
+    out = np.zeros(out_shape, dtype=in_np.dtype)
+    max_flat = H_out * W_out
+    if (idx_np < 0).any() or (idx_np >= max_flat).any():
+        raise IndexError("index out of range")
+
+    h_idx = idx_np // W_out
+    w_idx = idx_np % W_out
+    for n in range(N):
+        for c in range(C):
+            out[n, c, h_idx[n, c], w_idx[n, c]] = in_np[n, c]
+
+    return _from_numpy(np.ascontiguousarray(out), input.dtype, input.device)
 
 
 def ctc_loss(log_probs, targets, input_lengths, target_lengths, blank=0, reduction='mean', zero_infinity=False):

--- a/src/candle/_dispatch/schemas.py
+++ b/src/candle/_dispatch/schemas.py
@@ -655,3 +655,5 @@ def register_schemas():
     registry.register_schema("avg_pool3d", "avg_pool3d(Tensor input, Any kernel_size, Any stride, Any padding=None, bool ceil_mode=False, bool count_include_pad=True) -> Tensor")
     registry.register_schema("adaptive_avg_pool3d", "adaptive_avg_pool3d(Tensor input, Any output_size) -> Tensor")
     registry.register_schema("adaptive_max_pool1d", "adaptive_max_pool1d(Tensor input, Any output_size, bool return_indices=False) -> Tensor")
+    registry.register_schema("max_unpool1d", "max_unpool1d(Tensor input, Tensor indices, Any kernel_size, Any stride, Any padding, Any output_size=None) -> Tensor")
+    registry.register_schema("max_unpool2d", "max_unpool2d(Tensor input, Tensor indices, Any kernel_size, Any stride, Any padding, Any output_size=None) -> Tensor")

--- a/src/candle/nn/functional.py
+++ b/src/candle/nn/functional.py
@@ -13,6 +13,10 @@ def relu(input, inplace=False):
     from .._functional import relu as _relu
     return _relu(input)
 
+def relu_(input):
+    from .._functional import relu_ as _relu_
+    return _relu_(input)
+
 
 def sigmoid(input):
     from .._functional import sigmoid as _sigmoid
@@ -68,6 +72,11 @@ def leaky_relu(input, negative_slope=0.01, inplace=False):
 def elu(input, alpha=1.0, inplace=False):
     from .._dispatch import dispatch
     return dispatch("elu", input.device.type, input, alpha)
+
+
+def elu_(input, alpha=1.0):
+    input.copy_(elu(input, alpha=alpha))
+    return input
 
 
 def mish(input, inplace=False):
@@ -242,6 +251,20 @@ def max_pool1d(input, kernel_size, stride=None, padding=0, dilation=1,
                     _padding, _dilation, ceil_mode, return_indices)
 
 
+
+
+def max_pool1d_with_indices(input, kernel_size, stride=None, padding=0, dilation=1, ceil_mode=False):
+    return max_pool1d(
+        input,
+        kernel_size,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        ceil_mode=ceil_mode,
+        return_indices=True,
+    )
+
+
 def max_pool2d(input, kernel_size, stride=None, padding=0, dilation=1,
                ceil_mode=False, return_indices=False):
     from .._dispatch import dispatch
@@ -251,6 +274,20 @@ def max_pool2d(input, kernel_size, stride=None, padding=0, dilation=1,
     _dilation = (dilation, dilation) if isinstance(dilation, int) else tuple(dilation)
     return dispatch("max_pool2d", input.device.type, input, _kernel_size, _stride,
                     _padding, _dilation, ceil_mode, return_indices)
+
+
+
+
+def max_pool2d_with_indices(input, kernel_size, stride=None, padding=0, dilation=1, ceil_mode=False):
+    return max_pool2d(
+        input,
+        kernel_size,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        ceil_mode=ceil_mode,
+        return_indices=True,
+    )
 
 
 def avg_pool1d(input, kernel_size, stride=None, padding=0, ceil_mode=False,
@@ -289,6 +326,17 @@ def adaptive_avg_pool2d(input, output_size):
     else:
         _output_size = tuple(output_size)
     return dispatch("adaptive_avg_pool2d", input.device.type, input, _output_size)
+
+
+
+
+def adaptive_max_pool1d(input, output_size, return_indices=False):
+    from .._dispatch import dispatch
+    if isinstance(output_size, int):
+        _output_size = (output_size,)
+    else:
+        _output_size = tuple(output_size)
+    return dispatch("adaptive_max_pool1d", input.device.type, input, _output_size, return_indices)
 
 
 def adaptive_max_pool2d(input, output_size, return_indices=False):
@@ -632,6 +680,13 @@ def hardtanh(input, min_val=-1.0, max_val=1.0, inplace=False):
     return _hardtanh(input, min_val, max_val)
 
 
+
+
+def hardtanh_(input, min_val=-1.0, max_val=1.0):
+    input.copy_(hardtanh(input, min_val=min_val, max_val=max_val))
+    return input
+
+
 def logsigmoid(input):
     from .._functional import softplus as _softplus, neg as _neg
     return _neg(_softplus(_neg(input)))
@@ -893,9 +948,23 @@ def selu(input, inplace=False):
     return dispatch("selu", input.device.type, input)
 
 
+
+
+def selu_(input):
+    input.copy_(selu(input))
+    return input
+
+
 def celu(input, alpha=1.0, inplace=False):
     from .._dispatch import dispatch
     return dispatch("celu", input.device.type, input, alpha)
+
+
+
+
+def celu_(input, alpha=1.0):
+    input.copy_(celu(input, alpha=alpha))
+    return input
 
 
 def softplus(input, beta=1, threshold=20):
@@ -916,6 +985,13 @@ def softsign(input):
 def threshold(input, threshold, value, inplace=False):
     from .._dispatch import dispatch
     return dispatch("threshold", input.device.type, input, threshold, value)
+
+
+
+
+def threshold_(input, threshold_value, value):
+    input.copy_(threshold(input, threshold_value, value))
+    return input
 
 
 def glu(input, dim=-1):
@@ -954,6 +1030,13 @@ def hardshrink(input, lambd=0.5):
 def rrelu(input, lower=1.0/8, upper=1.0/3, training=False, inplace=False):
     from .._dispatch import dispatch
     return dispatch("rrelu", input.device.type, input, lower, upper, training)
+
+
+
+
+def rrelu_(input, lower=1.0/8, upper=1.0/3, training=False):
+    input.copy_(rrelu(input, lower=lower, upper=upper, training=training))
+    return input
 
 
 def cosine_similarity(x1, x2, dim=1, eps=1e-8):
@@ -1360,3 +1443,20 @@ def adaptive_avg_pool3d(input, output_size):
     else:
         _output_size = tuple(output_size)
     return dispatch("adaptive_avg_pool3d", input.device.type, input, _output_size)
+
+
+def max_unpool1d(input, indices, kernel_size, stride=None, padding=0, output_size=None):
+    from .._dispatch import dispatch
+    _kernel_size = (kernel_size,) if isinstance(kernel_size, int) else tuple(kernel_size)
+    _stride = _kernel_size if stride is None else ((stride,) if isinstance(stride, int) else tuple(stride))
+    _padding = (padding,) if isinstance(padding, int) else tuple(padding)
+    return dispatch("max_unpool1d", input.device.type, input, indices, _kernel_size, _stride, _padding, output_size)
+
+
+def max_unpool2d(input, indices, kernel_size, stride=None, padding=0, output_size=None):
+    from .._dispatch import dispatch
+    _kernel_size = (kernel_size, kernel_size) if isinstance(kernel_size, int) else tuple(kernel_size)
+    _stride = _kernel_size if stride is None else ((stride, stride) if isinstance(stride, int) else tuple(stride))
+    _padding = (padding, padding) if isinstance(padding, int) else tuple(padding)
+    return dispatch("max_unpool2d", input.device.type, input, indices, _kernel_size, _stride, _padding, output_size)
+

--- a/tests/cpu/test_nn_functional.py
+++ b/tests/cpu/test_nn_functional.py
@@ -1,6 +1,7 @@
 import candle as torch
 from candle.nn import functional as F
 import numpy as np
+import pytest
 
 
 def test_silu_cpu():
@@ -329,3 +330,102 @@ def test_kl_div_mean():
     expected_val = np.mean(tn * (np.log(tn + 1e-12) - pn))
     expected = torch.tensor(expected_val, device='cpu')
     assert torch.allclose(loss, expected, atol=1e-4)
+
+
+# --- CPU Parity P1 Tests ---
+
+
+def _assert_inplace_wrapper(fn, *args, expected):
+    x = torch.tensor([-1.0, 0.0, 2.0], device='cpu')
+    out = fn(x, *args)
+    assert out is x
+    assert torch.allclose(x, expected, atol=1e-6)
+
+
+def test_relu_inplace_wrapper_exists_and_mutates():
+    _assert_inplace_wrapper(F.relu_, expected=torch.tensor([0.0, 0.0, 2.0], device='cpu'))
+
+
+def test_elu_inplace_wrapper_exists_and_mutates():
+    expected = F.elu(torch.tensor([-1.0, 0.0, 2.0], device='cpu'))
+    _assert_inplace_wrapper(F.elu_, expected=expected)
+
+
+def test_hardtanh_inplace_wrapper_exists_and_mutates():
+    expected = torch.tensor([-0.5, 0.0, 0.5], device='cpu')
+    _assert_inplace_wrapper(F.hardtanh_, -0.5, 0.5, expected=expected)
+
+
+def test_rrelu_inplace_wrapper_exists_and_mutates_training_false():
+    x = torch.tensor([-1.0, 0.0, 2.0], device='cpu')
+    out = F.rrelu_(x, training=False)
+    assert out is x
+    # training=False should be deterministic slope=(lower+upper)/2
+    expected = F.rrelu(torch.tensor([-1.0, 0.0, 2.0], device='cpu'), training=False)
+    assert torch.allclose(x, expected, atol=1e-6)
+
+
+def test_threshold_inplace_wrapper_exists_and_mutates():
+    expected = torch.tensor([3.0, 3.0, 2.0], device='cpu')
+    _assert_inplace_wrapper(F.threshold_, 0.5, 3.0, expected=expected)
+
+
+def test_selu_inplace_wrapper_exists_and_mutates():
+    expected = F.selu(torch.tensor([-1.0, 0.0, 2.0], device='cpu'))
+    _assert_inplace_wrapper(F.selu_, expected=expected)
+
+
+def test_celu_inplace_wrapper_exists_and_mutates():
+    expected = F.celu(torch.tensor([-1.0, 0.0, 2.0], device='cpu'), alpha=0.75)
+    _assert_inplace_wrapper(F.celu_, 0.75, expected=expected)
+
+
+def test_max_pool1d_with_indices_returns_tuple():
+    x = torch.tensor([[[1.0, 3.0, 2.0, 4.0]]], device='cpu')
+    out, idx = F.max_pool1d_with_indices(x, kernel_size=2, stride=2)
+    assert out.shape == (1, 1, 2)
+    assert idx.shape == (1, 1, 2)
+
+
+def test_max_pool2d_with_indices_returns_tuple():
+    x = torch.tensor([[[[1.0, 3.0], [2.0, 4.0]]]], device='cpu')
+    out, idx = F.max_pool2d_with_indices(x, kernel_size=2)
+    assert out.shape == (1, 1, 1, 1)
+    assert idx.shape == (1, 1, 1, 1)
+
+
+def test_adaptive_max_pool1d_wrapper_exists():
+    x = torch.tensor([[[1.0, 3.0, 2.0, 4.0]]], device='cpu')
+    out = F.adaptive_max_pool1d(x, output_size=2)
+    assert out.shape == (1, 1, 2)
+
+
+def test_adaptive_max_pool2d_return_indices_returns_tuple():
+    x = torch.tensor([[[[1.0, 3.0], [2.0, 4.0]]]], device='cpu')
+    out, idx = F.adaptive_max_pool2d(x, output_size=(1, 1), return_indices=True)
+    assert out.shape == (1, 1, 1, 1)
+    assert idx.shape == (1, 1, 1, 1)
+
+
+def test_max_unpool1d_scatter_matches_indices():
+    x = torch.tensor([[[1.0, 3.0, 2.0, 4.0]]], device='cpu')
+    pooled, indices = F.max_pool1d_with_indices(x, kernel_size=2, stride=2)
+    out = F.max_unpool1d(pooled, indices, kernel_size=2, stride=2, output_size=(1, 1, 4))
+    expected = torch.tensor([[[0.0, 3.0, 0.0, 4.0]]], device='cpu')
+    assert torch.allclose(out, expected, atol=1e-6)
+
+
+def test_max_unpool2d_scatter_matches_indices():
+    x = torch.tensor([[[[1.0, 3.0], [2.0, 4.0]]]], device='cpu')
+    pooled, indices = F.max_pool2d_with_indices(x, kernel_size=2, stride=2)
+    out = F.max_unpool2d(pooled, indices, kernel_size=2, stride=2, output_size=(1, 1, 2, 2))
+    expected = torch.tensor([[[[0.0, 0.0], [0.0, 4.0]]]], device='cpu')
+    assert torch.allclose(out, expected, atol=1e-6)
+
+
+def test_max_unpool1d_invalid_index_raises():
+    x = torch.tensor([[[2.0, 1.0]]], device='cpu')
+    pooled = torch.tensor([[[2.0]]], device='cpu')
+    bad_indices = torch.tensor([[[5]]], device='cpu', dtype=torch.int64)
+    with pytest.raises((RuntimeError, ValueError, IndexError)):
+        F.max_unpool1d(pooled, bad_indices, kernel_size=2, stride=2, output_size=(1, 1, 2))


### PR DESCRIPTION
## Summary
- close high-impact CPU parity P1 gaps in `candle.nn.functional`
- add missing inplace activation wrappers: `relu_`, `elu_`, `hardtanh_`, `rrelu_`, `threshold_`, `selu_`, `celu_`
- add pooling wrappers: `max_pool1d_with_indices`, `max_pool2d_with_indices`, `adaptive_max_pool1d`
- add unpool wrappers: `max_unpool1d`, `max_unpool2d`
- implement CPU backend support for
  - `max_pool1d`/`max_pool2d` returning `(values, indices)` when `return_indices=True`
  - `max_unpool1d`/`max_unpool2d` scatter behavior + invalid-index checks
- register new schemas and CPU kernels for `max_unpool1d` and `max_unpool2d`
- add CPU tests covering all above APIs and behaviors

## Validation
- `PYTHONPATH=src pytest tests/cpu/test_nn_functional.py -k "inplace_wrapper_exists_and_mutates or with_indices_returns_tuple or adaptive_max_pool1d_wrapper_exists or adaptive_max_pool2d_return_indices_returns_tuple or max_unpool" -q`
- `PYTHONPATH=src pytest tests/cpu/test_nn_functional.py tests/cpu/test_top_level_ops.py -q`
- `PYTHONPATH=src pytest tests/cpu/test_ops_cpu.py tests/cpu/test_autograd_ops.py -q`
