### PR TITLE
feat(cpu): add multi_head_attention_forward wrapper

### DIFF
--- a/src/candle/nn/functional.py
+++ b/src/candle/nn/functional.py
@@ -719,6 +719,351 @@ def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.
     return matmul(attn_weight, value)
 
 
+def multi_head_attention_forward(
+    query,
+    key,
+    value,
+    embed_dim_to_check,
+    num_heads,
+    in_proj_weight,
+    in_proj_bias,
+    bias_k,
+    bias_v,
+    add_zero_attn,
+    dropout_p,
+    out_proj_weight,
+    out_proj_bias,
+    training=True,
+    key_padding_mask=None,
+    need_weights=True,
+    attn_mask=None,
+    use_separate_proj_weight=False,
+    q_proj_weight=None,
+    k_proj_weight=None,
+    v_proj_weight=None,
+    static_k=None,
+    static_v=None,
+    average_attn_weights=True,
+    is_causal=False,
+):
+    """Functional multi-head attention forward (torch.nn.functional parity).
+
+    This is a composite wrapper built from existing Candle ops. It intentionally
+    supports the subset needed by `nn.MultiheadAttention` and common usage.
+    """
+
+    import math
+
+    from .._creation import tensor as _tensor
+    from .._dtype import bool as bool_dtype
+    from .._functional import (
+        add as _add,
+        baddbmm as _baddbmm,
+        bmm as _bmm,
+        is_floating_point as _is_floating_point,
+        mean as _mean,
+        mul as _mul,
+        zeros_like as _zeros_like,
+    )
+
+    def _none_or_dtype(t):
+        return None if t is None else t.dtype
+
+    def _canonical_mask(mask, mask_name, other_type, other_name, target_type, *, check_other=True):
+        if mask is None:
+            return None
+        mask_dtype = mask.dtype
+        mask_is_float = _is_floating_point(mask)
+        if mask_dtype != bool_dtype and not mask_is_float:
+            raise AssertionError(f"only bool and floating types of {mask_name} are supported")
+        # Torch warns on mismatched types; we don't replicate warnings.
+        if check_other and other_type is not None and mask_dtype != other_type:
+            pass
+        if not mask_is_float:
+            # torch: zeros_like(mask, dtype=target_type).masked_fill_(mask, -inf)
+            neg_inf = _tensor(float('-inf'), device=query.device)
+            mask = _zeros_like(mask, dtype=target_type).masked_fill_(mask, neg_inf)
+        return mask
+
+    def _mha_shape_check(q, k, v, kpm, am, nh):
+        if q.ndim == 3:
+            is_batched = True
+            assert k.ndim == 3 and v.ndim == 3, (
+                "For batched (3-D) `query`, expected `key` and `value` to be 3-D"
+                f" but found {k.ndim}-D and {v.ndim}-D tensors respectively"
+            )
+            if kpm is not None:
+                assert kpm.ndim == 2, (
+                    "For batched (3-D) `query`, expected `key_padding_mask` to be `None` or 2-D"
+                    f" but found {kpm.ndim}-D tensor instead"
+                )
+            if am is not None:
+                assert am.ndim in (2, 3), (
+                    "For batched (3-D) `query`, expected `attn_mask` to be `None`, 2-D or 3-D"
+                    f" but found {am.ndim}-D tensor instead"
+                )
+        elif q.ndim == 2:
+            is_batched = False
+            assert k.ndim == 2 and v.ndim == 2, (
+                "For unbatched (2-D) `query`, expected `key` and `value` to be 2-D"
+                f" but found {k.ndim}-D and {v.ndim}-D tensors respectively"
+            )
+            if kpm is not None:
+                assert kpm.ndim == 1, (
+                    "For unbatched (2-D) `query`, expected `key_padding_mask` to be `None` or 1-D"
+                    f" but found {kpm.ndim}-D tensor instead"
+                )
+            if am is not None:
+                assert am.ndim in (2, 3), (
+                    "For unbatched (2-D) `query`, expected `attn_mask` to be `None`, 2-D or 3-D"
+                    f" but found {am.ndim}-D tensor instead"
+                )
+                if am.ndim == 3:
+                    expected_shape = (nh, q.shape[0], k.shape[0])
+                    assert am.shape == expected_shape, (
+                        f"Expected `attn_mask` shape to be {expected_shape} but got {am.shape}"
+                    )
+        else:
+            raise AssertionError(
+                f"query should be unbatched 2D or batched 3D tensor but received {q.ndim}-D query tensor"
+            )
+        return is_batched
+
+    def _check_key_padding_mask(kpm, src_len, bsz):
+        assert kpm.shape[0] == bsz, (
+            f"Expected key_padded_mask.shape[0] to be {bsz}, but got {kpm.shape[0]}"
+        )
+        assert kpm.shape[1] == src_len, (
+            f"Expected key_padded_mask.shape[1] to be {src_len}, but got {kpm.shape[1]}"
+        )
+
+    def _in_projection_packed(q, k, v, w, b=None):
+        # Keep the composite path simple and correct: split packed weights and
+        # apply three explicit projections instead of relying on stride-sensitive
+        # view/transposition tricks.
+        w_q, w_k, w_v = w.chunk(3)
+        if b is None:
+            b_q = b_k = b_v = None
+        else:
+            b_q, b_k, b_v = b.chunk(3)
+        return linear(q, w_q, b_q), linear(k, w_k, b_k), linear(v, w_v, b_v)
+
+    def _in_projection(q, k, v, w_q, w_k, w_v, b_q=None, b_k=None, b_v=None):
+        return linear(q, w_q, b_q), linear(k, w_k, b_k), linear(v, w_v, b_v)
+
+    is_batched = _mha_shape_check(query, key, value, key_padding_mask, attn_mask, num_heads)
+    if not is_batched:
+        query = query.unsqueeze(1)
+        key = key.unsqueeze(1)
+        value = value.unsqueeze(1)
+        if key_padding_mask is not None:
+            key_padding_mask = key_padding_mask.unsqueeze(0)
+
+    tgt_len, bsz, embed_dim = query.shape
+    src_len = key.shape[0]
+
+    key_padding_mask = _canonical_mask(
+        key_padding_mask,
+        "key_padding_mask",
+        other_type=_none_or_dtype(attn_mask),
+        other_name="attn_mask",
+        target_type=query.dtype,
+    )
+
+    if is_causal and attn_mask is None:
+        raise RuntimeError(
+            "Need attn_mask if specifying the is_causal hint. "
+            "You may use the Transformer module method "
+            "`generate_square_subsequent_mask` to create this mask."
+        )
+
+    if is_causal and key_padding_mask is None and not need_weights:
+        attn_mask = None
+    else:
+        attn_mask = _canonical_mask(
+            attn_mask,
+            "attn_mask",
+            other_type=None,
+            other_name="",
+            target_type=query.dtype,
+            check_other=False,
+        )
+        if key_padding_mask is not None:
+            is_causal = False
+
+    assert embed_dim == embed_dim_to_check, (
+        f"was expecting embedding dimension of {embed_dim_to_check}, but got {embed_dim}"
+    )
+    head_dim = embed_dim // num_heads
+    assert head_dim * num_heads == embed_dim, (
+        f"embed_dim {embed_dim} not divisible by num_heads {num_heads}"
+    )
+
+    if use_separate_proj_weight:
+        assert key.shape[:2] == value.shape[:2], (
+            f"key's sequence and batch dims {key.shape[:2]} do not match value's {value.shape[:2]}"
+        )
+    else:
+        assert key.shape == value.shape, (
+            f"key shape {key.shape} does not match value shape {value.shape}"
+        )
+
+    # in-projection
+    if not use_separate_proj_weight:
+        assert in_proj_weight is not None, (
+            "use_separate_proj_weight is False but in_proj_weight is None"
+        )
+        q, k, v = _in_projection_packed(query, key, value, in_proj_weight, in_proj_bias)
+    else:
+        assert q_proj_weight is not None, (
+            "use_separate_proj_weight is True but q_proj_weight is None"
+        )
+        assert k_proj_weight is not None, (
+            "use_separate_proj_weight is True but k_proj_weight is None"
+        )
+        assert v_proj_weight is not None, (
+            "use_separate_proj_weight is True but v_proj_weight is None"
+        )
+        if in_proj_bias is None:
+            b_q = b_k = b_v = None
+        else:
+            b_q, b_k, b_v = in_proj_bias.chunk(3)
+        q, k, v = _in_projection(query, key, value, q_proj_weight, k_proj_weight, v_proj_weight, b_q, b_k, b_v)
+
+    # prep attention mask
+    if attn_mask is not None:
+        if attn_mask.ndim == 2:
+            correct_2d_size = (tgt_len, src_len)
+            if attn_mask.shape != correct_2d_size:
+                raise RuntimeError(
+                    f"The shape of the 2D attn_mask is {attn_mask.shape}, but should be {correct_2d_size}."
+                )
+            attn_mask = attn_mask.unsqueeze(0)
+        elif attn_mask.ndim == 3:
+            correct_3d_size = (bsz * num_heads, tgt_len, src_len)
+            if attn_mask.shape != correct_3d_size:
+                raise RuntimeError(
+                    f"The shape of the 3D attn_mask is {attn_mask.shape}, but should be {correct_3d_size}."
+                )
+        else:
+            raise RuntimeError(f"attn_mask's dimension {attn_mask.ndim} is not supported")
+
+    if bias_k is not None and bias_v is not None:
+        assert static_k is None, "bias cannot be added to static key."
+        assert static_v is None, "bias cannot be added to static value."
+        k = cat([k, bias_k.repeat(1, bsz, 1)])
+        v = cat([v, bias_v.repeat(1, bsz, 1)])
+        if attn_mask is not None:
+            attn_mask = pad(attn_mask, (0, 1))
+        if key_padding_mask is not None:
+            key_padding_mask = pad(key_padding_mask, (0, 1))
+    else:
+        assert bias_k is None
+        assert bias_v is None
+
+    # reshape q, k, v for multihead attention and make batch first
+    q = q.reshape(tgt_len, bsz, num_heads, head_dim)
+    q = q.permute(1, 2, 0, 3).contiguous()
+    q = q.reshape(bsz * num_heads, tgt_len, head_dim)
+    if static_k is None:
+        k = k.reshape(k.shape[0], bsz, num_heads, head_dim)
+        k = k.permute(1, 2, 0, 3).contiguous()
+        k = k.reshape(bsz * num_heads, k.shape[2], head_dim)
+    else:
+        assert static_k.shape[0] == bsz * num_heads, (
+            f"expecting static_k.size(0) of {bsz * num_heads}, but got {static_k.shape[0]}"
+        )
+        assert static_k.shape[2] == head_dim, (
+            f"expecting static_k.size(2) of {head_dim}, but got {static_k.shape[2]}"
+        )
+        k = static_k
+    if static_v is None:
+        v = v.reshape(v.shape[0], bsz, num_heads, head_dim)
+        v = v.permute(1, 2, 0, 3).contiguous()
+        v = v.reshape(bsz * num_heads, v.shape[2], head_dim)
+    else:
+        assert static_v.shape[0] == bsz * num_heads, (
+            f"expecting static_v.size(0) of {bsz * num_heads}, but got {static_v.shape[0]}"
+        )
+        assert static_v.shape[2] == head_dim, (
+            f"expecting static_v.size(2) of {head_dim}, but got {static_v.shape[2]}"
+        )
+        v = static_v
+
+    if add_zero_attn:
+        zero_attn_shape = (bsz * num_heads, 1, head_dim)
+        k = cat([k, zeros(zero_attn_shape, dtype=k.dtype, device=k.device)], dim=1)
+        v = cat([v, zeros(zero_attn_shape, dtype=v.dtype, device=v.device)], dim=1)
+        if attn_mask is not None:
+            attn_mask = pad(attn_mask, (0, 1))
+        if key_padding_mask is not None:
+            key_padding_mask = pad(key_padding_mask, (0, 1))
+
+    src_len = k.shape[1]
+
+    if key_padding_mask is not None:
+        _check_key_padding_mask(key_padding_mask, src_len, bsz)
+        key_padding_mask = (
+            key_padding_mask.view(bsz, 1, 1, src_len)
+            .repeat(1, num_heads, 1, 1)
+            .reshape(bsz * num_heads, 1, src_len)
+        )
+        if attn_mask is None:
+            attn_mask = key_padding_mask
+        else:
+            attn_mask = _add(attn_mask, key_padding_mask)
+
+    if not training:
+        dropout_p = 0.0
+
+    if need_weights:
+        # q_scaled = q * sqrt(1/E)
+        _, _, E = q.shape
+        q_scaled = _mul(q, _tensor(math.sqrt(1.0 / float(E)), device=q.device))
+        assert not (is_causal and attn_mask is None), "FIXME: is_causal not implemented for need_weights"
+
+        if attn_mask is not None:
+            attn_output_weights = _baddbmm(attn_mask, q_scaled, k.transpose(-2, -1))
+        else:
+            attn_output_weights = _bmm(q_scaled, k.transpose(-2, -1))
+        attn_output_weights = softmax(attn_output_weights, dim=-1)
+        if dropout_p > 0.0:
+            attn_output_weights = dropout(attn_output_weights, p=dropout_p, training=training)
+
+        attn_output = _bmm(attn_output_weights, v)
+        attn_output = attn_output.transpose(0, 1).contiguous().view(tgt_len * bsz, embed_dim)
+        attn_output = linear(attn_output, out_proj_weight, out_proj_bias)
+        attn_output = attn_output.view(tgt_len, bsz, attn_output.shape[1])
+
+        attn_output_weights = attn_output_weights.view(bsz, num_heads, tgt_len, src_len)
+        if average_attn_weights:
+            attn_output_weights = _mean(attn_output_weights, dim=1)
+
+        if not is_batched:
+            attn_output = attn_output.squeeze(1)
+            attn_output_weights = attn_output_weights.squeeze(0)
+        return attn_output, attn_output_weights
+
+    # need_weights=False branch using SDPA
+    if attn_mask is not None:
+        if attn_mask.shape[0] == 1 and attn_mask.ndim == 3:
+            attn_mask = attn_mask.unsqueeze(0)
+        else:
+            attn_mask = attn_mask.reshape(bsz, num_heads, -1, src_len)
+
+    q = q.reshape(bsz, num_heads, tgt_len, head_dim)
+    k = k.reshape(bsz, num_heads, src_len, head_dim)
+    v = v.reshape(bsz, num_heads, src_len, head_dim)
+
+    attn_output = scaled_dot_product_attention(q, k, v, attn_mask=attn_mask, dropout_p=dropout_p, is_causal=is_causal)
+    attn_output = attn_output.permute(2, 0, 1, 3).contiguous().view(bsz * tgt_len, embed_dim)
+    attn_output = linear(attn_output, out_proj_weight, out_proj_bias)
+    attn_output = attn_output.view(tgt_len, bsz, attn_output.shape[1])
+    if not is_batched:
+        attn_output = attn_output.squeeze(1)
+    return attn_output, None
+
+
 def rms_norm(input, normalized_shape, weight=None, eps=1e-6):
     from .._functional import rms_norm as _rms_norm
     return _rms_norm(input, normalized_shape, weight, eps)
@@ -1673,4 +2018,3 @@ def max_unpool3d(input, indices, kernel_size, stride=None, padding=0, output_siz
     _stride = _kernel_size if stride is None else ((stride, stride, stride) if isinstance(stride, int) else tuple(stride))
     _padding = (padding, padding, padding) if isinstance(padding, int) else tuple(padding)
     return dispatch("max_unpool3d", input.device.type, input, indices, _kernel_size, _stride, _padding, output_size)
-

--- a/tests/cpu/test_nn_functional.py
+++ b/tests/cpu/test_nn_functional.py
@@ -593,3 +593,262 @@ def test_conv_tbc_wrapper_exists():
     ], device='cpu')
     assert out.shape == (2, 1, 1)
     assert torch.allclose(out, expected, atol=1e-6)
+
+
+def test_multi_head_attention_forward_wrapper_exists_basic_need_weights_true():
+    # Basic parity check against torch reference on CPU.
+    import torch as torch_ref
+    import torch.nn.functional as F_ref
+
+    torch_ref.manual_seed(0)
+    L, S, N, E, H = 2, 2, 1, 4, 2
+    query = torch_ref.randn(L, N, E)
+    key = torch_ref.randn(S, N, E)
+    value = torch_ref.randn(S, N, E)
+
+    in_proj_weight = torch_ref.randn(3 * E, E)
+    in_proj_bias = torch_ref.randn(3 * E)
+    out_proj_weight = torch_ref.randn(E, E)
+    out_proj_bias = torch_ref.randn(E)
+
+    out_ref, w_ref = F_ref.multi_head_attention_forward(
+        query,
+        key,
+        value,
+        embed_dim_to_check=E,
+        num_heads=H,
+        in_proj_weight=in_proj_weight,
+        in_proj_bias=in_proj_bias,
+        bias_k=None,
+        bias_v=None,
+        add_zero_attn=False,
+        dropout_p=0.0,
+        out_proj_weight=out_proj_weight,
+        out_proj_bias=out_proj_bias,
+        training=False,
+        key_padding_mask=None,
+        need_weights=True,
+        attn_mask=None,
+        use_separate_proj_weight=False,
+        q_proj_weight=None,
+        k_proj_weight=None,
+        v_proj_weight=None,
+        static_k=None,
+        static_v=None,
+        average_attn_weights=True,
+        is_causal=False,
+    )
+
+    # Run candle version with identical inputs.
+    q = torch.tensor(query.numpy())
+    k = torch.tensor(key.numpy())
+    v = torch.tensor(value.numpy())
+    w = torch.tensor(in_proj_weight.numpy())
+    b = torch.tensor(in_proj_bias.numpy())
+    ow = torch.tensor(out_proj_weight.numpy())
+    ob = torch.tensor(out_proj_bias.numpy())
+
+    out, attn_w = F.multi_head_attention_forward(
+        q,
+        k,
+        v,
+        embed_dim_to_check=E,
+        num_heads=H,
+        in_proj_weight=w,
+        in_proj_bias=b,
+        bias_k=None,
+        bias_v=None,
+        add_zero_attn=False,
+        dropout_p=0.0,
+        out_proj_weight=ow,
+        out_proj_bias=ob,
+        training=False,
+        key_padding_mask=None,
+        need_weights=True,
+        attn_mask=None,
+        use_separate_proj_weight=False,
+        q_proj_weight=None,
+        k_proj_weight=None,
+        v_proj_weight=None,
+        static_k=None,
+        static_v=None,
+        average_attn_weights=True,
+        is_causal=False,
+    )
+
+    assert out.shape == (L, N, E)
+    assert attn_w is not None
+    assert attn_w.shape == (N, L, S)
+    np.testing.assert_allclose(out.numpy(), out_ref.detach().numpy(), rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(attn_w.numpy(), w_ref.detach().numpy(), rtol=1e-5, atol=1e-5)
+
+
+def test_multi_head_attention_forward_attn_mask_bool_and_key_padding_mask_bool():
+    # Verify boolean mask semantics match torch: True means masked out.
+    import torch as torch_ref
+    import torch.nn.functional as F_ref
+
+    torch_ref.manual_seed(0)
+    L, S, N, E, H = 2, 2, 1, 4, 2
+    query = torch_ref.randn(L, N, E)
+    key = torch_ref.randn(S, N, E)
+    value = torch_ref.randn(S, N, E)
+    in_proj_weight = torch_ref.randn(3 * E, E)
+    in_proj_bias = torch_ref.randn(3 * E)
+    out_proj_weight = torch_ref.randn(E, E)
+    out_proj_bias = torch_ref.randn(E)
+
+    attn_mask = torch_ref.tensor([[False, True], [False, False]])
+    key_padding_mask = torch_ref.tensor([[False, True]])
+
+    out_ref, w_ref = F_ref.multi_head_attention_forward(
+        query,
+        key,
+        value,
+        embed_dim_to_check=E,
+        num_heads=H,
+        in_proj_weight=in_proj_weight,
+        in_proj_bias=in_proj_bias,
+        bias_k=None,
+        bias_v=None,
+        add_zero_attn=False,
+        dropout_p=0.0,
+        out_proj_weight=out_proj_weight,
+        out_proj_bias=out_proj_bias,
+        training=False,
+        key_padding_mask=key_padding_mask,
+        need_weights=True,
+        attn_mask=attn_mask,
+        use_separate_proj_weight=False,
+        q_proj_weight=None,
+        k_proj_weight=None,
+        v_proj_weight=None,
+        static_k=None,
+        static_v=None,
+        average_attn_weights=True,
+        is_causal=False,
+    )
+
+    q = torch.tensor(query.numpy())
+    k = torch.tensor(key.numpy())
+    v = torch.tensor(value.numpy())
+    w = torch.tensor(in_proj_weight.numpy())
+    b = torch.tensor(in_proj_bias.numpy())
+    ow = torch.tensor(out_proj_weight.numpy())
+    ob = torch.tensor(out_proj_bias.numpy())
+    am = torch.tensor(attn_mask.numpy(), dtype=torch.bool)
+    kpm = torch.tensor(key_padding_mask.numpy(), dtype=torch.bool)
+
+    out, attn_w = F.multi_head_attention_forward(
+        q,
+        k,
+        v,
+        embed_dim_to_check=E,
+        num_heads=H,
+        in_proj_weight=w,
+        in_proj_bias=b,
+        bias_k=None,
+        bias_v=None,
+        add_zero_attn=False,
+        dropout_p=0.0,
+        out_proj_weight=ow,
+        out_proj_bias=ob,
+        training=False,
+        key_padding_mask=kpm,
+        need_weights=True,
+        attn_mask=am,
+        use_separate_proj_weight=False,
+        q_proj_weight=None,
+        k_proj_weight=None,
+        v_proj_weight=None,
+        static_k=None,
+        static_v=None,
+        average_attn_weights=True,
+        is_causal=False,
+    )
+
+    np.testing.assert_allclose(out.numpy(), out_ref.detach().numpy(), rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(attn_w.numpy(), w_ref.detach().numpy(), rtol=1e-5, atol=1e-5)
+
+
+def test_multi_head_attention_forward_wrapper_need_weights_false_returns_none_weights():
+    import torch as torch_ref
+    import torch.nn.functional as F_ref
+
+    torch_ref.manual_seed(0)
+    L, S, N, E, H = 2, 2, 1, 4, 2
+    query = torch_ref.randn(L, N, E)
+    key = torch_ref.randn(S, N, E)
+    value = torch_ref.randn(S, N, E)
+    in_proj_weight = torch_ref.randn(3 * E, E)
+    in_proj_bias = torch_ref.randn(3 * E)
+    out_proj_weight = torch_ref.randn(E, E)
+    out_proj_bias = torch_ref.randn(E)
+
+    out_ref, w_ref = F_ref.multi_head_attention_forward(
+        query,
+        key,
+        value,
+        embed_dim_to_check=E,
+        num_heads=H,
+        in_proj_weight=in_proj_weight,
+        in_proj_bias=in_proj_bias,
+        bias_k=None,
+        bias_v=None,
+        add_zero_attn=False,
+        dropout_p=0.0,
+        out_proj_weight=out_proj_weight,
+        out_proj_bias=out_proj_bias,
+        training=False,
+        key_padding_mask=None,
+        need_weights=False,
+        attn_mask=None,
+        use_separate_proj_weight=False,
+        q_proj_weight=None,
+        k_proj_weight=None,
+        v_proj_weight=None,
+        static_k=None,
+        static_v=None,
+        average_attn_weights=True,
+        is_causal=False,
+    )
+    assert w_ref is None
+
+    q = torch.tensor(query.numpy())
+    k = torch.tensor(key.numpy())
+    v = torch.tensor(value.numpy())
+    w = torch.tensor(in_proj_weight.numpy())
+    b = torch.tensor(in_proj_bias.numpy())
+    ow = torch.tensor(out_proj_weight.numpy())
+    ob = torch.tensor(out_proj_bias.numpy())
+
+    out, attn_w = F.multi_head_attention_forward(
+        q,
+        k,
+        v,
+        embed_dim_to_check=E,
+        num_heads=H,
+        in_proj_weight=w,
+        in_proj_bias=b,
+        bias_k=None,
+        bias_v=None,
+        add_zero_attn=False,
+        dropout_p=0.0,
+        out_proj_weight=ow,
+        out_proj_bias=ob,
+        training=False,
+        key_padding_mask=None,
+        need_weights=False,
+        attn_mask=None,
+        use_separate_proj_weight=False,
+        q_proj_weight=None,
+        k_proj_weight=None,
+        v_proj_weight=None,
+        static_k=None,
+        static_v=None,
+        average_attn_weights=True,
+        is_causal=False,
+    )
+
+    assert attn_w is None
+    np.testing.assert_allclose(out.numpy(), out_ref.detach().numpy(), rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
## Summary
- add `multi_head_attention_forward` functional wrapper using existing ops
- align mask semantics and head reshaping with torch CPU
- add CPU nn.functional parity tests for attention forward

## Testing
- `PYTHONPATH=src pytest tests/cpu/test_nn_functional.py -k "multi_head_attention_forward" -q`
- `PYTHONPATH=src pytest tests/cpu/test_nn_functional.py -q`
