### PR TITLE
feat(mps): P3 GPU kernels — math, trig, erf, activations

### DIFF
--- a/src/candle/_backends/mps/metal_shaders.py
+++ b/src/candle/_backends/mps/metal_shaders.py
@@ -24,6 +24,9 @@ _FLOAT_ONLY_OPS = frozenset({
     "sqrt", "rsqrt", "exp", "log", "log2", "sin", "cos", "tanh",
     "sigmoid", "gelu", "silu", "floor", "ceil", "round",
     "tan", "trunc", "log10", "exp2", "square",
+    "log1p", "expm1", "reciprocal", "sinh", "cosh",
+    "asinh", "acosh", "atanh", "asin", "acos", "atan",
+    "erf", "erfc",
 })
 
 # ---------------------------------------------------------------------------
@@ -1383,6 +1386,23 @@ def _gen_pad_constant(types=None):
 _HEADER = """
 #include <metal_stdlib>
 using namespace metal;
+
+// Abramowitz & Stegun approximation for erf (max error ~1.5e-7)
+inline float _metal_erf(float x) {
+    float ax = abs(x);
+    float t = 1.0f / (1.0f + 0.3275911f * ax);
+    float t2 = t * t;
+    float t3 = t2 * t;
+    float t4 = t3 * t;
+    float t5 = t4 * t;
+    float y = 1.0f - (0.254829592f * t - 0.284496736f * t2
+              + 1.421413741f * t3 - 1.453152027f * t4
+              + 1.061405429f * t5) * exp(-ax * ax);
+    return x >= 0.0f ? y : -y;
+}
+inline half _metal_erf(half x) {
+    return half(_metal_erf(float(x)));
+}
 """
 
 # --- Binary element-wise ---
@@ -1400,6 +1420,9 @@ _BINARY_FLOAT_OPS = (
     ("fmod", "fmod(a[id], b[id])"),
     ("remainder", "a[id] - b[id] * floor(a[id] / b[id])"),
     ("logaddexp", "log(exp(a[id]) + exp(b[id]))"),
+    ("atan2", "atan2(a[id], b[id])"),
+    ("hypot", "sqrt(a[id] * a[id] + b[id] * b[id])"),
+    ("logaddexp2", "log2(exp2(a[id]) + exp2(b[id]))"),
 )
 
 # --- Unary element-wise (numeric types: float, half, int, long) ---
@@ -1430,6 +1453,19 @@ _UNARY_FLOAT_OPS = (
     ("log10", "log10(x)"),
     ("exp2", "exp2(x)"),
     ("square", "x * x"),
+    ("log1p", "log(1.0 + x)"),
+    ("expm1", "exp(x) - 1.0"),
+    ("reciprocal", "1.0 / x"),
+    ("sinh", "sinh(x)"),
+    ("cosh", "cosh(x)"),
+    ("asinh", "asinh(x)"),
+    ("acosh", "acosh(x)"),
+    ("atanh", "atanh(x)"),
+    ("asin", "asin(x)"),
+    ("acos", "acos(x)"),
+    ("atan", "atan(x)"),
+    ("erf", "_metal_erf(x)"),
+    ("erfc", "1.0f - _metal_erf(x)"),
 )
 
 # --- Comparison ops ---
@@ -1868,10 +1904,11 @@ def _build_msl_source():
     # Clamp with 2 scalars (min + max)
     parts.append(_gen_clamp())
 
-    # Unary predicate ops (float → bool): isinf, isnan, isfinite
+    # Unary predicate ops (float → bool): isinf, isnan, isfinite, signbit
     parts.append(_gen_unary_predicate("isinf", "isinf(a[id])"))
     parts.append(_gen_unary_predicate("isnan", "isnan(a[id])"))
     parts.append(_gen_unary_predicate("isfinite", "isfinite(a[id])"))
+    parts.append(_gen_unary_predicate("signbit", "signbit(a[id])"))
 
     # Full-tensor reductions (multi-dtype)
     # sum: identity=0, combine=add

--- a/src/candle/_backends/mps/ops.py
+++ b/src/candle/_backends/mps/ops.py
@@ -1918,6 +1918,8 @@ def square(a):
 
 
 def signbit(a):
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
+        return _dispatch_unary_predicate_gpu(a, "signbit")
     arr = np.signbit(_to_numpy(a))
     return _from_numpy(arr, bool_dtype, a.device)
 
@@ -1944,32 +1946,46 @@ def isfinite(a):
 
 
 def sinh(a):
+    if _can_use_gpu(a):
+        return _dispatch_unary_gpu(a, "sinh")
     return _from_numpy(np.sinh(_to_numpy(a)), a.dtype, a.device)
 
 
 def cosh(a):
+    if _can_use_gpu(a):
+        return _dispatch_unary_gpu(a, "cosh")
     return _from_numpy(np.cosh(_to_numpy(a)), a.dtype, a.device)
 
 
 def asinh(a):
+    if _can_use_gpu(a):
+        return _dispatch_unary_gpu(a, "asinh")
     return _from_numpy(np.arcsinh(_to_numpy(a)), a.dtype, a.device)
 
 
 def acosh(a):
+    if _can_use_gpu(a):
+        return _dispatch_unary_gpu(a, "acosh")
     return _from_numpy(np.arccosh(_to_numpy(a)), a.dtype, a.device)
 
 
 def atanh(a):
+    if _can_use_gpu(a):
+        return _dispatch_unary_gpu(a, "atanh")
     return _from_numpy(np.arctanh(_to_numpy(a)), a.dtype, a.device)
 
 
 def erf(a):
+    if _can_use_gpu(a):
+        return _dispatch_unary_gpu(a, "erf")
     arr = _to_numpy(a)
     out = np.vectorize(math.erf)(arr)
     return _from_numpy(out, a.dtype, a.device)
 
 
 def erfc(a):
+    if _can_use_gpu(a):
+        return _dispatch_unary_gpu(a, "erfc")
     arr = _to_numpy(a)
     out = np.vectorize(math.erfc)(arr)
     return _from_numpy(out, a.dtype, a.device)
@@ -2019,12 +2035,23 @@ def leaky_relu(a, negative_slope=0.01):
 
 
 def elu(a, alpha=1.0):
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
+        # elu(x) = x if x > 0, alpha*(exp(x)-1) otherwise
+        relu_a = _dispatch_unary_gpu(a, "relu")
+        exp_a = _dispatch_unary_gpu(a, "exp")
+        elu_part = mul(sub(exp_a, 1.0), alpha)
+        neg_part = clamp(elu_part, None, 0.0)
+        return add(relu_a, neg_part)
     arr = _to_numpy(a)
     out = np.where(arr > 0, arr, alpha * (np.exp(arr) - 1))
     return _from_numpy(out, a.dtype, a.device)
 
 
 def mish(a):
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
+        # mish(x) = x * tanh(softplus(x)) = x * tanh(log(1 + exp(x)))
+        sp = softplus(a)
+        return mul(a, _dispatch_unary_gpu(sp, "tanh"))
     arr = _to_numpy(a)
     out = arr * np.tanh(np.log1p(np.exp(arr)))
     return _from_numpy(out, a.dtype, a.device)
@@ -2208,18 +2235,33 @@ def max_(a, b):
 
 
 def hardswish(a):
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
+        # hardswish(x) = x * clamp(x + 3, 0, 6) / 6
+        shifted = add(a, 3.0)
+        clamped = clamp(shifted, 0.0, 6.0)
+        return div(mul(a, clamped), 6.0)
     arr = _to_numpy(a).astype(np.float64)
     out = arr * np.clip(arr + 3.0, 0.0, 6.0) / 6.0
     return _from_numpy(out.astype(to_numpy_dtype(a.dtype)), a.dtype, a.device)
 
 
 def hardsigmoid(a):
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
+        # hardsigmoid(x) = clamp(x + 3, 0, 6) / 6
+        shifted = add(a, 3.0)
+        clamped = clamp(shifted, 0.0, 6.0)
+        return div(clamped, 6.0)
     arr = _to_numpy(a).astype(np.float64)
     out = np.clip(arr + 3.0, 0.0, 6.0) / 6.0
     return _from_numpy(out.astype(to_numpy_dtype(a.dtype)), a.dtype, a.device)
 
 
 def softsign(a):
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
+        # softsign(x) = x / (1 + |x|)
+        abs_a = _dispatch_unary_gpu(a, "abs")
+        denom = add(abs_a, 1.0)
+        return div(a, denom)
     arr = _to_numpy(a).astype(np.float64)
     out = arr / (1.0 + np.abs(arr))
     return _from_numpy(out.astype(to_numpy_dtype(a.dtype)), a.dtype, a.device)
@@ -2317,22 +2359,37 @@ def where(cond, x, y):
 
 
 def atan(a):
+    if _can_use_gpu(a):
+        return _dispatch_unary_gpu(a, "atan")
     return _from_numpy(np.arctan(_to_numpy(a)), a.dtype, a.device)
 
 
 def atan2(a, b):
+    if isinstance(a, Tensor) and isinstance(b, Tensor) and _can_use_gpu(a) and _can_use_gpu(b):
+        return _dispatch_binary_gpu(a, b, "atan2")
     return _from_numpy(np.arctan2(_to_numpy(a), _to_numpy(b)), a.dtype, a.device)
 
 
 def asin(a):
+    if _can_use_gpu(a):
+        return _dispatch_unary_gpu(a, "asin")
     return _from_numpy(np.arcsin(_to_numpy(a)), a.dtype, a.device)
 
 
 def acos(a):
+    if _can_use_gpu(a):
+        return _dispatch_unary_gpu(a, "acos")
     return _from_numpy(np.arccos(_to_numpy(a)), a.dtype, a.device)
 
 
 def lerp(a, b, weight):
+    if _can_use_gpu(a) and _can_use_gpu(b):
+        # lerp(a, b, w) = a + w * (b - a)
+        diff = sub(b, a)
+        if isinstance(weight, Tensor):
+            return add(a, mul(diff, weight))
+        else:
+            return add(a, mul(diff, weight))
     arr_a = _to_numpy(a)
     arr_b = _to_numpy(b)
     if isinstance(weight, Tensor):
@@ -2370,10 +2427,14 @@ def logaddexp(a, b):
 
 
 def logaddexp2(a, b):
+    if isinstance(a, Tensor) and isinstance(b, Tensor) and _can_use_gpu(a) and _can_use_gpu(b):
+        return _dispatch_binary_gpu(a, b, "logaddexp2")
     return _from_numpy(np.logaddexp2(_to_numpy(a), _to_numpy(b)), a.dtype, a.device)
 
 
 def hypot(a, b):
+    if isinstance(a, Tensor) and isinstance(b, Tensor) and _can_use_gpu(a) and _can_use_gpu(b):
+        return _dispatch_binary_gpu(a, b, "hypot")
     return _from_numpy(np.hypot(_to_numpy(a), _to_numpy(b)), a.dtype, a.device)
 
 
@@ -3716,14 +3777,20 @@ def sub(a, b):
 
 
 def log1p(a):
+    if _can_use_gpu(a):
+        return _dispatch_unary_gpu(a, "log1p")
     return _from_numpy(np.log1p(_to_numpy(a)), a.dtype, a.device)
 
 
 def expm1(a):
+    if _can_use_gpu(a):
+        return _dispatch_unary_gpu(a, "expm1")
     return _from_numpy(np.expm1(_to_numpy(a)), a.dtype, a.device)
 
 
 def reciprocal(a):
+    if _can_use_gpu(a):
+        return _dispatch_unary_gpu(a, "reciprocal")
     return _from_numpy(1.0 / _to_numpy(a), a.dtype, a.device)
 
 

--- a/tests/mps/test_metal_infra.py
+++ b/tests/mps/test_metal_infra.py
@@ -1,5 +1,6 @@
 """Tests for MPS Metal infrastructure: multi-dtype, strided access,
 axis reduction, and comparison ops."""
+import math
 import numpy as np
 import pytest
 import candle as torch
@@ -1566,3 +1567,172 @@ class TestP2GPUOps:
         out = torch.roll(a, -1, 0)
         ref = np.roll(a_np, -1, axis=0)
         np.testing.assert_allclose(out.cpu().numpy(), ref)
+
+
+# ---------------------------------------------------------------------------
+# P3: Math, trig, error funcs, activations, predicates
+# ---------------------------------------------------------------------------
+
+class TestP3UnaryMath:
+    """log1p, expm1, reciprocal on GPU."""
+
+    @pytest.mark.parametrize("op,np_op", [
+        ("log1p", np.log1p),
+        ("expm1", np.expm1),
+    ])
+    def test_unary_math(self, op, np_op):
+        a_np = np.random.rand(64).astype(np.float32) + 0.1
+        a = torch.tensor(a_np, device="mps")
+        out = getattr(torch, op)(a).cpu().numpy()
+        np.testing.assert_allclose(out, np_op(a_np), rtol=1e-5, atol=1e-6)
+
+    def test_reciprocal(self):
+        a_np = np.random.rand(64).astype(np.float32) + 0.5
+        a = torch.tensor(a_np, device="mps")
+        out = torch.reciprocal(a).cpu().numpy()
+        np.testing.assert_allclose(out, 1.0 / a_np, rtol=1e-5, atol=1e-6)
+
+
+class TestP3Trig:
+    """sinh, cosh, asinh, acosh, atanh, asin, acos, atan, atan2."""
+
+    @pytest.mark.parametrize("op,np_op", [
+        ("sinh", np.sinh),
+        ("cosh", np.cosh),
+        ("asinh", np.arcsinh),
+        ("atanh", np.arctanh),
+        ("asin", np.arcsin),
+        ("acos", np.arccos),
+        ("atan", np.arctan),
+    ])
+    def test_trig_unary(self, op, np_op):
+        a_np = np.random.uniform(-0.9, 0.9, 64).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = getattr(torch, op)(a).cpu().numpy()
+        np.testing.assert_allclose(out, np_op(a_np), rtol=1e-5, atol=1e-5)
+
+    def test_acosh(self):
+        a_np = np.random.uniform(1.1, 5.0, 64).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.acosh(a).cpu().numpy()
+        np.testing.assert_allclose(out, np.arccosh(a_np), rtol=1e-5, atol=1e-5)
+
+    def test_atan2(self):
+        a_np = np.random.randn(64).astype(np.float32)
+        b_np = np.random.randn(64).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        b = torch.tensor(b_np, device="mps")
+        out = torch.atan2(a, b).cpu().numpy()
+        np.testing.assert_allclose(out, np.arctan2(a_np, b_np), rtol=1e-5, atol=1e-5)
+
+
+class TestP3ErrorFuncs:
+    """erf, erfc on GPU."""
+
+    def test_erf(self):
+        a_np = np.linspace(-3, 3, 128).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.erf(a).cpu().numpy()
+        ref = np.vectorize(math.erf)(a_np)
+        np.testing.assert_allclose(out, ref, rtol=1e-5, atol=2e-7)
+
+    def test_erfc(self):
+        a_np = np.linspace(-3, 3, 128).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.erfc(a).cpu().numpy()
+        ref = np.vectorize(math.erfc)(a_np)
+        np.testing.assert_allclose(out, ref, rtol=1e-5, atol=5e-7)
+
+
+class TestP3BinaryOps:
+    """hypot, logaddexp2 on GPU."""
+
+    def test_hypot(self):
+        a_np = np.random.randn(64).astype(np.float32)
+        b_np = np.random.randn(64).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        b = torch.tensor(b_np, device="mps")
+        out = torch.hypot(a, b).cpu().numpy()
+        np.testing.assert_allclose(out, np.hypot(a_np, b_np), rtol=1e-5, atol=1e-6)
+
+    def test_logaddexp2(self):
+        a_np = np.random.randn(64).astype(np.float32)
+        b_np = np.random.randn(64).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        b = torch.tensor(b_np, device="mps")
+        out = torch.logaddexp2(a, b).cpu().numpy()
+        np.testing.assert_allclose(out, np.logaddexp2(a_np, b_np), rtol=1e-4, atol=1e-5)
+
+
+class TestP3Activations:
+    """elu, mish, hardswish, hardsigmoid, softsign on GPU."""
+
+    def test_elu(self):
+        a_np = np.random.randn(128).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.nn.functional.elu(a, alpha=1.0).cpu().numpy()
+        ref = np.where(a_np > 0, a_np, 1.0 * (np.exp(a_np) - 1))
+        np.testing.assert_allclose(out, ref, rtol=1e-5, atol=1e-6)
+
+    def test_mish(self):
+        a_np = np.random.randn(128).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.nn.functional.mish(a).cpu().numpy()
+        ref = a_np * np.tanh(np.log1p(np.exp(a_np)))
+        np.testing.assert_allclose(out, ref, rtol=1e-4, atol=1e-5)
+
+    def test_hardswish(self):
+        a_np = np.random.randn(128).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.nn.functional.hardswish(a).cpu().numpy()
+        ref = a_np * np.clip(a_np + 3.0, 0.0, 6.0) / 6.0
+        np.testing.assert_allclose(out, ref, rtol=1e-5, atol=1e-6)
+
+    def test_hardsigmoid(self):
+        a_np = np.random.randn(128).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.nn.functional.hardsigmoid(a).cpu().numpy()
+        ref = np.clip(a_np + 3.0, 0.0, 6.0) / 6.0
+        np.testing.assert_allclose(out, ref, rtol=1e-5, atol=1e-6)
+
+    def test_softsign(self):
+        a_np = np.random.randn(128).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.nn.functional.softsign(a).cpu().numpy()
+        ref = a_np / (1.0 + np.abs(a_np))
+        np.testing.assert_allclose(out, ref, rtol=1e-5, atol=1e-6)
+
+
+class TestP3Predicates:
+    """signbit on GPU."""
+
+    def test_signbit(self):
+        a_np = np.array([-1.0, 0.0, 1.0, -0.5, float('inf'), float('-inf')],
+                        dtype=np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.signbit(a).cpu().numpy()
+        np.testing.assert_array_equal(out, np.signbit(a_np))
+
+
+class TestP3Lerp:
+    """lerp composite on GPU."""
+
+    def test_lerp_scalar_weight(self):
+        a_np = np.random.randn(64).astype(np.float32)
+        b_np = np.random.randn(64).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        b = torch.tensor(b_np, device="mps")
+        out = torch.lerp(a, b, 0.3).cpu().numpy()
+        ref = a_np + 0.3 * (b_np - a_np)
+        np.testing.assert_allclose(out, ref, rtol=1e-5, atol=1e-6)
+
+    def test_lerp_tensor_weight(self):
+        a_np = np.random.randn(64).astype(np.float32)
+        b_np = np.random.randn(64).astype(np.float32)
+        w_np = np.random.rand(64).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        b = torch.tensor(b_np, device="mps")
+        w = torch.tensor(w_np, device="mps")
+        out = torch.lerp(a, b, w).cpu().numpy()
+        ref = a_np + w_np * (b_np - a_np)
+        np.testing.assert_allclose(out, ref, rtol=1e-5, atol=1e-6)


### PR DESCRIPTION
## Summary

Adds Metal GPU paths for 25+ MPS ops, continuing the kernel rollout from #61 and #62.

### Unary math (new Metal shaders)
- **log1p, expm1, reciprocal** — common training ops

### Trig / hyperbolic (new Metal shaders)
- **sinh, cosh, asinh, acosh, atanh, asin, acos, atan** — all via MSL builtins

### Binary ops (new Metal shaders)
- **atan2, hypot, logaddexp2** — added to `_BINARY_FLOAT_OPS`

### Error functions (custom Metal implementation)
- **erf, erfc** — Abramowitz & Stegun polynomial approximation (`_metal_erf` helper in MSL preamble, max error ~1.5e-7). Metal doesn't have built-in erf/erfc.

### Activation composites (no new shaders)
- **elu** — `relu(x) + clamp(alpha*(exp(x)-1), max=0)`
- **mish** — `x * tanh(softplus(x))`
- **hardswish** — `x * clamp(x+3, 0, 6) / 6`
- **hardsigmoid** — `clamp(x+3, 0, 6) / 6`
- **softsign** — `x / (1 + |x|)`

### Other
- **signbit** — new predicate shader
- **lerp** — GPU composite via `a + w*(b-a)`

### Details
- All kernels support float32 and float16
- 24 new tests across 7 test classes
- 333 MPS tests pass, no regressions
