### PR TITLE
feat(cpu): add lp_pool3d and multilabel_margin_loss wrappers

### DIFF
--- a/src/candle/nn/functional.py
+++ b/src/candle/nn/functional.py
@@ -937,6 +937,58 @@ def multi_margin_loss(input, target, p=1, margin=1.0, weight=None, reduction='me
     raise ValueError(f"Invalid reduction mode: {reduction}")
 
 
+
+
+def multilabel_margin_loss(input, target, reduction='mean'):
+    from .._creation import tensor as _tensor, arange as _arange
+    from .._dispatch import dispatch
+    from .._functional import add, neg, mean, sum as _sum, clamp
+
+    if input.ndim != 2 or target.ndim != 2:
+        raise ValueError('multilabel_margin_loss expects 2D input and target')
+
+    n_batch, n_classes = input.shape
+    losses = []
+    one_t = _tensor(1.0, device=input.device)
+    c_t = _tensor(float(n_classes), device=input.device)
+
+    for n in range(n_batch):
+        t_row = target[n]
+        valid_mask = dispatch('ge', input.device.type, t_row, 0)
+        valid_idx = t_row[valid_mask]
+        if valid_idx.shape[0] == 0:
+            losses.append(_tensor(0.0, device=input.device))
+            continue
+
+        cls = _arange(n_classes, device=input.device).unsqueeze(1)
+        eq = dispatch('eq', input.device.type, cls, valid_idx.unsqueeze(0))
+        is_target = dispatch('any', input.device.type, eq, dim=1)
+
+        x_row = input[n]
+        x_targets = x_row[is_target]
+        not_target = dispatch('eq', input.device.type, is_target, False)
+        x_non = x_row[not_target]
+
+        if x_non.shape[0] == 0:
+            losses.append(_tensor(0.0, device=input.device))
+            continue
+
+        acc = _tensor(0.0, device=input.device)
+        for i in range(x_targets.shape[0]):
+            margins = add(one_t, add(x_non, neg(x_targets[i])))
+            acc = add(acc, _sum(clamp(margins, 0.0, None)))
+
+        losses.append(dispatch('div', input.device.type, acc, c_t))
+
+    batch = dispatch('stack', input.device.type, losses, 0)
+    if reduction == 'none':
+        return batch
+    if reduction == 'sum':
+        return _sum(batch)
+    if reduction == 'mean':
+        return mean(batch)
+    raise ValueError(f'Invalid reduction mode: {reduction}')
+
 def multilabel_soft_margin_loss(input, target, weight=None, reduction='mean'):
     from .._functional import mul, neg, log, add, mean, sum as _sum
     from .._creation import tensor as _tensor
@@ -1505,6 +1557,25 @@ def avg_pool3d(input, kernel_size, stride=None, padding=0, ceil_mode=False,
     return dispatch("avg_pool3d", input.device.type, input, _kernel_size, _stride,
                     _padding, ceil_mode, count_include_pad)
 
+
+
+
+def lp_pool3d(input, norm_type, kernel_size, stride=None, ceil_mode=False):
+    from .._functional import abs as _abs, pow as _pow
+    from .._creation import tensor as _tensor
+    p = float(norm_type)
+    if p <= 0:
+        raise ValueError('norm_type must be positive')
+    p_t = _tensor(p, device=input.device)
+    inv_p_t = _tensor(1.0 / p, device=input.device)
+    powered = _pow(_abs(input), p_t)
+    pooled = avg_pool3d(powered, kernel_size, stride=stride, padding=0, ceil_mode=ceil_mode, count_include_pad=True)
+    if isinstance(kernel_size, int):
+        vol = kernel_size * kernel_size * kernel_size
+    else:
+        vol = int(kernel_size[0]) * int(kernel_size[1]) * int(kernel_size[2])
+    vol_t = _tensor(float(vol), device=input.device)
+    return _pow(pooled * vol_t, inv_p_t)
 
 def adaptive_avg_pool3d(input, output_size):
     from .._dispatch import dispatch

--- a/tests/cpu/test_nn_functional.py
+++ b/tests/cpu/test_nn_functional.py
@@ -526,3 +526,24 @@ def test_lp_pool2d_wrapper_exists_matches_torch():
     expected = torch.tensor([[[[np.sqrt(30.0)]]]], device='cpu')
     assert out.shape == (1, 1, 1, 1)
     assert torch.allclose(out, expected, atol=1e-6)
+
+
+def test_lp_pool3d_wrapper_exists_matches_expected():
+    x = torch.tensor([[[[[1.0, -2.0], [3.0, -4.0]], [[5.0, -6.0], [7.0, -8.0]]]]], device='cpu')
+    out = F.lp_pool3d(x, norm_type=2.0, kernel_size=2, stride=2)
+    expected = torch.tensor([[[[[np.sqrt(204.0)]]]]], device='cpu')
+    assert out.shape == (1, 1, 1, 1, 1)
+    assert torch.allclose(out, expected, atol=1e-6)
+
+
+def test_multilabel_margin_loss_wrapper_exists_basic():
+    # input: (N=1, C=4), target uses class indices and -1 padding
+    input = torch.tensor([[0.9, 0.2, 0.8, -0.1]], device='cpu')
+    target = torch.tensor([[0, 2, -1, -1]], device='cpu', dtype=torch.int64)
+    loss = F.multilabel_margin_loss(input, target, reduction='mean')
+    # For y={0,2}, non-targets={1,3}:
+    # max(0, 1 - (x0-x1))=0.3, max(0,1-(x0-x3))=0.0
+    # max(0, 1 - (x2-x1))=0.4, max(0,1-(x2-x3))=0.1
+    # sum=0.8, divide by C=4 -> 0.2
+    expected = torch.tensor(0.2, device='cpu')
+    assert torch.allclose(loss, expected, atol=1e-6)


### PR DESCRIPTION
## Summary
- add missing `nn.functional.lp_pool3d` wrapper
- add missing `nn.functional.multilabel_margin_loss` wrapper
- add CPU tests validating both wrappers

## Validation
- `PYTHONPATH=src pytest tests/cpu/test_nn_functional.py -k "lp_pool3d_wrapper_exists_matches_expected or multilabel_margin_loss_wrapper_exists_basic" -v`
- `PYTHONPATH=src pytest tests/cpu/test_nn_functional.py -q`
