### PR TITLE
feat(cpu): add adaptive_max_pool1d_with_indices and leaky_relu_ wrappers

### DIFF
--- a/src/candle/nn/functional.py
+++ b/src/candle/nn/functional.py
@@ -69,6 +69,11 @@ def leaky_relu(input, negative_slope=0.01, inplace=False):
     return dispatch("leaky_relu", input.device.type, input, negative_slope)
 
 
+def leaky_relu_(input, negative_slope=0.01):
+    input.copy_(leaky_relu(input, negative_slope=negative_slope))
+    return input
+
+
 def elu(input, alpha=1.0, inplace=False):
     from .._dispatch import dispatch
     return dispatch("elu", input.device.type, input, alpha)
@@ -347,6 +352,10 @@ def adaptive_max_pool2d(input, output_size, return_indices=False):
         _output_size = tuple(output_size)
     return dispatch("adaptive_max_pool2d", input.device.type, input, _output_size,
                     return_indices)
+
+
+def adaptive_max_pool1d_with_indices(input, output_size):
+    return adaptive_max_pool1d(input, output_size, return_indices=True)
 
 
 def adaptive_max_pool2d_with_indices(input, output_size):

--- a/tests/cpu/test_nn_functional.py
+++ b/tests/cpu/test_nn_functional.py
@@ -471,3 +471,18 @@ def test_max_unpool3d_invalid_index_raises():
     bad_indices = torch.tensor([[[[[99]]]]], device='cpu', dtype=torch.int64)
     with pytest.raises((RuntimeError, ValueError, IndexError)):
         F.max_unpool3d(pooled, bad_indices, kernel_size=2, stride=2, output_size=(1, 1, 2, 2, 2))
+
+
+def test_adaptive_max_pool1d_with_indices_wrapper_exists():
+    x = torch.tensor([[[1.0, 3.0, 2.0, 4.0]]], device='cpu')
+    out, idx = F.adaptive_max_pool1d_with_indices(x, output_size=2)
+    assert out.shape == (1, 1, 2)
+    assert idx.shape == (1, 1, 2)
+
+
+def test_leaky_relu_inplace_wrapper_exists_and_mutates():
+    x = torch.tensor([-2.0, 0.0, 2.0], device='cpu')
+    out = F.leaky_relu_(x, negative_slope=0.1)
+    assert out is x
+    expected = torch.tensor([-0.2, 0.0, 2.0], device='cpu')
+    assert torch.allclose(x, expected, atol=1e-6)


### PR DESCRIPTION
## Summary
- add missing `nn.functional` parity wrapper `adaptive_max_pool1d_with_indices`
- add missing `nn.functional` in-place wrapper `leaky_relu_`
- add CPU tests covering both new APIs

## Validation
- `PYTHONPATH=src pytest tests/cpu/test_nn_functional.py -k "adaptive_max_pool1d_with_indices_wrapper_exists or leaky_relu_inplace_wrapper_exists_and_mutates" -v`
- `PYTHONPATH=src pytest tests/cpu/test_nn_functional.py -q`
