### PR TITLE
feat(mps): Phase 1 training GPU kernels

### DIFF
--- a/src/candle/_backends/mps/metal_compute.py
+++ b/src/candle/_backends/mps/metal_compute.py
@@ -558,6 +558,81 @@ class MetalKernelDispatcher:
                                     numel, scalar_fmt=scalar_fmt)
 
     # ------------------------------------------------------------------
+    # Dispatch: clamp with 2 scalars  (a, min, max → out)
+    # ------------------------------------------------------------------
+
+    def dispatch_clamp(self, kernel_name, a_buf, scalar1, scalar2, out_buf,
+                       numel, scalar_fmt="f"):
+        """Encode clamp kernel: out = clamp(a, min_val, max_val)."""
+        rt = get_runtime()
+        pipeline = self._get_pipeline(kernel_name)
+        tpg = self._threads_per_group(pipeline)
+        groups = (numel + tpg - 1) // tpg
+
+        cmd = rt.create_command_buffer()
+        enc = rt.get_compute_encoder(cmd)
+
+        s1_bytes = struct.pack(scalar_fmt, scalar1)
+        s2_bytes = struct.pack(scalar_fmt, scalar2)
+        scalar_size = len(s1_bytes)
+
+        if _HAS_PYOBJC:
+            enc.setComputePipelineState_(pipeline)
+            enc.setBuffer_offset_atIndex_(a_buf, 0, 0)
+            enc.setBytes_length_atIndex_(s1_bytes, scalar_size, 1)
+            enc.setBytes_length_atIndex_(s2_bytes, scalar_size, 2)
+            enc.setBuffer_offset_atIndex_(out_buf, 0, 3)
+            enc.setBytes_length_atIndex_(struct.pack("I", numel), 4, 4)
+            enc.dispatchThreadgroups_threadsPerThreadgroup_(
+                _MTLSize(groups, 1, 1), _MTLSize(tpg, 1, 1))
+            enc.endEncoding()
+        else:
+            _encode_clamp_ctypes(enc, pipeline, a_buf,
+                                 s1_bytes, s2_bytes, scalar_size,
+                                 out_buf, numel, groups, tpg)
+
+        rt.commit_and_wait(cmd)
+
+    def dispatch_clamp_strided(self, kernel_name, a_buf, scalar1, scalar2,
+                               out_buf, numel, shape_array, strides_a_array,
+                               ndim, scalar_fmt="f"):
+        """Encode strided clamp kernel: out = clamp(a[strided], min, max)."""
+        rt = get_runtime()
+        pipeline = self._get_pipeline(kernel_name)
+        tpg = self._threads_per_group(pipeline)
+        groups = (numel + tpg - 1) // tpg
+
+        cmd = rt.create_command_buffer()
+        enc = rt.get_compute_encoder(cmd)
+
+        s1_bytes = struct.pack(scalar_fmt, scalar1)
+        s2_bytes = struct.pack(scalar_fmt, scalar2)
+        scalar_size = len(s1_bytes)
+        shape_bytes = struct.pack(f"{ndim}I", *shape_array)
+        strides_bytes = struct.pack(f"{ndim}i", *strides_a_array)
+
+        if _HAS_PYOBJC:
+            enc.setComputePipelineState_(pipeline)
+            enc.setBuffer_offset_atIndex_(a_buf, 0, 0)
+            enc.setBytes_length_atIndex_(s1_bytes, scalar_size, 1)
+            enc.setBytes_length_atIndex_(s2_bytes, scalar_size, 2)
+            enc.setBuffer_offset_atIndex_(out_buf, 0, 3)
+            enc.setBytes_length_atIndex_(struct.pack("I", numel), 4, 4)
+            enc.setBytes_length_atIndex_(shape_bytes, len(shape_bytes), 5)
+            enc.setBytes_length_atIndex_(strides_bytes, len(strides_bytes), 6)
+            enc.setBytes_length_atIndex_(struct.pack("I", ndim), 4, 7)
+            enc.dispatchThreadgroups_threadsPerThreadgroup_(
+                _MTLSize(groups, 1, 1), _MTLSize(tpg, 1, 1))
+            enc.endEncoding()
+        else:
+            _encode_clamp_strided_ctypes(
+                enc, pipeline, a_buf, s1_bytes, s2_bytes, scalar_size,
+                out_buf, numel, shape_bytes, strides_bytes, ndim,
+                groups, tpg)
+
+        rt.commit_and_wait(cmd)
+
+    # ------------------------------------------------------------------
     # Dispatch: axis reduction  (input → reduced output along dim)
     # ------------------------------------------------------------------
 
@@ -899,5 +974,36 @@ def _encode_reduce_dim_ctypes(enc, pipeline, a_buf, out_buf,
     _ctypes_set_bytes(enc, struct.pack("I", outer_size), 4, 2)
     _ctypes_set_bytes(enc, struct.pack("I", reduce_size), 4, 3)
     _ctypes_set_bytes(enc, struct.pack("I", inner_size), 4, 4)
+    _ctypes_dispatch_threadgroups(enc, groups, tpg)
+    _ctypes_end_encoding(enc)
+
+
+def _encode_clamp_ctypes(enc, pipeline, a_buf, s1_bytes, s2_bytes,
+                          scalar_size, out_buf, numel, groups, tpg):
+    """Encode a clamp (2-scalar) kernel dispatch via ctypes."""
+    _ctypes_set_pipeline(enc, pipeline)
+    _ctypes_set_buffer(enc, a_buf, 0, 0)
+    _ctypes_set_bytes(enc, s1_bytes, scalar_size, 1)
+    _ctypes_set_bytes(enc, s2_bytes, scalar_size, 2)
+    _ctypes_set_buffer(enc, out_buf, 0, 3)
+    _ctypes_set_bytes(enc, struct.pack("I", numel), 4, 4)
+    _ctypes_dispatch_threadgroups(enc, groups, tpg)
+    _ctypes_end_encoding(enc)
+
+
+def _encode_clamp_strided_ctypes(enc, pipeline, a_buf, s1_bytes, s2_bytes,
+                                  scalar_size, out_buf, numel,
+                                  shape_bytes, strides_bytes, ndim,
+                                  groups, tpg):
+    """Encode a strided clamp (2-scalar) kernel dispatch via ctypes."""
+    _ctypes_set_pipeline(enc, pipeline)
+    _ctypes_set_buffer(enc, a_buf, 0, 0)
+    _ctypes_set_bytes(enc, s1_bytes, scalar_size, 1)
+    _ctypes_set_bytes(enc, s2_bytes, scalar_size, 2)
+    _ctypes_set_buffer(enc, out_buf, 0, 3)
+    _ctypes_set_bytes(enc, struct.pack("I", numel), 4, 4)
+    _ctypes_set_bytes(enc, shape_bytes, len(shape_bytes), 5)
+    _ctypes_set_bytes(enc, strides_bytes, len(strides_bytes), 6)
+    _ctypes_set_bytes(enc, struct.pack("I", ndim), 4, 7)
     _ctypes_dispatch_threadgroups(enc, groups, tpg)
     _ctypes_end_encoding(enc)

--- a/src/candle/_backends/mps/metal_shaders.py
+++ b/src/candle/_backends/mps/metal_shaders.py
@@ -134,6 +134,68 @@ kernel void {name}_scalar_strided_{suffix}(
 """
 
 # ---------------------------------------------------------------------------
+# Templates: unary predicate kernels (float → bool/uchar)
+# ---------------------------------------------------------------------------
+
+_UNARY_PREDICATE_TEMPLATE = """
+kernel void {name}_{suffix}(device const {type}* a [[buffer(0)]],
+                              device uchar* out      [[buffer(1)]],
+                              constant uint& N       [[buffer(2)]],
+                              uint id [[thread_position_in_grid]]) {{
+    if (id < N) out[id] = {expr} ? 1 : 0;
+}}
+"""
+
+_UNARY_PREDICATE_STRIDED_TEMPLATE = """
+kernel void {name}_strided_{suffix}(
+    device const {type}* a   [[buffer(0)]],
+    device uchar* out        [[buffer(1)]],
+    constant uint& N         [[buffer(2)]],
+    constant uint* shape     [[buffer(3)]],
+    constant int*  strides_a [[buffer(4)]],
+    constant uint& ndim      [[buffer(5)]],
+    uint id [[thread_position_in_grid]]) {{
+    if (id < N) {{
+        uint off_a = index_to_offset(id, shape, strides_a, ndim);
+        out[id] = {expr_strided} ? 1 : 0;
+    }}
+}}
+"""
+
+# ---------------------------------------------------------------------------
+# Templates: clamp with 2 scalars (min + max)
+# ---------------------------------------------------------------------------
+
+_CLAMP_TEMPLATE = """
+kernel void clamp_{suffix}(device const {type}* a    [[buffer(0)]],
+                             constant {type}& min_val [[buffer(1)]],
+                             constant {type}& max_val [[buffer(2)]],
+                             device {type}* out       [[buffer(3)]],
+                             constant uint& N         [[buffer(4)]],
+                             uint id [[thread_position_in_grid]]) {{
+    if (id < N) out[id] = clamp(a[id], min_val, max_val);
+}}
+"""
+
+_CLAMP_STRIDED_TEMPLATE = """
+kernel void clamp_strided_{suffix}(
+    device const {type}* a    [[buffer(0)]],
+    constant {type}& min_val  [[buffer(1)]],
+    constant {type}& max_val  [[buffer(2)]],
+    device {type}* out        [[buffer(3)]],
+    constant uint& N          [[buffer(4)]],
+    constant uint* shape      [[buffer(5)]],
+    constant int*  strides_a  [[buffer(6)]],
+    constant uint& ndim       [[buffer(7)]],
+    uint id [[thread_position_in_grid]]) {{
+    if (id < N) {{
+        uint off_a = index_to_offset(id, shape, strides_a, ndim);
+        out[id] = clamp(a[off_a], min_val, max_val);
+    }}
+}}
+"""
+
+# ---------------------------------------------------------------------------
 # Templates: comparison kernels (typed input, uchar output)
 # ---------------------------------------------------------------------------
 
@@ -233,6 +295,33 @@ def _gen_comparison(name, op, types=None):
             name=name, suffix=suffix, type=t, op=op))
         parts.append(_COMPARISON_SCALAR_TEMPLATE.format(
             name=name, suffix=suffix, type=t, op=op))
+    return "".join(parts)
+
+
+def _gen_unary_predicate(name, expr, types=None):
+    """Generate unary predicate kernels (typed input → uchar output)."""
+    if types is None:
+        types = _FLOAT_TYPES
+    parts = []
+    for t in types:
+        suffix = _SUFFIX[t]
+        parts.append(_UNARY_PREDICATE_TEMPLATE.format(
+            name=name, suffix=suffix, type=t, expr=expr))
+        strided_expr = expr.replace("a[id]", "a[off_a]")
+        parts.append(_UNARY_PREDICATE_STRIDED_TEMPLATE.format(
+            name=name, suffix=suffix, type=t, expr_strided=strided_expr))
+    return "".join(parts)
+
+
+def _gen_clamp(types=None):
+    """Generate clamp kernels (2-scalar: min + max) for given types."""
+    if types is None:
+        types = ("float", "half", "int", "long")
+    parts = []
+    for t in types:
+        suffix = _SUFFIX[t]
+        parts.append(_CLAMP_TEMPLATE.format(suffix=suffix, type=t))
+        parts.append(_CLAMP_STRIDED_TEMPLATE.format(suffix=suffix, type=t))
     return "".join(parts)
 
 
@@ -498,6 +587,39 @@ def _build_msl_source():
             parts.append(_UNARY_TEMPLATE.format(name=name, suffix=suffix, type=t, expr=e))
             parts.append(_UNARY_STRIDED_TEMPLATE.format(name=name, suffix=suffix, type=t, expr=e))
 
+    # Leaky ReLU via binary-scalar template (float/half)
+    for t in _FLOAT_TYPES:
+        suffix = _SUFFIX[t]
+        expr = f"(a[id] > ({t})0) ? a[id] : scalar * a[id]"
+        parts.append(_BINARY_SCALAR_TEMPLATE.format(
+            name="leaky_relu", suffix=suffix, type=t, expr=expr))
+        strided_expr = expr.replace("a[id]", "a[off_a]")
+        parts.append(_BINARY_SCALAR_STRIDED_TEMPLATE.format(
+            name="leaky_relu", suffix=suffix, type=t, expr_strided=strided_expr))
+
+    # clamp_min / clamp_max via binary-scalar template (float, half, int, long)
+    _CLAMP_SCALAR_TYPES = ("float", "half", "int", "long")
+    for t in _CLAMP_SCALAR_TYPES:
+        suffix = _SUFFIX[t]
+        # clamp_min: max(a, scalar)
+        parts.append(_BINARY_SCALAR_TEMPLATE.format(
+            name="clamp_min", suffix=suffix, type=t, expr="max(a[id], scalar)"))
+        parts.append(_BINARY_SCALAR_STRIDED_TEMPLATE.format(
+            name="clamp_min", suffix=suffix, type=t, expr_strided="max(a[off_a], scalar)"))
+        # clamp_max: min(a, scalar)
+        parts.append(_BINARY_SCALAR_TEMPLATE.format(
+            name="clamp_max", suffix=suffix, type=t, expr="min(a[id], scalar)"))
+        parts.append(_BINARY_SCALAR_STRIDED_TEMPLATE.format(
+            name="clamp_max", suffix=suffix, type=t, expr_strided="min(a[off_a], scalar)"))
+
+    # Clamp with 2 scalars (min + max)
+    parts.append(_gen_clamp())
+
+    # Unary predicate ops (float → bool): isinf, isnan, isfinite
+    parts.append(_gen_unary_predicate("isinf", "isinf(a[id])"))
+    parts.append(_gen_unary_predicate("isnan", "isnan(a[id])"))
+    parts.append(_gen_unary_predicate("isfinite", "isfinite(a[id])"))
+
     # Full-tensor reductions (multi-dtype)
     # sum: identity=0, combine=add
     parts.append(_gen_reduction(
@@ -640,6 +762,33 @@ kernel void softmax_f32(device const float* input [[buffer(0)]],
     }
 
     output[row * cols + col] = exp_val / sum_exp;
+}
+""")
+
+    # Softmax float16 (compute in float32 for numerical stability)
+    parts.append("""
+kernel void softmax_f16(device const half* input [[buffer(0)]],
+                        device half* output       [[buffer(1)]],
+                        constant uint& rows       [[buffer(2)]],
+                        constant uint& cols       [[buffer(3)]],
+                        uint2 pos [[thread_position_in_grid]]) {
+    uint row = pos.y;
+    uint col = pos.x;
+    if (row >= rows || col >= cols) return;
+
+    float max_val = -INFINITY;
+    for (uint c = 0; c < cols; c++) {
+        max_val = max(max_val, (float)input[row * cols + c]);
+    }
+
+    float exp_val = exp((float)input[row * cols + col] - max_val);
+
+    float sum_exp = 0.0f;
+    for (uint c = 0; c < cols; c++) {
+        sum_exp += exp((float)input[row * cols + c] - max_val);
+    }
+
+    output[row * cols + col] = (half)(exp_val / sum_exp);
 }
 """)
 

--- a/src/candle/_backends/mps/ops.py
+++ b/src/candle/_backends/mps/ops.py
@@ -118,6 +118,24 @@ def _dispatch_unary_gpu(a, kernel_base):
     return _from_metal_buffer(out_buf, out_shape, out_stride, a.dtype, a.device)
 
 
+def _dispatch_unary_predicate_gpu(a, kernel_base):
+    """Dispatch a unary predicate GPU kernel (float → bool), contiguous or strided."""
+    d = _get_dispatcher()
+    sfx = _kernel_suffix(a.dtype)
+    numel = a.numel()
+    out_buf = _alloc_output_buf(numel, bool_dtype)
+    if a.is_contiguous():
+        d.dispatch_unary(f"{kernel_base}_{sfx}", _metal_buf(a), out_buf, numel)
+    else:
+        d.dispatch_unary_strided(
+            f"{kernel_base}_strided_{sfx}", _metal_buf(a), out_buf, numel,
+            list(a.shape), list(a.stride), len(a.shape))
+    from ..._tensor import _compute_strides
+    out_shape = tuple(a.shape)
+    out_stride = _compute_strides(out_shape)
+    return _from_metal_buffer(out_buf, out_shape, out_stride, bool_dtype, a.device)
+
+
 def _scalar_value(val, dtype):
     """Convert a scalar to the appropriate Python type for the given dtype."""
     if dtype in (int32_dtype, int64_dtype, bool_dtype):
@@ -1588,16 +1606,22 @@ def signbit(a):
 
 
 def isnan(a):
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
+        return _dispatch_unary_predicate_gpu(a, "isnan")
     arr = np.isnan(_to_numpy(a))
     return _from_numpy(arr, bool_dtype, a.device)
 
 
 def isinf(a):
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
+        return _dispatch_unary_predicate_gpu(a, "isinf")
     arr = np.isinf(_to_numpy(a))
     return _from_numpy(arr, bool_dtype, a.device)
 
 
 def isfinite(a):
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
+        return _dispatch_unary_predicate_gpu(a, "isfinite")
     arr = np.isfinite(_to_numpy(a))
     return _from_numpy(arr, bool_dtype, a.device)
 
@@ -1649,6 +1673,24 @@ def silu(a):
 
 
 def leaky_relu(a, negative_slope=0.01):
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
+        d = _get_dispatcher()
+        sfx = _kernel_suffix(a.dtype)
+        numel = a.numel()
+        out_buf = _alloc_output_buf(numel, a.dtype)
+        scalar = float(negative_slope)
+        if a.is_contiguous():
+            d.dispatch_binary_scalar(f"leaky_relu_scalar_{sfx}", _metal_buf(a),
+                                     scalar, out_buf, numel,
+                                     scalar_fmt=_scalar_fmt(a.dtype))
+        else:
+            d.dispatch_binary_scalar_strided(
+                f"leaky_relu_scalar_strided_{sfx}", _metal_buf(a), scalar,
+                out_buf, numel, list(a.shape), list(a.stride),
+                len(a.shape), scalar_fmt=_scalar_fmt(a.dtype))
+        from ..._tensor import _compute_strides
+        return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape),
+                                  a.dtype, a.device)
     arr = _to_numpy(a)
     out = np.where(arr > 0, arr, negative_slope * arr)
     return _from_numpy(out, a.dtype, a.device)
@@ -1674,18 +1716,82 @@ def prelu(a, weight):
 
 
 def clamp(a, min_val=None, max_val=None):
-    arr = _to_numpy(a)
-    out = np.clip(arr, min_val, max_val)
-    return _from_numpy(out, a.dtype, a.device)
+    if min_val is not None and max_val is not None:
+        if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype, int32_dtype, int64_dtype):
+            d = _get_dispatcher()
+            sfx = _kernel_suffix(a.dtype)
+            numel = a.numel()
+            out_buf = _alloc_output_buf(numel, a.dtype)
+            s_min = _scalar_value(min_val, a.dtype)
+            s_max = _scalar_value(max_val, a.dtype)
+            fmt = _scalar_fmt(a.dtype)
+            if a.is_contiguous():
+                d.dispatch_clamp(f"clamp_{sfx}", _metal_buf(a),
+                                 s_min, s_max, out_buf, numel,
+                                 scalar_fmt=fmt)
+            else:
+                d.dispatch_clamp_strided(
+                    f"clamp_strided_{sfx}", _metal_buf(a),
+                    s_min, s_max, out_buf, numel,
+                    list(a.shape), list(a.stride), len(a.shape),
+                    scalar_fmt=fmt)
+            from ..._tensor import _compute_strides
+            return _from_metal_buffer(out_buf, a.shape,
+                                      _compute_strides(a.shape),
+                                      a.dtype, a.device)
+        arr = _to_numpy(a)
+        out = np.clip(arr, min_val, max_val)
+        return _from_numpy(out, a.dtype, a.device)
+    if min_val is not None:
+        return clamp_min(a, min_val)
+    if max_val is not None:
+        return clamp_max(a, max_val)
+    return a
 
 
 def clamp_min(a, min_val):
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype, int32_dtype, int64_dtype):
+        d = _get_dispatcher()
+        sfx = _kernel_suffix(a.dtype)
+        numel = a.numel()
+        out_buf = _alloc_output_buf(numel, a.dtype)
+        scalar = _scalar_value(min_val, a.dtype)
+        if a.is_contiguous():
+            d.dispatch_binary_scalar(f"clamp_min_scalar_{sfx}", _metal_buf(a),
+                                     scalar, out_buf, numel,
+                                     scalar_fmt=_scalar_fmt(a.dtype))
+        else:
+            d.dispatch_binary_scalar_strided(
+                f"clamp_min_scalar_strided_{sfx}", _metal_buf(a), scalar,
+                out_buf, numel, list(a.shape), list(a.stride),
+                len(a.shape), scalar_fmt=_scalar_fmt(a.dtype))
+        from ..._tensor import _compute_strides
+        return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape),
+                                  a.dtype, a.device)
     arr = _to_numpy(a)
     out = np.maximum(arr, min_val)
     return _from_numpy(out, a.dtype, a.device)
 
 
 def clamp_max(a, max_val):
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype, int32_dtype, int64_dtype):
+        d = _get_dispatcher()
+        sfx = _kernel_suffix(a.dtype)
+        numel = a.numel()
+        out_buf = _alloc_output_buf(numel, a.dtype)
+        scalar = _scalar_value(max_val, a.dtype)
+        if a.is_contiguous():
+            d.dispatch_binary_scalar(f"clamp_max_scalar_{sfx}", _metal_buf(a),
+                                     scalar, out_buf, numel,
+                                     scalar_fmt=_scalar_fmt(a.dtype))
+        else:
+            d.dispatch_binary_scalar_strided(
+                f"clamp_max_scalar_strided_{sfx}", _metal_buf(a), scalar,
+                out_buf, numel, list(a.shape), list(a.stride),
+                len(a.shape), scalar_fmt=_scalar_fmt(a.dtype))
+        from ..._tensor import _compute_strides
+        return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape),
+                                  a.dtype, a.device)
     arr = _to_numpy(a)
     out = np.minimum(arr, max_val)
     return _from_numpy(out, a.dtype, a.device)
@@ -2158,17 +2264,18 @@ def pad(a, pad_widths, mode='constant', value=0):
 
 
 def softmax(a, dim):
-    # GPU path: softmax over last dim for 2D contiguous float32
+    # GPU path: softmax over last dim for 2D+ contiguous float32/float16
     ndim = len(a.shape)
     actual_dim = dim if dim >= 0 else dim + ndim
-    if (_can_use_gpu(a) and a.dtype == float32_dtype
+    if (_can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype)
             and actual_dim == ndim - 1 and ndim >= 1):
         d = _get_dispatcher()
+        sfx = _kernel_suffix(a.dtype)
         numel = a.numel()
         cols = a.shape[-1]
         rows = numel // cols
         out_buf = _alloc_output_buf(numel, a.dtype)
-        d.dispatch_softmax_2d("softmax_f32", _metal_buf(a), out_buf,
+        d.dispatch_softmax_2d(f"softmax_{sfx}", _metal_buf(a), out_buf,
                               rows, cols)
         return _from_metal_buffer(out_buf, a.shape, a.stride, a.dtype, a.device)
     arr = _to_numpy(a)

--- a/tests/mps/test_metal_infra.py
+++ b/tests/mps/test_metal_infra.py
@@ -270,3 +270,146 @@ class TestComparisonOps:
         result = torch.eq(a, b)
         assert result.dtype.name == "bool"
         np.testing.assert_array_equal(result.cpu().numpy(), [True, False, True])
+
+
+# ---------------------------------------------------------------------------
+# Step 5: Phase 1 training ops
+# ---------------------------------------------------------------------------
+
+class TestPhase1Ops:
+    """Verify Phase 1 GPU kernels: leaky_relu, clamp, isinf/isnan/isfinite, softmax f16."""
+
+    # --- leaky_relu ---
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+    def test_leaky_relu_positive(self, dtype):
+        a = torch.tensor([1.0, 2.0, 3.0], dtype=dtype, device="mps")
+        result = torch.nn.functional.leaky_relu(a, 0.01)
+        np.testing.assert_allclose(result.cpu().numpy(), [1.0, 2.0, 3.0], rtol=1e-3)
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+    def test_leaky_relu_negative(self, dtype):
+        a = torch.tensor([-1.0, -2.0, -3.0], dtype=dtype, device="mps")
+        result = torch.nn.functional.leaky_relu(a, 0.1)
+        np.testing.assert_allclose(result.cpu().numpy(), [-0.1, -0.2, -0.3], rtol=1e-3)
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+    def test_leaky_relu_default_slope(self, dtype):
+        a = torch.tensor([1.0, -1.0, 0.0], dtype=dtype, device="mps")
+        result = torch.nn.functional.leaky_relu(a)
+        np.testing.assert_allclose(result.cpu().numpy(), [1.0, -0.01, 0.0], rtol=1e-3)
+
+    def test_leaky_relu_strided(self):
+        x = torch.tensor([[1.0, -2.0], [-3.0, 4.0]], device="mps")
+        xt = x.T
+        assert not xt.is_contiguous()
+        result = torch.nn.functional.leaky_relu(xt, 0.1)
+        expected = np.array([[1.0, -0.3], [-0.2, 4.0]])
+        np.testing.assert_allclose(result.cpu().numpy(), expected, rtol=1e-3)
+
+    # --- clamp ---
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+    def test_clamp_both_bounds(self, dtype):
+        a = torch.tensor([-3.0, -1.0, 0.5, 2.0, 5.0], dtype=dtype, device="mps")
+        result = torch.clamp(a, -1.0, 3.0)
+        np.testing.assert_allclose(result.cpu().numpy(),
+                                   [-1.0, -1.0, 0.5, 2.0, 3.0], rtol=1e-3)
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+    def test_clamp_min_only(self, dtype):
+        a = torch.tensor([-3.0, 0.0, 5.0], dtype=dtype, device="mps")
+        result = torch.clamp(a, 0.0)  # min_val positional
+        np.testing.assert_allclose(result.cpu().numpy(), [0.0, 0.0, 5.0], rtol=1e-3)
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+    def test_clamp_max_only(self, dtype):
+        a = torch.tensor([-3.0, 0.0, 5.0], dtype=dtype, device="mps")
+        result = torch.clamp(a, None, 1.0)  # min_val=None, max_val=1.0
+        np.testing.assert_allclose(result.cpu().numpy(), [-3.0, 0.0, 1.0], rtol=1e-3)
+
+    def test_clamp_strided(self):
+        x = torch.tensor([[-5.0, 3.0], [1.0, 8.0]], device="mps")
+        xt = x.T
+        result = torch.clamp(xt, 0.0, 5.0)
+        expected = np.array([[0.0, 1.0], [3.0, 5.0]])
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    def test_clamp_int32(self):
+        a = torch.tensor([-5, 0, 3, 10], dtype=torch.int32, device="mps")
+        result = torch.clamp(a, 0, 5)
+        np.testing.assert_array_equal(result.cpu().numpy(), [0, 0, 3, 5])
+
+    # --- clamp_min / clamp_max ---
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.int32])
+    def test_clamp_min_op(self, dtype):
+        if dtype == torch.float32:
+            a = torch.tensor([-3.0, 0.0, 5.0], dtype=dtype, device="mps")
+            result = torch.clamp_min(a, 0.0)
+            np.testing.assert_allclose(result.cpu().numpy(), [0.0, 0.0, 5.0])
+        else:
+            a = torch.tensor([-3, 0, 5], dtype=dtype, device="mps")
+            result = torch.clamp_min(a, 0)
+            np.testing.assert_array_equal(result.cpu().numpy(), [0, 0, 5])
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.int32])
+    def test_clamp_max_op(self, dtype):
+        if dtype == torch.float32:
+            a = torch.tensor([-3.0, 0.0, 5.0], dtype=dtype, device="mps")
+            result = torch.clamp_max(a, 1.0)
+            np.testing.assert_allclose(result.cpu().numpy(), [-3.0, 0.0, 1.0])
+        else:
+            a = torch.tensor([-3, 0, 5], dtype=dtype, device="mps")
+            result = torch.clamp_max(a, 1)
+            np.testing.assert_array_equal(result.cpu().numpy(), [-3, 0, 1])
+
+    # --- isinf / isnan / isfinite ---
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+    def test_isinf(self, dtype):
+        a = torch.tensor([1.0, float('inf'), float('-inf'), 0.0], dtype=dtype, device="mps")
+        result = torch.isinf(a)
+        assert result.dtype.name == "bool"
+        np.testing.assert_array_equal(result.cpu().numpy(), [False, True, True, False])
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+    def test_isnan(self, dtype):
+        a = torch.tensor([1.0, float('nan'), 0.0, float('nan')], dtype=dtype, device="mps")
+        result = torch.isnan(a)
+        assert result.dtype.name == "bool"
+        np.testing.assert_array_equal(result.cpu().numpy(), [False, True, False, True])
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+    def test_isfinite(self, dtype):
+        a = torch.tensor([1.0, float('inf'), float('nan'), 0.0], dtype=dtype, device="mps")
+        result = torch.isfinite(a)
+        assert result.dtype.name == "bool"
+        np.testing.assert_array_equal(result.cpu().numpy(), [True, False, False, True])
+
+    def test_isinf_strided(self):
+        x = torch.tensor([[1.0, float('inf')], [float('-inf'), 0.0]], device="mps")
+        xt = x.T
+        assert not xt.is_contiguous()
+        result = torch.isinf(xt)
+        assert result.dtype.name == "bool"
+        expected = np.array([[False, True], [True, False]])
+        np.testing.assert_array_equal(result.cpu().numpy(), expected)
+
+    # --- softmax float16 ---
+
+    def test_softmax_f16(self):
+        a = torch.tensor([[1.0, 2.0, 3.0], [1.0, 1.0, 1.0]],
+                         dtype=torch.float16, device="mps")
+        result = torch.nn.functional.softmax(a, dim=-1)
+        assert result.dtype == torch.float16
+        expected = np.array([[0.0900, 0.2447, 0.6652],
+                             [0.3333, 0.3333, 0.3333]], dtype=np.float16)
+        np.testing.assert_allclose(result.cpu().numpy(), expected, rtol=5e-2)
+
+    def test_softmax_f32_still_works(self):
+        a = torch.tensor([[1.0, 2.0, 3.0]], dtype=torch.float32, device="mps")
+        result = torch.nn.functional.softmax(a, dim=-1)
+        assert result.dtype == torch.float32
+        expected = np.array([[0.0900, 0.2447, 0.6652]], dtype=np.float32)
+        np.testing.assert_allclose(result.cpu().numpy(), expected, rtol=1e-3)


### PR DESCRIPTION
## Summary

- Add Metal GPU paths for 8 ops critical to training workloads: `leaky_relu`, `clamp`/`clamp_min`/`clamp_max`, `isinf`/`isnan`/`isfinite`, and extend `softmax` to float16
- New shader templates: unary predicate (float→bool) and 2-scalar clamp, with strided variants
- New `dispatch_clamp` / `dispatch_clamp_strided` compute methods (pyobjc + ctypes)
- 28 new tests covering all ops across dtypes, strided inputs, and edge cases

## Details

| Op | Dtypes | Contiguous | Strided |
|----|--------|:----------:|:-------:|
| `leaky_relu` | f32, f16 | Y | Y |
| `clamp` (min+max) | f32, f16, i32, i64 | Y | Y |
| `clamp_min` | f32, f16, i32, i64 | Y | Y |
| `clamp_max` | f32, f16, i32, i64 | Y | Y |
| `isinf` | f32, f16 | Y | Y |
| `isnan` | f32, f16 | Y | Y |
| `isfinite` | f32, f16 | Y | Y |
| `softmax` (f16) | f16 | Y | — |

Integer types for `isinf`/`isnan`/`isfinite` remain on numpy (correct: integers are always finite).

Softmax f16 computes intermediates in float32 for numerical stability.

## Test plan

- [x] 28 new tests in `TestPhase1Ops` all pass
- [x] Full MPS suite: 146/146 passed
- [x] CPU + contract suite: 1340 passed, 25 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)