### PR TITLE
feat(fsdp2): Phase 3 — mixed precision, summon_full_params, state_dict, 2D mesh

### DIFF
--- a/src/candle/distributed/_composable/fsdp/__init__.py
+++ b/src/candle/distributed/_composable/fsdp/__init__.py
@@ -8,10 +8,15 @@ Usage (bottom-up):
 """
 from contextlib import contextmanager
 
-from ._fsdp_common import FSDPMeshInfo
+from ._fsdp_common import FSDPMeshInfo, MixedPrecisionPolicy
 from ._fsdp_param import FSDPParam
 from ._fsdp_param_group import FSDPParamGroup
 from ._fsdp_state import FSDPState
+from ._fsdp_state_dict import (
+    get_model_state_dict,
+    set_model_state_dict,
+    get_optimizer_state_dict,
+)
 
 
 class FSDPModule:
@@ -53,6 +58,51 @@ class FSDPModule:
             for st, old in zip(states, old_values):
                 st._sync_gradients = old
 
+    @contextmanager
+    def summon_full_params(self, writeback=True, with_grads=False):
+        """Context manager that unshards all params in the FSDP subtree.
+
+        On enter: all-gather all parameters so they are full-sized.
+        On exit: if *writeback* is True, scatter modified params back to
+        shards; then reshard all parameters.
+
+        If *with_grads* is True, gradients on the unsharded params are
+        also made available (and written back on exit).
+        """
+        # Collect all param groups in the subtree
+        param_groups = []
+        for mod in self.modules():
+            st = getattr(mod, '_fsdp_state', None)
+            if st is not None and st.param_group is not None:
+                param_groups.append(st.param_group)
+
+        # Unshard all
+        for pg in param_groups:
+            pg.unshard()
+
+        # If with_grads, copy shard grads onto unsharded params
+        if with_grads:
+            for pg in param_groups:
+                for fp in pg.fsdp_params:
+                    shard_grad = fp._sharded_param.to_local().grad
+                    if shard_grad is not None and fp._unsharded_param is not None:
+                        fp._unsharded_param.grad = shard_grad
+
+        try:
+            yield
+        finally:
+            if writeback:
+                # Write modified unsharded params back to shards
+                for pg in param_groups:
+                    for fp in pg.fsdp_params:
+                        if fp._unsharded_param is not None:
+                            _writeback_to_shard(fp)
+                            if with_grads and fp._unsharded_param.grad is not None:
+                                _writeback_grad_to_shard(fp)
+            # Reshard all
+            for pg in param_groups:
+                pg.reshard()
+
 
 class _MockMeshInfo:
     """MeshInfo for single-process / mock scenarios (world_size=1)."""
@@ -70,7 +120,7 @@ class _MockMeshInfo:
             self.shard_mesh_rank = self.shard_process_group.rank()
 
 
-def fully_shard(module, *, mesh, reshard_after_forward=None):
+def fully_shard(module, *, mesh, reshard_after_forward=None, mp_policy=None):
     """Apply FSDP2 to a module. PyTorch-compatible composable API."""
     # 1. Build mesh info
     try:
@@ -94,7 +144,7 @@ def fully_shard(module, *, mesh, reshard_after_forward=None):
 
     # 3. Create FSDPParam for each parameter
     fsdp_params = [
-        FSDPParam(param, owner, name, mesh_info)
+        FSDPParam(param, owner, name, mesh_info, mp_policy=mp_policy)
         for name, param, owner in managed_params
     ]
 
@@ -111,7 +161,10 @@ def fully_shard(module, *, mesh, reshard_after_forward=None):
         reshard_after_forward = True
 
     # 6. Create FSDPState and register hooks
-    state = FSDPState(module, param_group, mesh_info, reshard_after_forward)
+    state = FSDPState(
+        module, param_group, mesh_info, reshard_after_forward,
+        mp_policy=mp_policy,
+    )
     module._fsdp_state = state
 
     # 7. Inject FSDPModule mixin
@@ -149,6 +202,39 @@ def _get_managed_params(module):
                 owner = getattr(owner, part)
             managed.append((leaf_name, param, owner))
     return managed
+
+
+def _writeback_to_shard(fp):
+    """Write modified unsharded param data back into the local shard."""
+    from ._fsdp_param import _chunk_tensor
+    unsharded = fp._unsharded_param
+    if unsharded is None:
+        return
+    world_size = fp._mesh_info.shard_mesh_size
+    rank = fp._mesh_info.shard_mesh_rank
+    if world_size == 1:
+        local = fp._sharded_param.to_local()
+        local.data = unsharded.data
+    else:
+        # Re-chunk the full param and copy this rank's shard
+        chunks = _chunk_tensor(unsharded.detach(), world_size, dim=fp._shard_dim)
+        local = fp._sharded_param.to_local()
+        local.data = chunks[rank].contiguous().data
+
+
+def _writeback_grad_to_shard(fp):
+    """Write unsharded grad back into the local shard grad."""
+    from ._fsdp_param import _chunk_tensor
+    unsharded = fp._unsharded_param
+    if unsharded is None or unsharded.grad is None:
+        return
+    world_size = fp._mesh_info.shard_mesh_size
+    rank = fp._mesh_info.shard_mesh_rank
+    if world_size == 1:
+        fp._sharded_param.to_local().grad = unsharded.grad
+    else:
+        chunks = _chunk_tensor(unsharded.grad.detach(), world_size, dim=fp._shard_dim)
+        fp._sharded_param.to_local().grad = chunks[rank].contiguous()
 
 
 def clip_grad_norm_(model, max_norm, norm_type=2.0, error_if_nonfinite=False):

--- a/src/candle/distributed/_composable/fsdp/_fsdp_common.py
+++ b/src/candle/distributed/_composable/fsdp/_fsdp_common.py
@@ -1,4 +1,25 @@
 """Common utilities for FSDP2."""
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class MixedPrecisionPolicy:
+    """Mixed precision configuration for FSDP2.
+
+    Matches ``torch.distributed.fsdp.MixedPrecisionPolicy``.
+
+    Attributes:
+        param_dtype: Cast parameters to this dtype during forward/backward
+            (e.g. bfloat16). ``None`` means no casting.
+        reduce_dtype: Cast gradients to this dtype before reduce-scatter
+            (e.g. float32). ``None`` means use the gradient's existing dtype.
+        output_dtype: Cast forward output to this dtype. ``None`` means
+            no casting.
+    """
+    param_dtype: Optional[object] = None   # candle.dtype
+    reduce_dtype: Optional[object] = None
+    output_dtype: Optional[object] = None
 
 
 class FSDPMeshInfo:

--- a/src/candle/distributed/_composable/fsdp/_fsdp_param.py
+++ b/src/candle/distributed/_composable/fsdp/_fsdp_param.py
@@ -19,10 +19,11 @@ class FSDPParam:
     the DTensor view.
     """
 
-    def __init__(self, param, module, param_name, mesh_info):
+    def __init__(self, param, module, param_name, mesh_info, mp_policy=None):
         self._module = module
         self._param_name = param_name
         self._mesh_info = mesh_info
+        self._mp_policy = mp_policy
         self._sharded_state = ShardedState.SHARDED
         self._orig_shape = param.shape
         self._orig_dtype = param.dtype
@@ -104,6 +105,13 @@ class FSDPParam:
                 orig_dim_size = self._orig_shape[self._shard_dim]
                 output = narrow(output, self._shard_dim, 0, orig_dim_size)
             self._unsharded_param = output
+        # Mixed precision: cast to param_dtype for forward/backward compute
+        if (self._mp_policy is not None
+                and self._mp_policy.param_dtype is not None
+                and self._unsharded_param.dtype != self._mp_policy.param_dtype):
+            self._unsharded_param = self._unsharded_param.to(
+                self._mp_policy.param_dtype
+            )
         self._unsharded_param.requires_grad = self._sharded_param.requires_grad
         self._set_param_on_module(self._unsharded_param)
         self._sharded_state = ShardedState.UNSHARDED
@@ -119,6 +127,13 @@ class FSDPParam:
             orig_dim_size = self._orig_shape[self._shard_dim]
             local = narrow(local, self._shard_dim, 0, orig_dim_size)
         self._unsharded_param = local
+        # Mixed precision: cast to param_dtype for forward/backward compute
+        if (self._mp_policy is not None
+                and self._mp_policy.param_dtype is not None
+                and self._unsharded_param.dtype != self._mp_policy.param_dtype):
+            self._unsharded_param = self._unsharded_param.to(
+                self._mp_policy.param_dtype
+            )
         self._unsharded_param.requires_grad = self._sharded_param.requires_grad
         self._set_param_on_module(self._unsharded_param)
         self._sharded_state = ShardedState.UNSHARDED
@@ -151,8 +166,21 @@ class FSDPParam:
             grad = self._unsharded_param.grad
         if grad is None:
             return
+
+        # Mixed precision: cast gradient to reduce_dtype before communication
+        reduce_dtype = (
+            self._mp_policy.reduce_dtype
+            if self._mp_policy is not None else None
+        )
+        if reduce_dtype is not None and grad.dtype != reduce_dtype:
+            grad = grad.to(reduce_dtype)
+
         world_size = self._mesh_info.shard_mesh_size
         if world_size == 1:
+            # Cast back to param storage dtype for optimizer
+            shard_dtype = self._sharded_param.to_local().dtype
+            if grad.dtype != shard_dtype:
+                grad = grad.to(shard_dtype)
             self._sharded_param.to_local().grad = grad
             return
         # Pad gradient if the original dim was not divisible by world_size
@@ -171,6 +199,10 @@ class FSDPParam:
         )
         pg = self._mesh_info.shard_process_group
         dist.reduce_scatter_tensor(reduced_grad, grad, group=pg)
+        # Cast reduced gradient back to param storage dtype for optimizer
+        shard_dtype = self._sharded_param.to_local().dtype
+        if reduced_grad.dtype != shard_dtype:
+            reduced_grad = reduced_grad.to(shard_dtype)
         self._sharded_param.to_local().grad = reduced_grad
 
     # ------------------------------------------------------------------

--- a/src/candle/distributed/_composable/fsdp/_fsdp_state.py
+++ b/src/candle/distributed/_composable/fsdp/_fsdp_state.py
@@ -5,11 +5,13 @@ from ....distributed.tensor.dtensor import DTensor
 class FSDPState:
     """Manages FSDP hook lifecycle for a module."""
 
-    def __init__(self, module, param_group, mesh_info, reshard_after_forward):
+    def __init__(self, module, param_group, mesh_info, reshard_after_forward,
+                 mp_policy=None):
         self.module = module
         self.param_group = param_group
         self.mesh_info = mesh_info
         self.reshard_after_forward = reshard_after_forward
+        self._mp_policy = mp_policy
         self._is_root = None
         self._pre_backward_hook_handles = []
         self._grad_count = 0
@@ -39,11 +41,15 @@ class FSDPState:
         return args, kwargs
 
     def _post_forward(self, module, args, output):
-        """Post-forward: register backward hooks + reshard."""
+        """Post-forward: register backward hooks + reshard + output cast."""
         self._register_pre_backward_hooks(output)
         self._register_post_backward_hooks()
         if self.reshard_after_forward:
             self.param_group.post_forward()
+        # Mixed precision: cast output to output_dtype
+        if (self._mp_policy is not None
+                and self._mp_policy.output_dtype is not None):
+            output = _cast_output(output, self._mp_policy.output_dtype)
         return output
 
     def _register_pre_backward_hooks(self, output):
@@ -152,3 +158,17 @@ def _extract_tensors_from_output(output):
         for v in output.values():
             tensors.extend(_extract_tensors_from_output(v))
     return tensors
+
+
+def _cast_output(output, dtype):
+    """Recursively cast tensors in *output* to *dtype*."""
+    from ...._tensor import Tensor
+    if isinstance(output, Tensor):
+        return output.to(dtype) if output.dtype != dtype else output
+    if isinstance(output, tuple):
+        return tuple(_cast_output(o, dtype) for o in output)
+    if isinstance(output, list):
+        return [_cast_output(o, dtype) for o in output]
+    if isinstance(output, dict):
+        return {k: _cast_output(v, dtype) for k, v in output.items()}
+    return output

--- a/src/candle/distributed/_composable/fsdp/_fsdp_state_dict.py
+++ b/src/candle/distributed/_composable/fsdp/_fsdp_state_dict.py
@@ -1,0 +1,200 @@
+"""FSDP-aware state_dict helpers for full and sharded checkpointing."""
+from ....distributed.tensor.dtensor import DTensor
+
+
+def _collect_fsdp_states(module):
+    """Collect all FSDPState objects in the module subtree."""
+    states = []
+    for mod in module.modules():
+        st = getattr(mod, '_fsdp_state', None)
+        if st is not None:
+            states.append(st)
+    return states
+
+
+def _collect_param_groups(module):
+    """Collect all FSDPParamGroup objects in the module subtree."""
+    groups = []
+    for st in _collect_fsdp_states(module):
+        if st.param_group is not None:
+            groups.append(st.param_group)
+    return groups
+
+
+def get_model_state_dict(model, *, type="full"):
+    """Get model state dict with FSDP awareness.
+
+    Parameters
+    ----------
+    model : nn.Module
+        FSDP-wrapped model.
+    type : str
+        ``"full"`` — all-gather all params, return full state dict.
+        ``"sharded"`` — return local shard state dict.
+
+    Returns
+    -------
+    dict
+        The state dict.
+    """
+    if type == "sharded":
+        return _get_sharded_model_state_dict(model)
+    elif type == "full":
+        return _get_full_model_state_dict(model)
+    else:
+        raise ValueError(f"Unknown state_dict type: {type!r}")
+
+
+def _get_full_model_state_dict(model):
+    """Unshard all params, collect full state dict, reshard."""
+    param_groups = _collect_param_groups(model)
+
+    # Unshard all
+    for pg in param_groups:
+        pg.unshard()
+
+    # Collect state dict from unsharded params
+    state_dict = {}
+    for name, param in model.named_parameters():
+        if isinstance(param, DTensor):
+            # During unshard, the module attr is replaced with the
+            # unsharded tensor, so walk the module tree to get it
+            state_dict[name] = _get_module_attr(model, name).detach()
+        else:
+            state_dict[name] = param.detach()
+
+    # Also collect buffers
+    for name, buf in model.named_buffers():
+        state_dict[name] = buf.detach()
+
+    # Reshard all
+    for pg in param_groups:
+        pg.reshard()
+
+    return state_dict
+
+
+def _get_sharded_model_state_dict(model):
+    """Return local shard state dict (each rank saves its own shard)."""
+    state_dict = {}
+    for name, param in model.named_parameters():
+        if isinstance(param, DTensor):
+            state_dict[name] = param.to_local().detach()
+        else:
+            state_dict[name] = param.detach()
+    for name, buf in model.named_buffers():
+        state_dict[name] = buf.detach()
+    return state_dict
+
+
+def set_model_state_dict(model, state_dict, *, type="full"):
+    """Load model state dict with FSDP awareness.
+
+    Parameters
+    ----------
+    model : nn.Module
+        FSDP-wrapped model.
+    state_dict : dict
+        State dict to load.
+    type : str
+        ``"full"`` — state dict contains full (unsharded) params.
+        ``"sharded"`` — state dict contains local shards.
+    """
+    if type == "sharded":
+        _set_sharded_model_state_dict(model, state_dict)
+    elif type == "full":
+        _set_full_model_state_dict(model, state_dict)
+    else:
+        raise ValueError(f"Unknown state_dict type: {type!r}")
+
+
+def _set_full_model_state_dict(model, state_dict):
+    """Load full state dict: unshard, overwrite, reshard + re-shard params."""
+    param_groups = _collect_param_groups(model)
+
+    # Unshard all
+    for pg in param_groups:
+        pg.unshard()
+
+    # Overwrite unsharded param data from state dict
+    for name, param in model.named_parameters():
+        if name not in state_dict:
+            continue
+        val = state_dict[name]
+        # Get the actual module attr (unsharded tensor during unshard)
+        attr = _get_module_attr(model, name)
+        attr.data = val.data if hasattr(val, 'data') else val
+
+    # Write back to shards and reshard
+    for pg in param_groups:
+        for fp in pg.fsdp_params:
+            if fp._unsharded_param is not None:
+                _writeback_to_shard_from_fp(fp)
+        pg.reshard()
+
+    # Load buffers directly
+    for name, buf in model.named_buffers():
+        if name in state_dict:
+            buf.data = state_dict[name].data
+
+
+def _set_sharded_model_state_dict(model, state_dict):
+    """Load sharded state dict: directly overwrite local shards."""
+    for name, param in model.named_parameters():
+        if name not in state_dict:
+            continue
+        if isinstance(param, DTensor):
+            param.to_local().data = state_dict[name].data
+        else:
+            param.data = state_dict[name].data
+    for name, buf in model.named_buffers():
+        if name in state_dict:
+            buf.data = state_dict[name].data
+
+
+def _writeback_to_shard_from_fp(fp):
+    """Write modified unsharded param data back into the local shard."""
+    from ._fsdp_param import _chunk_tensor
+    unsharded = fp._unsharded_param
+    if unsharded is None:
+        return
+    world_size = fp._mesh_info.shard_mesh_size
+    rank = fp._mesh_info.shard_mesh_rank
+    if world_size == 1:
+        local = fp._sharded_param.to_local()
+        local.data = unsharded.data
+    else:
+        chunks = _chunk_tensor(unsharded.detach(), world_size, dim=fp._shard_dim)
+        local = fp._sharded_param.to_local()
+        local.data = chunks[rank].contiguous().data
+
+
+def get_optimizer_state_dict(model, optimizer, *, type="full"):
+    """Get optimizer state dict with FSDP awareness.
+
+    Parameters
+    ----------
+    model : nn.Module
+        FSDP-wrapped model.
+    optimizer : Optimizer
+        The optimizer.
+    type : str
+        ``"full"`` or ``"sharded"``.
+
+    Returns
+    -------
+    dict
+        The optimizer state dict.
+    """
+    # For sharded, just return the raw optimizer state dict
+    # (optimizer already operates on local shards)
+    return optimizer.state_dict()
+
+
+def _get_module_attr(module, dotted_name):
+    """Resolve a dotted attribute name like 'fc1.weight' on a module."""
+    parts = dotted_name.split('.')
+    obj = module
+    for part in parts:
+        obj = getattr(obj, part)
+    return obj

--- a/src/candle/distributed/device_mesh.py
+++ b/src/candle/distributed/device_mesh.py
@@ -1,6 +1,7 @@
 """DeviceMesh — multi-dimensional device topology abstraction.
 
-MVP: 1D mesh only (pure FSDP). API aligned with torch.distributed.device_mesh.
+Supports 1D mesh (pure FSDP) and 2D mesh (HSDP: replicate + shard).
+API aligned with torch.distributed.device_mesh.
 """
 
 
@@ -8,8 +9,12 @@ class DeviceMesh:
     """Logical arrangement of devices for distributed training.
 
     Usage:
-        # After dist.init_process_group()
+        # 1D: pure FSDP
         mesh = DeviceMesh("npu", (world_size,), mesh_dim_names=("shard",))
+
+        # 2D: HSDP (replicate across nodes, shard within node)
+        mesh = DeviceMesh("npu", (num_replicas, shard_size),
+                          mesh_dim_names=("replicate", "shard"))
     """
 
     def __init__(self, device_type, mesh_shape, *, mesh_dim_names=None):
@@ -22,20 +27,53 @@ class DeviceMesh:
         self._init_process_groups()
 
     def _init_process_groups(self):
-        """Create ProcessGroups per mesh dimension.
-
-        1D MVP: reuse the global WORLD process group.
-        """
+        """Create ProcessGroups per mesh dimension."""
         from . import is_initialized
         if not is_initialized():
             return
         if len(self._mesh_shape) == 1:
             from . import _get_default_group
             self._dim_groups = [_get_default_group()]
+        elif len(self._mesh_shape) == 2:
+            self._init_2d_process_groups()
         else:
             raise NotImplementedError(
-                f"DeviceMesh only supports 1D mesh in MVP, got shape {self._mesh_shape}"
+                f"DeviceMesh supports up to 2D mesh, got shape {self._mesh_shape}"
             )
+
+    def _init_2d_process_groups(self):
+        """Create sub-process-groups for a 2D mesh.
+
+        For mesh shape ``(num_replicas, shard_size)``:
+        - dim 0 (replicate): groups of ranks at the same position within
+          each shard group (e.g., ranks [0, 2] and [1, 3] for 2x2).
+        - dim 1 (shard): groups of contiguous ranks within each replica
+          (e.g., ranks [0, 1] and [2, 3] for 2x2).
+        """
+        from . import new_group, get_rank
+        num_replicas, shard_size = self._mesh_shape
+        world_size = num_replicas * shard_size
+        my_rank = get_rank()
+
+        # dim 0: replicate groups — ranks that share the same intra-shard position
+        # For rank r, its shard-local position is r % shard_size
+        # Its replicate group contains ranks at that position across all replicas
+        my_shard_pos = my_rank % shard_size
+        replicate_ranks = [
+            replica * shard_size + my_shard_pos
+            for replica in range(num_replicas)
+        ]
+        replicate_pg = new_group(replicate_ranks)
+
+        # dim 1: shard groups — contiguous ranks within each replica
+        my_replica = my_rank // shard_size
+        shard_ranks = [
+            my_replica * shard_size + pos
+            for pos in range(shard_size)
+        ]
+        shard_pg = new_group(shard_ranks)
+
+        self._dim_groups = [replicate_pg, shard_pg]
 
     def get_group(self, mesh_dim=0):
         """Get the ProcessGroup for a mesh dimension."""

--- a/tests/cpu/test_fsdp_integration.py
+++ b/tests/cpu/test_fsdp_integration.py
@@ -234,3 +234,217 @@ def test_fsdp_clip_grad_norm():
     # After clipping, recompute norm — should be <= max_norm + epsilon
     norm_after = clip_grad_norm_(model, max_norm=1e10)  # large max_norm = no-op
     assert float(norm_after) <= 0.1 + 1e-4, f"Clipped norm {float(norm_after)} exceeds max_norm 0.1"
+
+
+# ======================================================================
+# Phase 3 tests
+# ======================================================================
+
+
+def test_mixed_precision_forward_backward():
+    """MixedPrecision: params cast to float16 during forward, grads reduced in float32."""
+    from candle.distributed._composable.fsdp import (
+        fully_shard, MixedPrecisionPolicy,
+    )
+
+    mp = MixedPrecisionPolicy(
+        param_dtype=torch.float16,
+        reduce_dtype=torch.float32,
+        output_dtype=torch.float32,
+    )
+    model = SimpleMLP(8)
+    mesh = MockMesh()
+    fully_shard(model.fc1, mesh=mesh, mp_policy=mp)
+    fully_shard(model.fc2, mesh=mesh, mp_policy=mp)
+    fully_shard(model, mesh=mesh, mp_policy=mp)
+
+    x = torch.randn(4, 8, requires_grad=True)
+    out = model(x)
+
+    # output_dtype should cast output to float32
+    assert out.dtype == torch.float32, f"Expected float32 output, got {out.dtype}"
+    assert out.shape == (4, 8)
+
+    loss = out.sum()
+    loss.backward()
+
+    # Gradients should exist and be in the original param dtype (float32 shards)
+    for name, param in model.named_parameters():
+        local = param.to_local() if isinstance(param, DTensor) else param
+        assert local.grad is not None, f"No gradient for {name}"
+
+
+def test_mixed_precision_param_dtype_casting():
+    """Verify params are cast to param_dtype during forward."""
+    from candle.distributed._composable.fsdp import (
+        fully_shard, MixedPrecisionPolicy,
+    )
+
+    mp = MixedPrecisionPolicy(param_dtype=torch.float16)
+    model = nn.Linear(8, 4)
+    mesh = MockMesh()
+    fully_shard(model, mesh=mesh, mp_policy=mp)
+
+    # During forward, the hook unshards and casts to float16
+    # We can verify by checking the param dtype inside forward
+    observed_dtypes = []
+
+    orig_forward = model.forward
+
+    def capturing_forward(x):
+        observed_dtypes.append(model.weight.dtype)
+        return orig_forward(x)
+
+    model.forward = capturing_forward
+
+    x = torch.randn(2, 8)
+    model(x)
+
+    assert len(observed_dtypes) == 1
+    assert observed_dtypes[0] == torch.float16, (
+        f"Expected float16 during forward, got {observed_dtypes[0]}"
+    )
+
+
+def test_summon_full_params_read():
+    """summon_full_params should expose full-sized params for reading."""
+    from candle.distributed._composable.fsdp import fully_shard
+
+    model = SimpleMLP(8)
+    mesh = MockMesh()
+    fully_shard(model.fc1, mesh=mesh)
+    fully_shard(model.fc2, mesh=mesh)
+    fully_shard(model, mesh=mesh)
+
+    # Params should be sharded (DTensor) outside context
+    assert isinstance(model.fc1.weight, DTensor)
+
+    with model.summon_full_params():
+        # Inside context, params should be unsharded (full-sized)
+        w = model.fc1.weight
+        assert w.shape == (16, 8), f"Expected (16, 8), got {w.shape}"
+        assert not isinstance(w, DTensor), "Should be plain tensor inside summon"
+
+    # After exit, params should be resharded
+    assert isinstance(model.fc1.weight, DTensor)
+
+
+def test_summon_full_params_writeback():
+    """summon_full_params with writeback should persist modifications."""
+    from candle.distributed._composable.fsdp import fully_shard
+
+    model = nn.Linear(8, 4)
+    mesh = MockMesh()
+    fully_shard(model, mesh=mesh)
+
+    with model.summon_full_params(writeback=True):
+        # Zero out all weights
+        model.weight.data = torch.zeros(4, 8)
+
+    # After writeback, the shard should contain zeros
+    local = model.weight.to_local() if isinstance(model.weight, DTensor) else model.weight
+    assert float(local.abs().sum()) == 0.0, "Writeback should have zeroed the shard"
+
+
+def test_summon_full_params_with_grads():
+    """summon_full_params(with_grads=True) should expose gradients."""
+    from candle.distributed._composable.fsdp import fully_shard
+
+    model = nn.Linear(8, 4)
+    mesh = MockMesh()
+    fully_shard(model, mesh=mesh)
+
+    # Run forward/backward to get gradients
+    x = torch.randn(2, 8, requires_grad=True)
+    out = model(x)
+    out.sum().backward()
+
+    with model.summon_full_params(with_grads=True):
+        assert model.weight.grad is not None, "Grad should be available inside summon"
+
+
+def test_state_dict_full_roundtrip():
+    """Full state dict save/load round-trip."""
+    from candle.distributed._composable.fsdp import (
+        fully_shard, get_model_state_dict, set_model_state_dict,
+    )
+
+    model = SimpleMLP(8)
+    mesh = MockMesh()
+    fully_shard(model.fc1, mesh=mesh)
+    fully_shard(model.fc2, mesh=mesh)
+    fully_shard(model, mesh=mesh)
+
+    # Get full state dict
+    sd = get_model_state_dict(model, type="full")
+    assert "fc1.weight" in sd
+    assert "fc2.weight" in sd
+    # Full state dict should have unsharded shapes
+    assert sd["fc1.weight"].shape == (16, 8), f"Expected (16, 8), got {sd['fc1.weight'].shape}"
+
+    # Modify model weights
+    with model.summon_full_params(writeback=True):
+        model.fc1.weight.data = torch.zeros(16, 8)
+
+    # Load original state dict back
+    set_model_state_dict(model, sd, type="full")
+
+    # Verify restoration
+    sd2 = get_model_state_dict(model, type="full")
+    diff = float((sd2["fc1.weight"] - sd["fc1.weight"]).abs().sum())
+    assert diff < 1e-6, f"State dict round-trip failed, diff={diff}"
+
+
+def test_state_dict_sharded_roundtrip():
+    """Sharded state dict save/load round-trip."""
+    from candle.distributed._composable.fsdp import (
+        fully_shard, get_model_state_dict, set_model_state_dict,
+    )
+
+    model = nn.Linear(8, 4)
+    mesh = MockMesh()
+    fully_shard(model, mesh=mesh)
+
+    sd = get_model_state_dict(model, type="sharded")
+    assert "weight" in sd
+
+    # Modify and restore
+    orig_weight = sd["weight"].detach()
+    with model.summon_full_params(writeback=True):
+        model.weight.data = torch.zeros(4, 8)
+
+    set_model_state_dict(model, {"weight": orig_weight, "bias": sd["bias"]}, type="sharded")
+
+    sd2 = get_model_state_dict(model, type="sharded")
+    diff = float((sd2["weight"] - orig_weight).abs().sum())
+    assert diff < 1e-6, f"Sharded state dict round-trip failed, diff={diff}"
+
+
+def test_shard_grad_op_strategy():
+    """reshard_after_forward=False (SHARD_GRAD_OP) keeps params unsharded after forward."""
+    from candle.distributed._composable.fsdp import fully_shard
+
+    model = SimpleMLP(8)
+    mesh = MockMesh()
+    fully_shard(model.fc1, mesh=mesh, reshard_after_forward=False)
+    fully_shard(model.fc2, mesh=mesh, reshard_after_forward=False)
+    fully_shard(model, mesh=mesh, reshard_after_forward=False)
+
+    x = torch.randn(4, 8, requires_grad=True)
+    out = model(x)
+    assert out.shape == (4, 8)
+
+    # After forward with reshard_after_forward=False, params should still be unsharded
+    # (the post_forward hook skips reshard)
+    w = model.fc1.weight
+    assert not isinstance(w, DTensor), (
+        "With SHARD_GRAD_OP, params should stay unsharded after forward"
+    )
+
+    # Backward should still work
+    loss = out.sum()
+    loss.backward()
+
+    for name, param in model.named_parameters():
+        local = param.to_local() if isinstance(param, DTensor) else param
+        assert local.grad is not None, f"No gradient for {name}"

--- a/tests/distributed/test_fsdp2_gloo.py
+++ b/tests/distributed/test_fsdp2_gloo.py
@@ -142,3 +142,185 @@ def _run_workers(world_size, timeout=120):
 def test_fsdp2_gloo_forward_backward():
     """FSDP2 forward+backward with 2 processes using Gloo backend."""
     _run_workers(world_size=2)
+
+
+# ======================================================================
+# Phase 3 multi-rank tests
+# ======================================================================
+
+_MP_WORKER_SCRIPT = textwrap.dedent(r'''
+import os
+import sys
+import traceback
+
+sys.path.insert(0, os.environ["_CANDLE_PROJECT_ROOT"])
+
+import candle as torch
+import candle.nn as nn
+import candle.distributed as dist
+from candle.distributed.device_mesh import DeviceMesh
+from candle.distributed._composable.fsdp import fully_shard, MixedPrecisionPolicy
+from candle.distributed.tensor.dtensor import DTensor
+
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+
+try:
+    dist.init_process_group(backend="gloo", rank=rank, world_size=world_size)
+
+    torch.manual_seed(42)
+    model = nn.Linear(8, 4)
+
+    mp = MixedPrecisionPolicy(
+        param_dtype=torch.float16,
+        reduce_dtype=torch.float32,
+        output_dtype=torch.float32,
+    )
+    mesh = DeviceMesh("cpu", (world_size,))
+    fully_shard(model, mesh=mesh, mp_policy=mp)
+
+    x = torch.randn(2, 8, requires_grad=True)
+    out = model(x)
+    assert out.shape == (2, 4), f"rank {rank}: bad shape {out.shape}"
+    assert out.dtype == torch.float32, f"rank {rank}: expected float32 output, got {out.dtype}"
+
+    loss = out.sum()
+    loss.backward()
+
+    local_weight = (
+        model.weight.to_local()
+        if isinstance(model.weight, DTensor)
+        else model.weight
+    )
+    assert local_weight.grad is not None, f"rank {rank}: no weight gradient"
+    # Grad should be in param storage dtype (float32) after reduce
+    assert local_weight.grad.dtype == torch.float32, (
+        f"rank {rank}: expected float32 grad, got {local_weight.grad.dtype}"
+    )
+    print(f"[rank {rank}] mixed precision forward+backward OK")
+
+    dist.destroy_process_group()
+    print(f"[rank {rank}] ALL TESTS PASSED")
+
+except Exception:
+    traceback.print_exc()
+    try:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+    except Exception:
+        pass
+    sys.exit(1)
+''')
+
+
+_SUMMON_WORKER_SCRIPT = textwrap.dedent(r'''
+import os
+import sys
+import traceback
+
+sys.path.insert(0, os.environ["_CANDLE_PROJECT_ROOT"])
+
+import candle as torch
+import candle.nn as nn
+import candle.distributed as dist
+from candle.distributed.device_mesh import DeviceMesh
+from candle.distributed._composable.fsdp import fully_shard
+from candle.distributed.tensor.dtensor import DTensor
+
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+
+try:
+    dist.init_process_group(backend="gloo", rank=rank, world_size=world_size)
+
+    torch.manual_seed(42)
+    model = nn.Linear(8, 4)
+
+    mesh = DeviceMesh("cpu", (world_size,))
+    fully_shard(model, mesh=mesh)
+
+    # Params should be sharded
+    assert isinstance(model.weight, DTensor), f"rank {rank}: weight should be DTensor"
+
+    with model.summon_full_params():
+        w = model.weight
+        assert w.shape == (4, 8), f"rank {rank}: expected (4, 8), got {w.shape}"
+        assert not isinstance(w, DTensor), f"rank {rank}: should be plain tensor inside summon"
+
+    # After exit, should be resharded
+    assert isinstance(model.weight, DTensor), f"rank {rank}: weight should be DTensor after summon"
+    print(f"[rank {rank}] summon_full_params OK")
+
+    dist.destroy_process_group()
+    print(f"[rank {rank}] ALL TESTS PASSED")
+
+except Exception:
+    traceback.print_exc()
+    try:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+    except Exception:
+        pass
+    sys.exit(1)
+''')
+
+
+def _run_workers_with_script(script, world_size, timeout=120):
+    """Spawn workers using a custom script."""
+    port = _find_free_port()
+
+    env = os.environ.copy()
+    env["MASTER_ADDR"] = "127.0.0.1"
+    env["MASTER_PORT"] = str(port)
+    env["WORLD_SIZE"] = str(world_size)
+    env["_CANDLE_PROJECT_ROOT"] = os.path.join(_PROJECT_ROOT, "src")
+
+    fd, worker_file = tempfile.mkstemp(suffix=".py", prefix="_fsdp2_gloo_worker_")
+    os.close(fd)
+    with open(worker_file, "w") as f:
+        f.write(script)
+
+    processes = []
+    try:
+        for rank in range(world_size):
+            env_rank = {**env, "RANK": str(rank)}
+            p = subprocess.Popen(
+                [sys.executable, worker_file],
+                env=env_rank,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+            processes.append(p)
+
+        outputs = []
+        for p in processes:
+            out, _ = p.communicate(timeout=timeout)
+            outputs.append(out.decode("utf-8", errors="replace"))
+
+        for rank, out in enumerate(outputs):
+            print(f"=== RANK {rank} ===")
+            print(out)
+
+        for rank, p in enumerate(processes):
+            assert p.returncode == 0, (
+                f"Worker rank {rank} exited with code {p.returncode}.\n"
+                f"Output:\n{outputs[rank]}"
+            )
+    finally:
+        try:
+            os.unlink(worker_file)
+        except OSError:
+            pass
+        for p in processes:
+            if p.poll() is None:
+                p.kill()
+
+
+def test_fsdp2_gloo_mixed_precision():
+    """FSDP2 mixed precision forward+backward with 2 processes using Gloo."""
+    _run_workers_with_script(_MP_WORKER_SCRIPT, world_size=2)
+
+
+def test_fsdp2_gloo_summon_full_params():
+    """FSDP2 summon_full_params with 2 processes using Gloo."""
+    _run_workers_with_script(_SUMMON_WORKER_SCRIPT, world_size=2)


### PR DESCRIPTION
## FSDP2 Phase 3 — Training-Ready Features

Adds the features needed for real-world FSDP2 training workloads: mixed precision, checkpointing support, and HSDP topology.

### Changes

**MixedPrecisionPolicy** (`_fsdp_common.py`)
- `param_dtype` — cast params during forward (e.g., float16/bfloat16)
- `reduce_dtype` — cast gradients before reduce-scatter
- `output_dtype` — cast forward output back to full precision

**Mixed precision wiring** (`_fsdp_param.py`, `_fsdp_state.py`, `__init__.py`)
- `fully_shard(..., mp_policy=mp)` threads the policy through FSDPParam and FSDPState
- `FSDPParam.unshard()` casts to `param_dtype`
- `FSDPState._post_forward()` casts output to `output_dtype`
- `FSDPParam.reduce_scatter_grad()` casts grad to `reduce_dtype` before communication, then back to storage dtype

**summon_full_params** (`__init__.py`)
- `FSDPModule.summon_full_params(writeback=True, with_grads=False)` context manager
- Unshards all params in the FSDP subtree on enter, reshards on exit
- Supports writeback of modified params and gradient access

**FSDP-aware state_dict** (new `_fsdp_state_dict.py`)
- `get_model_state_dict(model, type="full"|"sharded")`
- `set_model_state_dict(model, state_dict, type="full"|"sharded")`
- `get_optimizer_state_dict(model, optimizer)` passthrough
- Full mode: all-gathers params, collects/loads full state dict, reshards
- Sharded mode: operates directly on local DTensor shards

**SHARD_GRAD_OP strategy** — verified `reshard_after_forward=False` works end-to-end

**2D DeviceMesh for HSDP** (`device_mesh.py`)
- `DeviceMesh("cpu", (num_replicas, shard_size))` creates sub-process-groups per dimension
- dim 0 (replicate): ranks at same intra-shard position across replicas
- dim 1 (shard): contiguous ranks within each replica

### Tests

**CPU single-process** (8 new tests in `test_fsdp_integration.py`):
- Mixed precision forward/backward, param dtype casting verification
- summon_full_params: read, writeback, with_grads
- State dict full + sharded round-trip
- SHARD_GRAD_OP strategy

**Multi-rank Gloo** (2 new tests in `test_fsdp2_gloo.py`):
- Mixed precision with world_size=2
- summon_full_params with world_size=2

All 15 CPU FSDP tests pass. All 3 Gloo multi-rank tests pass. Full CPU+contract suite (1591 tests) passes.