### PR TITLE
docs: publish npu-first 0.1 install prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,21 @@ PyTorch is powerful — but it's also **2GB+ of C++ binaries**, hard to install 
 
 ### Install
 
+For the current source workflow:
+
 ```bash
-pip install candle
+git clone https://github.com/candle-org/candle.git
+cd candle
+pip install -e ".[test]"
 ```
 
-That's it. No CUDA toolkit, no compiler, no 10-minute build.
+If you only need the base package without test dependencies:
+
+```bash
+pip install -e .
+```
+
+Ascend NPU users must install CANN first and follow [docs/install-npu.md](docs/install-npu.md) before running device code.
 
 ### Write code the way you already know
 
@@ -60,6 +70,28 @@ x = torch.randn(2, 784, requires_grad=True)
 out = model(x)
 out.sum().backward()
 print(x.grad.shape)  # (2, 784)
+```
+
+### Ascend NPU quick start (0.1 GA path)
+
+See [docs/install-npu.md](docs/install-npu.md) for the full environment prerequisites. On a supported Ascend 910B host:
+
+```bash
+if [ -f /usr/local/Ascend/ascend-toolkit/latest/set_env.sh ]; then
+  source /usr/local/Ascend/ascend-toolkit/latest/set_env.sh
+fi
+export PYTHONPATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:${PYTHONPATH:-}
+python - <<'PY'
+import candle as torch
+
+assert torch.npu.is_available(verbose=True)
+x = torch.randn((4, 8), device='npu')
+w = torch.randn((8, 2), device='npu', requires_grad=True)
+y = torch.matmul(x, w)
+y.sum().backward()
+print(torch.npu.get_device_name())
+print(y.device)
+PY
 ```
 
 ### Or just `import torch` — seriously
@@ -101,6 +133,8 @@ candle.device("npu")    # Huawei Ascend (ACLNN)
 ```
 
 ### Ascend NPU — First-Class Support
+
+Candle's current `0.1.x` GA target is a single-card Ascend 910B training path. Install and runtime prerequisites are documented in [docs/install-npu.md](docs/install-npu.md), and the validated release surface is summarized in [docs/support-matrix.md](docs/support-matrix.md).
 
 Unlike wrapper libraries, Candle calls **ACLNN large kernels directly** via ctypes — no framework overhead, no Python-to-C++ bridge:
 

--- a/docs/install-npu.md
+++ b/docs/install-npu.md
@@ -1,0 +1,149 @@
+# Install Candle On Ascend NPU
+
+## Scope
+
+This guide documents the supported Candle `0.1.x` NPU path:
+
+- SoC: Ascend 910B
+- Topology: single-card only
+- Validation target: local golden training loop, checkpoint continuity, and no-CPU-fallback regression gates
+
+Everything outside that path remains experimental unless called out explicitly in [support-matrix.md](support-matrix.md).
+
+## Prerequisites
+
+Before installing Candle for NPU, make sure all of the following are true:
+
+- CANN is installed on the host.
+- If multiple CANN versions are installed, `/usr/local/Ascend/ascend-toolkit/latest` points to the newest installed version.
+- The newest toolkit contains:
+  - `/usr/local/Ascend/ascend-toolkit/latest/lib64`
+  - `/usr/local/Ascend/ascend-toolkit/latest/aarch64-linux/lib64`
+  - `/usr/local/Ascend/ascend-toolkit/latest/opp`
+  - `/usr/local/Ascend/ascend-toolkit/latest/python/site-packages`
+- Python can import Candle and the Ascend Python packages in the same environment.
+
+Candle's NPU loader aligns itself to `/usr/local/Ascend/ascend-toolkit/latest`, but you should still source the toolkit environment explicitly so the shell, Python path, and runtime libraries agree on one CANN version.
+
+## Environment Setup
+
+Start from a fresh shell. If your CANN installation provides `set_env.sh`, source it first:
+
+```bash
+if [ -f /usr/local/Ascend/ascend-toolkit/latest/set_env.sh ]; then
+  source /usr/local/Ascend/ascend-toolkit/latest/set_env.sh
+fi
+```
+
+Then make the runtime paths explicit:
+
+```bash
+export ASCEND_TOOLKIT_HOME=/usr/local/Ascend/ascend-toolkit/latest
+export ASCEND_HOME_PATH=/usr/local/Ascend/ascend-toolkit/latest
+export ASCEND_OPP_PATH=/usr/local/Ascend/ascend-toolkit/latest/opp
+export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/lib64:/usr/local/Ascend/ascend-toolkit/latest/aarch64-linux/lib64:${LD_LIBRARY_PATH:-}
+export PYTHONPATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:${PWD}/src:${PYTHONPATH:-}
+```
+
+If `set_env.sh` is not present on your host, you still need the exports above before importing Candle's NPU backend.
+
+## Install Candle
+
+For the current source workflow:
+
+```bash
+git clone https://github.com/candle-org/candle.git
+cd candle
+pip install -e ".[test]"
+```
+
+This installs Candle plus the test dependencies used by the 0.1 NPU validation path.
+
+## Verify NPU Availability
+
+Run a direct availability probe before running model code:
+
+```bash
+python - <<'PY'
+import candle as torch
+
+print('npu available:', torch.npu.is_available(verbose=True))
+if torch.npu.is_available():
+    print('device count:', torch.npu.device_count())
+    print('device name:', torch.npu.get_device_name())
+PY
+```
+
+Expected:
+
+- `npu available: True`
+- `device count` is at least `1`
+- `device name` reports an Ascend 910B device on the supported GA path
+
+If availability is `False`, keep `verbose=True` and fix the missing ACL/CANN import or library path issue before continuing.
+
+## Minimal NPU Quick Start
+
+Once availability is green, run a minimal device computation:
+
+```bash
+python - <<'PY'
+import candle as torch
+
+assert torch.npu.is_available(verbose=True)
+x = torch.randn((4, 8), device='npu')
+w = torch.randn((8, 2), device='npu', requires_grad=True)
+y = torch.matmul(x, w)
+y.sum().backward()
+print('device:', y.device)
+print('soc:', torch.npu.get_device_name())
+PY
+```
+
+Expected:
+
+- tensors stay on `npu`
+- backward completes on-device
+- no implicit CPU fallback is required for this path
+
+## Run The 0.1 Local NPU Gates
+
+The declared 0.1 NPU validation set is:
+
+```bash
+PYTHONPATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:src \
+pytest \
+  tests/npu/test_npu_golden_training_loop.py \
+  tests/npu/test_npu_training_checkpoint_continuity.py \
+  tests/npu/test_mul_scalar_regression_npu.py \
+  tests/npu/test_no_cpu_fallback_npu.py \
+  -v --tb=short
+```
+
+Expected:
+
+- all tests pass on a supported Ascend 910B host
+- the golden training loop stays finite and decreases loss
+- checkpoint save/load continues training after reload
+- declared NPU release paths do not round-trip through CPU
+
+## Troubleshooting
+
+### `torch.npu.is_available(verbose=True)` reports missing `acl`
+
+Your Ascend Python packages are not visible to the active interpreter. Re-check:
+
+- `source /usr/local/Ascend/ascend-toolkit/latest/set_env.sh`
+- `PYTHONPATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:${PWD}/src:${PYTHONPATH:-}`
+
+### Runtime libraries fail to load
+
+Re-check:
+
+- `LD_LIBRARY_PATH` includes both toolkit runtime directories
+- `/usr/local/Ascend/ascend-toolkit/latest` points to the newest installed CANN version
+- `ASCEND_OPP_PATH` points to `/usr/local/Ascend/ascend-toolkit/latest/opp`
+
+### Tests pass on CPU but not on NPU
+
+That is not an acceptable release workaround. Candle's NPU GA path must execute on NPU without runtime fallback to CPU.

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -2,21 +2,23 @@
 
 This matrix defines the effective support scope for Candle `0.1.x`.
 
+For NPU installation and runtime prerequisites, see [install-npu.md](install-npu.md).
+
 ## GA
 
-- Ascend 910B single-card training core path:
+- Ascend 910B single-card training core path on a host where the newest installed CANN toolkit is exposed through `/usr/local/Ascend/ascend-toolkit/latest` and sourced into the shell.
   - tensor creation,
   - forward ops used by baseline training,
   - autograd backward,
   - optimizer step,
-  - checkpoint save/load on critical path.
-- CPU fallback path for development and CI baseline.
+  - checkpoint save/load on the critical path.
+- CPU backend for development and CI baseline.
 
 ## Experimental
 
 - Additional NPU ops outside the baseline training path.
 - Transformers compatibility runner (`tests/run_test.py`) and related patches.
-- Partial distributed collectives where behavior is validated only in limited scenarios.
+- Partial distributed/HCCL collectives where behavior is validated only in limited scenarios.
 
 ## Not Supported In 0.1 Scope
 
@@ -31,9 +33,13 @@ This matrix defines the effective support scope for Candle `0.1.x`.
 
 0.1 release quality is evaluated by:
 
-- deterministic NPU golden training loop on Ascend 910B,
-- checkpoint continuity on NPU (save/load then continue training),
-- CPU fallback CI test baseline.
+- local Ascend 910B NPU gate set:
+  - `tests/npu/test_npu_golden_training_loop.py`,
+  - `tests/npu/test_npu_training_checkpoint_continuity.py`,
+  - `tests/npu/test_mul_scalar_regression_npu.py`,
+  - `tests/npu/test_no_cpu_fallback_npu.py`.
+- CPU + contract CI baseline.
+- MPS CI baseline for cross-backend regression visibility.
 
 ## Runtime Rule
 


### PR DESCRIPTION
## Summary
- add a dedicated Ascend NPU installation guide for the supported Candle `0.1.x` single-card Ascend 910B path
- update the README install flow and NPU quick-start so user-facing guidance matches the actual CANN runtime prerequisites
- tighten the support matrix around the validated local NPU gate set and the current GA-vs-experimental boundary

## Test Plan
- `export ASCEND_TOOLKIT_HOME=/usr/local/Ascend/ascend-toolkit/latest && export ASCEND_HOME_PATH=/usr/local/Ascend/ascend-toolkit/latest && export ASCEND_OPP_PATH=/usr/local/Ascend/ascend-toolkit/latest/opp && export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/lib64:/usr/local/Ascend/ascend-toolkit/latest/aarch64-linux/lib64:${LD_LIBRARY_PATH:-} && export PYTHONPATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:${PWD}/src:${PYTHONPATH:-} && python - <<'PY'`
  ```python
  import candle as torch
  print('npu available:', torch.npu.is_available(verbose=True))
  if torch.npu.is_available():
      print('device count:', torch.npu.device_count())
      print('device name:', torch.npu.get_device_name())
  ```
  Result: `npu available: True`, `device count: 8`, `device name: Ascend910B`
- `export ASCEND_TOOLKIT_HOME=/usr/local/Ascend/ascend-toolkit/latest && export ASCEND_HOME_PATH=/usr/local/Ascend/ascend-toolkit/latest && export ASCEND_OPP_PATH=/usr/local/Ascend/ascend-toolkit/latest/opp && export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/lib64:/usr/local/Ascend/ascend-toolkit/latest/aarch64-linux/lib64:${LD_LIBRARY_PATH:-} && export PYTHONPATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:${PWD}/src:${PYTHONPATH:-} && python -m pytest tests/npu/test_npu_golden_training_loop.py tests/npu/test_npu_training_checkpoint_continuity.py tests/npu/test_mul_scalar_regression_npu.py tests/npu/test_no_cpu_fallback_npu.py -q`
  Result: `14 passed in 4.23s`
