### PR TITLE
fix(parity): align index_select negative indices with torch

### DIFF
--- a/src/candle/_backends/cpu/ops.py
+++ b/src/candle/_backends/cpu/ops.py
@@ -503,6 +503,8 @@ def index_select(a, dim, index):
         dim += arr.ndim
     if dim < 0 or dim >= arr.ndim:
         raise ValueError("dim out of range")
+    if (idx < 0).any() or (idx >= arr.shape[dim]).any():
+        raise RuntimeError("INDICES element is out of DATA bounds")
     out = np.take(arr, idx, axis=dim)
     return _from_numpy(out, a.dtype, a.device)
 

--- a/tests/contract/test_training_core_index_select_parity.py
+++ b/tests/contract/test_training_core_index_select_parity.py
@@ -1,0 +1,24 @@
+import candle as torch
+
+from .helpers import run_training_core_parity_case
+
+
+def test_index_select_negative_index_matches_torch_error_contract():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="index_select_negative_index",
+        candle_fn=lambda x, index: torch.index_select(x, dim=1, index=index),
+        torch_fn=lambda x, index: real_torch.index_select(x, dim=1, index=index),
+        candle_inputs=lambda: (
+            torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=torch.float32),
+            torch.tensor([-1, 0], dtype=torch.int64),
+        ),
+        torch_inputs=lambda: (
+            real_torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=real_torch.float32),
+            real_torch.tensor([-1, 0], dtype=real_torch.int64),
+        ),
+        expect_error=True,
+    )
+
+    assert result["error_type_match"] is True

--- a/tests/cpu/test_ops_cpu.py
+++ b/tests/cpu/test_ops_cpu.py
@@ -770,10 +770,10 @@ def test_index_select_cpu():
     expected = np.take(x.numpy(), index.numpy().astype(np.int64), axis=1)
     np.testing.assert_allclose(torch.index_select(x, dim=1, index=index).numpy(), expected)
     neg_index = torch.tensor([-1, 0], dtype=torch.int64)
-    expected_neg = np.take(x.numpy(), neg_index.numpy().astype(np.int64), axis=1)
-    np.testing.assert_allclose(torch.index_select(x, dim=1, index=neg_index).numpy(), expected_neg)
+    with pytest.raises(RuntimeError, match="INDICES element is out of DATA bounds"):
+        torch.index_select(x, dim=1, index=neg_index)
     out_of_range = torch.tensor([3], dtype=torch.int64)
-    with pytest.raises(IndexError):
+    with pytest.raises(RuntimeError, match="INDICES element is out of DATA bounds"):
         torch.index_select(x, dim=1, index=out_of_range)
     bad_index = torch.tensor([[0, 1]], dtype=torch.int64)
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- add a torch-oracle contract for `index_select` negative-index error behavior
- align CPU `index_select` with torch by rejecting negative and out-of-range indices with `RuntimeError`
- update the existing CPU test so it matches torch semantics instead of numpy-style negative indexing

## Test Plan
- PYTHONPATH=src pytest tests/contract/test_training_core_index_select_parity.py -v --tb=short
- PYTHONPATH=src pytest tests/cpu/test_ops_cpu.py -k "index_select_cpu" -v --tb=short
- PYTHONPATH=src pytest tests/contract/test_training_core_index_select_parity.py tests/contract/test_training_core_smoke_parity.py -v --tb=short
- PYTHONPATH=src pytest tests/contract/ -v --tb=short
