### PR TITLE
test: add binary op contract parity

### DIFF
--- a/src/candle/_backends/npu/ops/shape.py
+++ b/src/candle/_backends/npu/ops/shape.py
@@ -754,6 +754,10 @@ def _npu_advanced_getitem(tensor, key):
 
     keys = list(key) if isinstance(key, tuple) else [key]
 
+    if any(isinstance(item, Tensor) and item.dtype.name == 'bool' for item in keys):
+        # TODO: re-enable native kernel when CANN fixes aclnnIndex bool-mask advanced indexing (161001)
+        raise RuntimeError('NPU boolean mask indexing is not supported')
+
     # Step 1: Expand bool Tensor indices BEFORE expanding Ellipsis.
     # A bool tensor of N dims consumes N real dims, and we need the correct
     # dim count for Ellipsis expansion.

--- a/src/candle/_creation.py
+++ b/src/candle/_creation.py
@@ -1,4 +1,7 @@
+import numpy as np
+
 from ._dtype import float32
+from ._dtype import bool as bool_dtype
 from ._functional import tensor as tensor_dispatch
 from ._functional import zeros as zeros_dispatch
 from ._functional import ones as ones_dispatch
@@ -16,7 +19,23 @@ from ._functional import randperm as randperm_dispatch
 from ._functional import normal as normal_dispatch
 
 
-def tensor(data, *, dtype=float32, device=None, requires_grad=False):
+def _infer_creation_dtype(data):
+    if isinstance(data, (np.ndarray, np.generic)):
+        return bool_dtype if data.dtype == np.bool_ else None
+    if hasattr(data, "dtype"):
+        return None
+    try:
+        arr = np.asarray(data)
+    except Exception:
+        return None
+    return bool_dtype if arr.dtype == np.bool_ else None
+
+
+def tensor(data, *, dtype=None, device=None, requires_grad=False):
+    if dtype is None:
+        dtype = _infer_creation_dtype(data)
+    if dtype is None:
+        dtype = float32
     return tensor_dispatch(data, dtype=dtype, device=device, requires_grad=requires_grad)
 
 
@@ -79,7 +98,6 @@ def randperm(n, *, dtype=None, device=None, generator=None):
 
 
 def from_numpy(ndarray):
-    import numpy as np
     from ._dtype import (
         float16, float32, float64, int8, int16, int32, int64,
         uint8, bool as bool_dtype, bfloat16,
@@ -94,6 +112,8 @@ def from_numpy(ndarray):
 
 
 def as_tensor(data, dtype=None, device=None):
+    if dtype is None:
+        dtype = _infer_creation_dtype(data)
     if dtype is None:
         dtype = float32
     return tensor_dispatch(data, dtype=dtype, device=device)

--- a/src/candle/_dispatch/schema.py
+++ b/src/candle/_dispatch/schema.py
@@ -198,6 +198,45 @@ class OpSchema:
             if op_name == "frac":
                 raise NotImplementedError(f"\"frac_cpu\" not implemented for '{dtype_label}'")
 
+        def _validate_binary_dtype_parity(op_name, a, b):
+            if not hasattr(a, "dtype") or not hasattr(b, "dtype"):
+                return
+
+            a_dtype = a.dtype
+            b_dtype = b.dtype
+            a_bool = getattr(a_dtype, "name", None) == "bool"
+            b_bool = getattr(b_dtype, "name", None) == "bool"
+
+            if op_name == "sub" and a_bool and b_bool:
+                raise RuntimeError(
+                    "Subtraction, the `-` operator, with two bool tensors is not supported. "
+                    "Use the `^` or `logical_xor()` operator instead."
+                )
+
+            if op_name in {"logaddexp", "logaddexp2", "hypot"}:
+                if not (
+                    (getattr(a_dtype, "is_floating_point", False) or getattr(a_dtype, "is_complex", False))
+                    or (getattr(b_dtype, "is_floating_point", False) or getattr(b_dtype, "is_complex", False))
+                ):
+                    kernel_name = {
+                        "logaddexp": "logaddexp_cpu",
+                        "logaddexp2": "logaddexp2_cpu",
+                        "hypot": "hypot_cpu",
+                    }[op_name]
+                    raise NotImplementedError(
+                        f'"{kernel_name}" not implemented for \'{_torch_dtype_label(a_dtype)}\''
+                    )
+
+            if op_name in {"pow", "remainder", "fmod"} and a_bool and b_bool:
+                kernel_name = {
+                    "pow": "pow",
+                    "remainder": "remainder_cpu",
+                    "fmod": "fmod_cpu",
+                }[op_name]
+                raise NotImplementedError(
+                    f'"{kernel_name}" not implemented for \'Bool\''
+                )
+
         def _validate_sum_mean_dim(value, input_tensor):
             # Match torch call-site validation for sum/mean(dim=...).
             if value is None:
@@ -715,6 +754,10 @@ class OpSchema:
             ptype = getattr(param, "type_name", None)
             if op_short_name in {"gelu", "silu", "mish", "frac"} and param.name == "input":
                 _validate_unary_requires_float(op_short_name, value)
+                continue
+            if op_short_name in {"sub", "pow", "logaddexp", "logaddexp2", "hypot", "remainder", "fmod"}:
+                if "input" in bound and "other" in bound:
+                    _validate_binary_dtype_parity(op_short_name, bound["input"], bound["other"])
                 continue
             if op_short_name == "sum" and param.name == "dim":
                 input_tensor = bound.get("input")

--- a/tests/contract/test_training_core_binary_parity.py
+++ b/tests/contract/test_training_core_binary_parity.py
@@ -163,3 +163,85 @@ def test_add_inplace_matches_torch_contract():
     )
 
     assert result["value_match"] is True
+
+
+def test_sub_bool_bool_error_matches_torch_contract():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="sub",
+        candle_fn=lambda x, y: torch.sub(x, y),
+        torch_fn=lambda x, y: real_torch.sub(x, y),
+        candle_inputs=lambda: (
+            torch.tensor([True, False, True], dtype=torch.bool),
+            torch.tensor([False, False, True], dtype=torch.bool),
+        ),
+        torch_inputs=lambda: (
+            real_torch.tensor([True, False, True], dtype=real_torch.bool),
+            real_torch.tensor([False, False, True], dtype=real_torch.bool),
+        ),
+        expect_error=True,
+    )
+
+    assert result["error_type_match"] is True
+    assert str(result["candle_error"]) == str(result["torch_error"])
+
+
+@pytest.mark.parametrize(
+    ("op_name", "torch_fn"),
+    [
+        ("logaddexp", lambda x, y, real_torch: real_torch.logaddexp(x, y)),
+        ("logaddexp2", lambda x, y, real_torch: real_torch.logaddexp2(x, y)),
+        ("hypot", lambda x, y, real_torch: real_torch.hypot(x, y)),
+    ],
+)
+def test_binary_int64_notimplemented_matches_torch_contract(op_name, torch_fn):
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name=op_name,
+        candle_fn=lambda x, y: getattr(torch, op_name)(x, y),
+        torch_fn=lambda x, y: torch_fn(x, y, real_torch),
+        candle_inputs=lambda: (
+            torch.tensor([1, -2, 3], dtype=torch.int64),
+            torch.tensor([2, 4, -1], dtype=torch.int64),
+        ),
+        torch_inputs=lambda: (
+            real_torch.tensor([1, -2, 3], dtype=real_torch.int64),
+            real_torch.tensor([2, 4, -1], dtype=real_torch.int64),
+        ),
+        expect_error=True,
+    )
+
+    assert result["error_type_match"] is True
+    assert str(result["candle_error"]) == str(result["torch_error"])
+
+
+@pytest.mark.parametrize(
+    ("op_name", "torch_fn"),
+    [
+        ("pow", lambda x, y, real_torch: real_torch.pow(x, y)),
+        ("remainder", lambda x, y, real_torch: real_torch.remainder(x, y)),
+        ("fmod", lambda x, y, real_torch: real_torch.fmod(x, y)),
+    ],
+)
+def test_binary_bool_notimplemented_matches_torch_contract(op_name, torch_fn):
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name=op_name,
+        candle_fn=lambda x, y: getattr(torch, op_name)(x, y),
+        torch_fn=lambda x, y: torch_fn(x, y, real_torch),
+        candle_inputs=lambda: (
+            torch.tensor([True, False, True], dtype=torch.bool),
+            torch.tensor([False, False, True], dtype=torch.bool),
+        ),
+        torch_inputs=lambda: (
+            real_torch.tensor([True, False, True], dtype=real_torch.bool),
+            real_torch.tensor([False, False, True], dtype=real_torch.bool),
+        ),
+        expect_error=True,
+    )
+
+    assert result["error_type_match"] is True
+    assert str(result["candle_error"]) == str(result["torch_error"])

--- a/tests/cpu/test_top_level_ops.py
+++ b/tests/cpu/test_top_level_ops.py
@@ -65,6 +65,16 @@ class TestCategoryA:
         out = torch.masked_fill(a, mask, 0.0)
         assert out.tolist() == [0.0, 2.0, 0.0]
 
+    def test_tensor_bool_input_infers_bool_dtype(self):
+        mask = torch.tensor([True, False, True])
+        assert mask.dtype == torch.bool
+        assert mask.tolist() == [True, False, True]
+
+    def test_tensor_explicit_float_dtype_overrides_bool_inference(self):
+        mask = torch.tensor([True, False, True], dtype=torch.float32)
+        assert mask.dtype == torch.float32
+        assert mask.tolist() == [1.0, 0.0, 1.0]
+
     def test_unfold(self):
         a = torch.arange(1, 8, dtype=torch.float32)
         out = torch.unfold(a, 0, 3, 2)


### PR DESCRIPTION
## Summary
- add binary contract parity coverage for PyTorch-specific bool/int64 error cases
- align schema-level binary validation with PyTorch error types/messages for the covered ops
- restore explicit NPU bool-mask indexing failure and fix top-level bool tensor creation inference so the contract exercises the intended path

## Testing
- PYTHONPATH=src pytest tests/contract/test_training_core_binary_parity.py -v
- PYTHONPATH=src pytest tests/contract/test_npu_indexing_no_cpu_roundtrip.py -v --tb=short
- PYTHONPATH=src pytest tests/cpu/test_top_level_ops.py -v --tb=short
- PYTHONPATH=src pytest tests/contract/ -v --tb=short
