### PR TITLE
feat(cpu): add conv_tbc, native_channel_shuffle, and triplet distance wrappers

### DIFF
--- a/src/candle/nn/functional.py
+++ b/src/candle/nn/functional.py
@@ -236,6 +236,15 @@ def conv_transpose2d(input, weight, bias=None, stride=1, padding=0,
                     _stride, _padding, _output_padding, groups, _dilation)
 
 
+
+
+def conv_tbc(input, weight, bias, pad=0):
+    # torch conv_tbc: input (T, B, C_in), weight (K, C_in, C_out), bias (C_out)
+    x = input.permute(1, 2, 0)
+    w = weight.permute(2, 1, 0)
+    y = conv1d(x, w, bias=bias, stride=1, padding=pad, dilation=1, groups=1)
+    return y.permute(2, 0, 1)
+
 def conv3d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
     from .._dispatch import dispatch
     _stride = (stride, stride, stride) if isinstance(stride, int) else tuple(stride)
@@ -856,6 +865,37 @@ def triplet_margin_loss(anchor, positive, negative, margin=1.0, p=2, eps=1e-6,
     raise ValueError(f"Invalid reduction mode: {reduction}")
 
 
+
+
+def triplet_margin_with_distance_loss(anchor, positive, negative, *, distance_function=None, margin=1.0, swap=False, reduction='mean'):
+    from .._functional import add, neg, mean, sum as _sum, clamp
+    from .._creation import tensor as _tensor
+    from .._dispatch import dispatch
+
+    if distance_function is None:
+        dist_ap = pairwise_distance(anchor, positive)
+        dist_an = pairwise_distance(anchor, negative)
+    else:
+        dist_ap = distance_function(anchor, positive)
+        dist_an = distance_function(anchor, negative)
+
+    if swap:
+        if distance_function is None:
+            dist_pn = pairwise_distance(positive, negative)
+        else:
+            dist_pn = distance_function(positive, negative)
+        dist_an = dispatch('min', anchor.device.type, dist_an, dist_pn)
+
+    margin_t = _tensor(float(margin), device=anchor.device)
+    losses = clamp(add(add(dist_ap, neg(dist_an)), margin_t), 0.0, None)
+    if reduction == 'none':
+        return losses
+    if reduction == 'mean':
+        return mean(losses)
+    if reduction == 'sum':
+        return _sum(losses)
+    raise ValueError(f'Invalid reduction mode: {reduction}')
+
 def hinge_embedding_loss(input, target, margin=1.0, reduction='mean'):
     from .._functional import add, neg, mean, sum as _sum, clamp, where
     from .._creation import tensor as _tensor
@@ -1239,6 +1279,18 @@ def pixel_unshuffle(input, downscale_factor):
     # Reshape: (N, C*r^2, H, W)
     x = dispatch("reshape", input.device.type, x, (N, C * r * r, H, W))
     return x
+
+
+def native_channel_shuffle(input, groups):
+    if input.ndim == 3:
+        n, c, l = input.shape
+        if c % groups != 0:
+            raise ValueError('Number of channels must be divisible by groups')
+        channels_per_group = c // groups
+        x = input.reshape((n, groups, channels_per_group, l))
+        x = x.permute((0, 2, 1, 3)).contiguous()
+        return x.reshape((n, c, l))
+    return channel_shuffle(input, groups)
 
 
 def channel_shuffle(input, groups):

--- a/tests/cpu/test_nn_functional.py
+++ b/tests/cpu/test_nn_functional.py
@@ -547,3 +547,49 @@ def test_multilabel_margin_loss_wrapper_exists_basic():
     # sum=0.8, divide by C=4 -> 0.2
     expected = torch.tensor(0.2, device='cpu')
     assert torch.allclose(loss, expected, atol=1e-6)
+
+
+def test_native_channel_shuffle_wrapper_exists_matches_channel_shuffle():
+    x = torch.tensor([[[1.0], [2.0], [3.0], [4.0]]], device='cpu')  # (N=1,C=4,L=1)
+    out = F.native_channel_shuffle(x, groups=2)
+
+    # Compare against torch reference on CPU using detached numpy values.
+    import torch as torch_ref
+    x_ref = torch_ref.tensor(x.numpy())
+    ref = torch_ref.nn.functional.native_channel_shuffle(x_ref, groups=2)
+
+    assert out.shape == x.shape
+    np.testing.assert_allclose(out.numpy(), ref.numpy(), rtol=1e-6, atol=1e-6)
+
+
+def test_triplet_margin_with_distance_loss_wrapper_exists():
+    anchor = torch.tensor([[0.0, 0.0]], device='cpu')
+    positive = torch.tensor([[1.0, 0.0]], device='cpu')
+    negative = torch.tensor([[3.0, 0.0]], device='cpu')
+    loss = F.triplet_margin_with_distance_loss(anchor, positive, negative, margin=1.0, reduction='mean')
+    # d(ap)=1, d(an)=3 => max(1 - 3 + 1, 0)=0
+    expected = torch.tensor(0.0, device='cpu')
+    assert torch.allclose(loss, expected, atol=1e-6)
+
+
+def test_conv_tbc_wrapper_exists():
+    # T=3, B=1, C_in=2
+    x = torch.tensor([
+        [[1.0, 2.0]],
+        [[3.0, 4.0]],
+        [[5.0, 6.0]],
+    ], device='cpu')
+    # weight shape: (K=2, C_in=2, C_out=1)
+    w = torch.tensor([
+        [[1.0], [1.0]],
+        [[1.0], [1.0]],
+    ], device='cpu')
+    b = torch.tensor([0.0], device='cpu')
+    out = F.conv_tbc(x, w, b, pad=0)
+    # out[t] = sum over k,c of x[t+k,c]*w[k,c]
+    expected = torch.tensor([
+        [[10.0]],
+        [[18.0]],
+    ], device='cpu')
+    assert out.shape == (2, 1, 1)
+    assert torch.allclose(out, expected, atol=1e-6)


### PR DESCRIPTION
## Summary
- add `conv_tbc` CPU functional wrapper by reusing `conv1d`
- add `native_channel_shuffle` wrapper with correct 3D CPU behavior
- add `triplet_margin_with_distance_loss` functional wrapper
- cover the new wrappers with CPU nn.functional tests

## Testing
- `PYTHONPATH=src pytest tests/cpu/test_nn_functional.py -k "native_channel_shuffle_wrapper_exists_matches_channel_shuffle or triplet_margin_with_distance_loss_wrapper_exists or conv_tbc_wrapper_exists" -q`
- `PYTHONPATH=src pytest tests/cpu/test_nn_functional.py -q`
