### PR TITLE
fix(autograd): preserve rrelu slope for backward

### DIFF
--- a/docs/plans/2026-03-11-cpu-inplace-activations.md
+++ b/docs/plans/2026-03-11-cpu-inplace-activations.md
@@ -1,0 +1,83 @@
+# CPU Inplace Activations Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Align inplace activation behavior (relu_, elu_, hardtanh_, rrelu_, threshold_, selu_, celu_, leaky_relu_) with PyTorch on CPU, focusing on autograd leaf checks and non-leaf allowlist.
+
+**Architecture:** Keep existing functional wrappers and dispatch. Add tests to cover leaf vs non-leaf inplace semantics. Ensure Tensor._check_inplace matches PyTorch rules. Avoid changing backend kernels unless test demands it.
+
+**Tech Stack:** Python, candle dispatch/autograd, pytest
+
+---
+
+### Task 1: Add failing test for non-leaf requires_grad inplace behavior
+
+**Files:**
+- Modify: `tests/cpu/test_nn_functional.py`
+
+**Step 1: Write failing test (non-leaf requires_grad should allow inplace)**
+
+```python
+def test_inplace_activation_non_leaf_requires_grad_allowed():
+    base = torch.tensor([-1.0, 0.0, 2.0], device='cpu')
+    x = base * 1.0  # non-leaf
+    out = F.relu_(x)
+    assert out is x
+    assert torch.allclose(x, torch.tensor([0.0, 0.0, 2.0], device='cpu'), atol=1e-6)
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=src pytest tests/cpu/test_nn_functional.py -k "inplace_activation_non_leaf_requires_grad_allowed" -v`
+Expected: FAIL with leaf-inplace RuntimeError (current behavior).
+
+**Step 3: Commit red test**
+
+```bash
+git add tests/cpu/test_nn_functional.py
+git commit -m "test(cpu): add non-leaf inplace activation behavior"
+```
+
+---
+
+### Task 2: Fix inplace leaf check to allow non-leaf requires_grad tensors
+
+**Files:**
+- Modify: `src/candle/_tensor.py`
+
+**Step 1: Implement minimal fix**
+
+Adjust `_check_inplace` to raise only for leaf tensors requiring grad, not all requires_grad tensors. Confirm view-of-leaf rule still enforced.
+
+**Step 2: Re-run test**
+
+Run: `PYTHONPATH=src pytest tests/cpu/test_nn_functional.py -k "inplace_activation_non_leaf_requires_grad_allowed" -v`
+Expected: PASS.
+
+**Step 3: Run leaf error test**
+
+Run: `PYTHONPATH=src pytest tests/cpu/test_nn_functional.py -k "inplace_activation_leaf_requires_grad_errors" -v`
+Expected: PASS.
+
+**Step 4: Commit green implementation**
+
+```bash
+git add src/candle/_tensor.py
+git commit -m "fix(autograd): allow inplace on non-leaf requires_grad tensors"
+```
+
+---
+
+### Task 3: Regression
+
+**Step 1: Run focused suite**
+
+Run: `PYTHONPATH=src pytest tests/cpu/test_nn_functional.py -k "inplace_activation" -v`
+Expected: PASS.
+
+**Step 2: Commit any stabilization changes (if needed)**
+
+```bash
+git add -A
+git commit -m "test(cpu): stabilize inplace activation tests"
+```

--- a/src/candle/_backends/autograd.py
+++ b/src/candle/_backends/autograd.py
@@ -121,6 +121,30 @@ def _autograd_unary_args(name, backward_impl, *, cpu_only=False, save_input=True
     return wrapper
 
 
+def _autograd_rrelu():
+    def wrapper(a, *args, **kwargs):
+        active_keyset = current_dispatch_keyset()
+        raw_keyset = _strip_autograd_keys(active_keyset)
+        out = redispatch("rrelu", raw_keyset, a, *args, **kwargs)
+        if GradMode.enabled and a.requires_grad:
+            slope = getattr(out, "_rrelu_slope", None)
+            node_holder = {}
+
+            def _backward(grad):
+                saved_a = node_holder["node"].saved_tensors()[0]
+                backward_keyset = _backward_dispatch_keyset(raw_keyset, active_keyset)
+                return _rrelu_backward(grad, a, saved_a, backward_keyset, args, kwargs, slope=slope)
+
+            node = Node(_backward, (a,))
+            node_holder["node"] = node
+            node.save_for_backward(a)
+            out.grad_fn = node
+            out.requires_grad = True
+        return out
+
+    return wrapper
+
+
 def _autograd_norm(name, backward_impl):
     """Autograd wrapper for normalization ops (layer_norm, batch_norm, rms_norm).
 
@@ -2600,7 +2624,7 @@ def _softshrink_backward(grad, _a, saved_a, keyset, args, kwargs):
         return (redispatch("mul", keyset, grad, mask),)
 
 
-def _rrelu_backward(grad, _a, saved_a, keyset, args, kwargs):
+def _rrelu_backward(grad, _a, saved_a, keyset, args, kwargs, slope=None):
     """Backward for rrelu: grad * (1 if x>=0 else slope). Slope saved on forward output."""
     with _grad_context(keyset):
         ones = saved_a._ones_like()
@@ -2609,8 +2633,9 @@ def _rrelu_backward(grad, _a, saved_a, keyset, args, kwargs):
             redispatch("ge", keyset, saved_a, zero), ones,
             redispatch("mul", keyset, ones, zero))
         neg_mask = redispatch("add", keyset, ones, redispatch("neg", keyset, pos_mask))
-        # Slope was saved during forward pass on _rrelu_slope attribute
-        slope = getattr(saved_a, '_rrelu_slope', None)
+        # Prefer slope captured from forward output; fall back to saved input attr.
+        if slope is None:
+            slope = getattr(saved_a, '_rrelu_slope', None)
         if slope is not None:
             factor = redispatch("add", keyset, pos_mask,
                 redispatch("mul", keyset, neg_mask, slope))
@@ -7378,7 +7403,7 @@ for _entry in (
     # Round 6 — Activation backward
     ("hardshrink", lambda: _autograd_unary_args("hardshrink", _hardshrink_backward)),
     ("softshrink", lambda: _autograd_unary_args("softshrink", _softshrink_backward)),
-    ("rrelu", lambda: _autograd_unary_args("rrelu", _rrelu_backward)),
+    ("rrelu", lambda: _autograd_rrelu()),
     # Round 6 — Zero backward (non-differentiable ops)
     ("ceil", lambda: _autograd_unary("ceil", _zero_backward, save_input=False)),
     ("floor", lambda: _autograd_unary("floor", _zero_backward, save_input=False)),

--- a/tests/cpu/test_nn_functional.py
+++ b/tests/cpu/test_nn_functional.py
@@ -555,6 +555,47 @@ def test_leaky_relu_inplace_wrapper_exists_and_mutates():
     assert torch.allclose(x, expected, atol=1e-6)
 
 
+
+def _assert_inplace_leaf_requires_grad_raises(fn, *args, **kwargs):
+    x = torch.tensor([-1.0, 0.0, 2.0], device='cpu')
+    x.requires_grad = True
+    with pytest.raises(RuntimeError):
+        fn(x, *args, **kwargs)
+
+
+def test_inplace_activation_non_leaf_requires_grad_allowed():
+    base = torch.tensor([-1.0, 0.0, 2.0], device='cpu')
+    base.requires_grad = True
+    x = base * 1.0
+    out = F.relu_(x)
+    assert out is x
+    assert torch.allclose(x, torch.tensor([0.0, 0.0, 2.0], device='cpu'), atol=1e-6)
+
+
+def test_inplace_activation_leaf_requires_grad_errors():
+    _assert_inplace_leaf_requires_grad_raises(F.relu_)
+    _assert_inplace_leaf_requires_grad_raises(F.elu_)
+    _assert_inplace_leaf_requires_grad_raises(F.hardtanh_, -0.5, 0.5)
+    _assert_inplace_leaf_requires_grad_raises(F.rrelu_, training=False)
+    _assert_inplace_leaf_requires_grad_raises(F.threshold_, 0.5, 3.0)
+    _assert_inplace_leaf_requires_grad_raises(F.selu_)
+    _assert_inplace_leaf_requires_grad_raises(F.celu_, 0.75)
+    _assert_inplace_leaf_requires_grad_raises(F.leaky_relu_, negative_slope=0.1)
+
+
+def test_rrelu_training_true_backward_uses_forward_slope():
+    # When training=True, backward should use the same random slope as forward.
+    torch.manual_seed(123)
+    x = torch.tensor([-2.0, -1.0, 0.0, 2.0], device='cpu')
+    x.requires_grad = True
+    out = F.rrelu(x, lower=0.1, upper=0.2, training=True)
+    out.sum().backward()
+    # For negative inputs, grad should match out / input (slope from forward).
+    neg_mask = x < 0
+    slopes = out[neg_mask].detach() / x[neg_mask].detach()
+    assert torch.allclose(x.grad[neg_mask], slopes, atol=1e-6)
+
+
 def test_upsample_alias_matches_interpolate_nearest_2d():
     x = torch.tensor([[[[1.0, 2.0], [3.0, 4.0]]]], device='cpu')
     out = F.upsample(x, size=(4, 4), mode='nearest')


### PR DESCRIPTION
## Summary
- add CPU inplace activation tests for leaf vs non-leaf autograd semantics
- ensure rrelu backward uses the forward random slope
- document the inplace activation plan

## Test Plan
- [x] `PYTHONPATH=src pytest tests/cpu/test_nn_functional.py -v`
- [x] `PYTHONPATH=src pytest tests/cpu/test_top_level_ops.py -v`
- [x] `PYTHONPATH=src pytest tests/contract/ -v --tb=short`
