### PR TITLE
npu: block bool-mask indexing to avoid CPU round-trips

### DIFF
--- a/docs/known-kernel-issues.md
+++ b/docs/known-kernel-issues.md
@@ -18,5 +18,6 @@ This document tracks native kernel bugs and their on-device composite workaround
 
 <!--
 Entry template:
+| `getitem` (bool mask) | npu | ACLNN index fails for bool-mask advanced indexing (aclnnIndexGetWorkspaceSize 161001). | Fail explicitly; no CPU fallback. | CANN 8.3 / Candle `0.1.x` | open |
 | `aten.op_name` | mps/cuda/npu | Brief error description | `op_a` + `op_b` composite | macOS XX.X / CANN X.X / CUDA XX.X | open/resolved |
 -->

--- a/src/candle/_backends/npu/ops.py
+++ b/src/candle/_backends/npu/ops.py
@@ -3955,8 +3955,15 @@ def contiguous(a):
 
 def getitem(tensor, key):
     """NPU tensor indexing — full support for basic and advanced indexing."""
+    from ..._tensor import Tensor
     if not isinstance(key, tuple):
         key = (key,)
+
+    for item in key:
+        if isinstance(item, Tensor) and item.dtype == bool_dtype:
+            raise RuntimeError("NPU boolean mask indexing is not supported")
+        if isinstance(item, Tensor) and item.dtype.is_floating_point and item.shape == tensor.shape:
+            raise RuntimeError("NPU boolean mask indexing is not supported")
 
     if _is_basic_index_key(key):
         view = _npu_basic_getitem_view(tensor, key)
@@ -3968,8 +3975,15 @@ def getitem(tensor, key):
 
 def setitem(tensor, key, value):
     """NPU tensor index assignment — full support for basic and advanced indexing."""
+    from ..._tensor import Tensor
     if not isinstance(key, tuple):
         key = (key,)
+
+    for item in key:
+        if isinstance(item, Tensor) and item.dtype == bool_dtype:
+            raise RuntimeError("NPU boolean mask indexing is not supported")
+        if isinstance(item, Tensor) and item.dtype.is_floating_point and item.shape == tensor.shape:
+            raise RuntimeError("NPU boolean mask indexing is not supported")
 
     if _is_basic_index_key(key):
         view = _npu_basic_getitem_view(tensor, key)
@@ -4529,7 +4543,10 @@ def _npu_advanced_getitem(tensor, key):
         if cur_dim < 0:
             continue
         adv_current_dims.append(cur_dim)
-        idx_tensor = _to_npu_index_tensor(dim_actions[i][1], prepared.device)
+        item = dim_actions[i][1]
+        idx_tensor = _to_npu_index_tensor(item, prepared.device)
+        if isinstance(idx_tensor, tuple):
+            raise RuntimeError("NPU boolean mask indexing is not supported")
         adv_index_tensors.append(idx_tensor)
 
     if not adv_index_tensors:
@@ -11358,4 +11375,3 @@ def upsample_nearest1d_op(a, output_size, scales=None):
     a_4d = view_backend.reshape(a, (N, C, 1, W))
     out_4d = dispatch("upsample_nearest2d", "npu", a_4d, [1, oW], None, scales)
     return view_backend.reshape(out_4d, (N, C, oW))
-

--- a/tests/contract/test_npu_indexing_no_cpu_roundtrip.py
+++ b/tests/contract/test_npu_indexing_no_cpu_roundtrip.py
@@ -1,0 +1,36 @@
+import pytest
+
+from candle import npu as npu_api
+from candle import tensor
+from candle._backends.npu import runtime as npu_runtime
+
+
+def _block_cpu_roundtrip(monkeypatch):
+    def _fail(*_args, **_kwargs):
+        raise AssertionError("CPU round-trip is not allowed in NPU indexing path")
+
+    monkeypatch.setattr(npu_runtime, "memcpy_d2h", _fail)
+    monkeypatch.setattr(npu_runtime, "_copy_cpu_to_npu", _fail)
+
+
+@pytest.mark.skipif(not npu_api.is_available(), reason="NPU not available")
+@pytest.mark.parametrize("case", ["basic", "tensor", "bool"])
+def test_npu_indexing_avoids_cpu_roundtrip(monkeypatch, case):
+    x = tensor([[1, 2, 3], [4, 5, 6]], device="npu")
+
+    if case == "tensor":
+        idx = tensor([0, 2], device="npu")
+    elif case == "bool":
+        mask = tensor([[True, False, True], [False, True, False]], device="npu")
+
+    _block_cpu_roundtrip(monkeypatch)
+
+    if case == "basic":
+        y = x[:, 1]
+        assert y is not None
+    elif case == "tensor":
+        y = x[0, idx]
+        assert y is not None
+    else:
+        with pytest.raises(RuntimeError, match="NPU boolean mask indexing is not supported"):
+            _ = x[mask]


### PR DESCRIPTION
## Summary
- block NPU boolean-mask indexing to avoid CPU round-trips and ACLNN failures
- add a contract test that asserts indexing avoids CPU round-trips
- document the known NPU bool-mask indexing issue

## Testing
- `PYTHONPATH=/home/lvyufeng/lvyufeng/candle/.worktrees/npu-no-cpu-roundtrip/src pytest tests/contract/test_npu_indexing_no_cpu_roundtrip.py -v --tb=short`
