### PR TITLE
feat(mps): enable AMP autocast and GradScaler

### DIFF
--- a/src/candle/_dispatch/dispatcher.py
+++ b/src/candle/_dispatch/dispatcher.py
@@ -445,6 +445,10 @@ def dispatch_with_keyset(name, keyset, dispatch_device, *args, **kwargs):
 
     if keyset.has(DispatchKey.Autocast):
         device_type = dispatch_device.type if hasattr(dispatch_device, "type") else dispatch_device
+        if device_type is None:
+            tensors = _extract_tensors(args, kwargs)
+            if tensors:
+                device_type = getattr(tensors[0].device, "type", None)
         casted_args, casted_kwargs = apply_autocast_policy(alias_name, args, kwargs, device_type)
         return redispatch(alias_name, keyset.without(DispatchKey.Autocast), *casted_args, **casted_kwargs)
 
@@ -488,6 +492,10 @@ def dispatch_with_keyset(name, keyset, dispatch_device, *args, **kwargs):
 
 def dispatch(name, dispatch_device, *args, **kwargs):
     tensors = _extract_tensors(args, kwargs)
+    # Infer autocast device from tensors when dispatch_device is not specified
+    autocast_device_type = getattr(dispatch_device, "type", dispatch_device)
+    if autocast_device_type is None and tensors:
+        autocast_device_type = getattr(tensors[0].device, "type", None)
     pipe = current_pipeline()
     keyset = DispatchKeySet.from_tensors(
         tensors,
@@ -495,7 +503,7 @@ def dispatch(name, dispatch_device, *args, **kwargs):
         pipeline_enabled=pipe is not None,
         functionalize_enabled=is_functionalize_enabled(),
         device=dispatch_device,
-        autocast_enabled=is_autocast_enabled(getattr(dispatch_device, "type", dispatch_device)),
+        autocast_enabled=is_autocast_enabled(autocast_device_type),
     )
     return dispatch_with_keyset(name, keyset, dispatch_device, *args, **kwargs)
 

--- a/src/candle/amp/autocast_mode.py
+++ b/src/candle/amp/autocast_mode.py
@@ -53,10 +53,19 @@ def _npu_available():
     return bool(getattr(npu_api, "is_available", lambda: False)())
 
 
+def _mps_available():
+    try:
+        from .. import mps as mps_api
+    except Exception:
+        return False
+    return bool(getattr(mps_api, "is_available", lambda: False)())
+
+
 _DEVICE_TYPE_AVAILABILITY = {
     "cpu": lambda: True,
     "cuda": _cuda_available,
     "npu": _npu_available,
+    "mps": _mps_available,
 }
 
 

--- a/src/candle/amp/grad_scaler.py
+++ b/src/candle/amp/grad_scaler.py
@@ -59,7 +59,11 @@ class GradScaler:
             return outputs
         from .._creation import tensor
         self._lazy_init_scale_growth_tracker()
-        return outputs * tensor(self._scale)
+        device = getattr(outputs, "device", None)
+        scale_t = tensor(self._scale)
+        if device is not None and getattr(device, "type", None) != "cpu":
+            scale_t = scale_t.to(device)
+        return outputs * scale_t
 
     def _params_for_optimizer(self, optimizer):
         if hasattr(optimizer, "param_groups"):

--- a/src/candle/amp/state.py
+++ b/src/candle/amp/state.py
@@ -71,7 +71,7 @@ def _normalize_device_type(device_type):
 
 def is_autocast_available(device_type):
     dev = _normalize_device_type(device_type)
-    return dev in {"cpu", "npu", "cuda"}
+    return dev in {"cpu", "npu", "cuda", "mps"}
 
 
 def is_autocast_enabled(device_type=None):

--- a/tests/mps/test_mps_amp.py
+++ b/tests/mps/test_mps_amp.py
@@ -1,0 +1,94 @@
+"""Tests for MPS AMP (Automatic Mixed Precision) autocast support."""
+import numpy as np
+import pytest
+import candle as torch
+
+
+class TestMPSAutocastBasic:
+    """Verify autocast context manager works for MPS."""
+
+    def test_autocast_enters_and_exits(self):
+        assert not torch.amp.autocast_mode.is_autocast_enabled("mps")
+        with torch.amp.autocast("mps"):
+            assert torch.amp.autocast_mode.is_autocast_enabled("mps")
+        assert not torch.amp.autocast_mode.is_autocast_enabled("mps")
+
+    def test_autocast_default_dtype_is_float16(self):
+        with torch.amp.autocast("mps"):
+            dtype = torch.amp.autocast_mode.get_autocast_dtype("mps")
+            assert dtype == torch.float16
+
+    def test_autocast_nested(self):
+        with torch.amp.autocast("mps"):
+            assert torch.amp.autocast_mode.is_autocast_enabled("mps")
+            with torch.amp.autocast("mps", enabled=False):
+                assert not torch.amp.autocast_mode.is_autocast_enabled("mps")
+            assert torch.amp.autocast_mode.is_autocast_enabled("mps")
+
+    def test_autocast_decorator(self):
+        @torch.amp.autocast("mps")
+        def fn(x):
+            return x + 1.0
+        x = torch.ones(4, device="mps")
+        result = fn(x)
+        assert result.device.type == "mps"
+
+
+class TestMPSAutocastPolicy:
+    """Verify autocast policies cast ops correctly on MPS."""
+
+    def test_matmul_casts_to_float16(self):
+        a = torch.randn(4, 4, device="mps", dtype=torch.float32)
+        b = torch.randn(4, 4, device="mps", dtype=torch.float32)
+        with torch.amp.autocast("mps"):
+            out = torch.matmul(a, b)
+        assert out.dtype == torch.float16
+
+    def test_softmax_stays_float32(self):
+        x = torch.randn(4, 4, device="mps", dtype=torch.float32)
+        with torch.amp.autocast("mps"):
+            out = torch.nn.functional.softmax(x, dim=1)
+        assert out.dtype == torch.float32
+
+    def test_add_stays_float32(self):
+        """Element-wise add is not in LOWER_PRECISION_FP list."""
+        a = torch.randn(4, device="mps", dtype=torch.float32)
+        b = torch.randn(4, device="mps", dtype=torch.float32)
+        with torch.amp.autocast("mps"):
+            out = a + b
+        assert out.dtype == torch.float32
+
+    def test_linear_casts_to_float16(self):
+        x = torch.randn(2, 8, device="mps", dtype=torch.float32)
+        w = torch.randn(4, 8, device="mps", dtype=torch.float32)
+        with torch.amp.autocast("mps"):
+            out = torch.nn.functional.linear(x, w)
+        assert out.dtype == torch.float16
+
+
+class TestMPSGradScaler:
+    """Verify GradScaler works with MPS tensors."""
+
+    def test_grad_scaler_basic(self):
+        scaler = torch.amp.GradScaler(device="mps")
+        assert scaler._device == "mps"
+
+    def test_grad_scaler_scale_and_step(self):
+        model_w = torch.randn(4, 4, device="mps", requires_grad=True)
+        x = torch.randn(2, 4, device="mps")
+
+        scaler = torch.amp.GradScaler(device="mps")
+        with torch.amp.autocast("mps"):
+            out = torch.matmul(x, model_w.t())
+            loss = out.sum()
+
+        scaler.scale(loss).backward()
+        scaler.step(torch.optim.SGD([model_w], lr=0.01))
+        scaler.update()
+
+    def test_grad_scaler_state_dict(self):
+        scaler = torch.amp.GradScaler(device="mps")
+        sd = scaler.state_dict()
+        assert "scale" in sd
+        assert "growth_factor" in sd
+        assert "backoff_factor" in sd


### PR DESCRIPTION
## Summary

- Enable MPS in autocast availability so `torch.amp.autocast("mps")` works with float16 default dtype
- Fix dispatcher to infer autocast device type from input tensors (needed when `dispatch_device=None`)
- Fix `GradScaler.scale()` to move scale tensor to output device, avoiding CPU/MPS mismatch
- 11 new MPS AMP tests

## Files Changed

| File | Changes |
|------|---------|
| `amp/autocast_mode.py` | Add `_mps_available()` + "mps" to `_DEVICE_TYPE_AVAILABILITY` |
| `amp/state.py` | Add "mps" to `is_autocast_available` set |
| `amp/grad_scaler.py` | Move scale tensor to output device in `scale()` |
| `_dispatch/dispatcher.py` | Infer autocast device type from tensors when dispatch_device is None |
| `tests/mps/test_mps_amp.py` | 11 new tests |

## Test plan

- [x] 11 MPS AMP tests pass (autocast, policy, GradScaler)
- [x] Full MPS suite: 242/242 passed (no regressions)
- [x] CPU + contract: 1399 passed, 25 skipped (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)