### PR TITLE
feat(mps): GPU-native Philox 4x32-10 RNG

### DIFF
--- a/docs/plans/2026-03-11-mps-gpu-rng-design.md
+++ b/docs/plans/2026-03-11-mps-gpu-rng-design.md
@@ -1,0 +1,67 @@
+# MPS GPU RNG — Philox 4x32-10
+
+## Goal
+
+Replace CPU-side numpy RNG for MPS tensors with GPU-native Philox 4x32-10 PRNG via Metal shaders. Per-device generators with deterministic self-consistent reproducibility.
+
+## Philox Metal Shaders
+
+Core Philox 4x32-10 implemented as MSL utility functions. Each thread computes `philox4x32_10(uint4 counter, uint2 key) -> uint4` independently.
+
+- **Counter**: `(gid, 0, offset, 0)` — gid = thread index, offset = per-op counter
+- **Key**: `(seed_lo, seed_hi)` — from 64-bit seed
+- **Output**: 4 random uint32 per call
+
+Kernels (each thread produces 4 output elements):
+
+| Kernel | Conversion |
+|--------|------------|
+| `philox_uniform_f32/f16` | `(uint >> 8) * (1/2^24)` → [0,1), then `low + val*(high-low)` |
+| `philox_normal_f32/f16` | Box-Muller on 2 uniform pairs → 4 normals, then `mean + val*std` |
+| `philox_bernoulli_f32` | uniform < p ? 1.0 : 0.0 |
+| `philox_randint_i32/i64` | `low + (uint % range)` |
+| `philox_dropout_f32/f16` | Fused: generate mask + multiply + scale in one kernel |
+
+Generator offset advances by `ceil(N/4)` per op.
+
+## Generator Class
+
+`_random.py::Generator` gains `device='mps'` support:
+- Stores `(seed, offset)`, no numpy RNG
+- `philox_engine_inputs(num_elements)` returns `(seed, offset)`, advances offset
+
+New `src/candle/mps.py`:
+- `is_available()`, `manual_seed(seed)`, `_default_generator`
+
+`manual_seed()` propagates to MPS (like NPU).
+
+## Op Integration
+
+### Creation (`mps/creation.py`)
+- `rand_create` → `philox_uniform` kernel
+- `randn_create` → `philox_normal` kernel
+- `randint_create` → `philox_randint` kernel
+- `randperm_create` → `philox_uniform` on GPU → CPU argsort → copy back
+
+### In-place (`mps/ops.py`)
+- `uniform_`, `normal_`, `bernoulli_` → GPU Philox kernels with `_can_use_gpu` guard
+
+### Dropout (`mps/ops.py`)
+- Fused `philox_dropout` kernel (mask + multiply + scale)
+
+### Dispatch (`metal_compute.py`)
+- `dispatch_philox_fill(kernel, out_buf, seed_lo, seed_hi, offset, N)`
+- `dispatch_philox_fill_params(kernel, out_buf, seed_lo, seed_hi, offset, p1, p2, N)`
+- `dispatch_philox_dropout(kernel, a_buf, out_buf, seed_lo, seed_hi, offset, prob, scale, N)`
+
+## Files
+
+| File | Changes |
+|------|---------|
+| `metal_shaders.py` | Philox utility + 5 kernel templates + generators |
+| `metal_compute.py` | 3 dispatch methods + ctypes encoders |
+| `creation.py` | GPU paths for rand/randn/randint/randperm |
+| `ops.py` | GPU paths for uniform_/normal_/bernoulli_/dropout |
+| `_random.py` | Generator MPS support, seed propagation |
+| `mps.py` | New module |
+| `test_mps_rng.py` | ~20 tests |

--- a/src/candle/_backends/mps/creation.py
+++ b/src/candle/_backends/mps/creation.py
@@ -1,3 +1,5 @@
+import ctypes
+
 import numpy as np
 
 from ..._dtype import to_numpy_dtype
@@ -12,6 +14,21 @@ def _contiguous_stride(shape):
         stride.append(acc)
         acc *= d
     return tuple(reversed(stride))
+
+
+def _get_mps_generator(generator=None):
+    """Return an MPS Philox generator (user-provided or default)."""
+    if generator is not None and hasattr(generator, 'device') and generator.device.type == 'mps':
+        return generator
+    from ...mps import _get_default_generator
+    return _get_default_generator()
+
+
+def _philox_seed_parts(gen, numel):
+    """Get (seed_lo, seed_hi, offset) and advance the generator."""
+    increment = (numel + 3) // 4
+    seed, offset = gen.philox_engine_inputs(increment)
+    return seed & 0xffffffff, (seed >> 32) & 0xffffffff, offset
 
 
 def tensor_create(data, dtype=None, device=None, requires_grad=False, memory_format=None):
@@ -104,6 +121,25 @@ def randn_create(shape, dtype=None, device=None, requires_grad=False, memory_for
     if isinstance(shape, int):
         shape = (shape,)
     shape = tuple(shape)
+    from ..._dtype import float32 as f32, float16 as f16
+    out_dtype = dtype if dtype is not None else f32
+    numel = 1
+    for s in shape:
+        numel *= s
+    if out_dtype in (f32, f16) and numel > 0:
+        gen = _get_mps_generator(generator)
+        seed_lo, seed_hi, offset = _philox_seed_parts(gen, numel)
+        sfx = "f32" if out_dtype == f32 else "f16"
+        fmt = "f" if out_dtype == f32 else "e"
+        from .ops import _alloc_output_buf, _from_metal_buffer, _get_dispatcher
+        out_buf = _alloc_output_buf(numel, out_dtype)
+        _get_dispatcher().dispatch_philox_fill(
+            f"philox_normal_{sfx}", out_buf, seed_lo, seed_hi, offset,
+            0.0, 1.0, numel, param_fmt=fmt)
+        stride = _contiguous_stride(shape)
+        t = _from_metal_buffer(out_buf, shape, stride, out_dtype, device)
+        t.requires_grad = requires_grad
+        return t
     from ..._random import _get_cpu_rng
     rng = generator._rng if (generator is not None and hasattr(generator, '_rng') and generator._rng is not None) else _get_cpu_rng()
     arr = rng.randn(*shape).astype(to_numpy_dtype(dtype))
@@ -116,6 +152,25 @@ def rand_create(shape, dtype=None, device=None, requires_grad=False, memory_form
     if isinstance(shape, int):
         shape = (shape,)
     shape = tuple(shape)
+    from ..._dtype import float32 as f32, float16 as f16
+    out_dtype = dtype if dtype is not None else f32
+    numel = 1
+    for s in shape:
+        numel *= s
+    if out_dtype in (f32, f16) and numel > 0:
+        gen = _get_mps_generator(generator)
+        seed_lo, seed_hi, offset = _philox_seed_parts(gen, numel)
+        sfx = "f32" if out_dtype == f32 else "f16"
+        fmt = "f" if out_dtype == f32 else "e"
+        from .ops import _alloc_output_buf, _from_metal_buffer, _get_dispatcher
+        out_buf = _alloc_output_buf(numel, out_dtype)
+        _get_dispatcher().dispatch_philox_fill(
+            f"philox_uniform_{sfx}", out_buf, seed_lo, seed_hi, offset,
+            0.0, 1.0, numel, param_fmt=fmt)
+        stride = _contiguous_stride(shape)
+        t = _from_metal_buffer(out_buf, shape, stride, out_dtype, device)
+        t.requires_grad = requires_grad
+        return t
     from ..._random import _get_cpu_rng
     rng = generator._rng if (generator is not None and hasattr(generator, '_rng') and generator._rng is not None) else _get_cpu_rng()
     arr = rng.random_sample(shape).astype(to_numpy_dtype(dtype))
@@ -125,7 +180,7 @@ def rand_create(shape, dtype=None, device=None, requires_grad=False, memory_form
 
 
 def randint_create(low, high=None, size=None, dtype=None, device=None, requires_grad=False, generator=None, **kwargs):
-    from ..._dtype import int64 as int64_dtype
+    from ..._dtype import int32 as i32, int64 as i64
     if high is None:
         low, high = 0, low
     if size is None:
@@ -133,21 +188,55 @@ def randint_create(low, high=None, size=None, dtype=None, device=None, requires_
     if isinstance(size, int):
         size = (size,)
     size = tuple(size)
+    out_dtype = dtype if dtype is not None else i64
+    numel = 1
+    for s in size:
+        numel *= s
+    if out_dtype in (i32, i64) and numel > 0:
+        gen = _get_mps_generator(generator)
+        seed_lo, seed_hi, offset = _philox_seed_parts(gen, numel)
+        sfx = "i32" if out_dtype == i32 else "i64"
+        int_fmt = "i" if out_dtype == i32 else "q"
+        from .ops import _alloc_output_buf, _from_metal_buffer, _get_dispatcher
+        out_buf = _alloc_output_buf(numel, out_dtype)
+        _get_dispatcher().dispatch_philox_randint(
+            f"philox_randint_{sfx}", out_buf, int(low), int(high),
+            seed_lo, seed_hi, offset, numel, int_fmt=int_fmt)
+        stride = _contiguous_stride(size)
+        t = _from_metal_buffer(out_buf, size, stride, out_dtype, device)
+        t.requires_grad = requires_grad
+        return t
     from ..._random import _get_cpu_rng
     rng = generator._rng if (generator is not None and hasattr(generator, '_rng') and generator._rng is not None) else _get_cpu_rng()
     arr = rng.randint(int(low), int(high), size=size).astype(np.int64)
-    out_dtype = dtype if dtype is not None else int64_dtype
     storage = mps_typed_storage_from_numpy(arr.ravel(), out_dtype, device=device)
     stride = _contiguous_stride(size)
     return Tensor(storage, size, stride, requires_grad=requires_grad)
 
 
 def randperm_create(n, dtype=None, device=None, requires_grad=False, generator=None, **kwargs):
-    from ..._dtype import int64 as int64_dtype
-    from ..._random import _get_cpu_rng
-    rng = generator._rng if (generator is not None and hasattr(generator, '_rng') and generator._rng is not None) else _get_cpu_rng()
-    arr = rng.permutation(int(n)).astype(np.int64)
-    out_dtype = dtype if dtype is not None else int64_dtype
-    storage = mps_typed_storage_from_numpy(arr.ravel(), out_dtype, device=device)
+    from ..._dtype import int64 as i64, float32 as f32
+    n = int(n)
+    out_dtype = dtype if dtype is not None else i64
+    if n > 0:
+        # Generate n uniform floats on GPU, argsort on CPU, copy back
+        gen = _get_mps_generator(generator)
+        seed_lo, seed_hi, offset = _philox_seed_parts(gen, n)
+        from .ops import _alloc_output_buf, _get_dispatcher
+        from .runtime import buffer_contents
+        float_buf = _alloc_output_buf(n, f32)
+        _get_dispatcher().dispatch_philox_fill(
+            "philox_uniform_f32", float_buf, seed_lo, seed_hi, offset,
+            0.0, 1.0, n, param_fmt="f")
+        ptr = buffer_contents(float_buf)
+        float_arr = np.frombuffer(
+            (ctypes.c_uint8 * (n * 4)).from_address(ptr),
+            dtype=np.float32, count=n)
+        indices = np.argsort(float_arr).astype(to_numpy_dtype(out_dtype))
+        storage = mps_typed_storage_from_numpy(indices, out_dtype, device=device)
+        stride = _contiguous_stride(indices.shape)
+        return Tensor(storage, indices.shape, stride, requires_grad=requires_grad)
+    arr = np.array([], dtype=to_numpy_dtype(out_dtype))
+    storage = mps_typed_storage_from_numpy(arr, out_dtype, device=device)
     stride = _contiguous_stride(arr.shape)
     return Tensor(storage, arr.shape, stride, requires_grad=requires_grad)

--- a/src/candle/_backends/mps/metal_compute.py
+++ b/src/candle/_backends/mps/metal_compute.py
@@ -837,6 +837,161 @@ class MetalKernelDispatcher:
         rt.commit_and_wait(cmd)
 
     # ------------------------------------------------------------------
+    # Dispatch: Philox RNG fill  (seed, offset → output)
+    # ------------------------------------------------------------------
+
+    def dispatch_philox_fill(self, kernel_name, out_buf, seed_lo, seed_hi,
+                             offset, param1, param2, numel,
+                             param_fmt="f"):
+        """Encode Philox RNG fill kernel (1 buf + 2 seed uint + 1 offset uint
+        + 2 params + 1 N uint). Works for uniform (low/high),
+        normal (mean/std)."""
+        rt = get_runtime()
+        pipeline = self._get_pipeline(kernel_name)
+        tpg = self._threads_per_group(pipeline)
+        threads = (numel + 3) // 4  # each thread produces 4 values
+        groups = (threads + tpg - 1) // tpg
+
+        cmd = rt.create_command_buffer()
+        enc = rt.get_compute_encoder(cmd)
+
+        p1_bytes = struct.pack(param_fmt, param1)
+        p2_bytes = struct.pack(param_fmt, param2)
+        p_size = len(p1_bytes)
+
+        if _HAS_PYOBJC:
+            enc.setComputePipelineState_(pipeline)
+            enc.setBuffer_offset_atIndex_(out_buf, 0, 0)
+            enc.setBytes_length_atIndex_(struct.pack("I", seed_lo), 4, 1)
+            enc.setBytes_length_atIndex_(struct.pack("I", seed_hi), 4, 2)
+            enc.setBytes_length_atIndex_(struct.pack("I", offset), 4, 3)
+            enc.setBytes_length_atIndex_(p1_bytes, p_size, 4)
+            enc.setBytes_length_atIndex_(p2_bytes, p_size, 5)
+            enc.setBytes_length_atIndex_(struct.pack("I", numel), 4, 6)
+            enc.dispatchThreadgroups_threadsPerThreadgroup_(
+                _MTLSize(groups, 1, 1), _MTLSize(tpg, 1, 1))
+            enc.endEncoding()
+        else:
+            _encode_philox_fill_ctypes(enc, pipeline, out_buf,
+                                       seed_lo, seed_hi, offset,
+                                       p1_bytes, p2_bytes, p_size,
+                                       numel, groups, tpg)
+
+        rt.commit_and_wait(cmd)
+
+    # ------------------------------------------------------------------
+    # Dispatch: Philox bernoulli  (prob, seed, offset → output)
+    # ------------------------------------------------------------------
+
+    def dispatch_philox_bernoulli(self, kernel_name, out_buf, prob,
+                                  seed_lo, seed_hi, offset, numel):
+        """Encode Philox bernoulli kernel (1 buf + prob + 2 seed + offset + N)."""
+        rt = get_runtime()
+        pipeline = self._get_pipeline(kernel_name)
+        tpg = self._threads_per_group(pipeline)
+        threads = (numel + 3) // 4
+        groups = (threads + tpg - 1) // tpg
+
+        cmd = rt.create_command_buffer()
+        enc = rt.get_compute_encoder(cmd)
+
+        if _HAS_PYOBJC:
+            enc.setComputePipelineState_(pipeline)
+            enc.setBuffer_offset_atIndex_(out_buf, 0, 0)
+            enc.setBytes_length_atIndex_(struct.pack("f", prob), 4, 1)
+            enc.setBytes_length_atIndex_(struct.pack("I", seed_lo), 4, 2)
+            enc.setBytes_length_atIndex_(struct.pack("I", seed_hi), 4, 3)
+            enc.setBytes_length_atIndex_(struct.pack("I", offset), 4, 4)
+            enc.setBytes_length_atIndex_(struct.pack("I", numel), 4, 5)
+            enc.dispatchThreadgroups_threadsPerThreadgroup_(
+                _MTLSize(groups, 1, 1), _MTLSize(tpg, 1, 1))
+            enc.endEncoding()
+        else:
+            _encode_philox_bernoulli_ctypes(enc, pipeline, out_buf, prob,
+                                            seed_lo, seed_hi, offset,
+                                            numel, groups, tpg)
+
+        rt.commit_and_wait(cmd)
+
+    # ------------------------------------------------------------------
+    # Dispatch: Philox randint  (low, high, seed, offset → output)
+    # ------------------------------------------------------------------
+
+    def dispatch_philox_randint(self, kernel_name, out_buf, low, high,
+                                seed_lo, seed_hi, offset, numel,
+                                int_fmt="i"):
+        """Encode Philox randint kernel."""
+        rt = get_runtime()
+        pipeline = self._get_pipeline(kernel_name)
+        tpg = self._threads_per_group(pipeline)
+        threads = (numel + 3) // 4
+        groups = (threads + tpg - 1) // tpg
+
+        cmd = rt.create_command_buffer()
+        enc = rt.get_compute_encoder(cmd)
+
+        lo_bytes = struct.pack(int_fmt, low)
+        hi_bytes = struct.pack(int_fmt, high)
+        i_size = len(lo_bytes)
+
+        if _HAS_PYOBJC:
+            enc.setComputePipelineState_(pipeline)
+            enc.setBuffer_offset_atIndex_(out_buf, 0, 0)
+            enc.setBytes_length_atIndex_(lo_bytes, i_size, 1)
+            enc.setBytes_length_atIndex_(hi_bytes, i_size, 2)
+            enc.setBytes_length_atIndex_(struct.pack("I", seed_lo), 4, 3)
+            enc.setBytes_length_atIndex_(struct.pack("I", seed_hi), 4, 4)
+            enc.setBytes_length_atIndex_(struct.pack("I", offset), 4, 5)
+            enc.setBytes_length_atIndex_(struct.pack("I", numel), 4, 6)
+            enc.dispatchThreadgroups_threadsPerThreadgroup_(
+                _MTLSize(groups, 1, 1), _MTLSize(tpg, 1, 1))
+            enc.endEncoding()
+        else:
+            _encode_philox_randint_ctypes(enc, pipeline, out_buf,
+                                          lo_bytes, hi_bytes, i_size,
+                                          seed_lo, seed_hi, offset,
+                                          numel, groups, tpg)
+
+        rt.commit_and_wait(cmd)
+
+    # ------------------------------------------------------------------
+    # Dispatch: Philox dropout  (input → output, fused mask+scale)
+    # ------------------------------------------------------------------
+
+    def dispatch_philox_dropout(self, kernel_name, a_buf, out_buf,
+                                prob, scale, seed_lo, seed_hi, offset,
+                                numel):
+        """Encode fused Philox dropout kernel."""
+        rt = get_runtime()
+        pipeline = self._get_pipeline(kernel_name)
+        tpg = self._threads_per_group(pipeline)
+        threads = (numel + 3) // 4
+        groups = (threads + tpg - 1) // tpg
+
+        cmd = rt.create_command_buffer()
+        enc = rt.get_compute_encoder(cmd)
+
+        if _HAS_PYOBJC:
+            enc.setComputePipelineState_(pipeline)
+            enc.setBuffer_offset_atIndex_(a_buf, 0, 0)
+            enc.setBuffer_offset_atIndex_(out_buf, 0, 1)
+            enc.setBytes_length_atIndex_(struct.pack("f", prob), 4, 2)
+            enc.setBytes_length_atIndex_(struct.pack("f", scale), 4, 3)
+            enc.setBytes_length_atIndex_(struct.pack("I", seed_lo), 4, 4)
+            enc.setBytes_length_atIndex_(struct.pack("I", seed_hi), 4, 5)
+            enc.setBytes_length_atIndex_(struct.pack("I", offset), 4, 6)
+            enc.setBytes_length_atIndex_(struct.pack("I", numel), 4, 7)
+            enc.dispatchThreadgroups_threadsPerThreadgroup_(
+                _MTLSize(groups, 1, 1), _MTLSize(tpg, 1, 1))
+            enc.endEncoding()
+        else:
+            _encode_philox_dropout_ctypes(enc, pipeline, a_buf, out_buf,
+                                          prob, scale, seed_lo, seed_hi,
+                                          offset, numel, groups, tpg)
+
+        rt.commit_and_wait(cmd)
+
+    # ------------------------------------------------------------------
     # Dispatch: axis reduction  (input → reduced output along dim)
     # ------------------------------------------------------------------
 
@@ -1214,8 +1369,72 @@ def _encode_clamp_strided_ctypes(enc, pipeline, a_buf, s1_bytes, s2_bytes,
 
 
 # ---------------------------------------------------------------------------
-# Phase 3: shape & index ctypes encoders
+# Philox RNG ctypes encoders
 # ---------------------------------------------------------------------------
+
+def _encode_philox_fill_ctypes(enc, pipeline, out_buf, seed_lo, seed_hi,
+                                offset, p1_bytes, p2_bytes, p_size,
+                                numel, groups, tpg):
+    """Encode Philox fill (uniform/normal) kernel via ctypes."""
+    _ctypes_set_pipeline(enc, pipeline)
+    _ctypes_set_buffer(enc, out_buf, 0, 0)
+    _ctypes_set_bytes(enc, struct.pack("I", seed_lo), 4, 1)
+    _ctypes_set_bytes(enc, struct.pack("I", seed_hi), 4, 2)
+    _ctypes_set_bytes(enc, struct.pack("I", offset), 4, 3)
+    _ctypes_set_bytes(enc, p1_bytes, p_size, 4)
+    _ctypes_set_bytes(enc, p2_bytes, p_size, 5)
+    _ctypes_set_bytes(enc, struct.pack("I", numel), 4, 6)
+    _ctypes_dispatch_threadgroups(enc, groups, tpg)
+    _ctypes_end_encoding(enc)
+
+
+def _encode_philox_bernoulli_ctypes(enc, pipeline, out_buf, prob,
+                                     seed_lo, seed_hi, offset,
+                                     numel, groups, tpg):
+    """Encode Philox bernoulli kernel via ctypes."""
+    _ctypes_set_pipeline(enc, pipeline)
+    _ctypes_set_buffer(enc, out_buf, 0, 0)
+    _ctypes_set_bytes(enc, struct.pack("f", prob), 4, 1)
+    _ctypes_set_bytes(enc, struct.pack("I", seed_lo), 4, 2)
+    _ctypes_set_bytes(enc, struct.pack("I", seed_hi), 4, 3)
+    _ctypes_set_bytes(enc, struct.pack("I", offset), 4, 4)
+    _ctypes_set_bytes(enc, struct.pack("I", numel), 4, 5)
+    _ctypes_dispatch_threadgroups(enc, groups, tpg)
+    _ctypes_end_encoding(enc)
+
+
+def _encode_philox_randint_ctypes(enc, pipeline, out_buf,
+                                   lo_bytes, hi_bytes, i_size,
+                                   seed_lo, seed_hi, offset,
+                                   numel, groups, tpg):
+    """Encode Philox randint kernel via ctypes."""
+    _ctypes_set_pipeline(enc, pipeline)
+    _ctypes_set_buffer(enc, out_buf, 0, 0)
+    _ctypes_set_bytes(enc, lo_bytes, i_size, 1)
+    _ctypes_set_bytes(enc, hi_bytes, i_size, 2)
+    _ctypes_set_bytes(enc, struct.pack("I", seed_lo), 4, 3)
+    _ctypes_set_bytes(enc, struct.pack("I", seed_hi), 4, 4)
+    _ctypes_set_bytes(enc, struct.pack("I", offset), 4, 5)
+    _ctypes_set_bytes(enc, struct.pack("I", numel), 4, 6)
+    _ctypes_dispatch_threadgroups(enc, groups, tpg)
+    _ctypes_end_encoding(enc)
+
+
+def _encode_philox_dropout_ctypes(enc, pipeline, a_buf, out_buf,
+                                   prob, scale, seed_lo, seed_hi,
+                                   offset, numel, groups, tpg):
+    """Encode fused Philox dropout kernel via ctypes."""
+    _ctypes_set_pipeline(enc, pipeline)
+    _ctypes_set_buffer(enc, a_buf, 0, 0)
+    _ctypes_set_buffer(enc, out_buf, 0, 1)
+    _ctypes_set_bytes(enc, struct.pack("f", prob), 4, 2)
+    _ctypes_set_bytes(enc, struct.pack("f", scale), 4, 3)
+    _ctypes_set_bytes(enc, struct.pack("I", seed_lo), 4, 4)
+    _ctypes_set_bytes(enc, struct.pack("I", seed_hi), 4, 5)
+    _ctypes_set_bytes(enc, struct.pack("I", offset), 4, 6)
+    _ctypes_set_bytes(enc, struct.pack("I", numel), 4, 7)
+    _ctypes_dispatch_threadgroups(enc, groups, tpg)
+    _ctypes_end_encoding(enc)
 
 def _encode_where_ctypes(enc, pipeline, cond_buf, x_buf, y_buf, out_buf,
                           numel, groups, tpg):

--- a/src/candle/_backends/mps/metal_shaders.py
+++ b/src/candle/_backends/mps/metal_shaders.py
@@ -764,9 +764,221 @@ kernel void relu_inplace_f16(device half* a [[buffer(0)]],
 """
 
 
+# ---------------------------------------------------------------------------
+# Philox 4x32-10 PRNG utility (shared across all RNG kernels)
+# ---------------------------------------------------------------------------
+
+_PHILOX_UTILITY = """
+// Philox 4x32-10 counter-based PRNG
+// Each call produces 4 independent uint32 random values.
+
+constant uint PHILOX_M0 = 0xD2511F53u;
+constant uint PHILOX_M1 = 0xCD9E8D57u;
+constant uint PHILOX_W0 = 0x9E3779B9u;
+constant uint PHILOX_W1 = 0xBB67AE85u;
+
+static inline uint4 philox4x32_round(uint4 ctr, uint2 key) {
+    ulong p0 = (ulong)PHILOX_M0 * (ulong)ctr.x;
+    ulong p1 = (ulong)PHILOX_M1 * (ulong)ctr.z;
+    return uint4(
+        (uint)(p1 >> 32) ^ ctr.y ^ key.x,
+        (uint)p1,
+        (uint)(p0 >> 32) ^ ctr.w ^ key.y,
+        (uint)p0
+    );
+}
+
+static inline uint4 philox4x32_10(uint4 ctr, uint2 key) {
+    for (int i = 0; i < 10; i++) {
+        ctr = philox4x32_round(ctr, key);
+        key.x += PHILOX_W0;
+        key.y += PHILOX_W1;
+    }
+    return ctr;
+}
+
+static inline float uint_to_uniform_f32(uint x) {
+    return (float)(x >> 8) * 5.9604644775390625e-08f;  // 1.0 / (1 << 24)
+}
+"""
+
+# ---------------------------------------------------------------------------
+# Templates: Philox RNG kernels
+# ---------------------------------------------------------------------------
+
+_PHILOX_UNIFORM_TEMPLATE = """
+kernel void philox_uniform_{suffix}(device {type}* output  [[buffer(0)]],
+                                     constant uint& seed_lo [[buffer(1)]],
+                                     constant uint& seed_hi [[buffer(2)]],
+                                     constant uint& offset  [[buffer(3)]],
+                                     constant {type}& low   [[buffer(4)]],
+                                     constant {type}& high  [[buffer(5)]],
+                                     constant uint& N       [[buffer(6)]],
+                                     uint gid [[thread_position_in_grid]]) {{
+    uint base = gid * 4;
+    if (base >= N) return;
+    uint4 ctr = uint4(gid, 0, offset, 0);
+    uint2 key = uint2(seed_lo, seed_hi);
+    uint4 r = philox4x32_10(ctr, key);
+    {type} range = high - low;
+    if (base < N) output[base] = ({type})(low + ({type})uint_to_uniform_f32(r.x) * range);
+    if (base + 1u < N) output[base + 1u] = ({type})(low + ({type})uint_to_uniform_f32(r.y) * range);
+    if (base + 2u < N) output[base + 2u] = ({type})(low + ({type})uint_to_uniform_f32(r.z) * range);
+    if (base + 3u < N) output[base + 3u] = ({type})(low + ({type})uint_to_uniform_f32(r.w) * range);
+}}
+"""
+
+_PHILOX_NORMAL_TEMPLATE = """
+kernel void philox_normal_{suffix}(device {type}* output  [[buffer(0)]],
+                                    constant uint& seed_lo [[buffer(1)]],
+                                    constant uint& seed_hi [[buffer(2)]],
+                                    constant uint& offset  [[buffer(3)]],
+                                    constant float& mean   [[buffer(4)]],
+                                    constant float& stddev [[buffer(5)]],
+                                    constant uint& N       [[buffer(6)]],
+                                    uint gid [[thread_position_in_grid]]) {{
+    uint base = gid * 4;
+    if (base >= N) return;
+    uint4 ctr = uint4(gid, 0, offset, 0);
+    uint2 key = uint2(seed_lo, seed_hi);
+    uint4 r = philox4x32_10(ctr, key);
+    float u1 = max(uint_to_uniform_f32(r.x), 1.17549435e-38f);
+    float u2 = uint_to_uniform_f32(r.y);
+    float u3 = max(uint_to_uniform_f32(r.z), 1.17549435e-38f);
+    float u4 = uint_to_uniform_f32(r.w);
+    float mag1 = sqrt(-2.0f * log(u1));
+    float mag2 = sqrt(-2.0f * log(u3));
+    float two_pi = 6.283185307179586f;
+    if (base < N) output[base] = ({type})(mean + stddev * mag1 * cos(two_pi * u2));
+    if (base + 1u < N) output[base + 1u] = ({type})(mean + stddev * mag1 * sin(two_pi * u2));
+    if (base + 2u < N) output[base + 2u] = ({type})(mean + stddev * mag2 * cos(two_pi * u4));
+    if (base + 3u < N) output[base + 3u] = ({type})(mean + stddev * mag2 * sin(two_pi * u4));
+}}
+"""
+
+_PHILOX_BERNOULLI_TEMPLATE = """
+kernel void philox_bernoulli_{suffix}(device {type}* output  [[buffer(0)]],
+                                       constant float& prob   [[buffer(1)]],
+                                       constant uint& seed_lo [[buffer(2)]],
+                                       constant uint& seed_hi [[buffer(3)]],
+                                       constant uint& offset  [[buffer(4)]],
+                                       constant uint& N       [[buffer(5)]],
+                                       uint gid [[thread_position_in_grid]]) {{
+    uint base = gid * 4;
+    if (base >= N) return;
+    uint4 ctr = uint4(gid, 0, offset, 0);
+    uint2 key = uint2(seed_lo, seed_hi);
+    uint4 r = philox4x32_10(ctr, key);
+    if (base < N) output[base] = (uint_to_uniform_f32(r.x) < prob) ? ({type})1 : ({type})0;
+    if (base + 1u < N) output[base + 1u] = (uint_to_uniform_f32(r.y) < prob) ? ({type})1 : ({type})0;
+    if (base + 2u < N) output[base + 2u] = (uint_to_uniform_f32(r.z) < prob) ? ({type})1 : ({type})0;
+    if (base + 3u < N) output[base + 3u] = (uint_to_uniform_f32(r.w) < prob) ? ({type})1 : ({type})0;
+}}
+"""
+
+_PHILOX_RANDINT_TEMPLATE = """
+kernel void philox_randint_{suffix}(device {type}* output  [[buffer(0)]],
+                                     constant {type}& low   [[buffer(1)]],
+                                     constant {type}& high  [[buffer(2)]],
+                                     constant uint& seed_lo [[buffer(3)]],
+                                     constant uint& seed_hi [[buffer(4)]],
+                                     constant uint& offset  [[buffer(5)]],
+                                     constant uint& N       [[buffer(6)]],
+                                     uint gid [[thread_position_in_grid]]) {{
+    uint base = gid * 4;
+    if (base >= N) return;
+    uint4 ctr = uint4(gid, 0, offset, 0);
+    uint2 key = uint2(seed_lo, seed_hi);
+    uint4 r = philox4x32_10(ctr, key);
+    uint range = (uint)(high - low);
+    if (base < N) output[base] = ({type})((int)low + (int)(r.x % range));
+    if (base + 1u < N) output[base + 1u] = ({type})((int)low + (int)(r.y % range));
+    if (base + 2u < N) output[base + 2u] = ({type})((int)low + (int)(r.z % range));
+    if (base + 3u < N) output[base + 3u] = ({type})((int)low + (int)(r.w % range));
+}}
+"""
+
+_PHILOX_DROPOUT_TEMPLATE = """
+kernel void philox_dropout_{suffix}(device const {type}* input [[buffer(0)]],
+                                     device {type}* output      [[buffer(1)]],
+                                     constant float& prob       [[buffer(2)]],
+                                     constant float& scale      [[buffer(3)]],
+                                     constant uint& seed_lo     [[buffer(4)]],
+                                     constant uint& seed_hi     [[buffer(5)]],
+                                     constant uint& offset      [[buffer(6)]],
+                                     constant uint& N           [[buffer(7)]],
+                                     uint gid [[thread_position_in_grid]]) {{
+    uint base = gid * 4;
+    if (base >= N) return;
+    uint4 ctr = uint4(gid, 0, offset, 0);
+    uint2 key = uint2(seed_lo, seed_hi);
+    uint4 r = philox4x32_10(ctr, key);
+    if (base < N) output[base] = (uint_to_uniform_f32(r.x) >= prob) ? ({type})((float)input[base] * scale) : ({type})0;
+    if (base + 1u < N) output[base + 1u] = (uint_to_uniform_f32(r.y) >= prob) ? ({type})((float)input[base + 1u] * scale) : ({type})0;
+    if (base + 2u < N) output[base + 2u] = (uint_to_uniform_f32(r.z) >= prob) ? ({type})((float)input[base + 2u] * scale) : ({type})0;
+    if (base + 3u < N) output[base + 3u] = (uint_to_uniform_f32(r.w) >= prob) ? ({type})((float)input[base + 3u] * scale) : ({type})0;
+}}
+"""
+
+
+def _gen_philox_uniform(types=None):
+    """Generate Philox uniform kernels."""
+    if types is None:
+        types = ("float", "half")
+    parts = []
+    for t in types:
+        suffix = _SUFFIX[t]
+        parts.append(_PHILOX_UNIFORM_TEMPLATE.format(suffix=suffix, type=t))
+    return "".join(parts)
+
+
+def _gen_philox_normal(types=None):
+    """Generate Philox normal (Box-Muller) kernels."""
+    if types is None:
+        types = ("float", "half")
+    parts = []
+    for t in types:
+        suffix = _SUFFIX[t]
+        parts.append(_PHILOX_NORMAL_TEMPLATE.format(suffix=suffix, type=t))
+    return "".join(parts)
+
+
+def _gen_philox_bernoulli(types=None):
+    """Generate Philox bernoulli kernels."""
+    if types is None:
+        types = ("float", "half")
+    parts = []
+    for t in types:
+        suffix = _SUFFIX[t]
+        parts.append(_PHILOX_BERNOULLI_TEMPLATE.format(suffix=suffix, type=t))
+    return "".join(parts)
+
+
+def _gen_philox_randint(types=None):
+    """Generate Philox randint kernels."""
+    if types is None:
+        types = ("int", "long")
+    parts = []
+    for t in types:
+        suffix = _SUFFIX[t]
+        parts.append(_PHILOX_RANDINT_TEMPLATE.format(suffix=suffix, type=t))
+    return "".join(parts)
+
+
+def _gen_philox_dropout(types=None):
+    """Generate Philox fused dropout kernels."""
+    if types is None:
+        types = ("float", "half")
+    parts = []
+    for t in types:
+        suffix = _SUFFIX[t]
+        parts.append(_PHILOX_DROPOUT_TEMPLATE.format(suffix=suffix, type=t))
+    return "".join(parts)
+
+
 def _build_msl_source():
     """Assemble the complete MSL source string."""
-    parts = [_HEADER, _STRIDED_INDEX_HELPER]
+    parts = [_HEADER, _STRIDED_INDEX_HELPER, _PHILOX_UTILITY]
 
     # Binary ops (all dtypes)
     for name, expr in _BINARY_OPS:
@@ -949,6 +1161,13 @@ def _build_msl_source():
     parts.append(_gen_index_select())
     parts.append(_gen_gather())
     parts.append(_gen_cat_copy())
+
+    # Philox RNG kernels
+    parts.append(_gen_philox_uniform())
+    parts.append(_gen_philox_normal())
+    parts.append(_gen_philox_bernoulli())
+    parts.append(_gen_philox_randint())
+    parts.append(_gen_philox_dropout())
 
     # Comparison ops
     for name, op in _COMPARISON_OPS:

--- a/src/candle/_backends/mps/ops.py
+++ b/src/candle/_backends/mps/ops.py
@@ -1452,6 +1452,19 @@ def zero_(a):
 
 
 def uniform_(a, low=0.0, high=1.0, generator=None):
+    if _can_use_gpu(a) and a.is_contiguous() and a.dtype in (float32_dtype, float16_dtype):
+        from ...mps import _get_default_generator
+        gen = generator if (generator is not None and hasattr(generator, 'device') and generator.device.type == 'mps') else _get_default_generator()
+        numel = a.numel()
+        increment = (numel + 3) // 4
+        seed, offset = gen.philox_engine_inputs(increment)
+        seed_lo, seed_hi = seed & 0xffffffff, (seed >> 32) & 0xffffffff
+        sfx = _kernel_suffix(a.dtype)
+        fmt = _scalar_fmt(a.dtype)
+        _get_dispatcher().dispatch_philox_fill(
+            f"philox_uniform_{sfx}", _metal_buf(a),
+            seed_lo, seed_hi, offset, low, high, numel, param_fmt=fmt)
+        return a
     from ..._random import _get_cpu_rng
     rng = generator._rng if (generator is not None and hasattr(generator, '_rng') and generator._rng is not None) else _get_cpu_rng()
     arr = _to_numpy(a)
@@ -1460,6 +1473,19 @@ def uniform_(a, low=0.0, high=1.0, generator=None):
 
 
 def normal_(a, mean=0.0, std=1.0, generator=None):
+    if _can_use_gpu(a) and a.is_contiguous() and a.dtype in (float32_dtype, float16_dtype):
+        from ...mps import _get_default_generator
+        gen = generator if (generator is not None and hasattr(generator, 'device') and generator.device.type == 'mps') else _get_default_generator()
+        numel = a.numel()
+        increment = (numel + 3) // 4
+        seed, offset = gen.philox_engine_inputs(increment)
+        seed_lo, seed_hi = seed & 0xffffffff, (seed >> 32) & 0xffffffff
+        sfx = _kernel_suffix(a.dtype)
+        fmt = _scalar_fmt(a.dtype)
+        _get_dispatcher().dispatch_philox_fill(
+            f"philox_normal_{sfx}", _metal_buf(a),
+            seed_lo, seed_hi, offset, mean, std, numel, param_fmt=fmt)
+        return a
     from ..._random import _get_cpu_rng
     rng = generator._rng if (generator is not None and hasattr(generator, '_rng') and generator._rng is not None) else _get_cpu_rng()
     arr = _to_numpy(a)
@@ -1468,6 +1494,19 @@ def normal_(a, mean=0.0, std=1.0, generator=None):
 
 
 def bernoulli_(a, p=0.5, generator=None):
+    is_scalar_p = not hasattr(p, '_numpy_view') and not hasattr(p, 'numpy')
+    if is_scalar_p and _can_use_gpu(a) and a.is_contiguous() and a.dtype in (float32_dtype, float16_dtype):
+        from ...mps import _get_default_generator
+        gen = generator if (generator is not None and hasattr(generator, 'device') and generator.device.type == 'mps') else _get_default_generator()
+        numel = a.numel()
+        increment = (numel + 3) // 4
+        seed, offset = gen.philox_engine_inputs(increment)
+        seed_lo, seed_hi = seed & 0xffffffff, (seed >> 32) & 0xffffffff
+        sfx = _kernel_suffix(a.dtype)
+        _get_dispatcher().dispatch_philox_bernoulli(
+            f"philox_bernoulli_{sfx}", _metal_buf(a), float(p),
+            seed_lo, seed_hi, offset, numel)
+        return a
     from ..._random import _get_cpu_rng
     rng = generator._rng if (generator is not None and hasattr(generator, '_rng') and generator._rng is not None) else _get_cpu_rng()
     arr = _to_numpy(a)
@@ -2437,6 +2476,23 @@ def group_norm(input, num_groups, weight=None, bias=None, eps=1e-5):
 def dropout(a, p=0.5, training=True):
     if not training or p == 0:
         return a
+    if p == 1.0:
+        return _from_numpy(np.zeros(_to_numpy(a).shape, dtype=_to_numpy(a).dtype), a.dtype, a.device)
+    if _can_use_gpu(a) and a.is_contiguous() and a.dtype in (float32_dtype, float16_dtype):
+        from ...mps import _get_default_generator
+        gen = _get_default_generator()
+        numel = a.numel()
+        increment = (numel + 3) // 4
+        seed, offset = gen.philox_engine_inputs(increment)
+        seed_lo, seed_hi = seed & 0xffffffff, (seed >> 32) & 0xffffffff
+        sfx = _kernel_suffix(a.dtype)
+        scale = 1.0 / (1.0 - p)
+        out_buf = _alloc_output_buf(numel, a.dtype)
+        _get_dispatcher().dispatch_philox_dropout(
+            f"philox_dropout_{sfx}", _metal_buf(a), out_buf,
+            float(p), float(scale), seed_lo, seed_hi, offset, numel)
+        stride = tuple(a.stride())
+        return _from_metal_buffer(out_buf, tuple(a.shape), stride, a.dtype, a.device)
     from ..._random import _get_cpu_rng
     rng = _get_cpu_rng()
     arr = _to_numpy(a)

--- a/src/candle/_random.py
+++ b/src/candle/_random.py
@@ -32,6 +32,14 @@ def manual_seed(seed: int):
     except Exception:
         pass
 
+    # Propagate to MPS
+    try:
+        from . import mps as _mps
+        if _mps.is_available():
+            _mps.manual_seed(seed)
+    except Exception:
+        pass
+
     return default_generator
 
 
@@ -47,6 +55,13 @@ def seed():
         from . import npu
         if npu.is_available():
             npu.manual_seed_all(s)
+    except Exception:
+        pass
+    # Propagate to MPS
+    try:
+        from . import mps as _mps
+        if _mps.is_available():
+            _mps.manual_seed(s)
     except Exception:
         pass
     return s
@@ -95,7 +110,7 @@ class Generator:
 
         if self.device.type == 'cpu':
             self._rng = np.random.RandomState(self._seed & 0xffffffff)
-        elif self.device.type == 'npu':
+        elif self.device.type in ('npu', 'mps'):
             self._rng = None
             self._offset = 0
         else:
@@ -114,7 +129,7 @@ class Generator:
 
         if self.device.type == 'cpu':
             self._rng = np.random.RandomState(seed & 0xffffffff)
-        elif self.device.type == 'npu':
+        elif self.device.type in ('npu', 'mps'):
             self._offset = 0
         return self
 
@@ -138,8 +153,8 @@ class Generator:
             state_bytes = state[1].view(np.uint8)
             pos = np.array([state[2]], dtype=np.int32).view(np.uint8)
             return tensor(np.concatenate([state_bytes, pos]), dtype=uint8)
-        elif self.device.type == 'npu':
-            # NPU state: seed (uint64) + offset (int64) = 16 bytes
+        elif self.device.type in ('npu', 'mps'):
+            # NPU/MPS state: seed (uint64) + offset (int64) = 16 bytes
             buf = np.zeros(16, dtype=np.uint8)
             buf[:8] = np.array([self._seed], dtype=np.uint64).view(np.uint8)
             buf[8:] = np.array([self._offset], dtype=np.int64).view(np.uint8)
@@ -156,24 +171,23 @@ class Generator:
             pos = raw[624 * 4:624 * 4 + 4].view(np.int32)[0]
             self._rng = np.random.RandomState()
             self._rng.set_state(('MT19937', state_array, int(pos), 0, 0.0))
-        elif self.device.type == 'npu':
+        elif self.device.type in ('npu', 'mps'):
             self._seed = int(raw[:8].view(np.uint64)[0])
             self._offset = int(raw[8:16].view(np.int64)[0])
 
     def philox_engine_inputs(self, increment=10):
-        """Get (seed, offset) for NPU ACLNN kernels and advance offset.
+        """Get (seed, offset) for Philox-based GPU kernels and advance offset.
 
-        This matches torch_npu's NPUGeneratorImpl::philox_engine_inputs().
-        The increment represents Philox rounds of separation between ops.
+        Works for both NPU (ACLNN) and MPS (Metal) generators.
 
         Args:
-            increment: Number of Philox rounds to advance. Default: 10.
+            increment: Number of Philox elements to advance. Default: 10.
 
         Returns:
             tuple: (seed, offset) as integers.
         """
-        if self.device.type != 'npu':
-            raise RuntimeError("philox_engine_inputs only for NPU generators")
+        if self.device.type not in ('npu', 'mps'):
+            raise RuntimeError("philox_engine_inputs only for NPU/MPS generators")
         seed = self._seed
         offset = self._offset
         self._offset += increment

--- a/src/candle/mps.py
+++ b/src/candle/mps.py
@@ -64,6 +64,31 @@ def memory_allocated(device=None):
     return 0
 
 
+# --- RNG ---
+
+_default_generator = None
+
+
+def _get_default_generator():
+    """Get or create the default MPS generator."""
+    global _default_generator
+    if _default_generator is None:
+        from ._random import Generator
+        _default_generator = Generator('mps')
+    return _default_generator
+
+
+def manual_seed(seed: int):
+    """Set the seed for generating random numbers on the MPS device."""
+    gen = _get_default_generator()
+    gen.manual_seed(seed)
+
+
+def manual_seed_all(seed: int):
+    """Set the seed for all MPS devices (only one exists)."""
+    manual_seed(seed)
+
+
 __all__ = [
     "is_available",
     "synchronize",
@@ -73,4 +98,7 @@ __all__ = [
     "get_device_properties",
     "empty_cache",
     "memory_allocated",
+    "manual_seed",
+    "manual_seed_all",
+    "_get_default_generator",
 ]

--- a/tests/mps/test_mps_rng.py
+++ b/tests/mps/test_mps_rng.py
@@ -1,0 +1,299 @@
+"""Tests for MPS GPU RNG (Philox 4x32-10)."""
+import numpy as np
+import pytest
+import candle as torch
+
+
+# ---------------------------------------------------------------------------
+# Reproducibility: same seed → same output
+# ---------------------------------------------------------------------------
+
+class TestPhiloxReproducibility:
+    """Verify deterministic RNG with manual_seed."""
+
+    def test_rand_reproducible_f32(self):
+        torch.manual_seed(42)
+        a = torch.rand(1000, device="mps")
+        torch.manual_seed(42)
+        b = torch.rand(1000, device="mps")
+        np.testing.assert_array_equal(a.cpu().numpy(), b.cpu().numpy())
+
+    def test_rand_reproducible_f16(self):
+        torch.manual_seed(42)
+        a = torch.rand(1000, dtype=torch.float16, device="mps")
+        torch.manual_seed(42)
+        b = torch.rand(1000, dtype=torch.float16, device="mps")
+        np.testing.assert_array_equal(a.cpu().numpy(), b.cpu().numpy())
+
+    def test_randn_reproducible_f32(self):
+        torch.manual_seed(123)
+        a = torch.randn(1000, device="mps")
+        torch.manual_seed(123)
+        b = torch.randn(1000, device="mps")
+        np.testing.assert_array_equal(a.cpu().numpy(), b.cpu().numpy())
+
+    def test_randn_reproducible_f16(self):
+        torch.manual_seed(123)
+        a = torch.randn(1000, dtype=torch.float16, device="mps")
+        torch.manual_seed(123)
+        b = torch.randn(1000, dtype=torch.float16, device="mps")
+        np.testing.assert_array_equal(a.cpu().numpy(), b.cpu().numpy())
+
+    def test_randint_reproducible_i64(self):
+        torch.manual_seed(99)
+        a = torch.randint(0, 100, (500,), device="mps")
+        torch.manual_seed(99)
+        b = torch.randint(0, 100, (500,), device="mps")
+        np.testing.assert_array_equal(a.cpu().numpy(), b.cpu().numpy())
+
+    def test_randint_reproducible_i32(self):
+        torch.manual_seed(99)
+        a = torch.randint(0, 100, (500,), dtype=torch.int32, device="mps")
+        torch.manual_seed(99)
+        b = torch.randint(0, 100, (500,), dtype=torch.int32, device="mps")
+        np.testing.assert_array_equal(a.cpu().numpy(), b.cpu().numpy())
+
+    def test_randperm_reproducible(self):
+        torch.manual_seed(77)
+        a = torch.randperm(100, device="mps")
+        torch.manual_seed(77)
+        b = torch.randperm(100, device="mps")
+        np.testing.assert_array_equal(a.cpu().numpy(), b.cpu().numpy())
+
+
+# ---------------------------------------------------------------------------
+# Independence: different seeds → different output
+# ---------------------------------------------------------------------------
+
+class TestPhiloxIndependence:
+    """Verify different seeds produce different outputs."""
+
+    def test_rand_different_seeds(self):
+        torch.manual_seed(1)
+        a = torch.rand(100, device="mps")
+        torch.manual_seed(2)
+        b = torch.rand(100, device="mps")
+        assert not np.array_equal(a.cpu().numpy(), b.cpu().numpy())
+
+    def test_randn_different_seeds(self):
+        torch.manual_seed(1)
+        a = torch.randn(100, device="mps")
+        torch.manual_seed(2)
+        b = torch.randn(100, device="mps")
+        assert not np.array_equal(a.cpu().numpy(), b.cpu().numpy())
+
+    def test_sequential_calls_different(self):
+        torch.manual_seed(42)
+        a = torch.rand(100, device="mps")
+        b = torch.rand(100, device="mps")
+        assert not np.array_equal(a.cpu().numpy(), b.cpu().numpy())
+
+
+# ---------------------------------------------------------------------------
+# Statistical correctness: distributions match expected properties
+# ---------------------------------------------------------------------------
+
+class TestPhiloxStatistics:
+    """Verify output distributions are statistically correct."""
+
+    def test_rand_range(self):
+        torch.manual_seed(42)
+        x = torch.rand(10000, device="mps")
+        vals = x.cpu().numpy()
+        assert vals.min() >= 0.0
+        assert vals.max() < 1.0
+
+    def test_rand_mean_std(self):
+        torch.manual_seed(42)
+        x = torch.rand(50000, device="mps")
+        vals = x.cpu().numpy()
+        # Uniform [0,1): mean ≈ 0.5, std ≈ 1/sqrt(12) ≈ 0.2887
+        assert abs(vals.mean() - 0.5) < 0.01
+        assert abs(vals.std() - 0.2887) < 0.01
+
+    def test_randn_mean_std(self):
+        torch.manual_seed(42)
+        x = torch.randn(50000, device="mps")
+        vals = x.cpu().numpy()
+        # Standard normal: mean ≈ 0, std ≈ 1
+        assert abs(vals.mean()) < 0.02
+        assert abs(vals.std() - 1.0) < 0.02
+
+    def test_randint_range(self):
+        torch.manual_seed(42)
+        x = torch.randint(10, 20, (5000,), device="mps")
+        vals = x.cpu().numpy()
+        assert vals.min() >= 10
+        assert vals.max() < 20
+
+    def test_randint_coverage(self):
+        torch.manual_seed(42)
+        x = torch.randint(0, 5, (10000,), device="mps")
+        vals = x.cpu().numpy()
+        unique = set(vals.tolist())
+        assert unique == {0, 1, 2, 3, 4}
+
+    def test_randperm_is_permutation(self):
+        torch.manual_seed(42)
+        x = torch.randperm(100, device="mps")
+        vals = sorted(x.cpu().numpy().tolist())
+        assert vals == list(range(100))
+
+
+# ---------------------------------------------------------------------------
+# In-place ops: uniform_, normal_, bernoulli_
+# ---------------------------------------------------------------------------
+
+class TestPhiloxInPlace:
+    """Verify in-place RNG ops use GPU Philox."""
+
+    def test_uniform_reproducible(self):
+        torch.manual_seed(42)
+        a = torch.empty(1000, device="mps")
+        a.uniform_(0.0, 1.0)
+        torch.manual_seed(42)
+        b = torch.empty(1000, device="mps")
+        b.uniform_(0.0, 1.0)
+        np.testing.assert_array_equal(a.cpu().numpy(), b.cpu().numpy())
+
+    def test_uniform_range(self):
+        torch.manual_seed(42)
+        a = torch.empty(5000, device="mps")
+        a.uniform_(-3.0, 3.0)
+        vals = a.cpu().numpy()
+        assert vals.min() >= -3.0
+        assert vals.max() < 3.0
+
+    def test_normal_reproducible(self):
+        torch.manual_seed(42)
+        a = torch.empty(1000, device="mps")
+        a.normal_(0.0, 1.0)
+        torch.manual_seed(42)
+        b = torch.empty(1000, device="mps")
+        b.normal_(0.0, 1.0)
+        np.testing.assert_array_equal(a.cpu().numpy(), b.cpu().numpy())
+
+    def test_normal_statistics(self):
+        torch.manual_seed(42)
+        a = torch.empty(50000, device="mps")
+        a.normal_(5.0, 2.0)
+        vals = a.cpu().numpy()
+        assert abs(vals.mean() - 5.0) < 0.05
+        assert abs(vals.std() - 2.0) < 0.05
+
+    def test_bernoulli_reproducible(self):
+        torch.manual_seed(42)
+        a = torch.empty(1000, device="mps")
+        a.bernoulli_(0.3)
+        torch.manual_seed(42)
+        b = torch.empty(1000, device="mps")
+        b.bernoulli_(0.3)
+        np.testing.assert_array_equal(a.cpu().numpy(), b.cpu().numpy())
+
+    def test_bernoulli_rate(self):
+        torch.manual_seed(42)
+        a = torch.empty(50000, device="mps")
+        a.bernoulli_(0.7)
+        vals = a.cpu().numpy()
+        assert set(np.unique(vals).tolist()).issubset({0.0, 1.0})
+        assert abs(vals.mean() - 0.7) < 0.02
+
+
+# ---------------------------------------------------------------------------
+# Dropout
+# ---------------------------------------------------------------------------
+
+class TestPhiloxDropout:
+    """Verify fused Philox dropout kernel."""
+
+    def test_dropout_reproducible(self):
+        torch.manual_seed(42)
+        x = torch.randn(1000, device="mps")
+        torch.manual_seed(100)
+        out1 = torch.nn.functional.dropout(x, p=0.5, training=True)
+        torch.manual_seed(100)
+        out2 = torch.nn.functional.dropout(x, p=0.5, training=True)
+        np.testing.assert_array_equal(out1.cpu().numpy(), out2.cpu().numpy())
+
+    def test_dropout_zeros_fraction(self):
+        torch.manual_seed(42)
+        x = torch.ones(10000, device="mps")
+        out = torch.nn.functional.dropout(x, p=0.5, training=True)
+        vals = out.cpu().numpy()
+        zero_frac = (vals == 0.0).mean()
+        assert abs(zero_frac - 0.5) < 0.03
+
+    def test_dropout_scaling(self):
+        torch.manual_seed(42)
+        x = torch.ones(10000, device="mps")
+        out = torch.nn.functional.dropout(x, p=0.3, training=True)
+        vals = out.cpu().numpy()
+        nonzero = vals[vals != 0.0]
+        expected_scale = 1.0 / (1.0 - 0.3)
+        np.testing.assert_allclose(nonzero, expected_scale, rtol=1e-5)
+
+    def test_dropout_eval_passthrough(self):
+        x = torch.randn(100, device="mps")
+        out = torch.nn.functional.dropout(x, p=0.5, training=False)
+        np.testing.assert_array_equal(out.cpu().numpy(), x.cpu().numpy())
+
+
+# ---------------------------------------------------------------------------
+# Multi-dimensional shapes
+# ---------------------------------------------------------------------------
+
+class TestPhiloxShapes:
+    """Verify RNG works with various tensor shapes."""
+
+    def test_rand_2d(self):
+        torch.manual_seed(42)
+        a = torch.rand(10, 20, device="mps")
+        assert a.shape == (10, 20)
+        vals = a.cpu().numpy()
+        assert vals.min() >= 0.0
+        assert vals.max() < 1.0
+
+    def test_randn_3d(self):
+        torch.manual_seed(42)
+        a = torch.randn(4, 8, 16, device="mps")
+        assert a.shape == (4, 8, 16)
+
+    def test_randint_2d(self):
+        torch.manual_seed(42)
+        a = torch.randint(0, 10, (5, 5), device="mps")
+        assert a.shape == (5, 5)
+        vals = a.cpu().numpy()
+        assert vals.min() >= 0
+        assert vals.max() < 10
+
+    def test_rand_small(self):
+        """Edge case: fewer than 4 elements (single Philox round)."""
+        torch.manual_seed(42)
+        a = torch.rand(3, device="mps")
+        torch.manual_seed(42)
+        b = torch.rand(3, device="mps")
+        np.testing.assert_array_equal(a.cpu().numpy(), b.cpu().numpy())
+
+
+# ---------------------------------------------------------------------------
+# Generator state
+# ---------------------------------------------------------------------------
+
+class TestMPSGenerator:
+    """Verify MPS generator state management."""
+
+    def test_mps_manual_seed(self):
+        torch.mps.manual_seed(42)
+        a = torch.rand(100, device="mps")
+        torch.mps.manual_seed(42)
+        b = torch.rand(100, device="mps")
+        np.testing.assert_array_equal(a.cpu().numpy(), b.cpu().numpy())
+
+    def test_generator_device(self):
+        gen = torch.mps._get_default_generator()
+        assert gen.device.type == "mps"
+
+    def test_generator_initial_seed(self):
+        torch.mps.manual_seed(12345)
+        gen = torch.mps._get_default_generator()
+        assert gen.initial_seed() == 12345


### PR DESCRIPTION
## Summary

- Add GPU-native Philox 4x32-10 PRNG via Metal shaders, replacing CPU numpy RNG for MPS tensors
- Implement per-device MPS generator with deterministic self-consistent reproducibility
- Add GPU paths for creation ops (`rand`, `randn`, `randint`, `randperm`) and in-place/functional ops (`uniform_`, `normal_`, `bernoulli_`, `dropout`)
- 5 Metal kernel templates: uniform (f32/f16), normal (f32/f16), bernoulli (f32/f16), randint (i32/i64), fused dropout (f32/f16)
- `candle.manual_seed()` now propagates to MPS generator

## Files Changed

| File | Changes |
|------|---------|
| `metal_shaders.py` | Philox utility + 5 kernel templates + 5 generators |
| `metal_compute.py` | 4 dispatch methods + 4 ctypes encoders |
| `creation.py` | GPU Philox paths for rand/randn/randint/randperm |
| `ops.py` | GPU Philox paths for uniform_/normal_/bernoulli_/dropout |
| `_random.py` | Generator MPS support, seed propagation |
| `mps.py` | manual_seed, _default_generator |
| `test_mps_rng.py` | 33 new tests |

## Test plan

- [x] 33 RNG tests pass (reproducibility, independence, statistics, in-place, dropout, shapes, generator)
- [x] Full MPS suite: 231/231 passed (no regressions)
- [x] CPU + contract: 1399 passed, 25 skipped (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)