### PR TITLE
feat(mps): add Phase 3 shape & index GPU kernels

### DIFF
--- a/src/candle/_backends/mps/metal_compute.py
+++ b/src/candle/_backends/mps/metal_compute.py
@@ -633,6 +633,210 @@ class MetalKernelDispatcher:
         rt.commit_and_wait(cmd)
 
     # ------------------------------------------------------------------
+    # Dispatch: where  (cond, x, y → out)
+    # ------------------------------------------------------------------
+
+    def dispatch_where(self, kernel_name, cond_buf, x_buf, y_buf, out_buf,
+                       numel):
+        """Encode and execute a where kernel (4 buffers + 1 uint)."""
+        rt = get_runtime()
+        pipeline = self._get_pipeline(kernel_name)
+        tpg = self._threads_per_group(pipeline)
+        groups = (numel + tpg - 1) // tpg
+
+        cmd = rt.create_command_buffer()
+        enc = rt.get_compute_encoder(cmd)
+
+        if _HAS_PYOBJC:
+            enc.setComputePipelineState_(pipeline)
+            enc.setBuffer_offset_atIndex_(cond_buf, 0, 0)
+            enc.setBuffer_offset_atIndex_(x_buf, 0, 1)
+            enc.setBuffer_offset_atIndex_(y_buf, 0, 2)
+            enc.setBuffer_offset_atIndex_(out_buf, 0, 3)
+            enc.setBytes_length_atIndex_(struct.pack("I", numel), 4, 4)
+            enc.dispatchThreadgroups_threadsPerThreadgroup_(
+                _MTLSize(groups, 1, 1), _MTLSize(tpg, 1, 1))
+            enc.endEncoding()
+        else:
+            _encode_where_ctypes(enc, pipeline, cond_buf, x_buf, y_buf,
+                                 out_buf, numel, groups, tpg)
+
+        rt.commit_and_wait(cmd)
+
+    # ------------------------------------------------------------------
+    # Dispatch: where_scalar  (cond, tensor, scalar → out)
+    # ------------------------------------------------------------------
+
+    def dispatch_where_scalar(self, kernel_name, cond_buf, tensor_buf,
+                              scalar, out_buf, numel, scalar_fmt="f"):
+        """Encode where with one scalar operand (3 bufs + 1 scalar + 1 uint)."""
+        rt = get_runtime()
+        pipeline = self._get_pipeline(kernel_name)
+        tpg = self._threads_per_group(pipeline)
+        groups = (numel + tpg - 1) // tpg
+
+        cmd = rt.create_command_buffer()
+        enc = rt.get_compute_encoder(cmd)
+
+        scalar_bytes = struct.pack(scalar_fmt, scalar)
+        scalar_size = len(scalar_bytes)
+
+        if _HAS_PYOBJC:
+            enc.setComputePipelineState_(pipeline)
+            enc.setBuffer_offset_atIndex_(cond_buf, 0, 0)
+            enc.setBuffer_offset_atIndex_(tensor_buf, 0, 1)
+            enc.setBytes_length_atIndex_(scalar_bytes, scalar_size, 2)
+            enc.setBuffer_offset_atIndex_(out_buf, 0, 3)
+            enc.setBytes_length_atIndex_(struct.pack("I", numel), 4, 4)
+            enc.dispatchThreadgroups_threadsPerThreadgroup_(
+                _MTLSize(groups, 1, 1), _MTLSize(tpg, 1, 1))
+            enc.endEncoding()
+        else:
+            _encode_where_scalar_ctypes(enc, pipeline, cond_buf, tensor_buf,
+                                        scalar_bytes, scalar_size, out_buf,
+                                        numel, groups, tpg)
+
+        rt.commit_and_wait(cmd)
+
+    # ------------------------------------------------------------------
+    # Dispatch: masked_fill  (a, mask, scalar → out)
+    # ------------------------------------------------------------------
+
+    def dispatch_masked_fill(self, kernel_name, a_buf, mask_buf, scalar,
+                             out_buf, numel, scalar_fmt="f"):
+        """Encode masked_fill kernel (3 bufs + 1 scalar + 1 uint)."""
+        rt = get_runtime()
+        pipeline = self._get_pipeline(kernel_name)
+        tpg = self._threads_per_group(pipeline)
+        groups = (numel + tpg - 1) // tpg
+
+        cmd = rt.create_command_buffer()
+        enc = rt.get_compute_encoder(cmd)
+
+        scalar_bytes = struct.pack(scalar_fmt, scalar)
+        scalar_size = len(scalar_bytes)
+
+        if _HAS_PYOBJC:
+            enc.setComputePipelineState_(pipeline)
+            enc.setBuffer_offset_atIndex_(a_buf, 0, 0)
+            enc.setBuffer_offset_atIndex_(mask_buf, 0, 1)
+            enc.setBytes_length_atIndex_(scalar_bytes, scalar_size, 2)
+            enc.setBuffer_offset_atIndex_(out_buf, 0, 3)
+            enc.setBytes_length_atIndex_(struct.pack("I", numel), 4, 4)
+            enc.dispatchThreadgroups_threadsPerThreadgroup_(
+                _MTLSize(groups, 1, 1), _MTLSize(tpg, 1, 1))
+            enc.endEncoding()
+        else:
+            _encode_masked_fill_ctypes(enc, pipeline, a_buf, mask_buf,
+                                       scalar_bytes, scalar_size, out_buf,
+                                       numel, groups, tpg)
+
+        rt.commit_and_wait(cmd)
+
+    # ------------------------------------------------------------------
+    # Dispatch: tril/triu  (a → out, with rows/cols/diagonal/N)
+    # ------------------------------------------------------------------
+
+    def dispatch_tril_triu(self, kernel_name, a_buf, out_buf, rows, cols,
+                           diagonal, numel):
+        """Encode tril/triu kernel (2 bufs + 2 uint + 1 int + 1 uint)."""
+        rt = get_runtime()
+        pipeline = self._get_pipeline(kernel_name)
+        tpg = self._threads_per_group(pipeline)
+        groups = (numel + tpg - 1) // tpg
+
+        cmd = rt.create_command_buffer()
+        enc = rt.get_compute_encoder(cmd)
+
+        if _HAS_PYOBJC:
+            enc.setComputePipelineState_(pipeline)
+            enc.setBuffer_offset_atIndex_(a_buf, 0, 0)
+            enc.setBuffer_offset_atIndex_(out_buf, 0, 1)
+            enc.setBytes_length_atIndex_(struct.pack("I", rows), 4, 2)
+            enc.setBytes_length_atIndex_(struct.pack("I", cols), 4, 3)
+            enc.setBytes_length_atIndex_(struct.pack("i", diagonal), 4, 4)
+            enc.setBytes_length_atIndex_(struct.pack("I", numel), 4, 5)
+            enc.dispatchThreadgroups_threadsPerThreadgroup_(
+                _MTLSize(groups, 1, 1), _MTLSize(tpg, 1, 1))
+            enc.endEncoding()
+        else:
+            _encode_tril_triu_ctypes(enc, pipeline, a_buf, out_buf,
+                                     rows, cols, diagonal, numel,
+                                     groups, tpg)
+
+        rt.commit_and_wait(cmd)
+
+    # ------------------------------------------------------------------
+    # Dispatch: index_select / gather  (input, index → output)
+    # ------------------------------------------------------------------
+
+    def dispatch_index_gather(self, kernel_name, input_buf, index_buf,
+                              out_buf, outer_size, idx_size, inner_size,
+                              input_dim_size, numel):
+        """Encode index_select or gather kernel (3 bufs + 4 uint)."""
+        rt = get_runtime()
+        pipeline = self._get_pipeline(kernel_name)
+        tpg = self._threads_per_group(pipeline)
+        groups = (numel + tpg - 1) // tpg
+
+        cmd = rt.create_command_buffer()
+        enc = rt.get_compute_encoder(cmd)
+
+        if _HAS_PYOBJC:
+            enc.setComputePipelineState_(pipeline)
+            enc.setBuffer_offset_atIndex_(input_buf, 0, 0)
+            enc.setBuffer_offset_atIndex_(index_buf, 0, 1)
+            enc.setBuffer_offset_atIndex_(out_buf, 0, 2)
+            enc.setBytes_length_atIndex_(struct.pack("I", outer_size), 4, 3)
+            enc.setBytes_length_atIndex_(struct.pack("I", idx_size), 4, 4)
+            enc.setBytes_length_atIndex_(struct.pack("I", inner_size), 4, 5)
+            enc.setBytes_length_atIndex_(struct.pack("I", input_dim_size), 4, 6)
+            enc.dispatchThreadgroups_threadsPerThreadgroup_(
+                _MTLSize(groups, 1, 1), _MTLSize(tpg, 1, 1))
+            enc.endEncoding()
+        else:
+            _encode_index_gather_ctypes(enc, pipeline, input_buf, index_buf,
+                                        out_buf, outer_size, idx_size,
+                                        inner_size, input_dim_size,
+                                        groups, tpg)
+
+        rt.commit_and_wait(cmd)
+
+    # ------------------------------------------------------------------
+    # Dispatch: cat_copy  (src → dst region)
+    # ------------------------------------------------------------------
+
+    def dispatch_cat_copy(self, kernel_name, src_buf, dst_buf, outer_size,
+                          src_dim, inner_size, dst_dim, offset, numel):
+        """Encode cat_copy kernel (2 bufs + 5 uint)."""
+        rt = get_runtime()
+        pipeline = self._get_pipeline(kernel_name)
+        tpg = self._threads_per_group(pipeline)
+        groups = (numel + tpg - 1) // tpg
+
+        cmd = rt.create_command_buffer()
+        enc = rt.get_compute_encoder(cmd)
+
+        if _HAS_PYOBJC:
+            enc.setComputePipelineState_(pipeline)
+            enc.setBuffer_offset_atIndex_(src_buf, 0, 0)
+            enc.setBuffer_offset_atIndex_(dst_buf, 0, 1)
+            enc.setBytes_length_atIndex_(struct.pack("I", outer_size), 4, 2)
+            enc.setBytes_length_atIndex_(struct.pack("I", src_dim), 4, 3)
+            enc.setBytes_length_atIndex_(struct.pack("I", inner_size), 4, 4)
+            enc.setBytes_length_atIndex_(struct.pack("I", dst_dim), 4, 5)
+            enc.setBytes_length_atIndex_(struct.pack("I", offset), 4, 6)
+            enc.dispatchThreadgroups_threadsPerThreadgroup_(
+                _MTLSize(groups, 1, 1), _MTLSize(tpg, 1, 1))
+            enc.endEncoding()
+        else:
+            _encode_cat_copy_ctypes(enc, pipeline, src_buf, dst_buf,
+                                    outer_size, src_dim, inner_size,
+                                    dst_dim, offset, groups, tpg)
+
+        rt.commit_and_wait(cmd)
+
+    # ------------------------------------------------------------------
     # Dispatch: axis reduction  (input → reduced output along dim)
     # ------------------------------------------------------------------
 
@@ -1005,5 +1209,96 @@ def _encode_clamp_strided_ctypes(enc, pipeline, a_buf, s1_bytes, s2_bytes,
     _ctypes_set_bytes(enc, shape_bytes, len(shape_bytes), 5)
     _ctypes_set_bytes(enc, strides_bytes, len(strides_bytes), 6)
     _ctypes_set_bytes(enc, struct.pack("I", ndim), 4, 7)
+    _ctypes_dispatch_threadgroups(enc, groups, tpg)
+    _ctypes_end_encoding(enc)
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: shape & index ctypes encoders
+# ---------------------------------------------------------------------------
+
+def _encode_where_ctypes(enc, pipeline, cond_buf, x_buf, y_buf, out_buf,
+                          numel, groups, tpg):
+    """Encode where kernel (4 buffers + 1 uint) via ctypes."""
+    _ctypes_set_pipeline(enc, pipeline)
+    _ctypes_set_buffer(enc, cond_buf, 0, 0)
+    _ctypes_set_buffer(enc, x_buf, 0, 1)
+    _ctypes_set_buffer(enc, y_buf, 0, 2)
+    _ctypes_set_buffer(enc, out_buf, 0, 3)
+    _ctypes_set_bytes(enc, struct.pack("I", numel), 4, 4)
+    _ctypes_dispatch_threadgroups(enc, groups, tpg)
+    _ctypes_end_encoding(enc)
+
+
+def _encode_where_scalar_ctypes(enc, pipeline, cond_buf, tensor_buf,
+                                 scalar_bytes, scalar_size, out_buf,
+                                 numel, groups, tpg):
+    """Encode where_scalar kernel (3 bufs + 1 scalar + 1 uint) via ctypes."""
+    _ctypes_set_pipeline(enc, pipeline)
+    _ctypes_set_buffer(enc, cond_buf, 0, 0)
+    _ctypes_set_buffer(enc, tensor_buf, 0, 1)
+    _ctypes_set_bytes(enc, scalar_bytes, scalar_size, 2)
+    _ctypes_set_buffer(enc, out_buf, 0, 3)
+    _ctypes_set_bytes(enc, struct.pack("I", numel), 4, 4)
+    _ctypes_dispatch_threadgroups(enc, groups, tpg)
+    _ctypes_end_encoding(enc)
+
+
+def _encode_masked_fill_ctypes(enc, pipeline, a_buf, mask_buf,
+                                scalar_bytes, scalar_size, out_buf,
+                                numel, groups, tpg):
+    """Encode masked_fill kernel (3 bufs + 1 scalar + 1 uint) via ctypes."""
+    _ctypes_set_pipeline(enc, pipeline)
+    _ctypes_set_buffer(enc, a_buf, 0, 0)
+    _ctypes_set_buffer(enc, mask_buf, 0, 1)
+    _ctypes_set_bytes(enc, scalar_bytes, scalar_size, 2)
+    _ctypes_set_buffer(enc, out_buf, 0, 3)
+    _ctypes_set_bytes(enc, struct.pack("I", numel), 4, 4)
+    _ctypes_dispatch_threadgroups(enc, groups, tpg)
+    _ctypes_end_encoding(enc)
+
+
+def _encode_tril_triu_ctypes(enc, pipeline, a_buf, out_buf,
+                              rows, cols, diagonal, numel, groups, tpg):
+    """Encode tril/triu kernel (2 bufs + 2 uint + 1 int + 1 uint) via ctypes."""
+    _ctypes_set_pipeline(enc, pipeline)
+    _ctypes_set_buffer(enc, a_buf, 0, 0)
+    _ctypes_set_buffer(enc, out_buf, 0, 1)
+    _ctypes_set_bytes(enc, struct.pack("I", rows), 4, 2)
+    _ctypes_set_bytes(enc, struct.pack("I", cols), 4, 3)
+    _ctypes_set_bytes(enc, struct.pack("i", diagonal), 4, 4)
+    _ctypes_set_bytes(enc, struct.pack("I", numel), 4, 5)
+    _ctypes_dispatch_threadgroups(enc, groups, tpg)
+    _ctypes_end_encoding(enc)
+
+
+def _encode_index_gather_ctypes(enc, pipeline, input_buf, index_buf, out_buf,
+                                 outer_size, idx_size, inner_size,
+                                 input_dim_size, groups, tpg):
+    """Encode index_select/gather kernel (3 bufs + 4 uint) via ctypes."""
+    _ctypes_set_pipeline(enc, pipeline)
+    _ctypes_set_buffer(enc, input_buf, 0, 0)
+    _ctypes_set_buffer(enc, index_buf, 0, 1)
+    _ctypes_set_buffer(enc, out_buf, 0, 2)
+    _ctypes_set_bytes(enc, struct.pack("I", outer_size), 4, 3)
+    _ctypes_set_bytes(enc, struct.pack("I", idx_size), 4, 4)
+    _ctypes_set_bytes(enc, struct.pack("I", inner_size), 4, 5)
+    _ctypes_set_bytes(enc, struct.pack("I", input_dim_size), 4, 6)
+    _ctypes_dispatch_threadgroups(enc, groups, tpg)
+    _ctypes_end_encoding(enc)
+
+
+def _encode_cat_copy_ctypes(enc, pipeline, src_buf, dst_buf,
+                             outer_size, src_dim, inner_size,
+                             dst_dim, offset, groups, tpg):
+    """Encode cat_copy kernel (2 bufs + 5 uint) via ctypes."""
+    _ctypes_set_pipeline(enc, pipeline)
+    _ctypes_set_buffer(enc, src_buf, 0, 0)
+    _ctypes_set_buffer(enc, dst_buf, 0, 1)
+    _ctypes_set_bytes(enc, struct.pack("I", outer_size), 4, 2)
+    _ctypes_set_bytes(enc, struct.pack("I", src_dim), 4, 3)
+    _ctypes_set_bytes(enc, struct.pack("I", inner_size), 4, 4)
+    _ctypes_set_bytes(enc, struct.pack("I", dst_dim), 4, 5)
+    _ctypes_set_bytes(enc, struct.pack("I", offset), 4, 6)
     _ctypes_dispatch_threadgroups(enc, groups, tpg)
     _ctypes_end_encoding(enc)

--- a/src/candle/_backends/mps/metal_shaders.py
+++ b/src/candle/_backends/mps/metal_shaders.py
@@ -223,6 +223,143 @@ kernel void {name}_scalar_{suffix}(device const {type}* a  [[buffer(0)]],
 # Templates: axis-reduce kernels
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Templates: shape & index kernels (Phase 3)
+# ---------------------------------------------------------------------------
+
+_WHERE_TEMPLATE = """
+kernel void where_{suffix}(device const uchar* cond [[buffer(0)]],
+                            device const {type}* x   [[buffer(1)]],
+                            device const {type}* y   [[buffer(2)]],
+                            device {type}* out        [[buffer(3)]],
+                            constant uint& N          [[buffer(4)]],
+                            uint id [[thread_position_in_grid]]) {{
+    if (id < N) out[id] = cond[id] ? x[id] : y[id];
+}}
+"""
+
+_WHERE_SCALAR_Y_TEMPLATE = """
+kernel void where_scalar_y_{suffix}(device const uchar* cond [[buffer(0)]],
+                                     device const {type}* x   [[buffer(1)]],
+                                     constant {type}& y_val    [[buffer(2)]],
+                                     device {type}* out        [[buffer(3)]],
+                                     constant uint& N          [[buffer(4)]],
+                                     uint id [[thread_position_in_grid]]) {{
+    if (id < N) out[id] = cond[id] ? x[id] : y_val;
+}}
+"""
+
+_WHERE_SCALAR_X_TEMPLATE = """
+kernel void where_scalar_x_{suffix}(device const uchar* cond [[buffer(0)]],
+                                     constant {type}& x_val    [[buffer(1)]],
+                                     device const {type}* y    [[buffer(2)]],
+                                     device {type}* out        [[buffer(3)]],
+                                     constant uint& N          [[buffer(4)]],
+                                     uint id [[thread_position_in_grid]]) {{
+    if (id < N) out[id] = cond[id] ? x_val : y[id];
+}}
+"""
+
+_MASKED_FILL_TEMPLATE = """
+kernel void masked_fill_{suffix}(device const {type}* a  [[buffer(0)]],
+                                  device const uchar* mask [[buffer(1)]],
+                                  constant {type}& value   [[buffer(2)]],
+                                  device {type}* out       [[buffer(3)]],
+                                  constant uint& N         [[buffer(4)]],
+                                  uint id [[thread_position_in_grid]]) {{
+    if (id < N) out[id] = mask[id] ? value : a[id];
+}}
+"""
+
+_TRIL_TEMPLATE = """
+kernel void tril_{suffix}(device const {type}* a [[buffer(0)]],
+                           device {type}* out      [[buffer(1)]],
+                           constant uint& rows     [[buffer(2)]],
+                           constant uint& cols     [[buffer(3)]],
+                           constant int& diagonal  [[buffer(4)]],
+                           constant uint& N        [[buffer(5)]],
+                           uint id [[thread_position_in_grid]]) {{
+    if (id >= N) return;
+    uint plane = rows * cols;
+    uint pos = id % plane;
+    uint row = pos / cols;
+    uint col = pos % cols;
+    out[id] = ((int)col <= (int)row + diagonal) ? a[id] : ({type})0;
+}}
+"""
+
+_TRIU_TEMPLATE = """
+kernel void triu_{suffix}(device const {type}* a [[buffer(0)]],
+                           device {type}* out      [[buffer(1)]],
+                           constant uint& rows     [[buffer(2)]],
+                           constant uint& cols     [[buffer(3)]],
+                           constant int& diagonal  [[buffer(4)]],
+                           constant uint& N        [[buffer(5)]],
+                           uint id [[thread_position_in_grid]]) {{
+    if (id >= N) return;
+    uint plane = rows * cols;
+    uint pos = id % plane;
+    uint row = pos / cols;
+    uint col = pos % cols;
+    out[id] = ((int)col >= (int)row + diagonal) ? a[id] : ({type})0;
+}}
+"""
+
+_INDEX_SELECT_TEMPLATE = """
+kernel void index_select_{suffix}(device const {type}* input   [[buffer(0)]],
+                                   device const int* indices    [[buffer(1)]],
+                                   device {type}* output        [[buffer(2)]],
+                                   constant uint& outer_size    [[buffer(3)]],
+                                   constant uint& idx_size      [[buffer(4)]],
+                                   constant uint& inner_size    [[buffer(5)]],
+                                   constant uint& input_dim_size [[buffer(6)]],
+                                   uint gid [[thread_position_in_grid]]) {{
+    if (gid >= outer_size * idx_size * inner_size) return;
+    uint inner_idx = gid % inner_size;
+    uint k = (gid / inner_size) % idx_size;
+    uint outer = gid / (idx_size * inner_size);
+    output[gid] = input[(outer * input_dim_size + (uint)indices[k]) * inner_size + inner_idx];
+}}
+"""
+
+_GATHER_TEMPLATE = """
+kernel void gather_{suffix}(device const {type}* input   [[buffer(0)]],
+                             device const int* indices    [[buffer(1)]],
+                             device {type}* output        [[buffer(2)]],
+                             constant uint& outer_size    [[buffer(3)]],
+                             constant uint& idx_size      [[buffer(4)]],
+                             constant uint& inner_size    [[buffer(5)]],
+                             constant uint& input_dim_size [[buffer(6)]],
+                             uint gid [[thread_position_in_grid]]) {{
+    if (gid >= outer_size * idx_size * inner_size) return;
+    uint inner_idx = gid % inner_size;
+    uint k = (gid / inner_size) % idx_size;
+    uint outer = gid / (idx_size * inner_size);
+    output[gid] = input[(outer * input_dim_size + (uint)indices[gid]) * inner_size + inner_idx];
+}}
+"""
+
+_CAT_COPY_TEMPLATE = """
+kernel void cat_copy_{suffix}(device const {type}* src [[buffer(0)]],
+                               device {type}* dst       [[buffer(1)]],
+                               constant uint& outer_size [[buffer(2)]],
+                               constant uint& src_dim    [[buffer(3)]],
+                               constant uint& inner_size [[buffer(4)]],
+                               constant uint& dst_dim    [[buffer(5)]],
+                               constant uint& offset     [[buffer(6)]],
+                               uint gid [[thread_position_in_grid]]) {{
+    if (gid >= outer_size * src_dim * inner_size) return;
+    uint inner_idx = gid % inner_size;
+    uint dim_idx = (gid / inner_size) % src_dim;
+    uint outer = gid / (src_dim * inner_size);
+    dst[(outer * dst_dim + offset + dim_idx) * inner_size + inner_idx] = src[gid];
+}}
+"""
+
+# ---------------------------------------------------------------------------
+# Templates: axis-reduce kernels
+# ---------------------------------------------------------------------------
+
 _REDUCE_DIM_TEMPLATE = """
 kernel void reduce_{name}_dim_{suffix}(
     device const {type}* input  [[buffer(0)]],
@@ -338,6 +475,75 @@ def _gen_reduce_dim(name, init, body, finalize, out_type=None, types=None):
             init=init.replace("{type}", t).replace("{out_type}", ot),
             body=body.replace("{type}", t),
             finalize=finalize.replace("{type}", t)))
+    return "".join(parts)
+
+
+def _gen_where(types=None):
+    """Generate where kernels (3 variants per type)."""
+    if types is None:
+        types = ("float", "half", "int", "long")
+    parts = []
+    for t in types:
+        suffix = _SUFFIX[t]
+        parts.append(_WHERE_TEMPLATE.format(suffix=suffix, type=t))
+        parts.append(_WHERE_SCALAR_Y_TEMPLATE.format(suffix=suffix, type=t))
+        parts.append(_WHERE_SCALAR_X_TEMPLATE.format(suffix=suffix, type=t))
+    return "".join(parts)
+
+
+def _gen_masked_fill(types=None):
+    """Generate masked_fill kernels (1 per type)."""
+    if types is None:
+        types = ("float", "half", "int", "long")
+    parts = []
+    for t in types:
+        suffix = _SUFFIX[t]
+        parts.append(_MASKED_FILL_TEMPLATE.format(suffix=suffix, type=t))
+    return "".join(parts)
+
+
+def _gen_tril_triu(types=None):
+    """Generate tril and triu kernels (2 per type)."""
+    if types is None:
+        types = ("float", "half", "int", "long")
+    parts = []
+    for t in types:
+        suffix = _SUFFIX[t]
+        parts.append(_TRIL_TEMPLATE.format(suffix=suffix, type=t))
+        parts.append(_TRIU_TEMPLATE.format(suffix=suffix, type=t))
+    return "".join(parts)
+
+
+def _gen_index_select(types=None):
+    """Generate index_select kernels (1 per type)."""
+    if types is None:
+        types = ("float", "half", "int", "long")
+    parts = []
+    for t in types:
+        suffix = _SUFFIX[t]
+        parts.append(_INDEX_SELECT_TEMPLATE.format(suffix=suffix, type=t))
+    return "".join(parts)
+
+
+def _gen_gather(types=None):
+    """Generate gather kernels (1 per type)."""
+    if types is None:
+        types = ("float", "half", "int", "long")
+    parts = []
+    for t in types:
+        suffix = _SUFFIX[t]
+        parts.append(_GATHER_TEMPLATE.format(suffix=suffix, type=t))
+    return "".join(parts)
+
+
+def _gen_cat_copy(types=None):
+    """Generate cat_copy kernels (1 per type, includes bool/uchar)."""
+    if types is None:
+        types = ("float", "half", "int", "long", "uchar")
+    parts = []
+    for t in types:
+        suffix = _SUFFIX[t]
+        parts.append(_CAT_COPY_TEMPLATE.format(suffix=suffix, type=t))
     return "".join(parts)
 
 
@@ -735,6 +941,14 @@ def _build_msl_source():
         finalize="acc",
         out_type="uchar",
         types=("float", "half", "int", "long", "uchar")))
+
+    # Shape & index kernels (Phase 3)
+    parts.append(_gen_where())
+    parts.append(_gen_masked_fill())
+    parts.append(_gen_tril_triu())
+    parts.append(_gen_index_select())
+    parts.append(_gen_gather())
+    parts.append(_gen_cat_copy())
 
     # Comparison ops
     for name, op in _COMPARISON_OPS:

--- a/src/candle/_backends/mps/ops.py
+++ b/src/candle/_backends/mps/ops.py
@@ -740,11 +740,64 @@ def topk(a, k, dim=-1, largest=True, sorted=True):
 
 
 def stack(tensors, dim=0):
+    # GPU path: composite via unsqueeze + cat
+    if (tensors and all(_can_use_gpu(t) and t.is_contiguous() for t in tensors)
+            and all(t.dtype == tensors[0].dtype for t in tensors)):
+        unsqueezed = [t.unsqueeze(dim) for t in tensors]
+        return cat(unsqueezed, dim=dim)
     arrays = [_to_numpy(t) for t in tensors]
     return _from_numpy(np.stack(arrays, axis=dim), tensors[0].dtype, tensors[0].device)
 
 
 def cat(tensors, dim=0):
+    # GPU path: all tensors GPU+contiguous+same dtype+ndim>0
+    if (tensors and len(tensors) > 0
+            and all(_can_use_gpu(t) and t.is_contiguous() and t.dim() > 0
+                    for t in tensors)
+            and all(t.dtype == tensors[0].dtype for t in tensors)):
+        dtype = tensors[0].dtype
+        ndim = tensors[0].dim()
+        d_pos = dim if dim >= 0 else dim + ndim
+        if 0 <= d_pos < ndim:
+            d = _get_dispatcher()
+            sfx = _kernel_suffix(dtype)
+            # Compute output shape
+            out_shape = list(tensors[0].shape)
+            total_dim = tensors[0].shape[d_pos]
+            for t in tensors[1:]:
+                total_dim += t.shape[d_pos]
+            out_shape[d_pos] = total_dim
+            out_numel = 1
+            for s in out_shape:
+                out_numel *= s
+            out_buf = _alloc_output_buf(out_numel, dtype)
+            # Compute outer_size and inner_size
+            outer_size = 1
+            for i in range(d_pos):
+                outer_size *= out_shape[i]
+            inner_size = 1
+            for i in range(d_pos + 1, ndim):
+                inner_size *= out_shape[i]
+            dst_dim = total_dim
+            offset = 0
+            for t in tensors:
+                src_dim = t.shape[d_pos]
+                src_numel = t.numel()
+                if src_numel > 0:
+                    d.dispatch_cat_copy(f"cat_copy_{sfx}", _metal_buf(t),
+                                        out_buf, outer_size, src_dim,
+                                        inner_size, dst_dim, offset,
+                                        src_numel)
+                offset += src_dim
+            out_stride = []
+            stride = 1
+            for s in reversed(out_shape):
+                out_stride.append(stride)
+                stride *= s
+            out_stride.reverse()
+            return _from_metal_buffer(out_buf, tuple(out_shape),
+                                      tuple(out_stride), dtype,
+                                      tensors[0].device)
     arrays = [_to_numpy(t) for t in tensors]
     return _from_numpy(np.concatenate(arrays, axis=dim), tensors[0].dtype, tensors[0].device)
 
@@ -847,6 +900,38 @@ def index_select(a, dim, index):
         dim += arr.ndim
     if dim < 0 or dim >= arr.ndim:
         raise ValueError("dim out of range")
+    # GPU path: a is GPU+contiguous
+    if _can_use_gpu(a) and a.is_contiguous():
+        d = _get_dispatcher()
+        sfx = _kernel_suffix(a.dtype)
+        idx_size = len(idx)
+        input_dim_size = a.shape[dim]
+        # Compute outer/inner sizes
+        outer_size = 1
+        for i in range(dim):
+            outer_size *= a.shape[i]
+        inner_size = 1
+        for i in range(dim + 1, a.dim()):
+            inner_size *= a.shape[i]
+        out_numel = outer_size * idx_size * inner_size
+        out_buf = _alloc_output_buf(out_numel, a.dtype)
+        # Cast indices to int32 for Metal
+        idx_i32 = idx.astype(np.int32)
+        idx_tensor = _from_numpy(idx_i32, int32_dtype, a.device)
+        d.dispatch_index_gather(f"index_select_{sfx}", _metal_buf(a),
+                                _metal_buf(idx_tensor), out_buf,
+                                outer_size, idx_size, inner_size,
+                                input_dim_size, out_numel)
+        out_shape = list(a.shape)
+        out_shape[dim] = idx_size
+        out_stride = []
+        stride = 1
+        for s in reversed(out_shape):
+            out_stride.append(stride)
+            stride *= s
+        out_stride.reverse()
+        return _from_metal_buffer(out_buf, tuple(out_shape), tuple(out_stride),
+                                  a.dtype, a.device)
     out = np.take(arr, idx, axis=dim)
     return _from_numpy(out, a.dtype, a.device)
 
@@ -869,6 +954,38 @@ def gather(a, dim, index):
         if i != dim and size != arr.shape[i]:
             raise ValueError("index shape mismatch")
     _check_index_range(idx, arr.shape[dim])
+    # GPU path: a and index are GPU+contiguous
+    if (_can_use_gpu(a) and a.is_contiguous()
+            and isinstance(index, Tensor) and _can_use_gpu(index)
+            and index.is_contiguous()):
+        d = _get_dispatcher()
+        sfx = _kernel_suffix(a.dtype)
+        idx_size = idx.shape[dim]
+        input_dim_size = a.shape[dim]
+        outer_size = 1
+        for i in range(dim):
+            outer_size *= idx.shape[i]
+        inner_size = 1
+        for i in range(dim + 1, idx.ndim):
+            inner_size *= idx.shape[i]
+        out_numel = outer_size * idx_size * inner_size
+        out_buf = _alloc_output_buf(out_numel, a.dtype)
+        # Cast indices to int32 for Metal
+        idx_i32 = idx.astype(np.int32)
+        idx_tensor = _from_numpy(idx_i32, int32_dtype, a.device)
+        d.dispatch_index_gather(f"gather_{sfx}", _metal_buf(a),
+                                _metal_buf(idx_tensor), out_buf,
+                                outer_size, idx_size, inner_size,
+                                input_dim_size, out_numel)
+        out_shape = tuple(idx.shape)
+        out_stride = []
+        stride = 1
+        for s in reversed(out_shape):
+            out_stride.append(stride)
+            stride *= s
+        out_stride.reverse()
+        return _from_metal_buffer(out_buf, out_shape, tuple(out_stride),
+                                  a.dtype, a.device)
     out = np.take_along_axis(arr, idx, axis=dim)
     return _from_numpy(out, a.dtype, a.device)
 
@@ -951,11 +1068,33 @@ def block_diag(*tensors):
 
 
 def tril(a, diagonal=0):
+    # GPU path: a is GPU+contiguous+ndim>=2
+    if _can_use_gpu(a) and a.is_contiguous() and a.dim() >= 2:
+        d = _get_dispatcher()
+        sfx = _kernel_suffix(a.dtype)
+        numel = a.numel()
+        rows = a.shape[-2]
+        cols = a.shape[-1]
+        out_buf = _alloc_output_buf(numel, a.dtype)
+        d.dispatch_tril_triu(f"tril_{sfx}", _metal_buf(a), out_buf,
+                             rows, cols, diagonal, numel)
+        return _from_metal_buffer(out_buf, a.shape, a.stride, a.dtype, a.device)
     out = np.tril(_to_numpy(a), k=diagonal)
     return _from_numpy(out, a.dtype, a.device)
 
 
 def triu(a, diagonal=0):
+    # GPU path: a is GPU+contiguous+ndim>=2
+    if _can_use_gpu(a) and a.is_contiguous() and a.dim() >= 2:
+        d = _get_dispatcher()
+        sfx = _kernel_suffix(a.dtype)
+        numel = a.numel()
+        rows = a.shape[-2]
+        cols = a.shape[-1]
+        out_buf = _alloc_output_buf(numel, a.dtype)
+        d.dispatch_tril_triu(f"triu_{sfx}", _metal_buf(a), out_buf,
+                             rows, cols, diagonal, numel)
+        return _from_metal_buffer(out_buf, a.shape, a.stride, a.dtype, a.device)
     out = np.triu(_to_numpy(a), k=diagonal)
     return _from_numpy(out, a.dtype, a.device)
 
@@ -1977,6 +2116,42 @@ def fmax(a, b):
 
 
 def where(cond, x, y):
+    # GPU path: both cond and x are GPU+contiguous
+    if (isinstance(x, Tensor) and _can_use_gpu(x) and x.is_contiguous()
+            and isinstance(cond, Tensor) and _can_use_gpu(cond) and cond.is_contiguous()):
+        d = _get_dispatcher()
+        sfx = _kernel_suffix(x.dtype)
+        numel = x.numel()
+        out_buf = _alloc_output_buf(numel, x.dtype)
+        # Ensure condition is uint8 (uchar) for the shader
+        if cond.dtype != bool_dtype:
+            cond_u8 = _from_numpy(
+                _to_numpy(cond).astype(np.bool_).astype(np.uint8),
+                bool_dtype, cond.device)
+        else:
+            cond_u8 = cond
+        cond_buf = _metal_buf(cond_u8)
+
+        if isinstance(y, Tensor) and _can_use_gpu(y) and y.is_contiguous() and y.shape == x.shape:
+            # Both tensors, same shape
+            d.dispatch_where(f"where_{sfx}", cond_buf, _metal_buf(x),
+                             _metal_buf(y), out_buf, numel)
+        elif not isinstance(y, Tensor):
+            # y is scalar
+            scalar_val = float(y) if x.dtype in (float32_dtype, float16_dtype) else int(y)
+            d.dispatch_where_scalar(f"where_scalar_y_{sfx}", cond_buf,
+                                    _metal_buf(x), scalar_val, out_buf,
+                                    numel, scalar_fmt=_scalar_fmt(x.dtype))
+        else:
+            # Fallback to numpy
+            cond_arr = _to_numpy(cond)
+            x_arr = _to_numpy(x)
+            y_arr = _to_numpy(y)
+            out = np.where(cond_arr, x_arr, y_arr)
+            return _from_numpy(out, x.dtype, x.device)
+        return _from_metal_buffer(out_buf, x.shape, x.stride, x.dtype, x.device)
+
+    # numpy fallback
     cond_arr = _to_numpy(cond)
     x_arr = _to_numpy(x)
     if isinstance(y, Tensor):
@@ -2459,6 +2634,26 @@ def expand(a, sizes):
 
 
 def masked_fill(a, mask, value):
+    # GPU path: a and mask are GPU+contiguous+same shape
+    if (_can_use_gpu(a) and a.is_contiguous()
+            and isinstance(mask, Tensor) and _can_use_gpu(mask)
+            and mask.is_contiguous() and mask.shape == a.shape):
+        d = _get_dispatcher()
+        sfx = _kernel_suffix(a.dtype)
+        numel = a.numel()
+        out_buf = _alloc_output_buf(numel, a.dtype)
+        # Ensure mask is uint8 (uchar) for the shader
+        if mask.dtype != bool_dtype:
+            mask_u8 = _from_numpy(
+                _to_numpy(mask).astype(np.bool_).astype(np.uint8),
+                bool_dtype, mask.device)
+        else:
+            mask_u8 = mask
+        scalar_val = float(value) if a.dtype in (float32_dtype, float16_dtype) else int(value)
+        d.dispatch_masked_fill(f"masked_fill_{sfx}", _metal_buf(a),
+                               _metal_buf(mask_u8), scalar_val, out_buf,
+                               numel, scalar_fmt=_scalar_fmt(a.dtype))
+        return _from_metal_buffer(out_buf, a.shape, a.stride, a.dtype, a.device)
     arr = _to_numpy(a).copy()
     m = _to_numpy(mask).astype(bool)
     arr[m] = value

--- a/tests/mps/test_metal_infra.py
+++ b/tests/mps/test_metal_infra.py
@@ -563,3 +563,259 @@ class TestPhase2Reductions:
                                  axis=1)) + arr.max(axis=1)
         np.testing.assert_allclose(r.cpu().numpy(), expected.astype(np.float16),
                                    rtol=5e-2)
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: Shape & Index GPU kernels
+# ---------------------------------------------------------------------------
+
+class TestPhase3ShapeIndex:
+    """Verify GPU kernels for where, masked_fill, tril, triu,
+    index_select, gather, cat, stack."""
+
+    # --- where ---
+
+    def test_where_f32(self):
+        cond = torch.tensor([True, False, True, False], device="mps")
+        x = torch.tensor([1.0, 2.0, 3.0, 4.0], device="mps")
+        y = torch.tensor([10.0, 20.0, 30.0, 40.0], device="mps")
+        result = torch.where(cond, x, y)
+        expected = np.array([1.0, 20.0, 3.0, 40.0])
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    def test_where_f16(self):
+        cond = torch.tensor([True, False, True], device="mps")
+        x = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float16, device="mps")
+        y = torch.tensor([10.0, 20.0, 30.0], dtype=torch.float16, device="mps")
+        result = torch.where(cond, x, y)
+        expected = np.array([1.0, 20.0, 3.0])
+        np.testing.assert_allclose(result.cpu().numpy(), expected, rtol=1e-3)
+
+    def test_where_i32(self):
+        cond = torch.tensor([True, False, True], device="mps")
+        x = torch.tensor([1, 2, 3], dtype=torch.int32, device="mps")
+        y = torch.tensor([10, 20, 30], dtype=torch.int32, device="mps")
+        result = torch.where(cond, x, y)
+        expected = np.array([1, 20, 3])
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    def test_where_scalar_y(self):
+        cond = torch.tensor([True, False, True, False], device="mps")
+        x = torch.tensor([1.0, 2.0, 3.0, 4.0], device="mps")
+        result = torch.where(cond, x, 0.0)
+        expected = np.array([1.0, 0.0, 3.0, 0.0])
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    def test_where_2d(self):
+        cond = torch.tensor([[True, False], [False, True]], device="mps")
+        x = torch.tensor([[1.0, 2.0], [3.0, 4.0]], device="mps")
+        y = torch.tensor([[10.0, 20.0], [30.0, 40.0]], device="mps")
+        result = torch.where(cond, x, y)
+        expected = np.array([[1.0, 20.0], [30.0, 4.0]])
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    # --- masked_fill ---
+
+    def test_masked_fill_f32(self):
+        a = torch.tensor([1.0, 2.0, 3.0, 4.0], device="mps")
+        mask = torch.tensor([True, False, True, False], device="mps")
+        result = a.masked_fill(mask, -1.0)
+        expected = np.array([-1.0, 2.0, -1.0, 4.0])
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    def test_masked_fill_f16(self):
+        a = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float16, device="mps")
+        mask = torch.tensor([False, True, False], device="mps")
+        result = a.masked_fill(mask, 0.0)
+        expected = np.array([1.0, 0.0, 3.0])
+        np.testing.assert_allclose(result.cpu().numpy(), expected, rtol=1e-3)
+
+    def test_masked_fill_i32(self):
+        a = torch.tensor([1, 2, 3, 4], dtype=torch.int32, device="mps")
+        mask = torch.tensor([True, True, False, False], device="mps")
+        result = a.masked_fill(mask, -99)
+        expected = np.array([-99, -99, 3, 4])
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    def test_masked_fill_2d(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]], device="mps")
+        mask = torch.tensor([[True, False], [False, True]], device="mps")
+        result = a.masked_fill(mask, 0.0)
+        expected = np.array([[0.0, 2.0], [3.0, 0.0]])
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    # --- tril ---
+
+    def test_tril_f32(self):
+        a = torch.ones(3, 3, device="mps")
+        result = torch.tril(a)
+        expected = np.tril(np.ones((3, 3)))
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    def test_tril_i32(self):
+        a = torch.ones(3, 3, dtype=torch.int32, device="mps")
+        result = torch.tril(a)
+        expected = np.tril(np.ones((3, 3)))
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    def test_tril_diagonal(self):
+        a = torch.ones(4, 4, device="mps")
+        result = torch.tril(a, diagonal=1)
+        expected = np.tril(np.ones((4, 4)), k=1)
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    def test_tril_batched(self):
+        a = torch.ones(2, 3, 3, device="mps")
+        result = torch.tril(a)
+        expected = np.tril(np.ones((3, 3)))
+        for b in range(2):
+            np.testing.assert_allclose(result[b].cpu().numpy(), expected)
+
+    # --- triu ---
+
+    def test_triu_f32(self):
+        a = torch.ones(3, 3, device="mps")
+        result = torch.triu(a)
+        expected = np.triu(np.ones((3, 3)))
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    def test_triu_i32(self):
+        a = torch.ones(3, 3, dtype=torch.int32, device="mps")
+        result = torch.triu(a)
+        expected = np.triu(np.ones((3, 3)))
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    def test_triu_diagonal(self):
+        a = torch.ones(4, 4, device="mps")
+        result = torch.triu(a, diagonal=-1)
+        expected = np.triu(np.ones((4, 4)), k=-1)
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    # --- index_select ---
+
+    def test_index_select_dim0_f32(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], device="mps")
+        idx = torch.tensor([0, 2], dtype=torch.int64, device="mps")
+        result = torch.index_select(a, 0, idx)
+        expected = np.array([[1.0, 2.0], [5.0, 6.0]])
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    def test_index_select_dim0_i32(self):
+        a = torch.tensor([[1, 2], [3, 4], [5, 6]], dtype=torch.int32, device="mps")
+        idx = torch.tensor([1, 2], dtype=torch.int64, device="mps")
+        result = torch.index_select(a, 0, idx)
+        expected = np.array([[3, 4], [5, 6]])
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    def test_index_select_dim1(self):
+        a = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], device="mps")
+        idx = torch.tensor([0, 2], dtype=torch.int64, device="mps")
+        result = torch.index_select(a, 1, idx)
+        expected = np.array([[1.0, 3.0], [4.0, 6.0]])
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    def test_index_select_3d(self):
+        a = torch.arange(24, dtype=torch.float32, device="mps").reshape(2, 3, 4)
+        idx = torch.tensor([1, 2], dtype=torch.int64, device="mps")
+        result = torch.index_select(a, 1, idx)
+        expected = np.arange(24).reshape(2, 3, 4)[:, [1, 2], :]
+        np.testing.assert_allclose(result.cpu().numpy(), expected.astype(np.float32))
+
+    # --- gather ---
+
+    def test_gather_dim0(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]], device="mps")
+        idx = torch.tensor([[0, 1], [1, 0]], dtype=torch.int64, device="mps")
+        result = torch.gather(a, 0, idx)
+        expected = np.array([[1.0, 4.0], [3.0, 2.0]])
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    def test_gather_dim1(self):
+        a = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], device="mps")
+        idx = torch.tensor([[2, 0], [1, 2]], dtype=torch.int64, device="mps")
+        result = torch.gather(a, 1, idx)
+        expected = np.array([[3.0, 1.0], [5.0, 6.0]])
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    def test_gather_i32(self):
+        a = torch.tensor([[10, 20, 30], [40, 50, 60]], dtype=torch.int32, device="mps")
+        idx = torch.tensor([[1, 0], [2, 1]], dtype=torch.int64, device="mps")
+        result = torch.gather(a, 1, idx)
+        expected = np.array([[20, 10], [60, 50]])
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    # --- cat ---
+
+    def test_cat_dim0_f32(self):
+        a = torch.tensor([1.0, 2.0, 3.0], device="mps")
+        b = torch.tensor([4.0, 5.0, 6.0], device="mps")
+        result = torch.cat([a, b], dim=0)
+        expected = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    def test_cat_dim0_f16(self):
+        a = torch.tensor([1.0, 2.0], dtype=torch.float16, device="mps")
+        b = torch.tensor([3.0, 4.0], dtype=torch.float16, device="mps")
+        result = torch.cat([a, b], dim=0)
+        expected = np.array([1.0, 2.0, 3.0, 4.0])
+        np.testing.assert_allclose(result.cpu().numpy(), expected, rtol=1e-3)
+
+    def test_cat_dim0_i32(self):
+        a = torch.tensor([1, 2, 3], dtype=torch.int32, device="mps")
+        b = torch.tensor([4, 5, 6], dtype=torch.int32, device="mps")
+        result = torch.cat([a, b], dim=0)
+        expected = np.array([1, 2, 3, 4, 5, 6])
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    def test_cat_dim1(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]], device="mps")
+        b = torch.tensor([[5.0], [6.0]], device="mps")
+        result = torch.cat([a, b], dim=1)
+        expected = np.array([[1.0, 2.0, 5.0], [3.0, 4.0, 6.0]])
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    def test_cat_multiple(self):
+        a = torch.tensor([1.0, 2.0], device="mps")
+        b = torch.tensor([3.0], device="mps")
+        c = torch.tensor([4.0, 5.0, 6.0], device="mps")
+        result = torch.cat([a, b, c], dim=0)
+        expected = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    def test_cat_3d(self):
+        a = torch.arange(12, dtype=torch.float32, device="mps").reshape(2, 2, 3)
+        b = torch.arange(12, 24, dtype=torch.float32, device="mps").reshape(2, 2, 3)
+        result = torch.cat([a, b], dim=0)
+        assert result.shape == (4, 2, 3)
+        expected = np.arange(24, dtype=np.float32).reshape(4, 2, 3)
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    # --- stack ---
+
+    def test_stack_dim0_f32(self):
+        a = torch.tensor([1.0, 2.0, 3.0], device="mps")
+        b = torch.tensor([4.0, 5.0, 6.0], device="mps")
+        result = torch.stack([a, b], dim=0)
+        expected = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    def test_stack_dim0_i32(self):
+        a = torch.tensor([1, 2, 3], dtype=torch.int32, device="mps")
+        b = torch.tensor([4, 5, 6], dtype=torch.int32, device="mps")
+        result = torch.stack([a, b], dim=0)
+        expected = np.array([[1, 2, 3], [4, 5, 6]])
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    def test_stack_dim1(self):
+        a = torch.tensor([1.0, 2.0, 3.0], device="mps")
+        b = torch.tensor([4.0, 5.0, 6.0], device="mps")
+        result = torch.stack([a, b], dim=1)
+        expected = np.array([[1.0, 4.0], [2.0, 5.0], [3.0, 6.0]])
+        np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+    def test_stack_2d(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]], device="mps")
+        b = torch.tensor([[5.0, 6.0], [7.0, 8.0]], device="mps")
+        result = torch.stack([a, b], dim=0)
+        expected = np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], dtype=np.float32)
+        np.testing.assert_allclose(result.cpu().numpy(), expected)


### PR DESCRIPTION
## Summary

- Add native Metal GPU kernels for 8 shape/index ops that previously fell back to numpy: `where`, `masked_fill`, `tril`, `triu`, `index_select`, `gather`, `cat`, `stack`
- These ops are critical for training workloads (attention masks, loss functions, embedding lookup, tensor assembly)
- Continues the MPS GPU kernel series after Phase 1 (#27) and Phase 2 (#28)

## Changes

**`metal_shaders.py`** — 9 kernel templates + 6 generator functions:
- `where` (3 variants: tensor-tensor, scalar_y, scalar_x), `masked_fill`, `tril`, `triu`, `index_select`, `gather`, `cat_copy`

**`metal_compute.py`** — 6 dispatch methods + 6 ctypes encoder fallbacks:
- `dispatch_where`, `dispatch_where_scalar`, `dispatch_masked_fill`, `dispatch_tril_triu`, `dispatch_index_gather`, `dispatch_cat_copy`

**`ops.py`** — GPU paths for all 8 ops:
- Automatic bool-to-uint8 conversion for condition/mask tensors (candle stores Python bools as float32)
- Int32 index casting for Metal compatibility
- `stack` implemented as zero-copy composite (`unsqueeze` + `cat`)
- `cat` uses multi-dispatch: one `cat_copy` kernel per input tensor with increasing offset

**`test_metal_infra.py`** — 33 new tests in `TestPhase3ShapeIndex`

## Test plan

- [x] All 33 Phase 3 tests pass (`pytest tests/mps/test_metal_infra.py::TestPhase3ShapeIndex`)
- [x] Full MPS suite: 198/198 passed, no regressions
- [x] CPU + contract suite: 1348 passed, 25 skipped, no regressions


🤖 Generated with [Claude Code](https://claude.com/claude-code)