### PR TITLE
test(contract): add training core torch parity gates

### DIFF
--- a/docs/plans/2026-03-09-training-core-backend-parity-design.md
+++ b/docs/plans/2026-03-09-training-core-backend-parity-design.md
@@ -1,0 +1,281 @@
+# Training Core Backend Parity Design
+
+## Context
+
+Candle already has a meaningful torch-like mechanism baseline: schema-first operator registration, dispatch keys, autograd, functionalize, AMP, and multiple backend entry points. The current gap is no longer just operator count. The higher-risk issue is backend semantic drift: the same high-frequency training op can behave differently across CPU, NPU, MPS, and CUDA, or differ from real PyTorch in dtype promotion, reduction semantics, aliasing, autograd, or error behavior.
+
+For the next phase, priority should shift from broadening operator surface area to hardening backend consistency for the training-critical subset. This aligns with the repository's documented 0.1 scope: stable single-card NPU training core path first, with CPU as development baseline and no CPU fallback from device backends.
+
+## Goal
+
+Build a contract-first parity layer for training-core high-frequency operators so Candle backends converge to PyTorch semantics instead of only converging to each other.
+
+Success means:
+
+- PyTorch is the only semantic source of truth for the targeted operator subset.
+- Candle `CPU/NPU/MPS/CUDA` all pass the same parity contracts, within explicit numeric tolerances where needed.
+- A minimal training loop gate stays green while parity coverage expands.
+- Backend bugs are exposed as backend bugs, not hidden by CPU fallback or backend-specific behavior drift.
+
+## Confirmed Scope
+
+This phase covers training-core high-frequency operators only.
+
+Included operator families:
+
+- `linear`
+- `activation`
+- `reduction`
+- `broadcast` and binary arithmetic needed by training
+- `reshape/view`
+- `indexing`
+- `optimizer-primitives`
+
+Representative first-wave operators inside those families:
+
+- `add`, `sub`, `mul`, `div`, `true_divide`
+- `matmul`, `mm`, `addmm`
+- `relu`, `sigmoid`, `tanh`, `gelu`, `silu`
+- `sum`, `mean`, `prod`, `norm`
+- `reshape`, `view`, `transpose`, `squeeze`, `unsqueeze`, `permute`, `flatten`
+- `getitem`, `setitem`, `gather`, `scatter`, `index_select`, `masked_select`
+- `add_`, `sub_`, `mul_`, `copy_`, `zero_`, and scalar-mixed optimizer updates
+
+Explicitly out of scope for this phase:
+
+- LLM-specific fused kernels and serving features
+- long-tail operator expansion outside the training core subset
+- FSDP, DeviceMesh, Tensor Parallel, and other distributed high-level features
+- true compile/JIT/export acceleration work
+- sparse tensor and quantized tensor system design
+
+## Non-Negotiable Principle
+
+Backend consistency must align to real PyTorch behavior, not merely to Candle CPU behavior.
+
+That means:
+
+- `torch` is the oracle for forward values, output dtype, shape, broadcast behavior, alias semantics, autograd behavior, optimizer update behavior, and error class.
+- Candle CPU is a diagnostic baseline only. It is useful for isolating whether a failure comes from a device backend or from shared eager/dispatch/autograd logic, but it is not the acceptance target.
+- Differences between Candle backends are acceptable only when they remain within explicit numeric tolerance while preserving PyTorch semantics.
+
+## Architectural Direction
+
+### 1. Contract-First, Family-Oriented Governance
+
+Work should be organized by operator family, not by backend and not by individual failing model scripts.
+
+Each family gets a parity contract that covers the semantic dimensions that matter for training:
+
+- forward numerical result
+- output dtype and promotion behavior
+- shape, stride, and view semantics where applicable
+- broadcast behavior
+- autograd gradients
+- inplace/view alias and version-counter behavior
+- error class and key error semantics
+
+This avoids the failure mode where one backend gets patched for one model case while the same operator family remains inconsistent elsewhere.
+
+### 2. Two-Layer Verification Model
+
+Verification should be split into two layers.
+
+Layer A is the primary gate: family-level parity contracts under `tests/contract/`. These compare Candle behavior directly against real PyTorch for targeted operators and semantic cases.
+
+Layer B is a minimal training smoke gate. This validates that the family contracts actually protect the training path: `forward -> loss -> backward -> optimizer.step`. The smoke gate is not the place to discover detailed operator drift; it exists to prevent regressions in the integrated training loop.
+
+### 3. Shared Parity Harness Instead of One-Off Tests
+
+The contract layer should use a shared parity harness rather than many hand-written backend-specific tests.
+
+The harness should accept:
+
+- operator under test
+- sample inputs
+- target comparison dimensions
+- expected alias/view flags
+- per-backend numeric tolerance overrides
+- expected exception type when the case is invalid
+
+The harness then runs:
+
+1. real PyTorch on CPU as semantic oracle,
+2. Candle on each enabled backend,
+3. forward and backward comparisons,
+4. optional aliasing/version checks,
+5. optional error checks.
+
+This keeps the cost of adding new parity cases low and makes backend drift visible in a uniform format.
+
+## Operator Family Breakdown
+
+### 1. Broadcast and Binary Arithmetic
+
+This is the first family to harden because it underpins linear layers, activations, reductions, and optimizer updates.
+
+Primary semantics to lock down:
+
+- dtype promotion matches PyTorch
+- scalar-tensor and tensor-tensor combinations behave identically
+- broadcast rules and failure cases match PyTorch
+- mixed-device behavior remains explicitly unsupported where Candle does not support it
+- inplace updates mutate correctly and preserve version semantics
+
+### 2. Reshape and View
+
+This family is the second priority because many training failures that look like operator bugs are actually alias/view semantic bugs.
+
+Primary semantics:
+
+- `reshape` vs `view` behavior follows PyTorch
+- view-producing ops preserve alias relationships
+- inplace writes on views obey PyTorch-style restrictions
+- version counters change when they should
+- backward through views matches PyTorch
+
+### 3. Reduction
+
+Reduction semantics are a common source of drift across backends and dtypes.
+
+Primary semantics:
+
+- integer and bool reduction dtype behavior matches PyTorch
+- `dim`, tuple dims, negative dims, and `keepdim` match PyTorch
+- numeric tolerances are backend-appropriate but semantically correct
+- backward behavior matches PyTorch for differentiable reductions
+
+### 4. Linear and Activation
+
+After arithmetic, views, and reductions are stable, linear and activation operators can be hardened on top of those foundations.
+
+Primary semantics:
+
+- `matmul/mm/addmm/linear` parity
+- activation forward parity for common training activations
+- activation backward parity
+- interaction with broadcast and dtype promotion remains torch-aligned
+
+### 5. Indexing
+
+Indexing sits later in the sequence because it depends heavily on alias rules, broadcast, and shape semantics already being stable.
+
+Primary semantics:
+
+- `getitem/setitem` and simple advanced indexing parity
+- gather/scatter/index_select semantics
+- masking semantics
+- gradient behavior where differentiable
+
+### 6. Optimizer Primitives
+
+This family finalizes the training loop by ensuring optimizer update kernels behave like PyTorch.
+
+Primary semantics:
+
+- inplace arithmetic used by optimizers matches PyTorch
+- scalar-mixed updates do not drift in dtype behavior
+- parameter mutation and version behavior remain correct
+- `zero_grad` and repeated step behavior stay stable
+
+## Execution Order
+
+The order of work should be:
+
+1. `broadcast/binary`
+2. `reshape/view`
+3. `reduction`
+4. `linear/activation`
+5. `indexing`
+6. `optimizer-primitives`
+
+This ordering is intentional. The first three families are semantic infrastructure for the latter three. If they are unstable, later fixes will be noisy and likely need to be redone.
+
+## Test Strategy
+
+### Contract Layer
+
+Add a new training-core parity contract suite under `tests/contract/`.
+
+Suggested file layout:
+
+- `tests/contract/test_training_core_parity_harness.py`
+- `tests/contract/test_training_core_binary_parity.py`
+- `tests/contract/test_training_core_view_parity.py`
+- `tests/contract/test_training_core_reduction_parity.py`
+- `tests/contract/test_training_core_linear_activation_parity.py`
+- `tests/contract/test_training_core_indexing_parity.py`
+- `tests/contract/test_training_core_optimizer_parity.py`
+
+These files should compare Candle to real PyTorch directly, not just compare Candle backends to each other.
+
+### Minimal Training Gate
+
+Add a compact integration gate that covers a minimal training loop, for example:
+
+- `Linear -> activation -> reduction(loss)`
+- backward pass
+- simple optimizer step
+- repeat for multiple steps
+
+This gate should validate:
+
+- loss remains finite
+- gradients are populated where expected
+- parameter updates stay numerically aligned with PyTorch within tolerance
+- repeated steps do not introduce backend-specific drift
+
+## Failure Classification
+
+Every parity failure should be classified into one of five buckets:
+
+- semantic mismatch
+- autograd mismatch
+- view/inplace alias mismatch
+- numeric tolerance overflow
+- backend unsupported or missing implementation
+
+This classification matters because the remediation path is different:
+
+- semantic mismatch often points to shared wrapper or dispatch logic
+- autograd mismatch points to backward registration or wrapper logic
+- alias mismatch points to view/inplace/version mechanics
+- numeric overflow points to backend kernel precision or accumulation behavior
+- unsupported points to explicit scope gaps or missing kernels
+
+## Remediation Rules
+
+- Never use CPU fallback to hide a device backend bug.
+- If a native device kernel is wrong, fix it or replace it with an on-device composite implementation.
+- If a backend limitation is known and temporarily tolerated, record it in `docs/known-kernel-issues.md` with the required fields.
+- If the bug is shared across backends, fix the common functional/dispatch/autograd layer before patching backend kernels.
+
+## First-Phase Deliverables
+
+At the end of phase 1, the repository should have:
+
+- a shared training-core PyTorch parity harness,
+- family-level parity contracts for the first three families (`broadcast/binary`, `reshape/view`, `reduction`),
+- a minimal training smoke gate tied to torch parity expectations,
+- a failure-classification workflow for backend parity bugs,
+- updated kernel-issue documentation for any accepted temporary backend-specific gaps.
+
+## Acceptance Criteria
+
+This phase is complete only if all of the following are true:
+
+- the targeted training-core parity contracts pass against real PyTorch,
+- supported backends differ only within approved numeric tolerances,
+- no targeted device-path parity gap is hidden by CPU fallback,
+- the minimal training loop gate remains green,
+- newly discovered backend limitations are documented explicitly instead of being left implicit.
+
+## Follow-Up After Design Approval
+
+Once implementation starts:
+
+1. create an execution plan with task-level sequencing,
+2. use TDD for each operator family,
+3. start from failing parity tests against real PyTorch,
+4. fix the smallest shared semantic layer possible before backend-specific patches,
+5. run targeted contracts plus the training smoke gate before each merge point.

--- a/docs/plans/2026-03-09-training-core-backend-parity-implementation-plan.md
+++ b/docs/plans/2026-03-09-training-core-backend-parity-implementation-plan.md
@@ -1,0 +1,476 @@
+# Training Core Backend Parity Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a PyTorch-oracle parity harness and close the first-wave backend consistency gaps for training-core operators, starting with binary arithmetic, reshape/view, and reduction semantics.
+
+**Architecture:** Keep Candle's existing schema-first dispatch architecture intact. Add parity contracts in `tests/contract/` that compare Candle directly against real PyTorch, then patch the smallest shared semantic layer possible before touching backend-specific kernels. Use a minimal training smoke gate only as an integration check, not as the primary discovery tool.
+
+**Tech Stack:** Python, pytest, Candle dispatch/autograd/functionalize stack, numpy-backed CPU kernels, NPU/MPS/CUDA backend kernels, real PyTorch as oracle
+
+---
+
+### Task 1: Build the shared training-core parity harness
+
+**Files:**
+- Create: `tests/contract/test_training_core_parity_harness.py`
+- Modify: `tests/contract/helpers.py`
+- Reference: `tests/contract/test_harness.py`
+- Reference: `tests/cpu/test_ops_cpu.py`
+
+**Step 1: Write the failing harness test**
+
+Add a focused contract test that proves the harness can:
+
+- run Candle and real PyTorch on the same scalar/binary op case,
+- compare output dtype and values,
+- compare exception type when a case is invalid.
+
+Use a tiny helper shape first, for example `add(int64, float32)` and `mean(int64)`.
+
+Suggested skeleton:
+
+```python
+import candle as torch
+import torch as real_torch
+
+from .helpers import run_training_core_parity_case
+
+
+def test_parity_harness_compares_forward_dtype_and_value():
+    result = run_training_core_parity_case(
+        op_name="add",
+        candle_fn=lambda a, b: torch.add(a, b),
+        torch_fn=lambda a, b: real_torch.add(a, b),
+        candle_inputs=lambda: (
+            torch.tensor([1, 2, 3], dtype=torch.int64),
+            torch.tensor([0.5, 0.5, 0.5], dtype=torch.float32),
+        ),
+        torch_inputs=lambda: (
+            real_torch.tensor([1, 2, 3], dtype=real_torch.int64),
+            real_torch.tensor([0.5, 0.5, 0.5], dtype=real_torch.float32),
+        ),
+    )
+    assert result["dtype_match"] is True
+    assert result["value_match"] is True
+```
+
+**Step 2: Run the new test to verify it fails**
+
+Run: `PYTHONPATH=src pytest tests/contract/test_training_core_parity_harness.py -v --tb=short`
+Expected: FAIL because `run_training_core_parity_case` does not exist yet.
+
+**Step 3: Write the minimal shared helper implementation**
+
+In `tests/contract/helpers.py`, add a reusable helper that:
+
+- constructs Candle and real-PyTorch inputs separately,
+- executes both functions,
+- returns a structured result with dtype/value/shape match booleans,
+- optionally compares exceptions,
+- uses `numpy.testing.assert_allclose` with configurable tolerances.
+
+Do not add backward or alias coverage yet. Keep Task 1 limited to forward + error scaffolding.
+
+**Step 4: Re-run the harness test**
+
+Run: `PYTHONPATH=src pytest tests/contract/test_training_core_parity_harness.py -v --tb=short`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/contract/test_training_core_parity_harness.py tests/contract/helpers.py
+git commit -m "test(contract): add training core parity harness scaffold"
+```
+
+---
+
+### Task 2: Extend the parity harness for backward and alias-aware cases
+
+**Files:**
+- Modify: `tests/contract/helpers.py`
+- Modify: `tests/contract/test_training_core_parity_harness.py`
+- Reference: `tests/contract/test_inplace_view_rules.py`
+- Reference: `tests/contract/test_autograd_contract.py`
+- Reference: `src/candle/_tensor.py`
+
+**Step 1: Write failing tests for backward and view/inplace support**
+
+Add two harness-level tests:
+
+- one that compares gradients for a simple differentiable case like `sum(relu(x * y))`,
+- one that compares alias/version-sensitive behavior for a view case, such as `base.view(...); view.add_(...)` raising or mutating like PyTorch.
+
+Suggested skeleton:
+
+```python
+def test_parity_harness_compares_gradients():
+    ...
+
+
+def test_parity_harness_can_check_view_inplace_behavior():
+    ...
+```
+
+**Step 2: Run the new tests to verify they fail**
+
+Run: `PYTHONPATH=src pytest tests/contract/test_training_core_parity_harness.py -k "gradient or view" -v --tb=short`
+Expected: FAIL because the helper does not yet compare grads or alias outcomes.
+
+**Step 3: Implement minimal helper support**
+
+Extend `tests/contract/helpers.py` with optional flags such as:
+
+- `check_backward=True`
+- `check_alias=True`
+- `compare_error_substring=True`
+
+For backward cases:
+
+- call `.backward()` on both Candle and real PyTorch outputs,
+- collect leaf grads,
+- compare grad dtype, shape, and value.
+
+For alias/view cases:
+
+- expose whether output is a view,
+- compare mutation side effects on the base tensor,
+- compare exception class and key message fragment when inplace-on-view is rejected.
+
+**Step 4: Re-run the targeted harness tests**
+
+Run: `PYTHONPATH=src pytest tests/contract/test_training_core_parity_harness.py -v --tb=short`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/contract/helpers.py tests/contract/test_training_core_parity_harness.py
+git commit -m "test(contract): extend training core parity harness for grads and alias checks"
+```
+
+---
+
+### Task 3: Add failing binary arithmetic parity contracts
+
+**Files:**
+- Create: `tests/contract/test_training_core_binary_parity.py`
+- Reference: `tests/cpu/test_ops_cpu.py`
+- Reference: `src/candle/_functional.py`
+- Reference: `src/candle/_backends/cpu/ops.py`
+- Reference: `src/candle/_backends/npu/ops.py`
+- Reference: `src/candle/_backends/mps/ops.py`
+
+**Step 1: Write failing parity contracts for binary arithmetic**
+
+Start with the highest-risk cases already hinted at by existing CPU parity tests:
+
+- `add(int64, float32)` dtype promotion
+- `mul(int64, float32)` dtype promotion
+- `div(int64, float32)` result dtype and values
+- `true_divide(int64, int32)` result dtype and values
+- `add(bool, int64)` promotion
+- broadcasted `add` with shape mismatch success and failure cases
+- inplace `add_` scalar/tensor update semantics
+
+Each contract should use the shared harness and run against Candle backends that are available in the environment.
+
+**Step 2: Run the binary parity tests to verify current failures**
+
+Run: `PYTHONPATH=src pytest tests/contract/test_training_core_binary_parity.py -v --tb=short`
+Expected: FAIL on at least one backend, likely from dtype promotion or backend-specific drift.
+
+**Step 3: Fix shared semantic issues first**
+
+Check shared wrappers before patching per-backend kernels:
+
+- `src/candle/_functional.py`
+- any common dtype utility in `src/candle/_dtype.py`
+
+If the failure is backend-specific, patch the smallest affected backend implementation:
+
+- CPU: `src/candle/_backends/cpu/ops.py`
+- NPU: `src/candle/_backends/npu/ops.py`
+- MPS: `src/candle/_backends/mps/ops.py`
+
+Implementation constraints:
+
+- match real PyTorch dtype promotion,
+- preserve no-CPU-fallback rule for device backends,
+- do not broaden scope to unrelated binary ops in the same commit.
+
+**Step 4: Re-run the binary parity tests**
+
+Run: `PYTHONPATH=src pytest tests/contract/test_training_core_binary_parity.py -v --tb=short`
+Expected: PASS.
+
+**Step 5: Run adjacent regressions**
+
+Run: `PYTHONPATH=src pytest tests/cpu/test_ops_cpu.py -k "dtype_promotion or true_divide or add_bool" -v --tb=short`
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add tests/contract/test_training_core_binary_parity.py src/candle/_functional.py src/candle/_dtype.py src/candle/_backends/cpu/ops.py src/candle/_backends/npu/ops.py src/candle/_backends/mps/ops.py
+git commit -m "fix(parity): align training core binary arithmetic with torch"
+```
+
+---
+
+### Task 4: Add failing reshape/view parity contracts
+
+**Files:**
+- Create: `tests/contract/test_training_core_view_parity.py`
+- Reference: `tests/contract/test_functionalize_view_writeback.py`
+- Reference: `tests/contract/test_inplace_view_rules.py`
+- Reference: `src/candle/_tensor.py`
+- Reference: `src/candle/_dispatch/dispatcher.py`
+- Reference: `src/candle/_dispatch/functionalize.py`
+- Reference: `src/candle/_backends/autograd.py`
+
+**Step 1: Write failing parity contracts for reshape/view semantics**
+
+Cover the first-wave training-relevant cases:
+
+- `reshape` vs `view` on contiguous input
+- `view` on non-contiguous input when PyTorch rejects it
+- inplace mutation through a view updates the base when allowed
+- inplace on a restricted leaf/view path raises the same exception class as PyTorch
+- backward through `reshape`, `view`, `transpose`, `squeeze`, and `unsqueeze`
+
+Use the parity harness for both forward and backward checks. For error cases, compare exception class and a stable substring, not the full line unless already contract-locked elsewhere.
+
+**Step 2: Run the view parity tests to verify current failures**
+
+Run: `PYTHONPATH=src pytest tests/contract/test_training_core_view_parity.py -v --tb=short`
+Expected: FAIL on one or more alias/version/backward cases.
+
+**Step 3: Implement the smallest semantic fixes**
+
+Expected code touch points:
+
+- `src/candle/_tensor.py` for `_check_inplace`, view metadata, version updates
+- `src/candle/_dispatch/dispatcher.py` for mutating-arg checks and version bumping
+- `src/candle/_dispatch/functionalize.py` for writeback behavior
+- `src/candle/_backends/autograd.py` for view backward wrappers
+
+Keep fixes tightly scoped to the failing parity cases.
+
+**Step 4: Re-run the view parity tests**
+
+Run: `PYTHONPATH=src pytest tests/contract/test_training_core_view_parity.py -v --tb=short`
+Expected: PASS.
+
+**Step 5: Run adjacent regressions**
+
+Run: `PYTHONPATH=src pytest tests/contract/test_inplace_view_rules.py tests/contract/test_functionalize_view_writeback.py tests/cpu/test_tensor_view.py -v --tb=short`
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add tests/contract/test_training_core_view_parity.py src/candle/_tensor.py src/candle/_dispatch/dispatcher.py src/candle/_dispatch/functionalize.py src/candle/_backends/autograd.py
+git commit -m "fix(parity): align training core view semantics with torch"
+```
+
+---
+
+### Task 5: Add failing reduction parity contracts
+
+**Files:**
+- Create: `tests/contract/test_training_core_reduction_parity.py`
+- Reference: `tests/cpu/test_ops_cpu.py`
+- Reference: `src/candle/_functional.py`
+- Reference: `src/candle/_backends/cpu/ops.py`
+- Reference: `src/candle/_backends/npu/ops.py`
+- Reference: `src/candle/_backends/mps/ops.py`
+
+**Step 1: Write failing parity contracts for reductions**
+
+Cover first-wave reduction semantics:
+
+- `mean(int64)` raises like PyTorch
+- `mean(int64, dtype=float32)` succeeds and matches values/dtype
+- `sum(int8, dtype=int64)` accumulates in target dtype
+- `sum/mean` with negative dim and tuple dims
+- `keepdim=True/False`
+- backward for differentiable floating-point `sum` and `mean`
+
+Add backend-tolerance configuration only where numerics require it. Do not weaken dtype or semantic assertions.
+
+**Step 2: Run the reduction parity tests to verify current failures**
+
+Run: `PYTHONPATH=src pytest tests/contract/test_training_core_reduction_parity.py -v --tb=short`
+Expected: FAIL, likely on MPS/NPU dtype handling and error semantics.
+
+**Step 3: Implement minimal fixes**
+
+Likely touch points:
+
+- `src/candle/_functional.py` for wrapper-level dtype/error behavior
+- `src/candle/_backends/cpu/ops.py::sum_` and `mean_`
+- `src/candle/_backends/npu/ops.py::sum_` and `mean`
+- `src/candle/_backends/mps/ops.py::sum_` and `mean_`
+
+Important constraints:
+
+- `sum(dtype=...)` must accumulate in target dtype when PyTorch does,
+- integer `mean` without explicit dtype must error like PyTorch,
+- do not add silent device fallback for unsupported reductions.
+
+**Step 4: Re-run the reduction parity tests**
+
+Run: `PYTHONPATH=src pytest tests/contract/test_training_core_reduction_parity.py -v --tb=short`
+Expected: PASS.
+
+**Step 5: Run adjacent regressions**
+
+Run: `PYTHONPATH=src pytest tests/cpu/test_ops_cpu.py -k "mean_int or sum_dtype" tests/cpu/test_top_level_ops.py -v --tb=short`
+Expected: PASS.
+
+**Step 6: Update known-kernel issues if any backend limitation remains accepted**
+
+If a backend still has a documented temporary limitation that is explicitly tolerated, add an entry to `docs/known-kernel-issues.md`.
+
+**Step 7: Commit**
+
+```bash
+git add tests/contract/test_training_core_reduction_parity.py src/candle/_functional.py src/candle/_backends/cpu/ops.py src/candle/_backends/npu/ops.py src/candle/_backends/mps/ops.py docs/known-kernel-issues.md
+git commit -m "fix(parity): align training core reduction semantics with torch"
+```
+
+---
+
+### Task 6: Add a minimal training-core torch parity smoke gate
+
+**Files:**
+- Create: `tests/contract/test_training_core_smoke_parity.py`
+- Reference: `tests/npu/test_npu_golden_training_loop.py`
+- Reference: `tests/cpu/test_optim.py`
+- Reference: `src/candle/nn/functional.py`
+- Reference: `src/candle/optim/sgd.py`
+
+**Step 1: Write the failing smoke parity test**
+
+Add a compact training loop that runs both Candle and real PyTorch on the same model/data/seed for a few steps:
+
+- one `Linear` layer,
+- one activation (`relu` or `gelu`),
+- one reduction loss (`mean` of squared error),
+- one optimizer (`SGD` first, no momentum),
+- 3 to 5 steps only.
+
+Assert:
+
+- all losses are finite,
+- loss direction is consistent,
+- parameter values after final step stay within tolerance of real PyTorch,
+- gradients are populated at each step.
+
+Keep this test CPU-first if needed for determinism. Make device expansion follow-up work, not part of this task.
+
+**Step 2: Run the smoke test to verify it fails or exposes drift**
+
+Run: `PYTHONPATH=src pytest tests/contract/test_training_core_smoke_parity.py -v --tb=short`
+Expected: FAIL until the parity harness and first-wave semantics are fully aligned.
+
+**Step 3: Fix any remaining shared training-core drift**
+
+Patch only the smallest remaining semantic gaps revealed by the smoke test. Do not turn the smoke test into a catch-all long-tail debugging bucket.
+
+**Step 4: Re-run the smoke test**
+
+Run: `PYTHONPATH=src pytest tests/contract/test_training_core_smoke_parity.py -v --tb=short`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/contract/test_training_core_smoke_parity.py src/candle/nn/functional.py src/candle/optim/sgd.py
+git commit -m "test(contract): add training core torch parity smoke gate"
+```
+
+---
+
+### Task 7: Run the focused contract gate for phase 1
+
+**Files:**
+- No code changes required unless regressions are found
+
+**Step 1: Run the phase-1 focused contract suite**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest \
+  tests/contract/test_training_core_parity_harness.py \
+  tests/contract/test_training_core_binary_parity.py \
+  tests/contract/test_training_core_view_parity.py \
+  tests/contract/test_training_core_reduction_parity.py \
+  tests/contract/test_training_core_smoke_parity.py \
+  -v --tb=short
+```
+
+Expected: PASS.
+
+**Step 2: Run adjacent regression contracts**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest \
+  tests/contract/test_inplace_view_rules.py \
+  tests/contract/test_functionalize_view_writeback.py \
+  tests/contract/test_autograd_contract.py \
+  tests/contract/test_dispatch_contract.py \
+  -v --tb=short
+```
+
+Expected: PASS.
+
+**Step 3: Commit any final doc or regression-fix updates**
+
+```bash
+git add <final-files>
+git commit -m "test(contract): finalize phase-1 training core parity gate"
+```
+
+---
+
+### Task 8: Optional phase-1.5 follow-up for linear/activation parity
+
+**Files:**
+- Create: `tests/contract/test_training_core_linear_activation_parity.py`
+- Reference: `src/candle/nn/functional.py`
+- Reference: `src/candle/_backends/autograd.py`
+
+**Step 1: Write failing linear/activation parity tests**
+
+Start with:
+
+- `linear` forward parity
+- `relu`, `gelu`, `silu` forward parity
+- backward parity for `linear + relu`
+
+**Step 2: Run tests to confirm failure where present**
+
+Run: `PYTHONPATH=src pytest tests/contract/test_training_core_linear_activation_parity.py -v --tb=short`
+Expected: FAIL if remaining drift exists.
+
+**Step 3: Implement minimal fixes**
+
+Patch shared wrappers or autograd/backend kernels only where needed.
+
+**Step 4: Re-run tests**
+
+Run: `PYTHONPATH=src pytest tests/contract/test_training_core_linear_activation_parity.py -v --tb=short`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/contract/test_training_core_linear_activation_parity.py src/candle/nn/functional.py src/candle/_backends/autograd.py src/candle/_backends/cpu/ops.py src/candle/_backends/npu/ops.py src/candle/_backends/mps/ops.py
+git commit -m "fix(parity): align training core linear and activation semantics with torch"
+```

--- a/src/candle/__init__.py
+++ b/src/candle/__init__.py
@@ -106,6 +106,7 @@ from . import compiler
 from .ops import ops
 from . import library
 from . import optim
+from . import nn
 from . import jit
 from . import profiler
 from . import multiprocessing
@@ -387,6 +388,7 @@ __all__ = [
     "library",
     "compiler",
     "optim",
+    "nn",
     "jit",
     "profiler",
     "compile",

--- a/src/candle/_backends/common/view.py
+++ b/src/candle/_backends/common/view.py
@@ -64,6 +64,13 @@ def view(a, shape):
     else:
         shape = tuple(shape)
 
+    if not a.is_contiguous():
+        raise RuntimeError(
+            "view size is not compatible with input tensor's size and stride "
+            "(at least one dimension spans across two contiguous subspaces). "
+            "Use .reshape(...) instead."
+        )
+
     size = 1
     for d in a.shape:
         size *= d

--- a/src/candle/_backends/cpu/ops.py
+++ b/src/candle/_backends/cpu/ops.py
@@ -105,6 +105,16 @@ def _promote_div_dtype(dtype_a, dtype_b):
 def _binary_out_dtype(a, b, *, for_div=False):
     dtype_a = _dtype_of(a)
     dtype_b = _dtype_of(b)
+
+    # Match torch tensor-scalar behavior for common floating-point scalars:
+    # float32_tensor * 0.5 stays float32 instead of promoting to float64.
+    if isinstance(a, Tensor) and not isinstance(b, Tensor):
+        if dtype_a.is_floating_point and isinstance(b, float):
+            return dtype_a if not for_div else dtype_a
+    if isinstance(b, Tensor) and not isinstance(a, Tensor):
+        if dtype_b.is_floating_point and isinstance(a, float):
+            return dtype_b if not for_div else dtype_b
+
     if for_div:
         return _promote_div_dtype(dtype_a, dtype_b)
     return _promote_binary_dtype(dtype_a, dtype_b)

--- a/tests/contract/helpers.py
+++ b/tests/contract/helpers.py
@@ -1,4 +1,5 @@
 import torch as pt
+import numpy as np
 
 
 def assert_torch_error(fn_mt, fn_torch):
@@ -18,3 +19,127 @@ def assert_torch_error(fn_mt, fn_torch):
 
     assert type(mt_exc) is type(torch_exc)
     assert str(mt_exc) == str(torch_exc)
+
+
+def _dtype_name(dtype):
+    return getattr(dtype, "name", str(dtype).split(".")[-1])
+
+
+def _to_numpy(value):
+    if hasattr(value, "detach"):
+        value = value.detach()
+    if hasattr(value, "to") and hasattr(value, "device"):
+        dev = getattr(value.device, "type", value.device)
+        if dev != "cpu":
+            value = value.to("cpu")
+    if hasattr(value, "numpy"):
+        return value.numpy()
+    return np.asarray(value)
+
+
+def _leaf_grads(values):
+    grads = []
+    for value in values:
+        if not hasattr(value, "requires_grad"):
+            continue
+        if not getattr(value, "requires_grad", False):
+            continue
+        grads.append(getattr(value, "grad", None))
+    return grads
+
+
+def _allclose_or_false(a, b, *, rtol, atol):
+    try:
+        np.testing.assert_allclose(_to_numpy(a), _to_numpy(b), rtol=rtol, atol=atol)
+        return True
+    except AssertionError:
+        return False
+
+
+def run_training_core_parity_case(
+    *,
+    op_name,
+    candle_fn,
+    torch_fn,
+    candle_inputs,
+    torch_inputs,
+    expect_error=False,
+    check_backward=False,
+    check_error_message=False,
+    error_message_fragment=None,
+    rtol=1e-5,
+    atol=1e-8,
+):
+    del op_name
+
+    mt_args = candle_inputs()
+    th_args = torch_inputs()
+
+    if expect_error:
+        try:
+            torch_fn(*th_args)
+        except Exception as th_exc:
+            torch_exc = th_exc
+        else:
+            torch_exc = None
+
+        try:
+            candle_fn(*mt_args)
+        except Exception as mt_exc:
+            candle_exc = mt_exc
+        else:
+            candle_exc = None
+
+        return {
+            "error_type_match": type(candle_exc) is type(torch_exc),
+            "error_message_match": (
+                True
+                if not check_error_message
+                else (
+                    torch_exc is not None
+                    and candle_exc is not None
+                    and error_message_fragment is not None
+                    and error_message_fragment in str(torch_exc)
+                    and error_message_fragment in str(candle_exc)
+                )
+            ),
+            "torch_error": torch_exc,
+            "candle_error": candle_exc,
+        }
+
+    mt_out = candle_fn(*mt_args)
+    th_out = torch_fn(*th_args)
+
+    shape_match = tuple(getattr(mt_out, "shape", ())) == tuple(getattr(th_out, "shape", ()))
+    dtype_match = _dtype_name(getattr(mt_out, "dtype", None)) == _dtype_name(getattr(th_out, "dtype", None))
+
+    mt_np = _to_numpy(mt_out)
+    th_np = _to_numpy(th_out)
+    try:
+        np.testing.assert_allclose(mt_np, th_np, rtol=rtol, atol=atol)
+        value_match = True
+    except AssertionError:
+        value_match = False
+
+    grad_count_match = None
+    grad_value_match = None
+    if check_backward:
+        mt_out.backward()
+        th_out.backward()
+        mt_grads = _leaf_grads(mt_args)
+        th_grads = _leaf_grads(th_args)
+        grad_count_match = len(mt_grads) == len(th_grads)
+        grad_value_match = grad_count_match and all(
+            ((mg is None and tg is None) or (mg is not None and tg is not None and _allclose_or_false(mg, tg, rtol=rtol, atol=atol)))
+            for mg, tg in zip(mt_grads, th_grads)
+        )
+
+    return {
+        "shape_match": shape_match,
+        "dtype_match": dtype_match,
+        "value_match": value_match,
+        "grad_count_match": grad_count_match,
+        "grad_value_match": grad_value_match,
+        "candle_output": mt_out,
+        "torch_output": th_out,
+    }

--- a/tests/contract/test_training_core_binary_parity.py
+++ b/tests/contract/test_training_core_binary_parity.py
@@ -1,0 +1,171 @@
+import candle as torch
+import pytest
+
+from .helpers import run_training_core_parity_case
+
+
+def test_add_dtype_promotion_matches_torch_contract():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="add",
+        candle_fn=lambda a, b: torch.add(a, b),
+        torch_fn=lambda a, b: real_torch.add(a, b),
+        candle_inputs=lambda: (
+            torch.tensor([1, 2, 3], dtype=torch.int64),
+            torch.tensor([0.5, 0.5, 0.5], dtype=torch.float32),
+        ),
+        torch_inputs=lambda: (
+            real_torch.tensor([1, 2, 3], dtype=real_torch.int64),
+            real_torch.tensor([0.5, 0.5, 0.5], dtype=real_torch.float32),
+        ),
+    )
+
+    assert result["dtype_match"] is True
+    assert result["value_match"] is True
+
+
+def test_mul_dtype_promotion_matches_torch_contract():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="mul",
+        candle_fn=lambda a, b: torch.mul(a, b),
+        torch_fn=lambda a, b: real_torch.mul(a, b),
+        candle_inputs=lambda: (
+            torch.tensor([1, 2, 3], dtype=torch.int64),
+            torch.tensor([0.5, 0.5, 0.5], dtype=torch.float32),
+        ),
+        torch_inputs=lambda: (
+            real_torch.tensor([1, 2, 3], dtype=real_torch.int64),
+            real_torch.tensor([0.5, 0.5, 0.5], dtype=real_torch.float32),
+        ),
+    )
+
+    assert result["dtype_match"] is True
+    assert result["value_match"] is True
+
+
+def test_div_dtype_promotion_matches_torch_contract():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="div",
+        candle_fn=lambda a, b: torch.div(a, b),
+        torch_fn=lambda a, b: real_torch.div(a, b),
+        candle_inputs=lambda: (
+            torch.tensor([2, 4, 6], dtype=torch.int64),
+            torch.tensor([2.0, 2.0, 2.0], dtype=torch.float32),
+        ),
+        torch_inputs=lambda: (
+            real_torch.tensor([2, 4, 6], dtype=real_torch.int64),
+            real_torch.tensor([2.0, 2.0, 2.0], dtype=real_torch.float32),
+        ),
+    )
+
+    assert result["dtype_match"] is True
+    assert result["value_match"] is True
+
+
+def test_true_divide_dtype_promotion_matches_torch_contract():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="true_divide",
+        candle_fn=lambda a, b: torch.true_divide(a, b),
+        torch_fn=lambda a, b: real_torch.true_divide(a, b),
+        candle_inputs=lambda: (
+            torch.tensor([2, 4, 6], dtype=torch.int64),
+            torch.tensor([2, 2, 2], dtype=torch.int32),
+        ),
+        torch_inputs=lambda: (
+            real_torch.tensor([2, 4, 6], dtype=real_torch.int64),
+            real_torch.tensor([2, 2, 2], dtype=real_torch.int32),
+        ),
+    )
+
+    assert result["dtype_match"] is True
+    assert result["value_match"] is True
+
+
+def test_add_bool_int64_promotion_matches_torch_contract():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="add",
+        candle_fn=lambda a, b: torch.add(a, b),
+        torch_fn=lambda a, b: real_torch.add(a, b),
+        candle_inputs=lambda: (
+            torch.tensor([True, False, True], dtype=torch.bool),
+            torch.tensor([1, 2, 3], dtype=torch.int64),
+        ),
+        torch_inputs=lambda: (
+            real_torch.tensor([True, False, True], dtype=real_torch.bool),
+            real_torch.tensor([1, 2, 3], dtype=real_torch.int64),
+        ),
+    )
+
+    assert result["dtype_match"] is True
+    assert result["value_match"] is True
+
+
+def test_add_broadcast_matches_torch_contract():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="add",
+        candle_fn=lambda a, b: torch.add(a, b),
+        torch_fn=lambda a, b: real_torch.add(a, b),
+        candle_inputs=lambda: (
+            torch.tensor([[1.0], [2.0]], dtype=torch.float32),
+            torch.tensor([10.0, 20.0, 30.0], dtype=torch.float32),
+        ),
+        torch_inputs=lambda: (
+            real_torch.tensor([[1.0], [2.0]], dtype=real_torch.float32),
+            real_torch.tensor([10.0, 20.0, 30.0], dtype=real_torch.float32),
+        ),
+    )
+
+    assert result["shape_match"] is True
+    assert result["value_match"] is True
+
+
+def test_add_broadcast_error_matches_torch_contract():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="add",
+        candle_fn=lambda a, b: torch.add(a, b),
+        torch_fn=lambda a, b: real_torch.add(a, b),
+        candle_inputs=lambda: (
+            torch.tensor([[1.0, 2.0]], dtype=torch.float32),
+            torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=torch.float32),
+        ),
+        torch_inputs=lambda: (
+            real_torch.tensor([[1.0, 2.0]], dtype=real_torch.float32),
+            real_torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=real_torch.float32),
+        ),
+        expect_error=True,
+    )
+
+    assert result["error_type_match"] is True
+
+
+def test_add_inplace_matches_torch_contract():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="add_",
+        candle_fn=lambda a, b: a.add_(b),
+        torch_fn=lambda a, b: a.add_(b),
+        candle_inputs=lambda: (
+            torch.tensor([1.0, 2.0, 3.0], dtype=torch.float32),
+            torch.tensor([0.5, 0.5, 0.5], dtype=torch.float32),
+        ),
+        torch_inputs=lambda: (
+            real_torch.tensor([1.0, 2.0, 3.0], dtype=real_torch.float32),
+            real_torch.tensor([0.5, 0.5, 0.5], dtype=real_torch.float32),
+        ),
+    )
+
+    assert result["value_match"] is True

--- a/tests/contract/test_training_core_parity_harness.py
+++ b/tests/contract/test_training_core_parity_harness.py
@@ -1,0 +1,81 @@
+import candle as torch
+import pytest
+
+from .helpers import run_training_core_parity_case
+
+
+def test_parity_harness_compares_forward_dtype_and_value():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="add",
+        candle_fn=lambda a, b: torch.add(a, b),
+        torch_fn=lambda a, b: real_torch.add(a, b),
+        candle_inputs=lambda: (
+            torch.tensor([1, 2, 3], dtype=torch.int64),
+            torch.tensor([0.5, 0.5, 0.5], dtype=torch.float32),
+        ),
+        torch_inputs=lambda: (
+            real_torch.tensor([1, 2, 3], dtype=real_torch.int64),
+            real_torch.tensor([0.5, 0.5, 0.5], dtype=real_torch.float32),
+        ),
+    )
+
+    assert result["dtype_match"] is True
+    assert result["shape_match"] is True
+    assert result["value_match"] is True
+
+
+def test_parity_harness_compares_exception_type():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="mean",
+        candle_fn=lambda a: torch.mean(a),
+        torch_fn=lambda a: real_torch.mean(a),
+        candle_inputs=lambda: (torch.tensor([1, 2, 3], dtype=torch.int64),),
+        torch_inputs=lambda: (real_torch.tensor([1, 2, 3], dtype=real_torch.int64),),
+        expect_error=True,
+    )
+
+    assert result["error_type_match"] is True
+
+
+def test_parity_harness_compares_gradients():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="sum_relu_mul",
+        candle_fn=lambda a, b: torch.sum(torch.relu(torch.mul(a, b))),
+        torch_fn=lambda a, b: real_torch.sum(real_torch.relu(real_torch.mul(a, b))),
+        candle_inputs=lambda: (
+            torch.tensor([1.0, -2.0, 3.0], dtype=torch.float32, requires_grad=True),
+            torch.tensor([0.5, 4.0, -1.0], dtype=torch.float32, requires_grad=True),
+        ),
+        torch_inputs=lambda: (
+            real_torch.tensor([1.0, -2.0, 3.0], dtype=real_torch.float32, requires_grad=True),
+            real_torch.tensor([0.5, 4.0, -1.0], dtype=real_torch.float32, requires_grad=True),
+        ),
+        check_backward=True,
+    )
+
+    assert result["grad_count_match"] is True
+    assert result["grad_value_match"] is True
+
+
+def test_parity_harness_compares_error_message_fragment_for_view_inplace():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="view_add_",
+        candle_fn=lambda x: x.view((4,)).add_(1.0),
+        torch_fn=lambda x: x.view((4,)).add_(1.0),
+        candle_inputs=lambda: (torch.ones((2, 2), dtype=torch.float32).requires_grad_(),),
+        torch_inputs=lambda: (real_torch.ones((2, 2), dtype=real_torch.float32, requires_grad=True),),
+        expect_error=True,
+        check_error_message=True,
+        error_message_fragment="view of a leaf Variable that requires grad",
+    )
+
+    assert result["error_type_match"] is True
+    assert result["error_message_match"] is True

--- a/tests/contract/test_training_core_reduction_parity.py
+++ b/tests/contract/test_training_core_reduction_parity.py
@@ -1,0 +1,110 @@
+import candle as torch
+
+from .helpers import run_training_core_parity_case
+
+
+def test_mean_int_without_dtype_matches_torch_contract():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="mean",
+        candle_fn=lambda a: torch.mean(a),
+        torch_fn=lambda a: real_torch.mean(a),
+        candle_inputs=lambda: (torch.tensor([1, 2, 3], dtype=torch.int64),),
+        torch_inputs=lambda: (real_torch.tensor([1, 2, 3], dtype=real_torch.int64),),
+        expect_error=True,
+    )
+
+    assert result["error_type_match"] is True
+
+
+def test_mean_int_with_dtype_matches_torch_contract():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="mean",
+        candle_fn=lambda a: torch.mean(a, dtype=torch.float32),
+        torch_fn=lambda a: real_torch.mean(a, dtype=real_torch.float32),
+        candle_inputs=lambda: (torch.tensor([1, 2, 3], dtype=torch.int64),),
+        torch_inputs=lambda: (real_torch.tensor([1, 2, 3], dtype=real_torch.int64),),
+    )
+
+    assert result["dtype_match"] is True
+    assert result["value_match"] is True
+
+
+def test_sum_dtype_accumulates_in_target_dtype_matches_torch_contract():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="sum",
+        candle_fn=lambda a: torch.sum(a, dtype=torch.int64),
+        torch_fn=lambda a: real_torch.sum(a, dtype=real_torch.int64),
+        candle_inputs=lambda: (torch.tensor([120, 120], dtype=torch.int8),),
+        torch_inputs=lambda: (real_torch.tensor([120, 120], dtype=real_torch.int8),),
+    )
+
+    assert result["dtype_match"] is True
+    assert result["value_match"] is True
+
+
+def test_sum_negative_dim_matches_torch_contract():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="sum",
+        candle_fn=lambda a: torch.sum(a, dim=-1),
+        torch_fn=lambda a: real_torch.sum(a, dim=-1),
+        candle_inputs=lambda: (torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float32),),
+        torch_inputs=lambda: (real_torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=real_torch.float32),),
+    )
+
+    assert result["shape_match"] is True
+    assert result["value_match"] is True
+
+
+def test_mean_tuple_dim_keepdim_matches_torch_contract():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="mean",
+        candle_fn=lambda a: torch.mean(a, dim=(0, 2), keepdim=True),
+        torch_fn=lambda a: real_torch.mean(a, dim=(0, 2), keepdim=True),
+        candle_inputs=lambda: (torch.tensor([[[1.0, 2.0], [3.0, 4.0]]], dtype=torch.float32),),
+        torch_inputs=lambda: (real_torch.tensor([[[1.0, 2.0], [3.0, 4.0]]], dtype=real_torch.float32),),
+    )
+
+    assert result["shape_match"] is True
+    assert result["value_match"] is True
+
+
+def test_sum_backward_matches_torch_contract():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="sum",
+        candle_fn=lambda a: torch.sum(a),
+        torch_fn=lambda a: real_torch.sum(a),
+        candle_inputs=lambda: (torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float32, requires_grad=True),),
+        torch_inputs=lambda: (real_torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=real_torch.float32, requires_grad=True),),
+        check_backward=True,
+    )
+
+    assert result["grad_count_match"] is True
+    assert result["grad_value_match"] is True
+
+
+def test_mean_backward_matches_torch_contract():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="mean",
+        candle_fn=lambda a: torch.mean(a),
+        torch_fn=lambda a: real_torch.mean(a),
+        candle_inputs=lambda: (torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float32, requires_grad=True),),
+        torch_inputs=lambda: (real_torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=real_torch.float32, requires_grad=True),),
+        check_backward=True,
+    )
+
+    assert result["grad_count_match"] is True
+    assert result["grad_value_match"] is True

--- a/tests/contract/test_training_core_smoke_parity.py
+++ b/tests/contract/test_training_core_smoke_parity.py
@@ -1,0 +1,73 @@
+import numpy as np
+
+import candle as torch
+
+
+def test_training_core_smoke_parity_matches_torch_cpu():
+    import torch as real_torch
+
+    x_data = [[1.0, 2.0], [3.0, 4.0]]
+    target_data = [[0.5], [1.5]]
+    weight_data = [[0.1, -0.2]]
+    bias_data = [0.3]
+    lr = 0.05
+    steps = 4
+
+    candle_model = torch.nn.Linear(2, 1, dtype=torch.float32)
+    candle_model.weight.data = torch.tensor(weight_data, dtype=torch.float32)
+    candle_model.bias.data = torch.tensor(bias_data, dtype=torch.float32)
+    candle_opt = torch.optim.SGD(candle_model.parameters(), lr=lr)
+
+    torch_model = real_torch.nn.Linear(2, 1, dtype=real_torch.float32)
+    with real_torch.no_grad():
+        torch_model.weight.copy_(real_torch.tensor(weight_data, dtype=real_torch.float32))
+        torch_model.bias.copy_(real_torch.tensor(bias_data, dtype=real_torch.float32))
+    torch_opt = real_torch.optim.SGD(torch_model.parameters(), lr=lr)
+
+    cx = torch.tensor(x_data, dtype=torch.float32)
+    cy = torch.tensor(target_data, dtype=torch.float32)
+    tx = real_torch.tensor(x_data, dtype=real_torch.float32)
+    ty = real_torch.tensor(target_data, dtype=real_torch.float32)
+
+    candle_losses = []
+    torch_losses = []
+
+    for _ in range(steps):
+        candle_opt.zero_grad()
+        cout = candle_model(cx)
+        cdiff = cout - cy
+        closs = torch.mean(cdiff * cdiff)
+        candle_losses.append(float(closs.item()))
+        closs.backward()
+        assert candle_model.weight.grad is not None
+        assert candle_model.bias.grad is not None
+        candle_opt.step()
+
+        torch_opt.zero_grad()
+        tout = torch_model(tx)
+        tdiff = tout - ty
+        tloss = real_torch.mean(tdiff * tdiff)
+        torch_losses.append(float(tloss.item()))
+        tloss.backward()
+        assert torch_model.weight.grad is not None
+        assert torch_model.bias.grad is not None
+        torch_opt.step()
+
+    assert all(np.isfinite(candle_losses))
+    assert all(np.isfinite(torch_losses))
+    assert candle_losses[-1] < candle_losses[0]
+    assert torch_losses[-1] < torch_losses[0]
+
+    np.testing.assert_allclose(candle_losses, torch_losses, rtol=1e-5, atol=1e-6)
+    np.testing.assert_allclose(
+        candle_model.weight.detach().numpy(),
+        torch_model.weight.detach().cpu().numpy(),
+        rtol=1e-5,
+        atol=1e-6,
+    )
+    np.testing.assert_allclose(
+        candle_model.bias.detach().numpy(),
+        torch_model.bias.detach().cpu().numpy(),
+        rtol=1e-5,
+        atol=1e-6,
+    )

--- a/tests/contract/test_training_core_view_parity.py
+++ b/tests/contract/test_training_core_view_parity.py
@@ -1,0 +1,71 @@
+import candle as torch
+
+from .helpers import run_training_core_parity_case
+
+
+def test_view_contiguous_matches_torch_contract():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="view",
+        candle_fn=lambda x: x.view((3, 2)),
+        torch_fn=lambda x: x.view((3, 2)),
+        candle_inputs=lambda: (torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=torch.float32),),
+        torch_inputs=lambda: (real_torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=real_torch.float32),),
+    )
+
+    assert result["shape_match"] is True
+    assert result["value_match"] is True
+
+
+def test_view_non_contiguous_error_matches_torch_contract():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="view",
+        candle_fn=lambda x: x.transpose(0, 1).view((6,)),
+        torch_fn=lambda x: x.transpose(0, 1).view((6,)),
+        candle_inputs=lambda: (torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=torch.float32),),
+        torch_inputs=lambda: (real_torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=real_torch.float32),),
+        expect_error=True,
+    )
+
+    assert result["error_type_match"] is True
+
+
+def test_view_inplace_error_matches_torch_contract():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="view_add_",
+        candle_fn=lambda x: x.view((4,)).add_(1.0),
+        torch_fn=lambda x: x.view((4,)).add_(1.0),
+        candle_inputs=lambda: (torch.ones((2, 2), dtype=torch.float32).requires_grad_(),),
+        torch_inputs=lambda: (real_torch.ones((2, 2), dtype=real_torch.float32, requires_grad=True),),
+        expect_error=True,
+        check_error_message=True,
+        error_message_fragment="view of a leaf Variable that requires grad",
+    )
+
+    assert result["error_type_match"] is True
+    assert result["error_message_match"] is True
+
+
+def test_view_backward_matches_torch_contract():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="transpose_sum",
+        candle_fn=lambda x: x.transpose(0, 1).sum(),
+        torch_fn=lambda x: x.transpose(0, 1).sum(),
+        candle_inputs=lambda: (
+            torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=torch.float32, requires_grad=True),
+        ),
+        torch_inputs=lambda: (
+            real_torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=real_torch.float32, requires_grad=True),
+        ),
+        check_backward=True,
+    )
+
+    assert result["grad_count_match"] is True
+    assert result["grad_value_match"] is True

--- a/tests/cpu/test_import.py
+++ b/tests/cpu/test_import.py
@@ -3,3 +3,8 @@ import candle as torch
 
 def test_import_has_tensor():
     assert hasattr(torch, "tensor")
+
+
+def test_import_has_nn_module():
+    assert hasattr(torch, "nn")
+    assert hasattr(torch.nn, "Linear")


### PR DESCRIPTION
## Summary

- add a PyTorch-oracle training-core parity harness for forward, error, gradient, and view/inplace checks
- add first-wave parity contracts for binary arithmetic, reshape/view, reduction semantics, and a minimal CPU training smoke gate
- fix non-contiguous `view()` semantics and float32 tensor-scalar promotion so training-core behavior aligns with PyTorch

## Test Plan

- `PYTHONPATH=src pytest tests/contract/test_training_core_parity_harness.py tests/contract/test_training_core_binary_parity.py tests/contract/test_training_core_view_parity.py tests/contract/test_training_core_reduction_parity.py tests/contract/test_training_core_smoke_parity.py -v --tb=short`
- `PYTHONPATH=src pytest tests/contract/test_inplace_view_rules.py tests/contract/test_functionalize_view_writeback.py tests/contract/test_autograd_contract.py tests/contract/test_dispatch_contract.py tests/cpu/test_import.py -v --tb=short`
