### PR TITLE
feat(mps): P2 GPU kernels — unary, activations, binary, flip/roll

### DIFF
--- a/src/candle/_backends/mps/metal_compute.py
+++ b/src/candle/_backends/mps/metal_compute.py
@@ -1243,6 +1243,72 @@ class MetalKernelDispatcher:
         rt.commit_and_wait(cmd)
 
     # ------------------------------------------------------------------
+    # Dispatch: flip  (input → output, reverse along dims)
+    # ------------------------------------------------------------------
+
+    def dispatch_flip(self, kernel_name, input_buf, output_buf,
+                      shape_packed, flip_mask_packed, ndim, total):
+        """Encode flip kernel (2 bufs + shape + flip_mask + ndim + total)."""
+        rt = get_runtime()
+        pipeline = self._get_pipeline(kernel_name)
+        tpg = self._threads_per_group(pipeline)
+        groups = (total + tpg - 1) // tpg
+
+        cmd = rt.create_command_buffer()
+        enc = rt.get_compute_encoder(cmd)
+
+        if _HAS_PYOBJC:
+            enc.setComputePipelineState_(pipeline)
+            enc.setBuffer_offset_atIndex_(input_buf, 0, 0)
+            enc.setBuffer_offset_atIndex_(output_buf, 0, 1)
+            enc.setBytes_length_atIndex_(shape_packed, len(shape_packed), 2)
+            enc.setBytes_length_atIndex_(flip_mask_packed, len(flip_mask_packed), 3)
+            enc.setBytes_length_atIndex_(struct.pack("I", ndim), 4, 4)
+            enc.setBytes_length_atIndex_(struct.pack("I", total), 4, 5)
+            enc.dispatchThreadgroups_threadsPerThreadgroup_(
+                _MTLSize(groups, 1, 1), _MTLSize(tpg, 1, 1))
+            enc.endEncoding()
+        else:
+            _encode_flip_ctypes(enc, pipeline, input_buf, output_buf,
+                                shape_packed, flip_mask_packed, ndim, total,
+                                groups, tpg)
+
+        rt.commit_and_wait(cmd)
+
+    # ------------------------------------------------------------------
+    # Dispatch: roll  (input → output, circular shift along dims)
+    # ------------------------------------------------------------------
+
+    def dispatch_roll(self, kernel_name, input_buf, output_buf,
+                      shape_packed, shifts_packed, ndim, total):
+        """Encode roll kernel (2 bufs + shape + shifts + ndim + total)."""
+        rt = get_runtime()
+        pipeline = self._get_pipeline(kernel_name)
+        tpg = self._threads_per_group(pipeline)
+        groups = (total + tpg - 1) // tpg
+
+        cmd = rt.create_command_buffer()
+        enc = rt.get_compute_encoder(cmd)
+
+        if _HAS_PYOBJC:
+            enc.setComputePipelineState_(pipeline)
+            enc.setBuffer_offset_atIndex_(input_buf, 0, 0)
+            enc.setBuffer_offset_atIndex_(output_buf, 0, 1)
+            enc.setBytes_length_atIndex_(shape_packed, len(shape_packed), 2)
+            enc.setBytes_length_atIndex_(shifts_packed, len(shifts_packed), 3)
+            enc.setBytes_length_atIndex_(struct.pack("I", ndim), 4, 4)
+            enc.setBytes_length_atIndex_(struct.pack("I", total), 4, 5)
+            enc.dispatchThreadgroups_threadsPerThreadgroup_(
+                _MTLSize(groups, 1, 1), _MTLSize(tpg, 1, 1))
+            enc.endEncoding()
+        else:
+            _encode_roll_ctypes(enc, pipeline, input_buf, output_buf,
+                                shape_packed, shifts_packed, ndim, total,
+                                groups, tpg)
+
+        rt.commit_and_wait(cmd)
+
+    # ------------------------------------------------------------------
     # Dispatch: Philox RNG fill  (seed, offset → output)
     # ------------------------------------------------------------------
 
@@ -2110,5 +2176,35 @@ def _encode_pad_constant_ctypes(enc, pipeline, input_buf, output_buf,
     _ctypes_set_bytes(enc, fill_val_bytes, fill_val_size, 5)
     _ctypes_set_bytes(enc, struct.pack("I", ndim), 4, 6)
     _ctypes_set_bytes(enc, struct.pack("I", total), 4, 7)
+    _ctypes_dispatch_threadgroups(enc, groups, tpg)
+    _ctypes_end_encoding(enc)
+
+
+def _encode_flip_ctypes(enc, pipeline, input_buf, output_buf,
+                         shape_packed, flip_mask_packed, ndim, total,
+                         groups, tpg):
+    """Encode flip kernel via ctypes."""
+    _ctypes_set_pipeline(enc, pipeline)
+    _ctypes_set_buffer(enc, input_buf, 0, 0)
+    _ctypes_set_buffer(enc, output_buf, 0, 1)
+    _ctypes_set_bytes(enc, shape_packed, len(shape_packed), 2)
+    _ctypes_set_bytes(enc, flip_mask_packed, len(flip_mask_packed), 3)
+    _ctypes_set_bytes(enc, struct.pack("I", ndim), 4, 4)
+    _ctypes_set_bytes(enc, struct.pack("I", total), 4, 5)
+    _ctypes_dispatch_threadgroups(enc, groups, tpg)
+    _ctypes_end_encoding(enc)
+
+
+def _encode_roll_ctypes(enc, pipeline, input_buf, output_buf,
+                         shape_packed, shifts_packed, ndim, total,
+                         groups, tpg):
+    """Encode roll kernel via ctypes."""
+    _ctypes_set_pipeline(enc, pipeline)
+    _ctypes_set_buffer(enc, input_buf, 0, 0)
+    _ctypes_set_buffer(enc, output_buf, 0, 1)
+    _ctypes_set_bytes(enc, shape_packed, len(shape_packed), 2)
+    _ctypes_set_bytes(enc, shifts_packed, len(shifts_packed), 3)
+    _ctypes_set_bytes(enc, struct.pack("I", ndim), 4, 4)
+    _ctypes_set_bytes(enc, struct.pack("I", total), 4, 5)
     _ctypes_dispatch_threadgroups(enc, groups, tpg)
     _ctypes_end_encoding(enc)

--- a/src/candle/_backends/mps/metal_shaders.py
+++ b/src/candle/_backends/mps/metal_shaders.py
@@ -23,6 +23,7 @@ _SUFFIX = dict(DTYPE_MAP)
 _FLOAT_ONLY_OPS = frozenset({
     "sqrt", "rsqrt", "exp", "log", "log2", "sin", "cos", "tanh",
     "sigmoid", "gelu", "silu", "floor", "ceil", "round",
+    "tan", "trunc", "log10", "exp2", "square",
 })
 
 # ---------------------------------------------------------------------------
@@ -1298,6 +1299,78 @@ kernel void pad_constant_{suffix}(
 """
 
 
+_FLIP_TEMPLATE = """
+kernel void flip_{suffix}(device const {type}* input [[buffer(0)]],
+                          device {type}* output       [[buffer(1)]],
+                          constant uint* shape         [[buffer(2)]],
+                          constant uint* flip_mask     [[buffer(3)]],
+                          constant uint& ndim          [[buffer(4)]],
+                          constant uint& total         [[buffer(5)]],
+                          uint id [[thread_position_in_grid]]) {{
+    if (id >= total) return;
+    uint coords[8];
+    uint remaining = id;
+    for (uint d = ndim; d > 0; d--) {{
+        coords[d-1] = remaining % shape[d-1];
+        remaining /= shape[d-1];
+    }}
+    uint in_idx = 0;
+    for (uint d2 = 0; d2 < ndim; d2++) {{
+        uint c = flip_mask[d2] ? (shape[d2] - 1 - coords[d2]) : coords[d2];
+        in_idx = in_idx * shape[d2] + c;
+    }}
+    output[id] = input[in_idx];
+}}
+"""
+
+_ROLL_TEMPLATE = """
+kernel void roll_{suffix}(device const {type}* input [[buffer(0)]],
+                          device {type}* output       [[buffer(1)]],
+                          constant uint* shape         [[buffer(2)]],
+                          constant int*  shifts        [[buffer(3)]],
+                          constant uint& ndim          [[buffer(4)]],
+                          constant uint& total         [[buffer(5)]],
+                          uint id [[thread_position_in_grid]]) {{
+    if (id >= total) return;
+    uint coords[8];
+    uint remaining = id;
+    for (uint d = ndim; d > 0; d--) {{
+        coords[d-1] = remaining % shape[d-1];
+        remaining /= shape[d-1];
+    }}
+    uint src_idx = 0;
+    for (uint d2 = 0; d2 < ndim; d2++) {{
+        int s = shifts[d2];
+        int dim_size = int(shape[d2]);
+        int src_c = int(coords[d2]) - s;
+        src_c = ((src_c % dim_size) + dim_size) % dim_size;
+        src_idx = src_idx * shape[d2] + uint(src_c);
+    }}
+    output[id] = input[src_idx];
+}}
+"""
+
+
+def _gen_flip(types=None):
+    if types is None:
+        types = _FLOAT_TYPES + ("int", "long")
+    parts = []
+    for t in types:
+        suffix = _SUFFIX[t]
+        parts.append(_FLIP_TEMPLATE.format(type=t, suffix=suffix))
+    return "".join(parts)
+
+
+def _gen_roll(types=None):
+    if types is None:
+        types = _FLOAT_TYPES + ("int", "long")
+    parts = []
+    for t in types:
+        suffix = _SUFFIX[t]
+        parts.append(_ROLL_TEMPLATE.format(type=t, suffix=suffix))
+    return "".join(parts)
+
+
 def _gen_pad_constant(types=None):
     if types is None:
         types = _FLOAT_TYPES + ("int", "long")
@@ -1326,6 +1399,7 @@ _BINARY_FLOAT_OPS = (
     ("pow", "pow(a[id], b[id])"),
     ("fmod", "fmod(a[id], b[id])"),
     ("remainder", "a[id] - b[id] * floor(a[id] / b[id])"),
+    ("logaddexp", "log(exp(a[id]) + exp(b[id]))"),
 )
 
 # --- Unary element-wise (numeric types: float, half, int, long) ---
@@ -1351,6 +1425,11 @@ _UNARY_FLOAT_OPS = (
     ("round", "rint(x)"),
     ("gelu", "0.5f * x * (1.0f + tanh(0.7978845608f * (x + 0.044715f * x * x * x)))"),
     ("silu", "x / (1.0f + exp(-x))"),
+    ("tan", "tan(x)"),
+    ("trunc", "trunc(x)"),
+    ("log10", "log10(x)"),
+    ("exp2", "exp2(x)"),
+    ("square", "x * x"),
 )
 
 # --- Comparison ops ---
@@ -1946,6 +2025,10 @@ def _build_msl_source():
 
     # Pad kernel
     parts.append(_gen_pad_constant())
+
+    # Flip / Roll kernels
+    parts.append(_gen_flip())
+    parts.append(_gen_roll())
 
     # Philox RNG kernels
     parts.append(_gen_philox_uniform())

--- a/src/candle/_backends/mps/ops.py
+++ b/src/candle/_backends/mps/ops.py
@@ -621,12 +621,65 @@ def masked_select(a, mask):
 
 
 def flip(a, dims):
+    if (_can_use_gpu(a) and a.is_contiguous()
+            and a.dtype in (float32_dtype, float16_dtype, int32_dtype, int64_dtype)
+            and len(a.shape) <= 8):
+        import struct
+        ndim = len(a.shape)
+        if isinstance(dims, int):
+            dims = (dims,)
+        norm_dims = set()
+        for d in dims:
+            norm_dims.add(d if d >= 0 else ndim + d)
+        flip_mask = [1 if d in norm_dims else 0 for d in range(ndim)]
+        total = a.numel()
+        if total > 0:
+            sfx = _kernel_suffix(a.dtype)
+            d = _get_dispatcher()
+            out_buf = _alloc_output_buf(total, a.dtype)
+            shape_packed = struct.pack(f"{ndim}I", *a.shape)
+            flip_packed = struct.pack(f"{ndim}I", *flip_mask)
+            d.dispatch_flip(f"flip_{sfx}", _metal_buf(a), out_buf,
+                            shape_packed, flip_packed, ndim, total)
+            from ..._tensor import _compute_strides
+            out_shape = tuple(a.shape)
+            return _from_metal_buffer(out_buf, out_shape,
+                                      _compute_strides(out_shape),
+                                      a.dtype, a.device)
     arr = _to_numpy(a)
     out = np.flip(arr, axis=dims)
     return _from_numpy(np.ascontiguousarray(out), a.dtype, a.device)
 
 
 def roll(a, shifts, dims=None):
+    if (_can_use_gpu(a) and a.is_contiguous()
+            and a.dtype in (float32_dtype, float16_dtype, int32_dtype, int64_dtype)
+            and len(a.shape) <= 8 and dims is not None):
+        import struct
+        ndim = len(a.shape)
+        if isinstance(shifts, int):
+            shifts = (shifts,)
+        if isinstance(dims, int):
+            dims = (dims,)
+        # Build per-dim shift array (0 for unshifted dims)
+        shift_arr = [0] * ndim
+        for s, d in zip(shifts, dims):
+            dd = d if d >= 0 else ndim + d
+            shift_arr[dd] = int(s)
+        total = a.numel()
+        if total > 0:
+            sfx = _kernel_suffix(a.dtype)
+            d = _get_dispatcher()
+            out_buf = _alloc_output_buf(total, a.dtype)
+            shape_packed = struct.pack(f"{ndim}I", *a.shape)
+            shifts_packed = struct.pack(f"{ndim}i", *shift_arr)
+            d.dispatch_roll(f"roll_{sfx}", _metal_buf(a), out_buf,
+                            shape_packed, shifts_packed, ndim, total)
+            from ..._tensor import _compute_strides
+            out_shape = tuple(a.shape)
+            return _from_metal_buffer(out_buf, out_shape,
+                                      _compute_strides(out_shape),
+                                      a.dtype, a.device)
     arr = _to_numpy(a)
     out = np.roll(arr, shift=shifts, axis=dims)
     return _from_numpy(np.ascontiguousarray(out), a.dtype, a.device)
@@ -1745,6 +1798,8 @@ def cos(a):
 
 
 def tan(a):
+    if _can_use_gpu(a):
+        return _dispatch_unary_gpu(a, "tan")
     return _from_numpy(np.tan(_to_numpy(a)), a.dtype, a.device)
 
 
@@ -1781,10 +1836,14 @@ def round(a):
 
 
 def trunc(a):
+    if _can_use_gpu(a):
+        return _dispatch_unary_gpu(a, "trunc")
     return _from_numpy(np.trunc(_to_numpy(a)), a.dtype, a.device)
 
 
 def frac(a):
+    if _can_use_gpu(a):
+        return sub(a, _dispatch_unary_gpu(a, "trunc"))
     arr = _to_numpy(a)
     out = arr - np.trunc(arr)
     return _from_numpy(out, a.dtype, a.device)
@@ -1825,10 +1884,14 @@ def log2(a):
 
 
 def log10(a):
+    if _can_use_gpu(a):
+        return _dispatch_unary_gpu(a, "log10")
     return _from_numpy(np.log10(_to_numpy(a)), a.dtype, a.device)
 
 
 def exp2(a):
+    if _can_use_gpu(a):
+        return _dispatch_unary_gpu(a, "exp2")
     return _from_numpy(np.exp2(_to_numpy(a)), a.dtype, a.device)
 
 
@@ -1847,6 +1910,8 @@ def sign(a):
 
 
 def square(a):
+    if _can_use_gpu(a):
+        return _dispatch_unary_gpu(a, "square")
     arr = _to_numpy(a)
     out = np.square(arr)
     return _from_numpy(np.ascontiguousarray(out), a.dtype, a.device)
@@ -1911,6 +1976,11 @@ def erfc(a):
 
 
 def softplus(a):
+    # GPU composite: log(1 + exp(x))
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
+        exp_a = _dispatch_unary_gpu(a, "exp")
+        sum_val = add(exp_a, 1.0)
+        return _dispatch_unary_gpu(sum_val, "log")
     arr = _to_numpy(a)
     out = np.log1p(np.exp(arr))
     return _from_numpy(out, a.dtype, a.device)
@@ -2050,12 +2120,16 @@ def clamp_max(a, max_val):
 
 
 def relu6(a):
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype, int32_dtype, int64_dtype):
+        return clamp(a, 0.0, 6.0)
     arr = _to_numpy(a)
     out = np.minimum(np.maximum(arr, 0.0), 6.0)
     return _from_numpy(out, a.dtype, a.device)
 
 
 def hardtanh(a, min_val=-1.0, max_val=1.0):
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype, int32_dtype, int64_dtype):
+        return clamp(a, min_val, max_val)
     arr = _to_numpy(a)
     out = np.clip(arr, min_val, max_val)
     return _from_numpy(out, a.dtype, a.device)
@@ -2064,12 +2138,32 @@ def hardtanh(a, min_val=-1.0, max_val=1.0):
 def selu(a):
     ALPHA = 1.6732632423543772
     SCALE = 1.0507009873554805
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
+        # scale * where(x > 0, x, alpha * (exp(x) - 1))
+        exp_a = _dispatch_unary_gpu(a, "exp")
+        elu_part = mul(sub(exp_a, 1.0), ALPHA)
+        relu_a = _dispatch_unary_gpu(a, "relu")
+        # where(x > 0, x, elu_part) = relu(x) + min(0, elu_part)
+        # Simpler: use the where op if available, or compute via masks
+        # relu(x) - relu(-elu_part) + elu_part = ... too complex
+        # Just use: selu = scale * (relu(x) + min(0, alpha*(exp(x)-1)))
+        neg_part = clamp(elu_part, None, 0.0)
+        result = add(relu_a, neg_part)
+        return mul(result, SCALE)
     arr = _to_numpy(a)
     out = SCALE * np.where(arr > 0, arr, ALPHA * (np.exp(arr) - 1))
     return _from_numpy(out, a.dtype, a.device)
 
 
 def celu(a, alpha=1.0):
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
+        # max(0, x) + min(0, alpha * (exp(x/alpha) - 1))
+        relu_a = _dispatch_unary_gpu(a, "relu")
+        scaled = div(a, alpha)
+        exp_scaled = _dispatch_unary_gpu(scaled, "exp")
+        elu_part = mul(sub(exp_scaled, 1.0), alpha)
+        neg_part = clamp(elu_part, None, 0.0)
+        return add(relu_a, neg_part)
     arr = _to_numpy(a)
     out = np.maximum(arr, 0.0) + np.minimum(0.0, alpha * (np.exp(arr / alpha) - 1))
     return _from_numpy(out, a.dtype, a.device)
@@ -2250,6 +2344,8 @@ def lerp(a, b, weight):
 
 
 def addcmul(a, b, c, value=1.0):
+    if _can_use_gpu(a) and _can_use_gpu(b) and _can_use_gpu(c):
+        return add(a, mul(mul(b, c), value))
     return _from_numpy(
         _to_numpy(a) + value * (_to_numpy(b) * _to_numpy(c)),
         a.dtype,
@@ -2258,6 +2354,8 @@ def addcmul(a, b, c, value=1.0):
 
 
 def addcdiv(a, b, c, value=1.0):
+    if _can_use_gpu(a) and _can_use_gpu(b) and _can_use_gpu(c):
+        return add(a, mul(div(b, c), value))
     return _from_numpy(
         _to_numpy(a) + value * (_to_numpy(b) / _to_numpy(c)),
         a.dtype,
@@ -2266,6 +2364,8 @@ def addcdiv(a, b, c, value=1.0):
 
 
 def logaddexp(a, b):
+    if isinstance(a, Tensor) and isinstance(b, Tensor) and _can_use_gpu(a) and _can_use_gpu(b):
+        return _dispatch_binary_gpu(a, b, "logaddexp")
     return _from_numpy(np.logaddexp(_to_numpy(a), _to_numpy(b)), a.dtype, a.device)
 
 

--- a/tests/mps/test_metal_infra.py
+++ b/tests/mps/test_metal_infra.py
@@ -1385,3 +1385,184 @@ class TestP1GPUOps:
         out = torch.addmm(inp, m1, m2, beta=0)
         ref = m1_np @ m2_np
         np.testing.assert_allclose(out.cpu().numpy(), ref, atol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# P2 GPU kernels: unary, activations, binary composites, flip/roll
+# ---------------------------------------------------------------------------
+
+class TestP2GPUOps:
+    """Verify P2 GPU-accelerated ops produce correct results on MPS."""
+
+    # ---- Unary float ops ----
+
+    def test_tan(self):
+        np.random.seed(100)
+        a_np = np.random.randn(64).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.tan(a)
+        np.testing.assert_allclose(out.cpu().numpy(), np.tan(a_np), atol=5e-4)
+
+    def test_trunc(self):
+        a_np = np.array([-2.7, -0.3, 0.0, 1.5, 3.9], dtype=np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.trunc(a)
+        np.testing.assert_allclose(out.cpu().numpy(), np.trunc(a_np), atol=1e-6)
+
+    def test_frac(self):
+        a_np = np.array([-2.7, -0.3, 0.0, 1.5, 3.9], dtype=np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.frac(a)
+        ref = a_np - np.trunc(a_np)
+        np.testing.assert_allclose(out.cpu().numpy(), ref, atol=1e-6)
+
+    def test_log10(self):
+        a_np = np.array([0.1, 1.0, 10.0, 100.0, 1000.0], dtype=np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.log10(a)
+        np.testing.assert_allclose(out.cpu().numpy(), np.log10(a_np), atol=1e-6)
+
+    def test_exp2(self):
+        a_np = np.array([-2.0, -1.0, 0.0, 1.0, 3.0], dtype=np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.exp2(a)
+        np.testing.assert_allclose(out.cpu().numpy(), np.exp2(a_np), atol=1e-6)
+
+    def test_square(self):
+        np.random.seed(101)
+        a_np = np.random.randn(128).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.square(a)
+        np.testing.assert_allclose(out.cpu().numpy(), np.square(a_np), atol=1e-5)
+
+    def test_tan_f16(self):
+        a_np = np.array([0.1, 0.5, 1.0, -0.5], dtype=np.float16)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.tan(a)
+        ref = np.tan(a_np.astype(np.float32)).astype(np.float16)
+        np.testing.assert_allclose(out.cpu().numpy(), ref, atol=5e-3)
+
+    # ---- Activation composites ----
+
+    def test_softplus(self):
+        np.random.seed(102)
+        a_np = np.random.randn(64).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.nn.functional.softplus(a)
+        ref = np.log1p(np.exp(a_np))
+        np.testing.assert_allclose(out.cpu().numpy(), ref, atol=1e-5)
+
+    def test_relu6(self):
+        a_np = np.array([-3.0, 0.0, 3.0, 6.0, 9.0], dtype=np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.nn.functional.relu6(a)
+        ref = np.minimum(np.maximum(a_np, 0.0), 6.0)
+        np.testing.assert_allclose(out.cpu().numpy(), ref, atol=1e-6)
+
+    def test_hardtanh(self):
+        a_np = np.array([-3.0, -1.0, 0.0, 1.0, 3.0], dtype=np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.nn.functional.hardtanh(a)
+        ref = np.clip(a_np, -1.0, 1.0)
+        np.testing.assert_allclose(out.cpu().numpy(), ref, atol=1e-6)
+
+    def test_selu(self):
+        np.random.seed(103)
+        a_np = np.random.randn(64).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.nn.functional.selu(a)
+        ALPHA = 1.6732632423543772
+        SCALE = 1.0507009873554805
+        ref = SCALE * np.where(a_np > 0, a_np, ALPHA * (np.exp(a_np) - 1))
+        np.testing.assert_allclose(out.cpu().numpy(), ref, atol=1e-5)
+
+    def test_celu(self):
+        np.random.seed(104)
+        a_np = np.random.randn(64).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.nn.functional.celu(a, alpha=1.5)
+        alpha = 1.5
+        ref = np.maximum(a_np, 0.0) + np.minimum(0.0, alpha * (np.exp(a_np / alpha) - 1))
+        np.testing.assert_allclose(out.cpu().numpy(), ref, atol=1e-5)
+
+    # ---- Binary composites ----
+
+    def test_addcmul(self):
+        np.random.seed(105)
+        a_np = np.random.randn(32).astype(np.float32)
+        b_np = np.random.randn(32).astype(np.float32)
+        c_np = np.random.randn(32).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        b = torch.tensor(b_np, device="mps")
+        c = torch.tensor(c_np, device="mps")
+        out = torch.addcmul(a, b, c, value=0.5)
+        ref = a_np + 0.5 * b_np * c_np
+        np.testing.assert_allclose(out.cpu().numpy(), ref, atol=1e-5)
+
+    def test_addcdiv(self):
+        np.random.seed(106)
+        a_np = np.random.randn(32).astype(np.float32)
+        b_np = np.random.randn(32).astype(np.float32)
+        c_np = np.random.uniform(0.5, 2.0, 32).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        b = torch.tensor(b_np, device="mps")
+        c = torch.tensor(c_np, device="mps")
+        out = torch.addcdiv(a, b, c, value=0.5)
+        ref = a_np + 0.5 * b_np / c_np
+        np.testing.assert_allclose(out.cpu().numpy(), ref, atol=1e-5)
+
+    def test_logaddexp(self):
+        np.random.seed(107)
+        a_np = np.random.randn(64).astype(np.float32)
+        b_np = np.random.randn(64).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        b = torch.tensor(b_np, device="mps")
+        out = torch.logaddexp(a, b)
+        ref = np.logaddexp(a_np, b_np)
+        np.testing.assert_allclose(out.cpu().numpy(), ref, atol=1e-5)
+
+    # ---- Flip / Roll ----
+
+    def test_flip_1d(self):
+        a_np = np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.flip(a, [0])
+        np.testing.assert_allclose(out.cpu().numpy(), a_np[::-1])
+
+    def test_flip_2d(self):
+        np.random.seed(108)
+        a_np = np.random.randn(4, 6).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.flip(a, [0, 1])
+        ref = np.flip(a_np, axis=(0, 1))
+        np.testing.assert_allclose(out.cpu().numpy(), ref)
+
+    def test_flip_single_dim(self):
+        np.random.seed(109)
+        a_np = np.random.randn(3, 4, 5).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.flip(a, [1])
+        ref = np.flip(a_np, axis=1)
+        np.testing.assert_allclose(out.cpu().numpy(), ref)
+
+    def test_roll_1d(self):
+        a_np = np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.roll(a, 2, 0)
+        ref = np.roll(a_np, 2, axis=0)
+        np.testing.assert_allclose(out.cpu().numpy(), ref)
+
+    def test_roll_2d(self):
+        np.random.seed(110)
+        a_np = np.random.randn(4, 6).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.roll(a, (1, -2), (0, 1))
+        ref = np.roll(np.roll(a_np, 1, axis=0), -2, axis=1)
+        np.testing.assert_allclose(out.cpu().numpy(), ref)
+
+    def test_roll_negative_shift(self):
+        a_np = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.roll(a, -1, 0)
+        ref = np.roll(a_np, -1, axis=0)
+        np.testing.assert_allclose(out.cpu().numpy(), ref)


### PR DESCRIPTION
## Summary

Adds GPU paths for 16 MPS ops that previously fell back to numpy, continuing the Metal compute kernel rollout from #61.

### Unary float ops (new Metal shaders)
- **tan, trunc, log10, exp2, square** — added to `_UNARY_FLOAT_OPS` dict, auto-generated contiguous + strided variants

### Activation composites (no new shaders, reuse existing GPU ops)
- **frac** — `sub(x, trunc(x))` on GPU
- **relu6** — delegates to `clamp(x, 0, 6)` GPU path
- **hardtanh** — delegates to `clamp(x, min, max)` GPU path
- **softplus** — `log(1 + exp(x))` via GPU exp/add/log
- **selu** — `scale * (relu(x) + clamp(alpha*(exp(x)-1), max=0))` on GPU
- **celu** — `relu(x) + clamp(alpha*(exp(x/alpha)-1), max=0)` on GPU

### Binary composites
- **addcmul** — `add(a, mul(mul(b, c), value))` on GPU
- **addcdiv** — `add(a, mul(div(b, c), value))` on GPU
- **logaddexp** — new Metal binary shader: `log(exp(a) + exp(b))`

### Spatial ops (new Metal shaders)
- **flip** — reverse elements along specified dims via coord decomposition
- **roll** — circular shift via modular arithmetic

### Details
- All kernels support float32 and float16
- Both pyobjc and ctypes dispatch paths for flip/roll
- 21 new tests in `TestP2GPUOps`
- 309 MPS tests pass, 1558 CPU/contract tests pass, no regressions

### Files changed
- `metal_shaders.py` — 5 unary entries + logaddexp binary + flip/roll templates
- `metal_compute.py` — dispatch_flip, dispatch_roll + ctypes helpers
- `ops.py` — GPU paths for all 16 ops
- `test_metal_infra.py` — TestP2GPUOps class
