### PR TITLE
feat(mps): GPU-accelerated P4 compute kernels

### DIFF
--- a/src/candle/_backends/mps/metal_compute.py
+++ b/src/candle/_backends/mps/metal_compute.py
@@ -1131,6 +1131,41 @@ class MetalKernelDispatcher:
         rt.commit_and_wait(cmd)
 
     # ------------------------------------------------------------------
+    # Dispatch: sort  (input → values + indices)
+    # ------------------------------------------------------------------
+
+    def dispatch_sort(self, kernel_name, input_buf, values_buf, indices_buf,
+                      outer_size, dim_size, inner_size, descending):
+        """Encode sort kernel (3 bufs + 4 setBytes)."""
+        rt = get_runtime()
+        pipeline = self._get_pipeline(kernel_name)
+        tpg = self._threads_per_group(pipeline)
+        numel = outer_size * inner_size
+        groups = (numel + tpg - 1) // tpg
+
+        cmd = rt.create_command_buffer()
+        enc = rt.get_compute_encoder(cmd)
+
+        if _HAS_PYOBJC:
+            enc.setComputePipelineState_(pipeline)
+            enc.setBuffer_offset_atIndex_(input_buf, 0, 0)
+            enc.setBuffer_offset_atIndex_(values_buf, 0, 1)
+            enc.setBuffer_offset_atIndex_(indices_buf, 0, 2)
+            enc.setBytes_length_atIndex_(struct.pack("I", outer_size), 4, 3)
+            enc.setBytes_length_atIndex_(struct.pack("I", dim_size), 4, 4)
+            enc.setBytes_length_atIndex_(struct.pack("I", inner_size), 4, 5)
+            enc.setBytes_length_atIndex_(struct.pack("I", 1 if descending else 0), 4, 6)
+            enc.dispatchThreadgroups_threadsPerThreadgroup_(
+                _MTLSize(groups, 1, 1), _MTLSize(tpg, 1, 1))
+            enc.endEncoding()
+        else:
+            _encode_sort_ctypes(enc, pipeline, input_buf, values_buf,
+                                indices_buf, outer_size, dim_size,
+                                inner_size, descending, groups, tpg)
+
+        rt.commit_and_wait(cmd)
+
+    # ------------------------------------------------------------------
     # Dispatch: adaptive_avg_pool2d
     # ------------------------------------------------------------------
 
@@ -2121,6 +2156,22 @@ def _encode_cumsum_ctypes(enc, pipeline, input_buf, output_buf,
     _ctypes_set_bytes(enc, struct.pack("I", outer_size), 4, 2)
     _ctypes_set_bytes(enc, struct.pack("I", dim_size), 4, 3)
     _ctypes_set_bytes(enc, struct.pack("I", inner_size), 4, 4)
+    _ctypes_dispatch_threadgroups(enc, groups, tpg)
+    _ctypes_end_encoding(enc)
+
+
+def _encode_sort_ctypes(enc, pipeline, input_buf, values_buf, indices_buf,
+                         outer_size, dim_size, inner_size, descending,
+                         groups, tpg):
+    """Encode sort kernel via ctypes."""
+    _ctypes_set_pipeline(enc, pipeline)
+    _ctypes_set_buffer(enc, input_buf, 0, 0)
+    _ctypes_set_buffer(enc, values_buf, 0, 1)
+    _ctypes_set_buffer(enc, indices_buf, 0, 2)
+    _ctypes_set_bytes(enc, struct.pack("I", outer_size), 4, 3)
+    _ctypes_set_bytes(enc, struct.pack("I", dim_size), 4, 4)
+    _ctypes_set_bytes(enc, struct.pack("I", inner_size), 4, 5)
+    _ctypes_set_bytes(enc, struct.pack("I", 1 if descending else 0), 4, 6)
     _ctypes_dispatch_threadgroups(enc, groups, tpg)
     _ctypes_end_encoding(enc)
 

--- a/src/candle/_backends/mps/metal_shaders.py
+++ b/src/candle/_backends/mps/metal_shaders.py
@@ -1074,6 +1074,106 @@ def _gen_cumsum(types=None):
     return "".join(parts)
 
 
+_CUMPROD_TEMPLATE = """
+kernel void cumprod_{suffix}(
+    device const {type}* input  [[buffer(0)]],
+    device {type}* output       [[buffer(1)]],
+    constant uint& outer_size   [[buffer(2)]],
+    constant uint& dim_size     [[buffer(3)]],
+    constant uint& inner_size   [[buffer(4)]],
+    uint gid [[thread_position_in_grid]])
+{{
+    uint total = outer_size * inner_size;
+    if (gid >= total) return;
+
+    uint outer = gid / inner_size;
+    uint inner = gid % inner_size;
+
+    float acc = 1.0f;
+    for (uint d = 0; d < dim_size; d++) {{
+        uint idx = outer * (dim_size * inner_size) + d * inner_size + inner;
+        acc *= (float)input[idx];
+        output[idx] = ({type})acc;
+    }}
+}}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Sort Metal compute shader (per-slice insertion sort)
+# ---------------------------------------------------------------------------
+
+_SORT_TEMPLATE = """
+kernel void sort_{suffix}(
+    device const {type}* input  [[buffer(0)]],
+    device {type}* values        [[buffer(1)]],
+    device int*   indices        [[buffer(2)]],
+    constant uint& outer_size   [[buffer(3)]],
+    constant uint& dim_size     [[buffer(4)]],
+    constant uint& inner_size   [[buffer(5)]],
+    constant uint& descending   [[buffer(6)]],
+    uint gid [[thread_position_in_grid]])
+{{
+    uint total = outer_size * inner_size;
+    if (gid >= total) return;
+
+    uint outer = gid / inner_size;
+    uint inner = gid % inner_size;
+    uint base = outer * (dim_size * inner_size) + inner;
+
+    // Copy slice to output and init indices
+    for (uint d = 0; d < dim_size; d++) {{
+        uint idx = base + d * inner_size;
+        values[idx] = input[idx];
+        indices[idx] = int(d);
+    }}
+
+    // Insertion sort along dim
+    for (uint i = 1; i < dim_size; i++) {{
+        uint pos_i = base + i * inner_size;
+        {type} key = values[pos_i];
+        int key_idx = indices[pos_i];
+        uint j = i;
+        while (j > 0) {{
+            uint pos_j = base + (j - 1) * inner_size;
+            bool should_swap;
+            if (descending) {{
+                should_swap = (float)values[pos_j] < (float)key;
+            }} else {{
+                should_swap = (float)values[pos_j] > (float)key;
+            }}
+            if (!should_swap) break;
+            values[base + j * inner_size] = values[pos_j];
+            indices[base + j * inner_size] = indices[pos_j];
+            j--;
+        }}
+        values[base + j * inner_size] = key;
+        indices[base + j * inner_size] = key_idx;
+    }}
+}}
+"""
+
+
+def _gen_sort(types=None):
+    if types is None:
+        types = _FLOAT_TYPES
+    parts = []
+    for t in types:
+        suffix = _SUFFIX[t]
+        parts.append(_SORT_TEMPLATE.format(type=t, suffix=suffix))
+    return "".join(parts)
+
+
+def _gen_cumprod(types=None):
+    if types is None:
+        types = _FLOAT_TYPES
+    parts = []
+    for t in types:
+        suffix = _SUFFIX[t]
+        parts.append(_CUMPROD_TEMPLATE.format(type=t, suffix=suffix))
+    return "".join(parts)
+
+
 # ---------------------------------------------------------------------------
 # Adaptive avg pool2d Metal compute shader
 # ---------------------------------------------------------------------------
@@ -1423,6 +1523,7 @@ _BINARY_FLOAT_OPS = (
     ("atan2", "atan2(a[id], b[id])"),
     ("hypot", "sqrt(a[id] * a[id] + b[id] * b[id])"),
     ("logaddexp2", "log2(exp2(a[id]) + exp2(b[id]))"),
+    ("floor_divide", "floor(a[id] / b[id])"),
 )
 
 # --- Unary element-wise (numeric types: float, half, int, long) ---
@@ -2052,6 +2153,12 @@ def _build_msl_source():
 
     # Cumsum kernel
     parts.append(_gen_cumsum())
+
+    # Cumprod kernel
+    parts.append(_gen_cumprod())
+
+    # Sort kernel
+    parts.append(_gen_sort())
 
     # Adaptive avg pool2d kernel
     parts.append(_gen_adaptive_avg_pool2d())

--- a/src/candle/_backends/mps/ops.py
+++ b/src/candle/_backends/mps/ops.py
@@ -71,6 +71,13 @@ def _alloc_output_buf(numel, dtype):
     return rt.create_buffer(numel * _itemsize(dtype))
 
 
+def _metal_buf_to_bytes(metal_buf, nbytes):
+    """Read raw bytes from a Metal buffer."""
+    from .runtime import buffer_contents
+    ptr = buffer_contents(metal_buf)
+    return bytes((ctypes.c_char * nbytes).from_address(ptr))
+
+
 def _from_metal_buffer(metal_buf, shape, stride, dtype, device):
     """Wrap an existing Metal buffer into a Tensor without copying data."""
     from .runtime import buffer_contents
@@ -686,6 +693,18 @@ def roll(a, shifts, dims=None):
 
 
 def rot90(a, k=1, dims=(0, 1)):
+    # GPU composite: rot90 = combinations of flip + transpose
+    if _can_use_gpu(a):
+        k = k % 4
+        if k == 0:
+            return a
+        d0, d1 = dims[0], dims[1]
+        if k == 1:
+            return flip(a.transpose(d0, d1), (d0,))
+        elif k == 2:
+            return flip(flip(a, (d0,)), (d1,))
+        else:  # k == 3
+            return flip(a, (d0,)).transpose(d0, d1)
     arr = _to_numpy(a)
     out = np.rot90(arr, k=k, axes=dims)
     return _from_numpy(np.ascontiguousarray(out), a.dtype, a.device)
@@ -749,6 +768,27 @@ def cumsum(a, dim=0):
 
 
 def cumprod(a, dim=0):
+    # GPU path: float32/float16, contiguous (same dispatch as cumsum)
+    if (_can_use_gpu(a) and a.is_contiguous()
+            and a.dtype in (float32_dtype, float16_dtype)):
+        ndim = len(a.shape)
+        if dim < 0:
+            dim = ndim + dim
+        outer_size = 1
+        for i in range(dim):
+            outer_size *= a.shape[i]
+        dim_size = a.shape[dim]
+        inner_size = 1
+        for i in range(dim + 1, ndim):
+            inner_size *= a.shape[i]
+        sfx = _kernel_suffix(a.dtype)
+        d = _get_dispatcher()
+        numel = outer_size * dim_size * inner_size
+        out_buf = _alloc_output_buf(numel, a.dtype)
+        d.dispatch_cumsum(f"cumprod_{sfx}", _metal_buf(a), out_buf,
+                          outer_size, dim_size, inner_size)
+        return _from_metal_buffer(out_buf, tuple(a.shape),
+                                  tuple(a.stride()), a.dtype, a.device)
     return _from_numpy(np.cumprod(_to_numpy(a), axis=dim), a.dtype, a.device)
 
 
@@ -775,7 +815,37 @@ def cummax(a, dim=0):
     )
 
 
+def _sort_gpu(a, dim, descending):
+    """GPU sort helper returning (values_buf, indices_buf, shape, strides)."""
+    ndim = len(a.shape)
+    if dim < 0:
+        dim = ndim + dim
+    outer_size = 1
+    for i in range(dim):
+        outer_size *= a.shape[i]
+    dim_size = a.shape[dim]
+    inner_size = 1
+    for i in range(dim + 1, ndim):
+        inner_size *= a.shape[i]
+    sfx = _kernel_suffix(a.dtype)
+    d = _get_dispatcher()
+    numel = outer_size * dim_size * inner_size
+    values_buf = _alloc_output_buf(numel, a.dtype)
+    indices_buf = _alloc_output_buf(numel, int32_dtype)
+    d.dispatch_sort(f"sort_{sfx}", _metal_buf(a), values_buf, indices_buf,
+                    outer_size, dim_size, inner_size, descending)
+    return values_buf, indices_buf, numel
+
+
 def argsort(a, dim=-1, descending=False, stable=False):
+    if (_can_use_gpu(a) and a.is_contiguous()
+            and a.dtype in (float32_dtype, float16_dtype)):
+        _, indices_buf, numel = _sort_gpu(a, dim, descending)
+        # Convert int32 indices to int64
+        idx_np = np.frombuffer(
+            _metal_buf_to_bytes(indices_buf, numel * 4),
+            dtype=np.int32).astype(np.int64).reshape(a.shape)
+        return _from_numpy(idx_np, int64_dtype, a.device)
     arr = _to_numpy(a)
     kind = "stable" if stable else "quicksort"
     if descending:
@@ -786,6 +856,20 @@ def argsort(a, dim=-1, descending=False, stable=False):
 
 
 def sort(a, dim=-1, descending=False, stable=False):
+    if (_can_use_gpu(a) and a.is_contiguous()
+            and a.dtype in (float32_dtype, float16_dtype)):
+        values_buf, indices_buf, numel = _sort_gpu(a, dim, descending)
+        from ..._tensor import _compute_strides
+        out_shape = tuple(a.shape)
+        out_stride = _compute_strides(out_shape)
+        values = _from_metal_buffer(values_buf, out_shape, out_stride,
+                                    a.dtype, a.device)
+        # Convert int32 indices to int64
+        idx_np = np.frombuffer(
+            _metal_buf_to_bytes(indices_buf, numel * 4),
+            dtype=np.int32).astype(np.int64).reshape(a.shape)
+        indices = _from_numpy(idx_np, int64_dtype, a.device)
+        return (values, indices)
     arr = _to_numpy(a)
     kind = "stable" if stable else "quicksort"
     if descending:
@@ -800,6 +884,16 @@ def sort(a, dim=-1, descending=False, stable=False):
 
 
 def topk(a, k, dim=-1, largest=True, sorted=True):
+    if (_can_use_gpu(a) and a.is_contiguous()
+            and a.dtype in (float32_dtype, float16_dtype)):
+        values, indices = sort(a, dim=dim, descending=largest)
+        # Slice first k along dim
+        ndim = len(a.shape)
+        if dim < 0:
+            dim = ndim + dim
+        slices = [slice(None)] * ndim
+        slices[dim] = slice(0, k)
+        return (values[tuple(slices)], indices[tuple(slices)])
     arr = _to_numpy(a)
     if largest:
         idx = np.argsort(-arr, axis=dim)
@@ -3343,6 +3437,8 @@ def prod_(a, dim=None, keepdim=False):
 
 
 def floor_divide(a, b):
+    if _can_use_gpu(a):
+        return _dispatch_binary_gpu(a, b, "floor_divide")
     a_np = _to_numpy(a)
     b_np = _to_numpy(b) if isinstance(b, Tensor) else b
     out = np.floor_divide(a_np, b_np)

--- a/tests/mps/test_metal_infra.py
+++ b/tests/mps/test_metal_infra.py
@@ -1736,3 +1736,145 @@ class TestP3Lerp:
         out = torch.lerp(a, b, w).cpu().numpy()
         ref = a_np + w_np * (b_np - a_np)
         np.testing.assert_allclose(out, ref, rtol=1e-5, atol=1e-6)
+
+
+class TestP4GPUOps:
+    """P4 GPU kernels: floor_divide, cumprod, rot90, sort/argsort/topk."""
+
+    # --- floor_divide ---
+    def test_floor_divide_f32(self):
+        a_np = np.random.randn(256).astype(np.float32) * 10
+        b_np = np.random.randn(256).astype(np.float32) * 5 + 0.5
+        a = torch.tensor(a_np, device="mps")
+        b = torch.tensor(b_np, device="mps")
+        out = torch.floor_divide(a, b).cpu().numpy()
+        ref = np.floor_divide(a_np, b_np)
+        np.testing.assert_allclose(out, ref, rtol=1e-5, atol=1e-5)
+
+    def test_floor_divide_f16(self):
+        a_np = np.random.randn(128).astype(np.float16) * 5
+        b_np = (np.random.randn(128).astype(np.float16) * 2 + 1.0)
+        a = torch.tensor(a_np, device="mps")
+        b = torch.tensor(b_np, device="mps")
+        out = torch.floor_divide(a, b).cpu().numpy()
+        ref = np.floor_divide(a_np, b_np)
+        np.testing.assert_allclose(out, ref, rtol=0.05, atol=0.1)
+
+    # --- cumprod ---
+    def test_cumprod_f32(self):
+        a_np = np.random.rand(4, 8).astype(np.float32) + 0.5
+        a = torch.tensor(a_np, device="mps")
+        out = torch.cumprod(a, dim=1).cpu().numpy()
+        ref = np.cumprod(a_np, axis=1)
+        np.testing.assert_allclose(out, ref, rtol=1e-5, atol=1e-5)
+
+    def test_cumprod_dim0(self):
+        a_np = np.random.rand(8, 4).astype(np.float32) + 0.5
+        a = torch.tensor(a_np, device="mps")
+        out = torch.cumprod(a, dim=0).cpu().numpy()
+        ref = np.cumprod(a_np, axis=0)
+        np.testing.assert_allclose(out, ref, rtol=1e-5, atol=1e-5)
+
+    def test_cumprod_f16(self):
+        a_np = np.random.rand(4, 8).astype(np.float16) + 0.5
+        a = torch.tensor(a_np, device="mps")
+        out = torch.cumprod(a, dim=1).cpu().numpy()
+        ref = np.cumprod(a_np, axis=1)
+        np.testing.assert_allclose(out, ref, rtol=0.05, atol=0.05)
+
+    # --- rot90 ---
+    def test_rot90_k1(self):
+        a_np = np.random.randn(4, 5).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.rot90(a, 1).cpu().numpy()
+        ref = np.rot90(a_np, 1)
+        np.testing.assert_allclose(out, ref, rtol=1e-5, atol=1e-6)
+
+    def test_rot90_k2(self):
+        a_np = np.random.randn(4, 5).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.rot90(a, 2).cpu().numpy()
+        ref = np.rot90(a_np, 2)
+        np.testing.assert_allclose(out, ref, rtol=1e-5, atol=1e-6)
+
+    def test_rot90_k3(self):
+        a_np = np.random.randn(4, 5).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.rot90(a, 3).cpu().numpy()
+        ref = np.rot90(a_np, 3)
+        np.testing.assert_allclose(out, ref, rtol=1e-5, atol=1e-6)
+
+    # --- sort ---
+    def test_sort_f32(self):
+        a_np = np.random.randn(4, 16).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        values, indices = torch.sort(a, dim=1)
+        v_np = values.cpu().numpy()
+        i_np = indices.cpu().numpy()
+        ref_idx = np.argsort(a_np, axis=1)
+        ref_val = np.take_along_axis(a_np, ref_idx, axis=1)
+        np.testing.assert_allclose(v_np, ref_val, rtol=1e-5, atol=1e-6)
+        np.testing.assert_array_equal(i_np, ref_idx)
+
+    def test_sort_descending(self):
+        a_np = np.random.randn(4, 16).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        values, indices = torch.sort(a, dim=1, descending=True)
+        v_np = values.cpu().numpy()
+        i_np = indices.cpu().numpy()
+        ref_idx = np.argsort(-a_np, axis=1)
+        ref_val = np.take_along_axis(a_np, ref_idx, axis=1)
+        np.testing.assert_allclose(v_np, ref_val, rtol=1e-5, atol=1e-6)
+        np.testing.assert_array_equal(i_np, ref_idx)
+
+    def test_sort_dim0(self):
+        a_np = np.random.randn(8, 4).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        values, indices = torch.sort(a, dim=0)
+        v_np = values.cpu().numpy()
+        i_np = indices.cpu().numpy()
+        ref_idx = np.argsort(a_np, axis=0)
+        ref_val = np.take_along_axis(a_np, ref_idx, axis=0)
+        np.testing.assert_allclose(v_np, ref_val, rtol=1e-5, atol=1e-6)
+        np.testing.assert_array_equal(i_np, ref_idx)
+
+    # --- argsort ---
+    def test_argsort_f32(self):
+        a_np = np.random.randn(4, 16).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.argsort(a, dim=1).cpu().numpy()
+        ref = np.argsort(a_np, axis=1)
+        np.testing.assert_array_equal(out, ref)
+
+    def test_argsort_descending(self):
+        a_np = np.random.randn(4, 16).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        out = torch.argsort(a, dim=1, descending=True).cpu().numpy()
+        ref = np.argsort(-a_np, axis=1)
+        np.testing.assert_array_equal(out, ref)
+
+    # --- topk ---
+    def test_topk_f32(self):
+        a_np = np.random.randn(4, 32).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        values, indices = torch.topk(a, k=5, dim=1)
+        v_np = values.cpu().numpy()
+        i_np = indices.cpu().numpy()
+        # Verify values are sorted descending
+        for row in range(4):
+            assert np.all(np.diff(v_np[row]) <= 0)
+        # Verify values match gathered from input
+        gathered = np.take_along_axis(a_np, i_np, axis=1)
+        np.testing.assert_allclose(v_np, gathered, rtol=1e-5, atol=1e-6)
+
+    def test_topk_smallest(self):
+        a_np = np.random.randn(4, 32).astype(np.float32)
+        a = torch.tensor(a_np, device="mps")
+        values, indices = torch.topk(a, k=5, dim=1, largest=False)
+        v_np = values.cpu().numpy()
+        i_np = indices.cpu().numpy()
+        # Verify values are sorted ascending
+        for row in range(4):
+            assert np.all(np.diff(v_np[row]) >= 0)
+        gathered = np.take_along_axis(a_np, i_np, axis=1)
+        np.testing.assert_allclose(v_np, gathered, rtol=1e-5, atol=1e-6)


### PR DESCRIPTION
## Summary

Add Metal GPU paths for 6 more ops, continuing the MPS GPU acceleration effort (P4 batch).

## New GPU Kernels

| Op | Approach |
|----|----------|
| `floor_divide` | Binary float shader: `floor(a/b)` |
| `cumprod` | Scan shader (like cumsum but multiplicative) |
| `sort` | Per-slice insertion sort with indices tracking |
| `argsort` | Built on sort GPU kernel |
| `topk` | Built on sort + slice |
| `rot90` | GPU composite via flip + transpose |

## Helper

- `_metal_buf_to_bytes()` — reads raw bytes from Metal buffer for int32→int64 index conversion

## Files Changed

| File | Changes |
|------|---------|
| `metal_shaders.py` | `floor_divide` binary op, `cumprod` template, `sort` template |
| `metal_compute.py` | `dispatch_sort` method + ctypes fallback |
| `ops.py` | GPU paths for all 6 ops + `_metal_buf_to_bytes` helper |
| `test_metal_infra.py` | 15 new tests in `TestP4GPUOps` |

## Test Results

- 348 MPS tests passed
- 1575 CPU/contract tests passed
- No regressions