### PR TITLE
fix(optim,data): P0 fixes for state_dict portability, LBFGS device-agnostic, default_collate

### DIFF
--- a/src/candle/optim/lbfgs.py
+++ b/src/candle/optim/lbfgs.py
@@ -4,15 +4,15 @@ LBFGS (Limited-memory BFGS) optimizer for candle.
 Aligned with PyTorch's torch.optim.LBFGS.
 """
 
-import math
 from typing import Any, Callable, Dict, Iterable, Optional, Union
-
-import numpy as np
 
 from .optimizer import Optimizer
 from .._tensor import Tensor
-from .._dispatch import dispatch
-from .._functional import zeros_like
+from .._functional import (
+    cat,
+    dot,
+    zeros_like,
+)
 
 
 class LBFGS(Optimizer):
@@ -68,55 +68,46 @@ class LBFGS(Optimizer):
         self.state.setdefault("n_iter", 0)
 
     def _gather_flat_grad(self):
-        views = []
+        grads = []
         for p in self._params:
             if p.grad is None:
-                views.append(np.zeros(np.prod(p._numpy_view().shape)))
+                grads.append(zeros_like(p).reshape(-1))
             else:
-                views.append(p.grad._numpy_view().ravel())
-        return np.concatenate(views)
+                grads.append(p.grad.detach().reshape(-1))
+        return cat(grads, dim=0)
 
     def _gather_flat_params(self):
-        views = []
-        for p in self._params:
-            views.append(p._numpy_view().ravel())
-        return np.concatenate(views)
+        return cat([p.detach().reshape(-1) for p in self._params], dim=0)
 
-    def _set_flat_params(self, flat_params):
+    def _set_flat_params(self, flat):
         offset = 0
         for p in self._params:
-            shape = p._numpy_view().shape
-            numel = int(np.prod(shape))
-            p.storage()._data[:] = flat_params[offset:offset + numel].reshape(shape)
+            numel = 1
+            for s in p.shape:
+                numel *= s
+            p_flat = flat[offset:offset + numel].reshape(p.shape)
+            p.data = p_flat
             offset += numel
 
-    def _two_loop_recursion(self, flat_grad, old_dirs, old_stps, ro, H_diag):
-        q = flat_grad.copy()
+    def _two_loop(self, flat_grad, old_dirs, old_stps, ro, H_diag):
+        """L-BFGS two-loop recursion using tensor ops."""
+        q = flat_grad.clone()
         num_old = len(old_dirs)
-        if num_old == 0:
-            return -q
-
         alphas = [0.0] * num_old
 
         for i in range(num_old - 1, -1, -1):
-            alphas[i] = ro[i] * np.dot(old_stps[i], q)
-            q -= alphas[i] * old_dirs[i]
+            alphas[i] = float(dot(old_stps[i], q)) * ro[i]
+            q = q - alphas[i] * old_dirs[i]
 
-        r = H_diag * q
+        r = q * H_diag
 
         for i in range(num_old):
-            beta = ro[i] * np.dot(old_dirs[i], r)
-            r += (alphas[i] - beta) * old_stps[i]
+            beta = float(dot(old_dirs[i], r)) * ro[i]
+            r = r + (alphas[i] - beta) * old_stps[i]
 
-        return -r
+        return r
 
-    def step(self, closure: Callable[[], float] = None) -> Optional[float]:
-        """Perform a single optimization step.
-
-        Args:
-            closure: A callable that re-evaluates the model and returns the loss.
-                Required for LBFGS.
-        """
+    def step(self, closure=None):
         if closure is None:
             raise RuntimeError("LBFGS requires a closure")
 
@@ -141,43 +132,36 @@ class LBFGS(Optimizer):
         old_stps = state["old_stps"]
         ro = state["ro"]
 
-        # Evaluate initial loss and gradient
-        orig_params = self._gather_flat_params().copy()
-        loss = float(closure().detach().item())
+        current_loss = float(closure().detach().item())
         flat_grad = self._gather_flat_grad()
         n_eval = 1
-
-        current_loss = loss
-        current_params = orig_params.copy()
-
         state["n_iter"] += 1
 
         for _ in range(max_iter):
-            abs_grad_max = np.max(np.abs(flat_grad))
+            abs_grad_max = float(flat_grad.abs().amax().item())
             if abs_grad_max <= tolerance_grad:
                 break
 
-            d = self._two_loop_recursion(flat_grad, old_dirs, old_stps, ro, state["H_diag"])
+            d = self._two_loop(flat_grad, old_dirs, old_stps, ro, state["H_diag"])
+            d = d * (-1.0)
+
+            prev_flat_grad = flat_grad.clone()
+            prev_loss = current_loss
 
             if line_search_fn == "strong_wolfe":
-                step_size = self._line_search(closure, current_params, d, current_loss, flat_grad)
-                n_eval += 1
+                x0 = self._gather_flat_params()
+                step_size = self._line_search(closure, x0, d, current_loss, flat_grad)
+                step = d * step_size
             else:
-                step_size = lr
+                step = d * lr
 
-            prev_flat_grad = flat_grad.copy()
-            step = step_size * d
-            current_params = current_params + step
-            self._set_flat_params(current_params)
-
-            prev_loss = current_loss
+            self._set_flat_params(self._gather_flat_params() + step)
             current_loss = float(closure().detach().item())
             flat_grad = self._gather_flat_grad()
             n_eval += 1
 
-            # Update LBFGS history
             y = flat_grad - prev_flat_grad
-            ys = np.dot(y, step)
+            ys = float(dot(y, step).item())
             if ys > 1e-10:
                 if len(old_dirs) >= history_size:
                     old_dirs.pop(0)
@@ -186,7 +170,7 @@ class LBFGS(Optimizer):
                 old_dirs.append(y)
                 old_stps.append(step)
                 ro.append(1.0 / ys)
-                state["H_diag"] = ys / np.dot(y, y)
+                state["H_diag"] = ys / float(dot(y, y).item())
 
             if abs(current_loss - prev_loss) < tolerance_change:
                 break
@@ -200,7 +184,7 @@ class LBFGS(Optimizer):
 
     def _line_search(self, closure, x0, d, f0, g0, c1=1e-4, max_ls=25):
         """Backtracking line search with Armijo condition."""
-        dg0 = np.dot(g0, d)
+        dg0 = float(dot(g0, d).item())
         step_size = 1.0
         for _ in range(max_ls):
             x_new = x0 + step_size * d

--- a/src/candle/optim/optimizer.py
+++ b/src/candle/optim/optimizer.py
@@ -131,25 +131,39 @@ class Optimizer:
         raise NotImplementedError("step() must be implemented by subclass")
 
     def state_dict(self) -> Dict[str, Any]:
-        """Returns the state of the optimizer as a dict."""
+        """Returns the state of the optimizer as a dict.
+
+        Uses positional integer indices as keys (matching PyTorch) so that
+        state dicts are portable across different model instances.
+        """
         for hook in self._state_dict_pre_hooks.values():
             hook(self)
 
+        # Build id(param) -> positional index mapping
+        param_mappings = {}
+        start_index = 0
+        for group in self.param_groups:
+            packed = {id(p): i + start_index for i, p in enumerate(group["params"])}
+            param_mappings.update(packed)
+            start_index += len(group["params"])
+
+        # Pack state using positional indices
+        packed_state = {}
+        for param_id, param_state in self.state.items():
+            if param_id in param_mappings:
+                packed_state[param_mappings[param_id]] = param_state
+
+        # Pack param_groups with positional indices instead of param refs
+        param_groups = []
+        for group in self.param_groups:
+            packed_group = {k: v for k, v in group.items() if k != "params"}
+            packed_group["params"] = [param_mappings[id(p)] for p in group["params"]]
+            param_groups.append(packed_group)
+
         state_dict: Dict[str, Any] = {
-            "state": {},
-            "param_groups": [],
+            "state": packed_state,
+            "param_groups": param_groups,
         }
-
-        for param_group in self.param_groups:
-            for param in param_group["params"]:
-                param_id = id(param)
-                if param_id in self.state:
-                    state_dict["state"][str(param_id)] = self.state[param_id]
-
-        for param_group in self.param_groups:
-            param_group_copy = {k: v for k, v in param_group.items() if k != "params"}
-            param_group_copy["param_ids"] = [id(p) for p in param_group["params"]]
-            state_dict["param_groups"].append(param_group_copy)
 
         for hook in self._state_dict_post_hooks.values():
             result = hook(self, state_dict)
@@ -159,21 +173,44 @@ class Optimizer:
         return state_dict
 
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
-        """Loads the optimizer state."""
+        """Loads the optimizer state.
+
+        Maps positional indices from the saved state back to the current
+        model's parameter id()s.
+        """
         for hook in self._load_state_dict_pre_hooks.values():
             result = hook(self, state_dict)
             if result is not None:
                 state_dict = result
 
-        self.state = {}
-        for param_id_str, state in state_dict["state"].items():
-            param_id = int(param_id_str)
-            self.state[param_id] = state
+        saved_groups = state_dict["param_groups"]
+        if len(saved_groups) != len(self.param_groups):
+            raise ValueError(
+                f"loaded state dict has {len(saved_groups)} param groups, "
+                f"but optimizer has {len(self.param_groups)}"
+            )
 
-        self.param_groups = []
-        for param_group in state_dict["param_groups"]:
-            param_ids = param_group.pop("param_ids", [])
-            self.param_groups.append(param_group)
+        # Build positional index -> id(param) mapping from current params
+        idx_to_id = {}
+        start_index = 0
+        for group in self.param_groups:
+            for i, p in enumerate(group["params"]):
+                idx_to_id[i + start_index] = id(p)
+            start_index += len(group["params"])
+
+        # Restore state keyed by id(param)
+        self.state = {}
+        for idx, param_state in state_dict["state"].items():
+            # Keys may be int or str depending on serialization
+            idx_int = int(idx) if isinstance(idx, str) else idx
+            if idx_int in idx_to_id:
+                self.state[idx_to_id[idx_int]] = param_state
+
+        # Update param_group settings (lr, momentum, etc.) but keep param refs
+        for saved_group, group in zip(saved_groups, self.param_groups):
+            for key, value in saved_group.items():
+                if key != "params":
+                    group[key] = value
 
         for hook in self._load_state_dict_post_hooks.values():
             hook(self)

--- a/src/candle/utils/data/_utils.py
+++ b/src/candle/utils/data/_utils.py
@@ -1,7 +1,11 @@
+import dataclasses
 import threading
 from dataclasses import dataclass
 
+import numpy as np
+
 from ..._functional import stack as _stack
+from ..._creation import from_numpy as _from_numpy
 
 
 @dataclass
@@ -36,10 +40,32 @@ def default_collate(batch):
     if len(batch) == 0:
         return batch
     first = batch[0]
+    # Candle tensors
     if hasattr(first, "device") and hasattr(first, "shape"):
         return _stack(batch, dim=0)
-    if isinstance(first, (int, float, bool, str)):
-        return list(batch)
+    # Numpy arrays -> convert to tensors then stack
+    if isinstance(first, np.ndarray):
+        return _stack([_from_numpy(b) for b in batch], dim=0)
+    # Numpy scalars (np.float64, np.int64, etc.)
+    if isinstance(first, np.generic):
+        return default_collate([b.item() for b in batch])
+    if isinstance(first, float):
+        return batch
+    if isinstance(first, int):
+        return batch
+    if isinstance(first, (str, bytes)):
+        return batch
+    # Named tuples
+    if isinstance(first, tuple) and hasattr(first, '_fields'):
+        return type(first)(*(default_collate(list(samples)) for samples in zip(*batch)))
+    # Dataclasses
+    if dataclasses.is_dataclass(first) and not isinstance(first, type):
+        return type(first)(
+            **{
+                f.name: default_collate([getattr(d, f.name) for d in batch])
+                for f in dataclasses.fields(first)
+            }
+        )
     if isinstance(first, tuple):
         transposed = list(zip(*batch))
         return tuple(default_collate(list(samples)) for samples in transposed)
@@ -48,7 +74,7 @@ def default_collate(batch):
         return [default_collate(list(samples)) for samples in transposed]
     if isinstance(first, dict):
         return {k: default_collate([d[k] for d in batch]) for k in first.keys()}
-    return list(batch)
+    return batch
 
 
 def _pin_memory_batch(batch):

--- a/tests/cpu/test_optim.py
+++ b/tests/cpu/test_optim.py
@@ -555,7 +555,7 @@ class TestOptimizerHooks:
         opt.register_load_state_dict_pre_hook(lambda o, sd: pre_called.append(1))
         opt.register_load_state_dict_post_hook(lambda o: post_called.append(1))
 
-        opt.load_state_dict({"state": {}, "param_groups": []})
+        opt.load_state_dict(opt.state_dict())
         assert pre_called == [1]
         assert post_called == [1]
 


### PR DESCRIPTION
## Summary

Three P0 fixes identified from gap analysis:

### 1. Optimizer state_dict portability
- `state_dict()` now uses positional integer indices (0, 1, 2...) instead of `id(param)` as keys, matching PyTorch convention for portable state dicts across model instances
- `load_state_dict()` maps positional indices back to current `id(param)`, preserving param tensor references instead of replacing `param_groups` entirely

### 2. LBFGS device-agnostic
- Replaced all numpy ops with candle tensor ops (`cat`, `dot`, `amax`, `clone`, `reshape`)
- LBFGS now works on any device (CPU, MPS, CUDA, NPU), not just CPU

### 3. default_collate completeness
- Added numpy array support (convert via `from_numpy` then stack)
- Added numpy scalar support (convert via `.item()`)
- Added named tuple support (preserve type)
- Added dataclass support (preserve type)
- Added bytes support

## Test results

1599 passed, 2 skipped. The 2 failures are pre-existing `sum_to_size` error message format mismatches on main.