### PR TITLE
feat(data): complete torch.utils.data API alignment

### DIFF
--- a/src/candle/utils/data/__init__.py
+++ b/src/candle/utils/data/__init__.py
@@ -1,6 +1,12 @@
 from .distributed import DistributedSampler
-from .dataset import Dataset, IterableDataset, TensorDataset, ConcatDataset, Subset
-from .sampler import Sampler, SequentialSampler, RandomSampler, BatchSampler
+from .dataset import (
+    Dataset, IterableDataset, TensorDataset, ConcatDataset, Subset,
+    ChainDataset, StackDataset, random_split,
+)
+from .sampler import (
+    Sampler, SequentialSampler, RandomSampler, BatchSampler,
+    SubsetRandomSampler, WeightedRandomSampler,
+)
 from ._utils import default_collate, default_convert, get_worker_info
 from .dataloader import DataLoader
 
@@ -10,11 +16,16 @@ __all__ = [
     "IterableDataset",
     "TensorDataset",
     "ConcatDataset",
+    "ChainDataset",
+    "StackDataset",
     "Subset",
+    "random_split",
     "Sampler",
     "SequentialSampler",
     "RandomSampler",
     "BatchSampler",
+    "SubsetRandomSampler",
+    "WeightedRandomSampler",
     "DataLoader",
     "default_collate",
     "default_convert",

--- a/src/candle/utils/data/dataset.py
+++ b/src/candle/utils/data/dataset.py
@@ -1,3 +1,7 @@
+import math
+import random as _random
+
+
 class Dataset:
     def __getitem__(self, index):
         raise NotImplementedError
@@ -5,10 +9,16 @@ class Dataset:
     def __len__(self):
         raise NotImplementedError
 
+    def __add__(self, other):
+        return ConcatDataset([self, other])
+
 
 class IterableDataset:
     def __iter__(self):
         raise NotImplementedError
+
+    def __add__(self, other):
+        return ChainDataset([self, other])
 
 
 class TensorDataset(Dataset):
@@ -65,3 +75,96 @@ class Subset(Dataset):
 
     def __len__(self):
         return len(self.indices)
+
+
+class ChainDataset(IterableDataset):
+    def __init__(self, datasets):
+        self.datasets = list(datasets)
+        for ds in self.datasets:
+            if not isinstance(ds, IterableDataset):
+                raise TypeError(
+                    "ChainDataset only supports IterableDataset, "
+                    f"but got {type(ds).__name__}"
+                )
+
+    def __iter__(self):
+        for ds in self.datasets:
+            yield from ds
+
+    def __len__(self):
+        total = 0
+        for ds in self.datasets:
+            total += len(ds)
+        return total
+
+
+class StackDataset(Dataset):
+    def __init__(self, *args, **kwargs):
+        if args and kwargs:
+            raise ValueError(
+                "StackDataset accepts either positional or keyword "
+                "arguments, not both"
+            )
+        if not args and not kwargs:
+            raise ValueError("StackDataset requires at least one dataset")
+        if args:
+            self._datasets = list(args)
+            self._keys = None
+        else:
+            self._datasets = list(kwargs.values())
+            self._keys = list(kwargs.keys())
+        length = len(self._datasets[0])
+        for ds in self._datasets[1:]:
+            if len(ds) != length:
+                raise ValueError("All datasets must have the same length")
+
+    def __getitem__(self, index):
+        items = [ds[index] for ds in self._datasets]
+        if self._keys is not None:
+            return dict(zip(self._keys, items))
+        return tuple(items)
+
+    def __getitems__(self, indices):
+        samples = []
+        for idx in indices:
+            samples.append(self[idx])
+        return samples
+
+    def __len__(self):
+        return len(self._datasets[0])
+
+
+def random_split(dataset, lengths, generator=None):
+    """Randomly split a dataset into non-overlapping new datasets."""
+    n = len(dataset)
+    if (math.isclose(sum(lengths), 1.0)
+            and all(isinstance(x, float) for x in lengths)):
+        subset_lengths = []
+        for i, frac in enumerate(lengths):
+            if frac < 0 or frac > 1:
+                raise ValueError(
+                    f"Fraction at index {i} is not between 0 and 1"
+                )
+            n_items = int(math.floor(n * frac))
+            subset_lengths.append(n_items)
+        remainder = n - sum(subset_lengths)
+        indices_order = sorted(
+            range(len(lengths)), key=lambda i: lengths[i], reverse=True
+        )
+        for i in range(remainder):
+            subset_lengths[indices_order[i]] += 1
+        lengths = subset_lengths
+    if sum(lengths) != n:
+        raise ValueError(
+            "Sum of input lengths does not equal the length of the "
+            f"input dataset (expected {n}, got {sum(lengths)})"
+        )
+    rng = generator if generator is not None else _random
+    indices = list(range(n))
+    rng.shuffle(indices)
+    subsets = []
+    offset = 0
+    for length in lengths:
+        subsets.append(Subset(dataset, indices[offset:offset + length]))
+        offset += length
+    return subsets

--- a/src/candle/utils/data/sampler.py
+++ b/src/candle/utils/data/sampler.py
@@ -63,3 +63,52 @@ class BatchSampler(Sampler):
         if self.drop_last:
             return n // self.batch_size
         return (n + self.batch_size - 1) // self.batch_size
+
+
+class SubsetRandomSampler(Sampler):
+    def __init__(self, indices, generator=None):
+        self.indices = list(indices)
+        self.generator = generator
+
+    def __iter__(self):
+        rng = self.generator if self.generator is not None else random
+        idx = list(self.indices)
+        rng.shuffle(idx)
+        return iter(idx)
+
+    def __len__(self):
+        return len(self.indices)
+
+
+class WeightedRandomSampler(Sampler):
+    def __init__(self, weights, num_samples, replacement=True, generator=None):
+        if not isinstance(num_samples, int) or num_samples < 0:
+            raise ValueError(
+                f"num_samples should be a non-negative integer, got {num_samples}"
+            )
+        self.weights = list(weights)
+        self.num_samples = num_samples
+        self.replacement = replacement
+        self.generator = generator
+
+    def __iter__(self):
+        rng = self.generator if self.generator is not None else random
+        if self.replacement:
+            yield from rng.choices(
+                range(len(self.weights)),
+                weights=self.weights,
+                k=self.num_samples,
+            )
+        else:
+            # Weighted sampling without replacement
+            w = list(self.weights)
+            indices = list(range(len(w)))
+            for _ in range(self.num_samples):
+                chosen = rng.choices(
+                    indices, weights=[w[i] for i in indices], k=1
+                )[0]
+                yield chosen
+                indices.remove(chosen)
+
+    def __len__(self):
+        return self.num_samples


### PR DESCRIPTION
## Summary

Adds missing `torch.utils.data` classes and utilities to close the API gap with PyTorch.

## Changes

**dataset.py**
- `Dataset.__add__` → returns `ConcatDataset`
- `IterableDataset.__add__` → returns `ChainDataset`
- `ChainDataset` — chains multiple `IterableDataset`s, yields from each sequentially
- `StackDataset` — zips datasets into tuple (positional args) or dict (keyword args) output, with `__getitems__` for batched fetching
- `random_split()` — splits a dataset into non-overlapping `Subset`s; supports both integer lengths and float fractions

**sampler.py**
- `SubsetRandomSampler` — shuffles a given list of indices each iteration
- `WeightedRandomSampler` — weighted sampling with or without replacement

**__init__.py**
- Exports all new symbols

## Design Decisions

- Uses Python `random` module (not numpy) for all randomness, matching existing candle sampler patterns
- `random_split` accepts `random.Random` as generator (candle convention)
- `WeightedRandomSampler` without replacement uses iterative weighted selection with index removal
- No DataPipe classes — deprecated in PyTorch, replaced by torchdata