### PR TITLE
chore(bench): migrate pipeline_npu benchmarks

### DIFF
--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmark package namespace."""

--- a/benchmarks/pipeline_npu/__init__.py
+++ b/benchmarks/pipeline_npu/__init__.py
@@ -1,0 +1,1 @@
+"""Pipeline NPU benchmark helpers."""

--- a/benchmarks/pipeline_npu/bench.py
+++ b/benchmarks/pipeline_npu/bench.py
@@ -1,0 +1,61 @@
+import candle
+
+from .cases import CASES
+from .utils import measure, summarize
+
+
+def _resolve_dtype(dtype_name):
+    return getattr(candle, dtype_name)
+
+
+def _sync_for(device):
+    if device == "npu" and hasattr(candle, "npu") and candle.npu.is_available():
+        return candle.npu.synchronize
+    return None
+
+
+def run_case(case, *, device="cpu", pipeline=False, warmup=5, iters=20):
+    dtype = _resolve_dtype(case["dtype"])
+    forward = case["builder"](device, dtype)
+    sync = _sync_for(device)
+
+    def _run_once():
+        if pipeline:
+            with candle.pipeline(max_ops=64):
+                forward()
+        else:
+            forward()
+
+    samples = measure(_run_once, warmup=warmup, iters=iters, sync=sync)
+    mean, median, p95 = summarize(samples)
+
+    op_count = 0
+    if pipeline:
+        with candle.pipeline(max_ops=64) as pipe:
+            forward()
+            pipe.flush()
+            dump = pipe.debug_dump()
+            op_count = len(dump.get("entries", []))
+
+    return {
+        "case_id": case["case_id"],
+        "batch": case["batch"],
+        "seq": case["seq"],
+        "hidden": case["hidden"],
+        "heads": case["heads"],
+        "dtype": case["dtype"],
+        "mean_ms": float(mean),
+        "median_ms": float(median),
+        "p95_ms": float(p95),
+        "op_count": int(op_count),
+    }
+
+
+def run():
+    results = {}
+    for name, case in CASES.items():
+        results[name] = run_case(case, device="cpu", pipeline=False, warmup=1, iters=1)
+    return results
+
+
+__all__ = ["CASES", "run_case", "run"]

--- a/benchmarks/pipeline_npu/cases.py
+++ b/benchmarks/pipeline_npu/cases.py
@@ -1,0 +1,297 @@
+import candle
+import candle.nn.functional as F
+
+
+def _case_a1(device, dtype):
+    x = candle.randn((1, 128, 1024), device=device, dtype=dtype)
+    w1 = candle.randn((1024, 1024), device=device, dtype=dtype)
+    w2 = candle.randn((1024, 1024), device=device, dtype=dtype)
+
+    def forward():
+        y = (x @ w1).relu()
+        z = y @ w2
+        return z
+
+    return forward
+
+
+def _case_a2(device, dtype):
+    b, s, h, heads = 1, 512, 1024, 16
+    x = candle.randn((b, s, h), device=device, dtype=dtype)
+    wq = candle.randn((h, h), device=device, dtype=dtype)
+    wk = candle.randn((h, h), device=device, dtype=dtype)
+    wv = candle.randn((h, h), device=device, dtype=dtype)
+    wo = candle.randn((h, h), device=device, dtype=dtype)
+    head_dim = h // heads
+
+    def forward():
+        q = x @ wq
+        k = x @ wk
+        v = x @ wv
+        q = q.reshape((b, s, heads, head_dim)).transpose(1, 2)
+        k = k.reshape((b, s, heads, head_dim)).transpose(1, 2)
+        v = v.reshape((b, s, heads, head_dim)).transpose(1, 2)
+        attn = candle.matmul(q.contiguous(), k.contiguous().transpose(-2, -1))
+        attn = F.softmax(attn, dim=-1)
+        out = candle.matmul(attn.contiguous(), v.contiguous())
+        out = out.transpose(1, 2).reshape((b, s, h))
+        return out @ wo
+
+    return forward
+
+
+def _case_a2s(device, dtype):
+    b, s, h, heads = 2, 256, 512, 8
+    x = candle.randn((b, s, h), device=device, dtype=dtype)
+    wq = candle.randn((h, h), device=device, dtype=dtype)
+    wk = candle.randn((h, h), device=device, dtype=dtype)
+    wv = candle.randn((h, h), device=device, dtype=dtype)
+    wo = candle.randn((h, h), device=device, dtype=dtype)
+    head_dim = h // heads
+
+    def forward():
+        q = x @ wq
+        k = x @ wk
+        v = x @ wv
+        q = q.reshape((b, s, heads, head_dim)).transpose(1, 2)
+        k = k.reshape((b, s, heads, head_dim)).transpose(1, 2)
+        v = v.reshape((b, s, heads, head_dim)).transpose(1, 2)
+        attn = candle.matmul(q.contiguous(), k.contiguous().transpose(-2, -1))
+        attn = F.softmax(attn, dim=-1)
+        out = candle.matmul(attn.contiguous(), v.contiguous())
+        out = out.transpose(1, 2).reshape((b, s, h))
+        return out @ wo
+
+    return forward
+
+
+def _case_a3(device, dtype):
+    b, s, h = 8, 128, 2048
+    x = candle.randn((b, s, h), device=device, dtype=dtype)
+    w1 = candle.randn((h, 4 * h), device=device, dtype=dtype)
+    w2 = candle.randn((4 * h, h), device=device, dtype=dtype)
+
+    def forward():
+        y = F.silu(x @ w1)
+        return y @ w2
+
+    return forward
+
+
+def _block(device, dtype, *, b, s, h, heads):
+    x = candle.randn((b, s, h), device=device, dtype=dtype)
+    wq = candle.randn((h, h), device=device, dtype=dtype)
+    wk = candle.randn((h, h), device=device, dtype=dtype)
+    wv = candle.randn((h, h), device=device, dtype=dtype)
+    wo = candle.randn((h, h), device=device, dtype=dtype)
+    w1 = candle.randn((h, 4 * h), device=device, dtype=dtype)
+    w2 = candle.randn((4 * h, h), device=device, dtype=dtype)
+    head_dim = h // heads
+
+    def forward():
+        y = F.layer_norm(x, (h,))
+        q = y @ wq
+        k = y @ wk
+        v = y @ wv
+        q = q.reshape((b, s, heads, head_dim)).transpose(1, 2)
+        k = k.reshape((b, s, heads, head_dim)).transpose(1, 2)
+        v = v.reshape((b, s, heads, head_dim)).transpose(1, 2)
+        attn = candle.matmul(q.contiguous(), k.contiguous().transpose(-2, -1))
+        attn = F.softmax(attn, dim=-1)
+        out = candle.matmul(attn.contiguous(), v.contiguous())
+        out = out.transpose(1, 2).reshape((b, s, h))
+        x1 = x + (out @ wo)
+        z = F.layer_norm(x1, (h,))
+        z = F.gelu(z @ w1)
+        return x1 + (z @ w2)
+
+    return forward
+
+
+def _case_b1(device, dtype):
+    return _block(device, dtype, b=1, s=512, h=2048, heads=16)
+
+
+def _case_b1s(device, dtype):
+    return _block(device, dtype, b=2, s=256, h=512, heads=8)
+
+
+def _case_b2(device, dtype):
+    return _block(device, dtype, b=4, s=128, h=1024, heads=8)
+
+
+def _case_b3(device, dtype):
+    return _block(device, dtype, b=1, s=2048, h=1024, heads=16)
+
+
+def _case_c1(device, dtype):
+    block = _block(device, dtype, b=1, s=512, h=1024, heads=16)
+
+    def forward():
+        out = block()
+        out = block()
+        out = block()
+        out = block()
+        return out
+
+    return forward
+
+
+def _case_c2(device, dtype):
+    block = _block(device, dtype, b=2, s=256, h=1024, heads=16)
+
+    def forward():
+        out = block()
+        out = block()
+        out = block()
+        out = block()
+        return out
+
+    return forward
+
+
+def _case_d1(device, dtype):
+    block = _block(device, dtype, b=2, s=256, h=512, heads=8)
+
+    def forward():
+        out = block()
+        out = block()
+        out = block()
+        out = block()
+        out = block()
+        out = block()
+        out = block()
+        out = block()
+        return out
+
+    return forward
+
+
+def _case_d2(device, dtype):
+    b, s, h = 8, 128, 256
+    x = candle.randn((b, s, h), device=device, dtype=dtype)
+    bias = candle.randn((h,), device=device, dtype=dtype)
+    scale = candle.randn((h,), device=device, dtype=dtype)
+
+    def forward():
+        y = x
+        for _ in range(12):
+            y = y + bias
+            y = F.relu(y)
+            y = y * scale
+            y = y + y
+        return y
+
+    return forward
+
+
+CASES = {
+    "A1": {
+        "case_id": "A1",
+        "batch": 1,
+        "seq": 128,
+        "hidden": 1024,
+        "heads": None,
+        "dtype": "float16",
+        "builder": _case_a1,
+    },
+    "A2": {
+        "case_id": "A2",
+        "batch": 1,
+        "seq": 512,
+        "hidden": 1024,
+        "heads": 16,
+        "dtype": "float16",
+        "builder": _case_a2,
+    },
+    "A2s": {
+        "case_id": "A2s",
+        "batch": 2,
+        "seq": 256,
+        "hidden": 512,
+        "heads": 8,
+        "dtype": "float16",
+        "builder": _case_a2s,
+    },
+    "A3": {
+        "case_id": "A3",
+        "batch": 8,
+        "seq": 128,
+        "hidden": 2048,
+        "heads": None,
+        "dtype": "float16",
+        "builder": _case_a3,
+    },
+    "B1": {
+        "case_id": "B1",
+        "batch": 1,
+        "seq": 512,
+        "hidden": 2048,
+        "heads": 16,
+        "dtype": "float16",
+        "builder": _case_b1,
+    },
+    "B1s": {
+        "case_id": "B1s",
+        "batch": 2,
+        "seq": 256,
+        "hidden": 512,
+        "heads": 8,
+        "dtype": "float16",
+        "builder": _case_b1s,
+    },
+    "B2": {
+        "case_id": "B2",
+        "batch": 4,
+        "seq": 128,
+        "hidden": 1024,
+        "heads": 8,
+        "dtype": "float16",
+        "builder": _case_b2,
+    },
+    "B3": {
+        "case_id": "B3",
+        "batch": 1,
+        "seq": 2048,
+        "hidden": 1024,
+        "heads": 16,
+        "dtype": "float16",
+        "builder": _case_b3,
+    },
+    "C1": {
+        "case_id": "C1",
+        "batch": 1,
+        "seq": 512,
+        "hidden": 1024,
+        "heads": 16,
+        "dtype": "float16",
+        "builder": _case_c1,
+    },
+    "C2": {
+        "case_id": "C2",
+        "batch": 2,
+        "seq": 256,
+        "hidden": 1024,
+        "heads": 16,
+        "dtype": "float16",
+        "builder": _case_c2,
+    },
+    "D1": {
+        "case_id": "D1",
+        "batch": 2,
+        "seq": 256,
+        "hidden": 512,
+        "heads": 8,
+        "dtype": "float16",
+        "builder": _case_d1,
+    },
+    "D2": {
+        "case_id": "D2",
+        "batch": 8,
+        "seq": 128,
+        "hidden": 256,
+        "heads": None,
+        "dtype": "float16",
+        "builder": _case_d2,
+    },
+}

--- a/benchmarks/pipeline_npu/utils.py
+++ b/benchmarks/pipeline_npu/utils.py
@@ -1,0 +1,31 @@
+import time
+
+
+def measure(fn, *, warmup=5, iters=20, sync=None):
+    for _ in range(warmup):
+        if sync is not None:
+            sync()
+        fn()
+        if sync is not None:
+            sync()
+
+    samples = []
+    for _ in range(iters):
+        if sync is not None:
+            sync()
+        start = time.perf_counter()
+        fn()
+        if sync is not None:
+            sync()
+        samples.append((time.perf_counter() - start) * 1000.0)
+    return samples
+
+
+def summarize(samples):
+    if not samples:
+        return 0.0, 0.0, 0.0
+    values = sorted(samples)
+    mean = sum(values) / len(values)
+    median = values[len(values) // 2]
+    p95 = values[int(len(values) * 0.95) - 1]
+    return mean, median, p95


### PR DESCRIPTION
## Summary
- Migrate pipeline benchmark suite into `benchmarks/` from mindnlp.
- Update imports to use candle for pipeline benchmark runs.

## Test Plan
- [x] `PYTHONPATH=src pytest tests/npu/test_pipeline_npu_bench_smoke.py -v --tb=short`
- [x] `PYTHONPATH=src pytest tests/contract/ -v --tb=short`
