### PR TITLE
feat: add sum_to_size cpu parity

### DIFF
--- a/docs/plans/2026-03-12-cpu-sum-to-size-design.md
+++ b/docs/plans/2026-03-12-cpu-sum-to-size-design.md
@@ -1,0 +1,38 @@
+# CPU sum_to_size Design
+
+**Goal:** Add `sum_to_size` on CPU with full PyTorch error-message parity, correct forward/backward semantics, and contract tests that compare candle vs. real torch.
+
+**Scope**
+- Schema registration already exists: `sum_to_size(Tensor input, int[] size) -> Tensor`.
+- Add full argument validation to match PyTorch error strings.
+- Implement CPU kernel, meta inference, autograd backward, and contract tests.
+- Export functional/tensor API already exists.
+
+**Non-Goals**
+- No new GPU/NPU kernels.
+- No additional operator families beyond `sum_to_size`.
+
+**Architecture**
+- `src/candle/_dispatch/schema.py`: add `sum_to_size`-specific validation that mirrors PyTorch type errors for `size` (top-level types and per-element errors with exact messages).
+- `src/candle/_backends/cpu/ops.py`: implement `sum_to_size` by reducing over extra leading dims and dims where `target==1` and input dim > 1, matching PyTorch expandability rules. If target size equals input shape, return the input view directly.
+- `src/candle/_backends/meta/infer.py`: add `infer_sum_to_size` returning the target shape with correct error handling for non-expandable sizes.
+- `src/candle/_backends/cpu/__init__.py`: register `sum_to_size` with CPU kernel and meta.
+- `src/candle/_backends/autograd.py`: add backward that expands grad to input shape using `expand` (consistent with PyTorch semantics).
+
+**Error Semantics**
+- Invalid top-level `size` types raise `TypeError` with exact PyTorch text: "must be tuple of ints, not <type>".
+- Invalid first element raises: "must be tuple of ints, but found element of type <type> at pos 0".
+- Invalid later element raises: "failed to unpack the object at pos <idx> with error \"type must be tuple of ints,but got <type>\"".
+- Bool elements are treated like ints except at position 0 (matches PyTorch).
+- Non-expandable sizes raise `RuntimeError`: "size {[...] } is not expandable to size {[...]}".
+
+**Testing**
+- Expand `tests/contract/test_training_core_sum_to_size_parity.py` to cover:
+  - Forward parity for typical sizes and scalar output.
+  - Full error-message matrix vs real torch.
+  - Backward parity for reduction cases.
+  - View-like behavior when target size equals input shape (storage sharing).
+
+**Risks**
+- Error-message strings must match exactly; tests compare against real torch.
+- Backward must broadcast correctly for all rank reductions.

--- a/docs/plans/2026-03-12-cpu-sum-to-size-implementation-plan.md
+++ b/docs/plans/2026-03-12-cpu-sum-to-size-implementation-plan.md
@@ -1,0 +1,197 @@
+# sum_to_size Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `sum_to_size` with full PyTorch error-message parity on CPU, including schema validation, kernel, meta inference, autograd, and expanded contract tests.
+
+**Architecture:** Implement size validation in schema layer, CPU kernel in ops, meta inference for shapes, and autograd backward that expands grad to input shape. Expand contract tests to diff against real torch errors.
+
+**Tech Stack:** Python, pytest, candle dispatch/autograd/meta frameworks.
+
+---
+
+### Task 1: Expand contract tests for full error-message parity
+
+**Files:**
+- Modify: `tests/contract/test_training_core_sum_to_size_parity.py`
+
+**Step 1: Write the failing test**
+
+Add tests that compare candle vs torch for:
+- top-level invalid sizes: `True`, `1.5`, `"1"`, `None`
+- first element invalid: `("1", 3)`, `(1.5, 3)`, `(None, 3)`, `([1], 3)`
+- later element invalid: `(1, "1")`, `(1, 1.5)`, `(1, None)`, `(1, [3])`, `(1, True, "a")`
+- bool element first vs later (`(True, 3)` invalid, `(1, True)` valid)
+- empty list accepted
+- size mismatch errors for `[0, 3]`, `[-1, 3]`, `[1, 2, 3]`, `[2, 2]`
+- view behavior when size equals input shape (storage sharing)
+
+**Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=src pytest tests/contract/test_training_core_sum_to_size_parity.py -v`
+Expected: FAIL with missing kernel / schema validation errors.
+
+---
+
+### Task 2: Add schema validation for sum_to_size size argument
+
+**Files:**
+- Modify: `src/candle/_dispatch/schema.py`
+
+**Step 1: Write the failing test**
+
+No new test; use expanded contract test.
+
+**Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=src pytest tests/contract/test_training_core_sum_to_size_parity.py::test_sum_to_size_type_error_matches_torch_contract -v`
+Expected: FAIL with mismatched error messages.
+
+**Step 3: Write minimal implementation**
+
+Add `_validate_sum_to_size_size` inside `_validate_types`:
+- If `size` is bool/float/str/None → `TypeError` with `sum_to_size(): argument 'size' (position 1) must be tuple of ints, not <type>`.
+- If `size` is list/tuple:
+  - empty sequence → accept
+  - first element invalid (`not int` or `bool` or `None` or list/tuple/str/float) → `TypeError` "must be tuple of ints, but found element of type <type> at pos 0"
+  - later invalid → `TypeError` "failed to unpack the object at pos <idx+1> with error \"type must be tuple of ints,but got <type>\"".
+  - treat bool elements as ints except for position 0 (per PyTorch).
+- If `size` is int → accept.
+
+Wire into `_validate_types` when `op_short_name == "sum_to_size"` and param is `size`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=src pytest tests/contract/test_training_core_sum_to_size_parity.py::test_sum_to_size_type_error_matches_torch_contract -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+`git add src/candle/_dispatch/schema.py tests/contract/test_training_core_sum_to_size_parity.py`
+`git commit -m "test: expand sum_to_size contract parity"`
+
+---
+
+### Task 3: Implement CPU kernel for sum_to_size
+
+**Files:**
+- Modify: `src/candle/_backends/cpu/ops.py`
+
+**Step 1: Write the failing test**
+
+Use existing contract test `test_sum_to_size_forward_matches_torch_contract`.
+
+**Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=src pytest tests/contract/test_training_core_sum_to_size_parity.py::test_sum_to_size_forward_matches_torch_contract -v`
+Expected: FAIL with missing kernel registration.
+
+**Step 3: Write minimal implementation**
+
+Add `sum_to_size(a, size)`:
+- Normalize size to tuple of ints.
+- If size matches `a.shape`, return `a`.
+- Validate expandability against `a.shape` (right-aligned):
+  - If `len(size) > a.dim()` or any target dim <= 0 or mismatch where target not 1 and not equal → raise `RuntimeError` with `size {[...]} is not expandable to size {[...]}.'
+- Reduce `a` using numpy:
+  - While extra leading dims exist, sum over axis 0.
+  - For each dimension where target == 1 and current dim > 1, sum over that axis with keepdims.
+- Return tensor from numpy with original dtype/device.
+
+**Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=src pytest tests/contract/test_training_core_sum_to_size_parity.py::test_sum_to_size_forward_matches_torch_contract -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+`git add src/candle/_backends/cpu/ops.py`
+`git commit -m "feat: add cpu sum_to_size"`
+
+---
+
+### Task 4: Add meta inference and CPU registration
+
+**Files:**
+- Modify: `src/candle/_backends/meta/infer.py`
+- Modify: `src/candle/_backends/cpu/__init__.py`
+
+**Step 1: Write the failing test**
+
+Use existing contract tests.
+
+**Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=src pytest tests/contract/test_training_core_sum_to_size_parity.py::test_sum_to_size_scalar_shape_matches_torch_contract -v`
+Expected: FAIL or mismatch.
+
+**Step 3: Write minimal implementation**
+
+Add `infer_sum_to_size(a, size)`:
+- Determine target shape like kernel logic.
+- Raise same expandability `RuntimeError` for invalid sizes.
+- Return `TensorSpec(shape=target, stride=_contiguous_stride(target), dtype=a.dtype)`.
+
+Register in `src/candle/_backends/cpu/__init__.py`:
+- Add import for `sum_to_size` and register: `registry.register("sum_to_size", "cpu", sum_to_size, meta=meta_infer.infer_sum_to_size)`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=src pytest tests/contract/test_training_core_sum_to_size_parity.py::test_sum_to_size_scalar_shape_matches_torch_contract -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+`git add src/candle/_backends/meta/infer.py src/candle/_backends/cpu/__init__.py`
+`git commit -m "feat: register sum_to_size meta"`
+
+---
+
+### Task 5: Add autograd backward for sum_to_size
+
+**Files:**
+- Modify: `src/candle/_backends/autograd.py`
+
+**Step 1: Write the failing test**
+
+Use `test_sum_to_size_backward_matches_torch_contract`.
+
+**Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=src pytest tests/contract/test_training_core_sum_to_size_parity.py::test_sum_to_size_backward_matches_torch_contract -v`
+Expected: FAIL with missing autograd kernel.
+
+**Step 3: Write minimal implementation**
+
+Add `_sum_to_size_backward(grad, a, _saved_a, keyset, args, kwargs)`:
+- Extract target size from args.
+- Use `redispatch("expand", keyset, grad, a.shape)` after ensuring grad is reshaped to target size.
+- Return expanded grad for input; no grad for size.
+
+Register in autograd table:
+- Add `("sum_to_size", lambda: _autograd_unary_args("sum_to_size", _sum_to_size_backward, save_input=False))`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=src pytest tests/contract/test_training_core_sum_to_size_parity.py::test_sum_to_size_backward_matches_torch_contract -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+`git add src/candle/_backends/autograd.py`
+`git commit -m "feat: add sum_to_size autograd"`
+
+---
+
+### Task 6: Full contract gate
+
+**Step 1: Run full contract tests**
+
+Run: `PYTHONPATH=src pytest tests/contract/ -v --tb=short`
+Expected: PASS.
+
+**Step 2: Final commit (if needed)**
+
+`git add tests/contract/test_training_core_sum_to_size_parity.py`
+`git commit -m "test: expand sum_to_size parity coverage"`
+

--- a/src/candle/__init__.py
+++ b/src/candle/__init__.py
@@ -122,6 +122,7 @@ from ._functional import unique, searchsorted, kthvalue, median
 # Category A: Export existing functions
 from ._functional import eq, ne, lt, le, gt, ge
 from ._functional import select, expand, masked_fill, unfold
+from ._functional import sum_to_size
 from ._functional import slice, slice_copy, slice_scatter, expand_copy
 from ._functional import as_strided_, as_strided_copy, as_strided_scatter
 from ._functional import scatter_, scatter_add_

--- a/src/candle/_backends/autograd.py
+++ b/src/candle/_backends/autograd.py
@@ -347,6 +347,18 @@ def _sum_backward(grad, _a, saved_a, keyset):
         return (redispatch("mul", keyset, grad, ones),)
 
 
+def _sum_to_size_backward(grad, a, _saved_a, keyset, args, _kwargs):
+    target = args[0]
+    if isinstance(target, int):
+        target = (target,)
+    target = tuple(target)
+    with _grad_context(keyset):
+        reduced = reduce_grad(grad, target)
+        expanded = redispatch("expand", keyset, reduced, a.shape)
+        expanded = redispatch("contiguous", keyset, expanded)
+        return (expanded,)
+
+
 def _mean_backward(grad, _a, saved_a, keyset):
     with _grad_context(keyset):
         numel = saved_a.numel()
@@ -7250,6 +7262,7 @@ for _entry in (
     ("squeeze", lambda: _autograd_view("squeeze", _squeeze_backward)),
     ("unsqueeze", lambda: _autograd_view("unsqueeze", _unsqueeze_backward)),
     ("expand", lambda: _autograd_view("expand", _expand_backward)),
+    ("sum_to_size", lambda: _autograd_unary_args("sum_to_size", _sum_to_size_backward, save_input=False)),
     ("permute", lambda: _autograd_view("permute", _permute_backward)),
     ("slice", lambda: _autograd_unary_args("slice", _slice_backward, save_input=False)),
     ("as_strided_scatter", lambda: _autograd_binary_args("as_strided_scatter", _as_strided_scatter_backward, save_inputs=False), False),

--- a/src/candle/_backends/cpu/__init__.py
+++ b/src/candle/_backends/cpu/__init__.py
@@ -181,6 +181,7 @@ from .ops import (
     narrow,
     select,
     expand,
+    sum_to_size,
     masked_fill,
     masked_fill_,
     index_put_,
@@ -450,6 +451,7 @@ registry.register("linalg_qr", "cpu", linalg_qr)
 registry.register("narrow", "cpu", narrow)
 registry.register("select", "cpu", select)
 registry.register("expand", "cpu", expand)
+registry.register("sum_to_size", "cpu", sum_to_size, meta=meta_infer.infer_sum_to_size)
 registry.register("masked_fill", "cpu", masked_fill, meta=meta_infer.infer_unary)
 registry.register("masked_fill_", "cpu", masked_fill_, meta=meta_infer.infer_unary)
 registry.register("index_put_", "cpu", index_put_)

--- a/src/candle/_backends/cpu/ops.py
+++ b/src/candle/_backends/cpu/ops.py
@@ -1739,6 +1739,61 @@ def expand(a, sizes):
     return Tensor(a.storage(), tuple(out_shape), tuple(out_stride), a.offset)
 
 
+def sum_to_size(a, size):
+    if isinstance(size, list):
+        size = tuple(size)
+    elif isinstance(size, int):
+        size = (size,)
+
+    target = tuple(int(v) for v in size)
+    input_shape = tuple(a.shape)
+
+    if target == input_shape:
+        return a
+
+    if len(target) > len(input_shape) or any(dim <= 0 for dim in target):
+        raise RuntimeError(f"size {{{list(target)}}} is not expandable to size {{{list(input_shape)}}}.")
+
+    ndiff = len(input_shape) - len(target)
+    padded_target = (1,) * ndiff + target
+
+    for tgt, src in zip(padded_target, input_shape):
+        if tgt != 1 and tgt != src:
+            raise RuntimeError(f"size {{{list(target)}}} is not expandable to size {{{list(input_shape)}}}.")
+
+    arr = _to_numpy(a)
+    needs_reduce = ndiff > 0
+
+    if not needs_reduce:
+        for tgt, src in zip(target, input_shape):
+            if tgt == 1 and src != 1:
+                needs_reduce = True
+                break
+
+    if not needs_reduce:
+        return a
+
+    if a.dtype.is_floating_point or a.dtype.is_complex:
+        out_dtype = a.dtype
+        acc_dtype = None
+    else:
+        out_dtype = int64_dtype
+        acc_dtype = np.int64
+
+    if acc_dtype is not None:
+        arr = arr.astype(acc_dtype, copy=False)
+
+    while arr.ndim > len(target):
+        arr = arr.sum(axis=0)
+
+    for axis, (tgt, src) in enumerate(zip(target, arr.shape)):
+        if tgt == 1 and src != 1:
+            arr = arr.sum(axis=axis, keepdims=True)
+
+    arr = np.array(arr)
+    return _from_numpy(arr.astype(to_numpy_dtype(out_dtype), copy=False), out_dtype, a.device)
+
+
 def slice_op(a, dim, start=0, end=9223372036854775807, step=1):
     if step <= 0:
         raise RuntimeError("slice step must be positive")

--- a/src/candle/_backends/meta/infer.py
+++ b/src/candle/_backends/meta/infer.py
@@ -47,6 +47,41 @@ def infer_unary_bool(a, *args, **kwargs):
     return TensorSpec(shape=tuple(a.shape), stride=_contiguous_stride(a.shape), dtype=bool_dtype)
 
 
+def infer_sum_to_size(a, size):
+    if isinstance(size, list):
+        size = tuple(size)
+    elif isinstance(size, int):
+        size = (size,)
+
+    target = tuple(int(v) for v in size)
+    input_shape = tuple(a.shape)
+
+    if len(target) > len(input_shape) or any(dim <= 0 for dim in target):
+        raise RuntimeError(f"size {{{list(target)}}} is not expandable to size {{{list(input_shape)}}}.")
+
+    ndiff = len(input_shape) - len(target)
+    padded_target = (1,) * ndiff + target
+
+    for tgt, src in zip(padded_target, input_shape):
+        if tgt != 1 and tgt != src:
+            raise RuntimeError(f"size {{{list(target)}}} is not expandable to size {{{list(input_shape)}}}.")
+
+    needs_reduce = ndiff > 0
+    if not needs_reduce:
+        for tgt, src in zip(target, input_shape):
+            if tgt == 1 and src != 1:
+                needs_reduce = True
+                break
+
+    if needs_reduce and not (a.dtype.is_floating_point or a.dtype.is_complex):
+        out_dtype = int64_dtype
+    else:
+        out_dtype = a.dtype
+
+    return TensorSpec(shape=target, stride=_contiguous_stride(target), dtype=out_dtype)
+
+
+
 def infer_sum(a, dim=None, keepdim=False):
     shape = list(a.shape)
     if isinstance(dim, (list, tuple)) and len(dim) == 0:

--- a/src/candle/_dispatch/dispatcher.py
+++ b/src/candle/_dispatch/dispatcher.py
@@ -343,6 +343,9 @@ def _format_dispatch_context(op_name, dispatch_device):
 
 
 def _wrap_dispatch_error(exc, op_name, dispatch_device):
+    # Keep PyTorch parity for specific ops where tests compare exact messages.
+    if op_name in {"sum_to_size"} and isinstance(exc, RuntimeError):
+        return exc
     context = _format_dispatch_context(op_name, dispatch_device)
     msg = f"{exc} [{context}]"
     exc_type = type(exc)

--- a/src/candle/_dispatch/schema.py
+++ b/src/candle/_dispatch/schema.py
@@ -620,6 +620,49 @@ class OpSchema:
                     raise RuntimeError("permute(): duplicate dims are not allowed.")
                 seen.add(norm)
 
+        def _validate_sum_to_size_size(value):
+            # Match torch.sum_to_size type errors for size argument.
+            if isinstance(value, bool):
+                raise TypeError(
+                    f"{op_short_name}(): argument 'size' (position 1) must be tuple of ints, not bool"
+                )
+            if isinstance(value, int):
+                return
+            if isinstance(value, float):
+                raise TypeError(
+                    f"{op_short_name}(): argument 'size' (position 1) must be tuple of ints, not float"
+                )
+            if isinstance(value, str):
+                raise TypeError(
+                    f"{op_short_name}(): argument 'size' (position 1) must be tuple of ints, not str"
+                )
+            if value is None:
+                raise TypeError(
+                    f"{op_short_name}(): argument 'size' (position 1) must be tuple of ints, not NoneType"
+                )
+            if isinstance(value, (list, tuple)):
+                if not value:
+                    return
+                first = value[0]
+                if not isinstance(first, int) or isinstance(first, bool):
+                    first_type = type(first).__name__
+                    raise TypeError(
+                        f"{op_short_name}(): argument 'size' (position 1) must be tuple of ints, "
+                        f"but found element of type {first_type} at pos 0"
+                    )
+                for idx, item in enumerate(value[1:], start=1):
+                    if not isinstance(item, int):
+                        item_type = type(item).__name__
+                        raise TypeError(
+                            f"{op_short_name}(): argument 'size' failed to unpack the object at pos {idx + 1} "
+                            f"with error \"type must be tuple of ints,but got {item_type}\""
+                        )
+                return
+            other_type = type(value).__name__
+            raise TypeError(
+                f"{op_short_name}(): argument 'size' (position 1) must be tuple of ints, not {other_type}"
+            )
+
         def _validate_transpose_dims(dim0, dim1):
             valid0 = isinstance(dim0, int) and not isinstance(dim0, bool)
             valid1 = isinstance(dim1, int) and not isinstance(dim1, bool)
@@ -684,6 +727,9 @@ class OpSchema:
             if op_short_name == "permute" and param.name == "dims":
                 input_tensor = bound.get("input")
                 _validate_permute_dims(value, input_tensor)
+                continue
+            if op_short_name == "sum_to_size" and param.name == "size":
+                _validate_sum_to_size_size(value)
                 continue
             if op_short_name == "topk" and param.name == "k":
                 _validate_topk_k(value)

--- a/src/candle/_dispatch/schemas.py
+++ b/src/candle/_dispatch/schemas.py
@@ -377,6 +377,7 @@ def register_schemas():
     registry.register_schema("narrow", "narrow(Tensor(a) input, int dim, int start, int length) -> Tensor(a)")
     registry.register_schema("select", "select(Tensor(a) input, int dim, int index) -> Tensor(a)")
     registry.register_schema("expand", "expand(Tensor(a) input, int[] sizes) -> Tensor(a)")
+    registry.register_schema("sum_to_size", "sum_to_size(Tensor input, int[] size) -> Tensor")
     registry.register_schema("unfold", "unfold(Tensor(a) input, int dimension, int size, int step) -> Tensor(a)")
     registry.register_schema("slice", "slice(Tensor(a) input, int dim, int start=0, int end=9223372036854775807, int step=1) -> Tensor(a)")
     registry.register_schema("slice_copy", "slice_copy(Tensor input, int dim, int start=0, int end=9223372036854775807, int step=1) -> Tensor")

--- a/src/candle/_functional.py
+++ b/src/candle/_functional.py
@@ -911,6 +911,18 @@ def expand(a, *sizes):
     return dispatch("expand", a.device.type, a, sizes)
 
 
+def sum_to_size(a, *size):
+    if len(size) == 1:
+        arg = size[0]
+        if isinstance(arg, (tuple, list)):
+            size = tuple(arg)
+        else:
+            size = arg
+    else:
+        size = tuple(size)
+    return dispatch("sum_to_size", a.device.type, a, size)
+
+
 def slice(input, dim, start=0, end=9223372036854775807, step=1):
     return dispatch("slice", input.device.type, input, dim, start, end, step)
 

--- a/src/candle/_tensor.py
+++ b/src/candle/_tensor.py
@@ -66,6 +66,7 @@ from ._functional import mm as mm_dispatch, bmm as bmm_dispatch
 from ._functional import floor_divide as floor_divide_dispatch
 from ._functional import slice as slice_dispatch, slice_copy as slice_copy_dispatch, slice_scatter as slice_scatter_dispatch
 from ._functional import expand_copy as expand_copy_dispatch
+from ._functional import sum_to_size as sum_to_size_dispatch
 from ._functional import as_strided_ as as_strided__dispatch
 from ._functional import as_strided_copy as as_strided_copy_dispatch
 from ._functional import as_strided_scatter as as_strided_scatter_dispatch
@@ -1533,6 +1534,9 @@ class Tensor:
 
     def expand_copy(self, *sizes):
         return expand_copy_dispatch(self, sizes)
+
+    def sum_to_size(self, *size):
+        return sum_to_size_dispatch(self, *size)
 
     def expand_as(self, other):
         return expand_dispatch(self, *other.shape)

--- a/tests/contract/test_training_core_sum_to_size_parity.py
+++ b/tests/contract/test_training_core_sum_to_size_parity.py
@@ -1,0 +1,171 @@
+import candle as torch
+
+
+def test_sum_to_size_forward_matches_torch_contract():
+    import torch as real_torch
+
+    candle_out = torch.sum_to_size(torch.arange(6, dtype=torch.float32).reshape(2, 3), 1, 3)
+    torch_out = real_torch.arange(6, dtype=real_torch.float32).reshape(2, 3).sum_to_size(1, 3)
+
+    assert candle_out.shape == torch_out.shape
+    assert candle_out.numpy().tolist() == torch_out.numpy().tolist()
+
+
+def test_sum_to_size_scalar_shape_matches_torch_contract():
+    import torch as real_torch
+
+    candle_out = torch.sum_to_size(torch.arange(6, dtype=torch.float32).reshape(2, 3), ())
+    torch_out = real_torch.arange(6, dtype=real_torch.float32).reshape(2, 3).sum_to_size(())
+
+    assert candle_out.shape == torch_out.shape
+    assert candle_out.numpy().tolist() == torch_out.numpy().tolist()
+
+
+def test_sum_to_size_invalid_shape_message_matches_torch_contract():
+    import torch as real_torch
+
+    candle_in = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    torch_in = real_torch.arange(6, dtype=real_torch.float32).reshape(2, 3)
+
+    try:
+        torch_in.sum_to_size(2, 2)
+    except Exception as torch_exc:
+        torch_type = type(torch_exc)
+        torch_msg = str(torch_exc)
+    else:
+        torch_type = None
+        torch_msg = None
+
+    try:
+        torch.sum_to_size(candle_in, 2, 2)
+    except Exception as candle_exc:
+        candle_type = type(candle_exc)
+        candle_msg = str(candle_exc)
+    else:
+        candle_type = None
+        candle_msg = None
+
+    assert candle_type is torch_type
+    assert candle_msg == torch_msg
+
+
+def test_sum_to_size_type_error_matches_torch_contract():
+    import torch as real_torch
+
+    candle_in = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    torch_in = real_torch.arange(6, dtype=real_torch.float32).reshape(2, 3)
+
+    try:
+        torch_in.sum_to_size(True)
+    except Exception as torch_exc:
+        torch_type = type(torch_exc)
+        torch_msg = str(torch_exc)
+    else:
+        torch_type = None
+        torch_msg = None
+
+    try:
+        torch.sum_to_size(candle_in, True)
+    except Exception as candle_exc:
+        candle_type = type(candle_exc)
+        candle_msg = str(candle_exc)
+    else:
+        candle_type = None
+        candle_msg = None
+
+    assert candle_type is torch_type
+    assert candle_msg == torch_msg
+
+
+def test_sum_to_size_type_error_matrix_matches_torch_contract():
+    import torch as real_torch
+
+    candle_in = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    torch_in = real_torch.arange(6, dtype=real_torch.float32).reshape(2, 3)
+
+    cases = [
+        ("top_bool", True),
+        ("top_float", 1.5),
+        ("top_str", "1"),
+        ("top_none", None),
+        ("first_str", ("1", 3)),
+        ("first_float", (1.5, 3)),
+        ("first_bool", (True, 3)),
+        ("first_none", (None, 3)),
+        ("first_list", ([1], 3)),
+        ("late_str", (1, "1")),
+        ("late_float", (1, 1.5)),
+        ("late_none", (1, None)),
+        ("late_list", (1, [3])),
+        ("late_bool_then_str", (1, True, "a")),
+        ("late_bool_then_none", (1, True, None)),
+        ("first_bool_list", [True, 3]),
+        ("mismatch_zero", [0, 3]),
+        ("mismatch_neg", [-1, 3]),
+        ("mismatch_long", [1, 2, 3]),
+        ("mismatch_shape", [2, 2]),
+        ("mismatch_false", [1, False]),
+    ]
+
+    for name, size in cases:
+        try:
+            torch_in.sum_to_size(size)
+        except Exception as torch_exc:
+            torch_type = type(torch_exc)
+            torch_msg = str(torch_exc)
+        else:
+            torch_type = None
+            torch_msg = None
+
+        try:
+            torch.sum_to_size(candle_in, size)
+        except Exception as candle_exc:
+            candle_type = type(candle_exc)
+            candle_msg = str(candle_exc)
+        else:
+            candle_type = None
+            candle_msg = None
+
+        assert candle_type is torch_type, f"{name} type mismatch"
+        assert candle_msg == torch_msg, f"{name} message mismatch"
+
+
+def test_sum_to_size_valid_sizes_match_torch_contract():
+    import torch as real_torch
+
+    candle_in = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    torch_in = real_torch.arange(6, dtype=real_torch.float32).reshape(2, 3)
+
+    for size in ([], [1, True], (1, True)):
+        candle_out = torch.sum_to_size(candle_in, size)
+        torch_out = torch_in.sum_to_size(size)
+
+        assert candle_out.shape == torch_out.shape
+        assert candle_out.numpy().tolist() == torch_out.numpy().tolist()
+
+
+def test_sum_to_size_returns_view_when_size_matches():
+    candle_in = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    candle_out = torch.sum_to_size(candle_in, 2, 3)
+
+    assert candle_out.shape == candle_in.shape
+    assert candle_out.storage() is candle_in.storage()
+
+
+def test_sum_to_size_backward_matches_torch_contract():
+    import torch as real_torch
+
+    candle_leaf = torch.arange(6, dtype=torch.float32).requires_grad_()
+    candle_in = candle_leaf.reshape(2, 3)
+    torch_leaf = real_torch.arange(6, dtype=real_torch.float32, requires_grad=True)
+    torch_in = torch_leaf.reshape(2, 3)
+
+    candle_out = torch.sum_to_size(candle_in, 1, 3).sum()
+    torch_out = torch_in.sum_to_size(1, 3).sum()
+
+    candle_out.backward()
+    torch_out.backward()
+
+    assert candle_leaf.grad is not None
+    assert torch_leaf.grad is not None
+    assert candle_leaf.grad.numpy().tolist() == torch_leaf.grad.numpy().tolist()


### PR DESCRIPTION
## Summary
- add CPU `sum_to_size` kernel with PyTorch error-message parity, dtype promotion, and view behavior
- add schema-level size validation, meta inference, and autograd backward for `sum_to_size`
- expand contract tests and document design/plan for this feature

## Test Plan
- [x] `PYTHONPATH=src pytest tests/contract/test_training_core_sum_to_size_parity.py -v`
- [x] `PYTHONPATH=src pytest tests/contract/ -v --tb=short`
