### PR TITLE
feat(mps): add Phase 2 reduction GPU kernels

### DIFF
--- a/src/candle/_backends/mps/metal_shaders.py
+++ b/src/candle/_backends/mps/metal_shaders.py
@@ -666,6 +666,21 @@ def _build_msl_source():
     parts.append(_gen_arg_reduction(
         "argmin", "LONG_MAX", "<", types=("long",)))
 
+    # Full-tensor prod reduction
+    parts.append(_gen_reduction(
+        "prod", "({type})1",
+        "shared[lid] * shared[lid + s]"))
+
+    # Full-tensor any/all reductions (uchar only — input is pre-cast to bool)
+    parts.append(_gen_reduction(
+        "any", "0",
+        "(shared[lid] || shared[lid + s]) ? (uchar)1 : (uchar)0",
+        types=("uchar",)))
+    parts.append(_gen_reduction(
+        "all", "1",
+        "(shared[lid] && shared[lid + s]) ? (uchar)1 : (uchar)0",
+        types=("uchar",)))
+
     # Axis-reduce kernels (dim reduction)
     parts.append(_gen_reduce_dim(
         "sum",
@@ -705,6 +720,21 @@ def _build_msl_source():
         body="if (val < best) { best = val; best_idx = r; }",
         finalize="best_idx",
         out_type="uint"))
+    # any/all axis-reduce (typed input → uchar output)
+    parts.append(_gen_reduce_dim(
+        "any",
+        init="uchar acc = 0;",
+        body="if (val != 0) acc = 1;",
+        finalize="acc",
+        out_type="uchar",
+        types=("float", "half", "int", "long", "uchar")))
+    parts.append(_gen_reduce_dim(
+        "all",
+        init="uchar acc = 1;",
+        body="if (val == 0) acc = 0;",
+        finalize="acc",
+        out_type="uchar",
+        types=("float", "half", "int", "long", "uchar")))
 
     # Comparison ops
     for name, op in _COMPARISON_OPS:

--- a/src/candle/_backends/mps/ops.py
+++ b/src/candle/_backends/mps/ops.py
@@ -232,6 +232,9 @@ def _gpu_reduce_single_dim(a, dim, op_name, keepdim):
     if op_name in ("argmax", "argmin"):
         out_buf = _alloc_output_buf(out_numel, int32_dtype)
         out_dtype = int64_dtype
+    elif op_name in ("any", "all"):
+        out_buf = _alloc_output_buf(out_numel, bool_dtype)
+        out_dtype = bool_dtype
     else:
         out_buf = _alloc_output_buf(out_numel, a.dtype)
         out_dtype = a.dtype
@@ -476,16 +479,66 @@ def mean_(a, dim=None, keepdim=False):
 def std_(a, dim=None, keepdim=False, unbiased=True):
     if not a.dtype.is_floating_point and not a.dtype.is_complex:
         raise RuntimeError("std and var only support floating point and complex dtypes")
+    # GPU composite: sqrt(var)
+    if _can_use_gpu(a) and a.is_contiguous() and a.dtype.is_floating_point:
+        v = var_(a, dim=dim, unbiased=unbiased, keepdim=keepdim)
+        return sqrt(v)
     ddof = 1 if unbiased else 0
     out = np.std(_to_numpy(a), axis=dim, keepdims=keepdim, ddof=ddof)
     return _from_numpy(np.ascontiguousarray(out), a.dtype, a.device)
 
 
 def all_(a, dim=None, keepdim=False):
+    if _can_use_gpu(a) and a.is_contiguous():
+        # GPU path: axis reduction (dim specified)
+        if dim is not None:
+            ndim = len(a.shape)
+            if isinstance(dim, int):
+                return _gpu_reduce_single_dim(a, dim, "all", keepdim)
+            dim_tuple = dim if isinstance(dim, tuple) else tuple(dim)
+            result = a
+            for d in sorted([x % ndim for x in dim_tuple], reverse=True):
+                result = _gpu_reduce_single_dim(result, d, "all", keepdim)
+            return result
+        # GPU path: full-tensor reduction (dim=None)
+        # Convert to bool if not already
+        if a.dtype != bool_dtype:
+            a = ne(a, 0)
+        d = _get_dispatcher()
+        out_buf = _alloc_output_buf(1, bool_dtype)
+        d.dispatch_reduction("all_partial_u8", "all_final_u8",
+                             _metal_buf(a), out_buf, a.numel())
+        ndim = len(a.shape)
+        out_shape = (1,) * ndim if keepdim else ()
+        out_stride = (1,) * ndim if keepdim else ()
+        return _from_metal_buffer(out_buf, out_shape, out_stride, bool_dtype, a.device)
     return _from_numpy(np.all(_to_numpy(a), axis=dim, keepdims=keepdim), bool_dtype, a.device)
 
 
 def any_(a, dim=None, keepdim=False):
+    if _can_use_gpu(a) and a.is_contiguous():
+        # GPU path: axis reduction (dim specified)
+        if dim is not None:
+            ndim = len(a.shape)
+            if isinstance(dim, int):
+                return _gpu_reduce_single_dim(a, dim, "any", keepdim)
+            dim_tuple = dim if isinstance(dim, tuple) else tuple(dim)
+            result = a
+            for d in sorted([x % ndim for x in dim_tuple], reverse=True):
+                result = _gpu_reduce_single_dim(result, d, "any", keepdim)
+            return result
+        # GPU path: full-tensor reduction (dim=None)
+        # Convert to bool if not already
+        if a.dtype != bool_dtype:
+            a = ne(a, 0)
+        d = _get_dispatcher()
+        out_buf = _alloc_output_buf(1, bool_dtype)
+        d.dispatch_reduction("any_partial_u8", "any_final_u8",
+                             _metal_buf(a), out_buf, a.numel())
+        ndim = len(a.shape)
+        out_shape = (1,) * ndim if keepdim else ()
+        out_stride = (1,) * ndim if keepdim else ()
+        return _from_metal_buffer(out_buf, out_shape, out_stride, bool_dtype, a.device)
     return _from_numpy(np.any(_to_numpy(a), axis=dim, keepdims=keepdim), bool_dtype, a.device)
 
 
@@ -2549,6 +2602,30 @@ def unfold(a, dimension, size, step):
 
 
 def var_(a, dim=None, unbiased=True, keepdim=False):
+    # GPU composite using E[X^2] - E[X]^2 (avoids broadcast sub)
+    if _can_use_gpu(a) and a.is_contiguous() and a.dtype.is_floating_point:
+        sq = mul(a, a)
+        mean_sq = mean_(sq, dim=dim, keepdim=keepdim)
+        mean_val = mean_(a, dim=dim, keepdim=keepdim)
+        mean_val_sq = mul(mean_val, mean_val)
+        var_val = sub(mean_sq, mean_val_sq)
+        if unbiased:
+            if dim is None:
+                n = a.numel()
+            else:
+                if isinstance(dim, int):
+                    dims = (dim,)
+                else:
+                    dims = tuple(dim)
+                n = 1
+                ndim = len(a.shape)
+                for d in dims:
+                    n *= a.shape[d % ndim]
+            if n > 1:
+                correction = float(n) / float(n - 1)
+                var_val = mul(var_val, correction)
+        return var_val
+
     arr = _to_numpy(a)
     ddof = 1 if unbiased else 0
     if dim is not None:
@@ -2578,6 +2655,29 @@ def norm_(a, p=2, dim=None, keepdim=False):
 
 
 def prod_(a, dim=None, keepdim=False):
+    ndim = len(a.shape)
+
+    # GPU path: full-tensor reduction (dim=None)
+    if dim is None and _can_use_gpu(a) and a.is_contiguous():
+        d = _get_dispatcher()
+        sfx = _kernel_suffix(a.dtype)
+        out_buf = _alloc_output_buf(1, a.dtype)
+        d.dispatch_reduction(f"prod_partial_{sfx}", f"prod_final_{sfx}",
+                             _metal_buf(a), out_buf, a.numel())
+        out_shape = (1,) * ndim if keepdim else ()
+        out_stride = (1,) * ndim if keepdim else ()
+        return _from_metal_buffer(out_buf, out_shape, out_stride, a.dtype, a.device)
+
+    # GPU path: axis reduction (dim specified)
+    if dim is not None and _can_use_gpu(a) and a.is_contiguous():
+        if isinstance(dim, int):
+            return _gpu_reduce_single_dim(a, dim, "prod", keepdim)
+        dim_tuple = dim if isinstance(dim, tuple) else tuple(dim)
+        result = a
+        for d in sorted([x % ndim for x in dim_tuple], reverse=True):
+            result = _gpu_reduce_single_dim(result, d, "prod", keepdim)
+        return result
+
     arr = _to_numpy(a)
     if dim is not None:
         out = np.prod(arr, axis=dim, keepdims=keepdim)
@@ -3189,6 +3289,25 @@ def median(a, dim=None, keepdim=False):
 
 def logsumexp(a, dim, keepdim=False):
     """Numerically stable logsumexp: log(sum(exp(x), dim))."""
+    # GPU composite: amax → sub → exp → sum → log → add
+    if _can_use_gpu(a) and a.is_contiguous() and a.dtype.is_floating_point:
+        max_val = amax(a, dim=dim, keepdim=True)
+        # expand max_val to match a's shape for broadcast subtraction
+        max_expanded = expand(max_val, tuple(a.shape))
+        shifted = sub(a, max_expanded)
+        exp_shifted = exp(shifted)
+        sum_exp = sum_(exp_shifted, dim=dim, keepdim=keepdim)
+        log_sum = log(sum_exp)
+        if keepdim:
+            result = add(log_sum, max_val)
+        else:
+            ndim = len(a.shape)
+            d = dim % ndim if isinstance(dim, int) else dim
+            from ..common.view import squeeze as _squeeze
+            max_squeezed = _squeeze(max_val, d)
+            result = add(log_sum, max_squeezed)
+        return result
+
     arr = _to_numpy(a)
     max_val = np.max(arr, axis=dim, keepdims=True)
     exp_shifted = np.exp(arr - max_val)

--- a/tests/mps/test_metal_infra.py
+++ b/tests/mps/test_metal_infra.py
@@ -413,3 +413,153 @@ class TestPhase1Ops:
         assert result.dtype == torch.float32
         expected = np.array([[0.0900, 0.2447, 0.6652]], dtype=np.float32)
         np.testing.assert_allclose(result.cpu().numpy(), expected, rtol=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# Step 6: Phase 2 reduction ops
+# ---------------------------------------------------------------------------
+
+class TestPhase2Reductions:
+    """Verify Phase 2 GPU reduction kernels: prod, any, all, var, std, logsumexp."""
+
+    # --- prod ---
+
+    def test_prod_dim(self):
+        t = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], device="mps")
+        r0 = torch.prod(t, dim=0)
+        np.testing.assert_allclose(r0.cpu().numpy(), [4.0, 10.0, 18.0])
+        r1 = torch.prod(t, dim=1)
+        np.testing.assert_allclose(r1.cpu().numpy(), [6.0, 120.0])
+
+    def test_prod_full_tensor(self):
+        t = torch.tensor([[1.0, 2.0], [3.0, 4.0]], device="mps")
+        result = torch.prod(t)
+        np.testing.assert_allclose(result.cpu().numpy(), 24.0)
+
+    def test_prod_keepdim(self):
+        t = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], device="mps")
+        result = torch.prod(t, dim=1, keepdim=True)
+        assert result.shape == (2, 1)
+        np.testing.assert_allclose(result.cpu().numpy(), [[6.0], [120.0]])
+
+    def test_prod_int32(self):
+        t = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.int32, device="mps")
+        result = torch.prod(t, dim=1)
+        np.testing.assert_array_equal(result.cpu().numpy(), [6, 120])
+
+    # --- any ---
+
+    def test_any_dim(self):
+        t = torch.tensor([[True, False, False], [False, False, False]], device="mps")
+        r0 = torch.any(t, dim=0)
+        assert r0.dtype.name == "bool"
+        np.testing.assert_array_equal(r0.cpu().numpy(), [True, False, False])
+        r1 = torch.any(t, dim=1)
+        np.testing.assert_array_equal(r1.cpu().numpy(), [True, False])
+
+    def test_any_full_tensor(self):
+        t_true = torch.tensor([[False, True], [False, False]], device="mps")
+        assert torch.any(t_true).cpu().numpy() == True
+        t_false = torch.tensor([[False, False], [False, False]], device="mps")
+        assert torch.any(t_false).cpu().numpy() == False
+
+    def test_any_numeric(self):
+        t = torch.tensor([[0.0, 1.0, 0.0], [0.0, 0.0, 0.0]], device="mps")
+        r = torch.any(t, dim=1)
+        assert r.dtype.name == "bool"
+        np.testing.assert_array_equal(r.cpu().numpy(), [True, False])
+
+    # --- all ---
+
+    def test_all_dim(self):
+        t = torch.tensor([[True, True, False], [True, True, True]], device="mps")
+        r0 = torch.all(t, dim=0)
+        assert r0.dtype.name == "bool"
+        np.testing.assert_array_equal(r0.cpu().numpy(), [True, True, False])
+        r1 = torch.all(t, dim=1)
+        np.testing.assert_array_equal(r1.cpu().numpy(), [False, True])
+
+    def test_all_full_tensor(self):
+        t_true = torch.tensor([[True, True], [True, True]], device="mps")
+        assert torch.all(t_true).cpu().numpy() == True
+        t_false = torch.tensor([[True, True], [True, False]], device="mps")
+        assert torch.all(t_false).cpu().numpy() == False
+
+    def test_all_numeric(self):
+        t = torch.tensor([[1.0, 2.0, 3.0], [1.0, 0.0, 3.0]], device="mps")
+        r = torch.all(t, dim=1)
+        assert r.dtype.name == "bool"
+        np.testing.assert_array_equal(r.cpu().numpy(), [True, False])
+
+    # --- var ---
+
+    def test_var_dim(self):
+        t = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], device="mps")
+        # unbiased (default)
+        r = torch.var(t, dim=1)
+        expected = np.var(np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float32),
+                         axis=1, ddof=1)
+        np.testing.assert_allclose(r.cpu().numpy(), expected, rtol=1e-5)
+        # biased
+        r_biased = torch.var(t, dim=1, unbiased=False)
+        expected_biased = np.var(np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float32),
+                                axis=1, ddof=0)
+        np.testing.assert_allclose(r_biased.cpu().numpy(), expected_biased, rtol=1e-5)
+
+    def test_var_full_tensor(self):
+        t = torch.tensor([1.0, 2.0, 3.0, 4.0], device="mps")
+        r = torch.var(t)
+        expected = np.var(np.array([1, 2, 3, 4], dtype=np.float32), ddof=1)
+        np.testing.assert_allclose(r.cpu().numpy(), expected, rtol=1e-5)
+
+    def test_var_keepdim(self):
+        t = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], device="mps")
+        r = torch.var(t, dim=1, keepdim=True)
+        assert r.shape == (2, 1)
+
+    # --- std ---
+
+    def test_std_dim(self):
+        t = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], device="mps")
+        r = torch.std(t, dim=1)
+        expected = np.std(np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float32),
+                         axis=1, ddof=1)
+        np.testing.assert_allclose(r.cpu().numpy(), expected, rtol=1e-5)
+
+    def test_std_full_tensor(self):
+        t = torch.tensor([1.0, 2.0, 3.0, 4.0], device="mps")
+        r = torch.std(t)
+        expected = np.std(np.array([1, 2, 3, 4], dtype=np.float32), ddof=1)
+        np.testing.assert_allclose(r.cpu().numpy(), expected, rtol=1e-5)
+
+    # --- logsumexp ---
+
+    def test_logsumexp_dim(self):
+        t = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], device="mps")
+        r = torch.logsumexp(t, dim=1)
+        arr = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float32)
+        expected = np.log(np.sum(np.exp(arr), axis=1))
+        np.testing.assert_allclose(r.cpu().numpy(), expected, rtol=1e-5)
+
+    def test_logsumexp_keepdim(self):
+        t = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], device="mps")
+        r = torch.logsumexp(t, dim=1, keepdim=True)
+        assert r.shape == (2, 1)
+
+    def test_logsumexp_large_values(self):
+        """Numerical stability: large inputs should not overflow."""
+        t = torch.tensor([1000.0, 1001.0, 1002.0], device="mps")
+        r = torch.logsumexp(t, dim=0)
+        arr = np.array([1000, 1001, 1002], dtype=np.float32)
+        expected = np.log(np.sum(np.exp(arr - arr.max()))) + arr.max()
+        np.testing.assert_allclose(r.cpu().numpy(), expected, rtol=1e-5)
+
+    def test_logsumexp_f16(self):
+        t = torch.tensor([[1.0, 2.0, 3.0]], dtype=torch.float16, device="mps")
+        r = torch.logsumexp(t, dim=1)
+        assert r.dtype == torch.float16
+        arr = np.array([[1, 2, 3]], dtype=np.float16)
+        expected = np.log(np.sum(np.exp(arr - arr.max(axis=1, keepdims=True)),
+                                 axis=1)) + arr.max(axis=1)
+        np.testing.assert_allclose(r.cpu().numpy(), expected.astype(np.float16),
+                                   rtol=5e-2)


### PR DESCRIPTION
## Summary
- Add native Metal GPU kernels for `prod`, `any`, `all` reductions (axis-reduce + full-tensor two-pass)
- Add GPU composite paths for `var` (E[X^2]-E[X]^2), `std` (sqrt(var)), and `logsumexp` (amax/sub/exp/sum/log) — all computation stays on Metal GPU
- 19 new tests in `TestPhase2Reductions` covering dim/full-tensor/keepdim/dtype/numerical stability

## Test plan
- [x] All 19 Phase 2 tests pass (`TestPhase2Reductions`)
- [x] Full MPS suite: 165/165 passed (no regressions)
- [x] CPU + contract suite: 1346/1346 passed (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)