### PR TITLE
feat(mps): add GPU-accelerated conv2d via Metal compute shader

### DIFF
--- a/src/candle/_backends/mps/metal_compute.py
+++ b/src/candle/_backends/mps/metal_compute.py
@@ -837,6 +837,44 @@ class MetalKernelDispatcher:
         rt.commit_and_wait(cmd)
 
     # ------------------------------------------------------------------
+    # Dispatch: conv2d  (input, weight, bias, output + packed params)
+    # ------------------------------------------------------------------
+
+    def dispatch_conv2d(self, kernel_name, input_buf, weight_buf, bias_buf,
+                        output_buf, N, C_in, H_in, W_in, C_out, kH, kW,
+                        H_out, W_out, sH, sW, pH, pW, dH, dW,
+                        has_bias, numel):
+        """Encode conv2d kernel (4 bufs + 17 packed uint params)."""
+        rt = get_runtime()
+        pipeline = self._get_pipeline(kernel_name)
+        tpg = self._threads_per_group(pipeline)
+        groups = (numel + tpg - 1) // tpg
+
+        cmd = rt.create_command_buffer()
+        enc = rt.get_compute_encoder(cmd)
+
+        params = struct.pack("17I", N, C_in, H_in, W_in, C_out, kH, kW,
+                             H_out, W_out, sH, sW, pH, pW, dH, dW,
+                             has_bias, numel)
+
+        if _HAS_PYOBJC:
+            enc.setComputePipelineState_(pipeline)
+            enc.setBuffer_offset_atIndex_(input_buf, 0, 0)
+            enc.setBuffer_offset_atIndex_(weight_buf, 0, 1)
+            enc.setBuffer_offset_atIndex_(bias_buf, 0, 2)
+            enc.setBuffer_offset_atIndex_(output_buf, 0, 3)
+            enc.setBytes_length_atIndex_(params, len(params), 4)
+            enc.dispatchThreadgroups_threadsPerThreadgroup_(
+                _MTLSize(groups, 1, 1), _MTLSize(tpg, 1, 1))
+            enc.endEncoding()
+        else:
+            _encode_conv2d_ctypes(enc, pipeline, input_buf, weight_buf,
+                                  bias_buf, output_buf, params,
+                                  groups, tpg)
+
+        rt.commit_and_wait(cmd)
+
+    # ------------------------------------------------------------------
     # Dispatch: Philox RNG fill  (seed, offset → output)
     # ------------------------------------------------------------------
 
@@ -1519,5 +1557,18 @@ def _encode_cat_copy_ctypes(enc, pipeline, src_buf, dst_buf,
     _ctypes_set_bytes(enc, struct.pack("I", inner_size), 4, 4)
     _ctypes_set_bytes(enc, struct.pack("I", dst_dim), 4, 5)
     _ctypes_set_bytes(enc, struct.pack("I", offset), 4, 6)
+    _ctypes_dispatch_threadgroups(enc, groups, tpg)
+    _ctypes_end_encoding(enc)
+
+
+def _encode_conv2d_ctypes(enc, pipeline, input_buf, weight_buf, bias_buf,
+                           output_buf, params, groups, tpg):
+    """Encode conv2d kernel (4 bufs + packed params) via ctypes."""
+    _ctypes_set_pipeline(enc, pipeline)
+    _ctypes_set_buffer(enc, input_buf, 0, 0)
+    _ctypes_set_buffer(enc, weight_buf, 0, 1)
+    _ctypes_set_buffer(enc, bias_buf, 0, 2)
+    _ctypes_set_buffer(enc, output_buf, 0, 3)
+    _ctypes_set_bytes(enc, params, len(params), 4)
     _ctypes_dispatch_threadgroups(enc, groups, tpg)
     _ctypes_end_encoding(enc)

--- a/src/candle/_backends/mps/metal_shaders.py
+++ b/src/candle/_backends/mps/metal_shaders.py
@@ -548,6 +548,76 @@ def _gen_cat_copy(types=None):
 
 
 # ---------------------------------------------------------------------------
+# Conv2d Metal compute shader
+# ---------------------------------------------------------------------------
+
+_CONV2D_TEMPLATE = """
+kernel void conv2d_{suffix}(
+    device const {type}* input   [[buffer(0)]],
+    device const {type}* weight  [[buffer(1)]],
+    device const {type}* bias    [[buffer(2)]],
+    device {type}* output        [[buffer(3)]],
+    constant uint* p             [[buffer(4)]],
+    uint gid [[thread_position_in_grid]])
+{{
+    // p: [N, C_in, H_in, W_in, C_out, kH, kW, H_out, W_out,
+    //     sH, sW, pH, pW, dH, dW, has_bias, total]
+    uint total = p[16];
+    if (gid >= total) return;
+
+    uint W_out = p[8]; uint H_out = p[7]; uint C_out = p[4];
+    uint ow = gid % W_out;
+    uint tmp = gid / W_out;
+    uint oh = tmp % H_out;
+    tmp /= H_out;
+    uint co = tmp % C_out;
+    uint n = tmp / C_out;
+
+    uint C_in = p[1]; uint H_in = p[2]; uint W_in = p[3];
+    uint kH = p[5]; uint kW = p[6];
+    uint sH = p[9]; uint sW = p[10];
+    uint pH = p[11]; uint pW = p[12];
+    uint dH = p[13]; uint dW = p[14];
+
+    float acc = 0.0f;
+    for (uint ci = 0; ci < C_in; ci++) {{
+        for (uint kh = 0; kh < kH; kh++) {{
+            for (uint kw = 0; kw < kW; kw++) {{
+                int ih = (int)(oh * sH + kh * dH) - (int)pH;
+                int iw = (int)(ow * sW + kw * dW) - (int)pW;
+                if (ih >= 0 && ih < (int)H_in && iw >= 0 && iw < (int)W_in) {{
+                    uint in_idx = n * (C_in * H_in * W_in)
+                                + ci * (H_in * W_in)
+                                + (uint)ih * W_in + (uint)iw;
+                    uint w_idx = co * (C_in * kH * kW)
+                               + ci * (kH * kW)
+                               + kh * kW + kw;
+                    acc += (float)input[in_idx] * (float)weight[w_idx];
+                }}
+            }}
+        }}
+    }}
+
+    if (p[15] != 0u) {{
+        acc += (float)bias[co];
+    }}
+    output[gid] = ({type})acc;
+}}
+"""
+
+
+def _gen_conv2d(types=None):
+    """Generate conv2d kernels (float/half only)."""
+    if types is None:
+        types = _FLOAT_TYPES
+    parts = []
+    for t in types:
+        suffix = _SUFFIX[t]
+        parts.append(_CONV2D_TEMPLATE.format(type=t, suffix=suffix))
+    return "".join(parts)
+
+
+# ---------------------------------------------------------------------------
 # Build the full MSL source
 # ---------------------------------------------------------------------------
 
@@ -1161,6 +1231,9 @@ def _build_msl_source():
     parts.append(_gen_index_select())
     parts.append(_gen_gather())
     parts.append(_gen_cat_copy())
+
+    # Conv2d compute kernel
+    parts.append(_gen_conv2d())
 
     # Philox RNG kernels
     parts.append(_gen_philox_uniform())

--- a/src/candle/_backends/mps/ops.py
+++ b/src/candle/_backends/mps/ops.py
@@ -2958,14 +2958,38 @@ def rms_norm(input, normalized_shape, weight=None, eps=1e-6):
 
 
 def conv2d(input, weight, bias=None, stride=(1, 1), padding=(0, 0), dilation=(1, 1), groups=1):
-    """Conv2d forward using numpy. Input: (N,C,H,W), Weight: (O,C/g,kH,kW)."""
+    """Conv2d forward. Input: (N,C,H,W), Weight: (O,C/g,kH,kW).
+
+    GPU path via MPSCNNConvolution for float32/float16, contiguous, groups=1.
+    Falls back to numpy otherwise.
+    """
+    # GPU path: float32/float16, contiguous, groups=1
+    if (groups == 1 and _can_use_gpu(input) and _can_use_gpu(weight) and
+        input.dtype in (float32_dtype, float16_dtype) and
+        input.is_contiguous() and weight.is_contiguous()):
+        N, C_in, H_in, W_in = input.shape
+        C_out, C_in_w, kH, kW = weight.shape
+        if C_in == C_in_w:
+            sH, sW = stride if isinstance(stride, tuple) else (stride, stride)
+            pH, pW = padding if isinstance(padding, tuple) else (padding, padding)
+            dH, dW = dilation if isinstance(dilation, tuple) else (dilation, dilation)
+
+            # Check output dimensions are valid
+            H_out = (H_in + 2 * pH - (kH - 1) * dH - 1) // sH + 1
+            W_out = (W_in + 2 * pW - (kW - 1) * dW - 1) // sW + 1
+            if H_out > 0 and W_out > 0:
+                return _conv2d_gpu(input, weight, bias,
+                                   sH, sW, pH, pW, dH, dW,
+                                   N, C_in, H_in, W_in, C_out, kH, kW, H_out, W_out)
+
+    # NumPy fallback
     inp = _to_numpy(input)
     w = _to_numpy(weight)
     N, C_in, H, W = inp.shape
     C_out, C_in_g, kH, kW = w.shape
-    sH, sW = stride
-    pH, pW = padding
-    dH, dW = dilation
+    sH, sW = stride if isinstance(stride, tuple) else (stride, stride)
+    pH, pW = padding if isinstance(padding, tuple) else (padding, padding)
+    dH, dW = dilation if isinstance(dilation, tuple) else (dilation, dilation)
 
     # Effective kernel size with dilation
     ekH = (kH - 1) * dH + 1
@@ -3005,6 +3029,41 @@ def conv2d(input, weight, bias=None, stride=(1, 1), padding=(0, 0), dilation=(1,
         out += b[np.newaxis, :, np.newaxis, np.newaxis]
 
     return _from_numpy(np.ascontiguousarray(out.astype(inp.dtype)), input.dtype, input.device)
+
+
+def _conv2d_gpu(input, weight, bias, sH, sW, pH, pW, dH, dW,
+                N, C_in, H_in, W_in, C_out, kH, kW, H_out, W_out):
+    """GPU conv2d via Metal compute shader."""
+    d = _get_dispatcher()
+    sfx = _kernel_suffix(input.dtype)
+    numel = N * C_out * H_out * W_out
+
+    input_buf = _metal_buf(input)
+    weight_buf = _metal_buf(weight)
+    out_buf = _alloc_output_buf(numel, input.dtype)
+
+    # Bias: need a valid buffer even when None (Metal requires all bindings)
+    has_bias = 0
+    if bias is not None and _can_use_gpu(bias):
+        bias_buf = _metal_buf(bias)
+        has_bias = 1
+    else:
+        from .runtime import get_runtime
+        bias_buf = get_runtime().create_buffer(4)  # dummy 4 bytes
+
+    d.dispatch_conv2d(
+        f"conv2d_{sfx}", input_buf, weight_buf, bias_buf, out_buf,
+        N, C_in, H_in, W_in, C_out, kH, kW,
+        H_out, W_out, sH, sW, pH, pW, dH, dW,
+        has_bias, numel)
+
+    out_shape = (N, C_out, H_out, W_out)
+    out_stride = tuple()
+    s = 1
+    for dim in reversed(out_shape):
+        out_stride = (s,) + out_stride
+        s *= dim
+    return _from_metal_buffer(out_buf, out_shape, out_stride, input.dtype, input.device)
 
 
 def conv1d(input, weight, bias=None, stride=(1,), padding=(0,), dilation=(1,), groups=1):

--- a/tests/mps/test_metal_infra.py
+++ b/tests/mps/test_metal_infra.py
@@ -819,3 +819,144 @@ class TestPhase3ShapeIndex:
         result = torch.stack([a, b], dim=0)
         expected = np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], dtype=np.float32)
         np.testing.assert_allclose(result.cpu().numpy(), expected)
+
+
+# ---------------------------------------------------------------------------
+# Conv2d GPU kernel tests
+# ---------------------------------------------------------------------------
+
+class TestConv2dGPU:
+    """Verify conv2d Metal compute shader correctness."""
+
+    def _conv2d_ref(self, x_np, w_np, b_np=None, stride=1, padding=0, dilation=1):
+        """CPU reference conv2d via candle's numpy path."""
+        x = torch.tensor(x_np)
+        w = torch.tensor(w_np)
+        b = torch.tensor(b_np) if b_np is not None else None
+        return torch.nn.functional.conv2d(
+            x, w, bias=b, stride=stride, padding=padding, dilation=dilation
+        ).numpy()
+
+    def test_basic_f32(self):
+        np.random.seed(0)
+        x = torch.tensor(np.random.randn(1, 3, 8, 8).astype(np.float32), device="mps")
+        w = torch.tensor(np.random.randn(4, 3, 3, 3).astype(np.float32), device="mps")
+        out = torch.nn.functional.conv2d(x, w)
+        ref = self._conv2d_ref(x.cpu().numpy(), w.cpu().numpy())
+        assert out.shape == (1, 4, 6, 6)
+        assert out.device.type == "mps"
+        np.testing.assert_allclose(out.cpu().numpy(), ref, atol=1e-5)
+
+    def test_basic_f16(self):
+        np.random.seed(1)
+        x = torch.tensor(np.random.randn(1, 3, 8, 8).astype(np.float32), device="mps")
+        w = torch.tensor(np.random.randn(4, 3, 3, 3).astype(np.float32), device="mps")
+        # f32 reference
+        ref_f32 = torch.nn.functional.conv2d(x, w)
+        # f16 GPU
+        out = torch.nn.functional.conv2d(x.to(torch.float16), w.to(torch.float16))
+        assert out.dtype == torch.float16
+        np.testing.assert_allclose(
+            out.to(torch.float32).cpu().numpy(), ref_f32.cpu().numpy(), atol=0.05)
+
+    def test_with_bias(self):
+        np.random.seed(2)
+        x_np = np.random.randn(2, 3, 6, 6).astype(np.float32)
+        w_np = np.random.randn(8, 3, 3, 3).astype(np.float32)
+        b_np = np.random.randn(8).astype(np.float32)
+        x = torch.tensor(x_np, device="mps")
+        w = torch.tensor(w_np, device="mps")
+        b = torch.tensor(b_np, device="mps")
+        out = torch.nn.functional.conv2d(x, w, bias=b)
+        ref = self._conv2d_ref(x_np, w_np, b_np)
+        np.testing.assert_allclose(out.cpu().numpy(), ref, atol=1e-5)
+
+    def test_padding(self):
+        np.random.seed(3)
+        x_np = np.random.randn(1, 1, 5, 5).astype(np.float32)
+        w_np = np.random.randn(1, 1, 3, 3).astype(np.float32)
+        x = torch.tensor(x_np, device="mps")
+        w = torch.tensor(w_np, device="mps")
+        out = torch.nn.functional.conv2d(x, w, padding=1)
+        ref = self._conv2d_ref(x_np, w_np, padding=1)
+        assert out.shape == (1, 1, 5, 5)
+        np.testing.assert_allclose(out.cpu().numpy(), ref, atol=1e-5)
+
+    def test_stride(self):
+        np.random.seed(4)
+        x_np = np.random.randn(1, 2, 8, 8).astype(np.float32)
+        w_np = np.random.randn(4, 2, 3, 3).astype(np.float32)
+        x = torch.tensor(x_np, device="mps")
+        w = torch.tensor(w_np, device="mps")
+        out = torch.nn.functional.conv2d(x, w, stride=2)
+        ref = self._conv2d_ref(x_np, w_np, stride=2)
+        assert out.shape == (1, 4, 3, 3)
+        np.testing.assert_allclose(out.cpu().numpy(), ref, atol=1e-5)
+
+    def test_dilation(self):
+        np.random.seed(5)
+        x_np = np.random.randn(1, 1, 8, 8).astype(np.float32)
+        w_np = np.random.randn(2, 1, 3, 3).astype(np.float32)
+        x = torch.tensor(x_np, device="mps")
+        w = torch.tensor(w_np, device="mps")
+        out = torch.nn.functional.conv2d(x, w, dilation=2)
+        ref = self._conv2d_ref(x_np, w_np, dilation=2)
+        assert out.shape == (1, 2, 4, 4)
+        np.testing.assert_allclose(out.cpu().numpy(), ref, atol=1e-5)
+
+    def test_stride_padding_combined(self):
+        np.random.seed(6)
+        x_np = np.random.randn(2, 4, 16, 16).astype(np.float32)
+        w_np = np.random.randn(8, 4, 3, 3).astype(np.float32)
+        b_np = np.random.randn(8).astype(np.float32)
+        x = torch.tensor(x_np, device="mps")
+        w = torch.tensor(w_np, device="mps")
+        b = torch.tensor(b_np, device="mps")
+        out = torch.nn.functional.conv2d(x, w, bias=b, stride=2, padding=1)
+        ref = self._conv2d_ref(x_np, w_np, b_np, stride=2, padding=1)
+        assert out.shape == (2, 8, 8, 8)
+        np.testing.assert_allclose(out.cpu().numpy(), ref, atol=1e-5)
+
+    def test_1x1_conv(self):
+        """1x1 convolution (pointwise)."""
+        np.random.seed(7)
+        x_np = np.random.randn(1, 16, 4, 4).astype(np.float32)
+        w_np = np.random.randn(32, 16, 1, 1).astype(np.float32)
+        x = torch.tensor(x_np, device="mps")
+        w = torch.tensor(w_np, device="mps")
+        out = torch.nn.functional.conv2d(x, w)
+        ref = self._conv2d_ref(x_np, w_np)
+        assert out.shape == (1, 32, 4, 4)
+        np.testing.assert_allclose(out.cpu().numpy(), ref, atol=1e-5)
+
+    def test_large_kernel(self):
+        """Conv with 5x5 kernel."""
+        np.random.seed(8)
+        x_np = np.random.randn(1, 3, 16, 16).astype(np.float32)
+        w_np = np.random.randn(8, 3, 5, 5).astype(np.float32)
+        x = torch.tensor(x_np, device="mps")
+        w = torch.tensor(w_np, device="mps")
+        out = torch.nn.functional.conv2d(x, w, padding=2)
+        ref = self._conv2d_ref(x_np, w_np, padding=2)
+        assert out.shape == (1, 8, 16, 16)
+        np.testing.assert_allclose(out.cpu().numpy(), ref, atol=1e-5)
+
+    def test_batched(self):
+        """Batched conv2d with N > 1."""
+        np.random.seed(9)
+        x_np = np.random.randn(4, 3, 8, 8).astype(np.float32)
+        w_np = np.random.randn(16, 3, 3, 3).astype(np.float32)
+        x = torch.tensor(x_np, device="mps")
+        w = torch.tensor(w_np, device="mps")
+        out = torch.nn.functional.conv2d(x, w)
+        ref = self._conv2d_ref(x_np, w_np)
+        assert out.shape == (4, 16, 6, 6)
+        np.testing.assert_allclose(out.cpu().numpy(), ref, atol=1e-5)
+
+    def test_nn_conv2d_module(self):
+        """Test nn.Conv2d module on MPS."""
+        layer = torch.nn.Conv2d(3, 16, kernel_size=3, padding=1).to("mps")
+        x = torch.randn(2, 3, 8, 8, device="mps")
+        out = layer(x)
+        assert out.shape == (2, 16, 8, 8)
+        assert out.device.type == "mps"


### PR DESCRIPTION
## Summary
- Add GPU-accelerated conv2d for MPS backend using a custom Metal compute shader
- Each GPU thread computes one output element with float32 accumulation (even for float16 inputs) for numerical stability
- Supports stride, padding, dilation, and optional bias; groups=1 only on GPU, groups>1 falls back to numpy
- Replaces the previously attempted (but incorrect) MPSCNNConvolution approach

## Changes
| File | Changes |
|------|---------|
| `metal_shaders.py` | `_CONV2D_TEMPLATE` + `_gen_conv2d()` generator (f32/f16) |
| `metal_compute.py` | `dispatch_conv2d()` with packed 17-uint params buffer + ctypes fallback |
| `ops.py` | Rewrite `_conv2d_gpu` to use Metal compute dispatcher |
| `test_metal_infra.py` | 11 new `TestConv2dGPU` tests |

## Test plan
- [x] 11 conv2d GPU tests: basic f32/f16, bias, padding, stride, dilation, combined stride+padding, 1x1, 5x5, batched, nn.Conv2d module
- [x] Full MPS test suite (253 passed, 0 failed)
- [x] CPU + contract tests (1403 passed, 0 regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)