### PR TITLE
fix: route hard activations through backend kernels

### DIFF
--- a/docs/plans/2026-03-13-cpu-hard-activation-dispatch-plan.md
+++ b/docs/plans/2026-03-13-cpu-hard-activation-dispatch-plan.md
@@ -1,0 +1,148 @@
+# CPU Hard Activation Dispatch Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Route `torch.nn.functional.hardswish`, `torch.nn.functional.hardsigmoid`, and `torch.nn.functional.softsign` through their registered backend ops and add focused CPU/contract tests that lock down forward parity and dispatch routing.
+
+**Architecture:** Keep this batch tightly scoped to the public functional API path plus focused tests. The schemas and CPU backend kernels already exist. This batch should prove the public API reaches the registered backend path instead of staying on composite Python implementations.
+
+**Tech Stack:** Python, pytest, Candle dispatch stack, CPU backend kernels, PyTorch forward parity reference.
+
+---
+
+### Task 1: Add focused CPU regression tests for hard activation routing and forward parity
+
+**Files:**
+- Modify: `tests/cpu/test_nn_functional.py`
+
+**Step 1: Write the failing tests**
+
+Add focused tests for:
+- `F.hardswish(x)` matches PyTorch numerically on a simple float input
+- `F.hardsigmoid(x)` matches PyTorch numerically on a simple float input
+- `F.softsign(x)` matches PyTorch numerically on a simple float input
+- `F.hardswish(...)` routes through `dispatch("hardswish", ...)`
+- `F.hardsigmoid(...)` routes through `dispatch("hardsigmoid", ...)`
+- `F.softsign(...)` routes through `dispatch("softsign", ...)`
+
+Use local `import torch as torch_ref` in the parity tests and compare `out.numpy()` to `ref.detach().numpy()` with `np.testing.assert_allclose(...)`.
+
+**Step 2: Run the targeted CPU slice and verify RED**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/cpu/test_nn_functional.py -k "hardswish or hardsigmoid or softsign" -v --tb=short
+```
+
+Expected: the dispatch-routing tests fail because `nn.functional` still uses composite implementations.
+
+---
+
+### Task 2: Add one focused contract parity test file for the hard activation trio
+
+**Files:**
+- Create: `tests/contract/test_training_core_hard_activation_parity.py`
+
+**Step 1: Write contract parity tests using the existing harness**
+
+Add one parity-harness style forward test per op:
+- `hardswish`
+- `hardsigmoid`
+- `softsign`
+
+Each test should assert:
+- `result["dtype_match"] is True`
+- `result["shape_match"] is True`
+- `result["value_match"] is True`
+
+**Step 2: Run the targeted contract slice**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/contract/test_training_core_hard_activation_parity.py -v --tb=short
+```
+
+Expected: pass once the public functional path and tests are correct.
+
+---
+
+### Task 3: Route the public functional APIs through dispatch
+
+**Files:**
+- Modify: `src/candle/nn/functional.py`
+
+**Step 1: Replace the composite implementations with dispatch**
+
+Update:
+- `hardswish()` to call `dispatch("hardswish", input.device.type, input)`
+- `hardsigmoid()` to call `dispatch("hardsigmoid", input.device.type, input)`
+- `softsign()` to call `dispatch("softsign", input.device.type, input)`
+
+Keep the public signatures unchanged.
+
+**Step 2: Re-run the targeted CPU and contract tests**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/cpu/test_nn_functional.py -k "hardswish or hardsigmoid or softsign" -v --tb=short
+PYTHONPATH=src pytest tests/contract/test_training_core_hard_activation_parity.py -v --tb=short
+```
+
+Expected: both targeted slices pass.
+
+---
+
+### Task 4: Run adjacent regression coverage
+
+**Step 1: Run the full functional CPU file**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/cpu/test_nn_functional.py -v --tb=short
+```
+
+**Step 2: Run the required contract gate**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/contract/ -v --tb=short
+```
+
+**Step 3: Run the broader CPU gate**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/cpu/ -v --tb=short
+```
+
+---
+
+### Task 5: Commit the batch cleanly
+
+**Files:**
+- Modify: `src/candle/nn/functional.py`
+- Modify: `tests/cpu/test_nn_functional.py`
+- Create: `tests/contract/test_training_core_hard_activation_parity.py`
+- Add: `docs/plans/2026-03-13-cpu-hard-activation-dispatch-plan.md`
+
+**Step 1: Inspect diff**
+
+Run:
+
+```bash
+git status --short
+git diff -- src/candle/nn/functional.py tests/cpu/test_nn_functional.py tests/contract/test_training_core_hard_activation_parity.py docs/plans/2026-03-13-cpu-hard-activation-dispatch-plan.md
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/candle/nn/functional.py tests/cpu/test_nn_functional.py tests/contract/test_training_core_hard_activation_parity.py docs/plans/2026-03-13-cpu-hard-activation-dispatch-plan.md
+git commit -m "fix: route hard activations through backend kernels"
+```

--- a/src/candle/nn/functional.py
+++ b/src/candle/nn/functional.py
@@ -1420,19 +1420,13 @@ def poisson_nll_loss(input, target, log_input=True, full=False, eps=1e-8,
 
 
 def hardswish(input, inplace=False):
-    from .._functional import relu6 as _relu6, mul as _mul, add as _add, div as _div
-    from .._creation import tensor as _tensor
-    three = _tensor(3.0, device=input.device)
-    six = _tensor(6.0, device=input.device)
-    return _div(_mul(input, _relu6(_add(input, three))), six)
+    from .._dispatch import dispatch
+    return dispatch("hardswish", input.device.type, input)
 
 
 def hardsigmoid(input, inplace=False):
-    from .._functional import relu6 as _relu6, add as _add, div as _div
-    from .._creation import tensor as _tensor
-    three = _tensor(3.0, device=input.device)
-    six = _tensor(6.0, device=input.device)
-    return _div(_relu6(_add(input, three)), six)
+    from .._dispatch import dispatch
+    return dispatch("hardsigmoid", input.device.type, input)
 
 
 def selu(input, inplace=False):
@@ -1468,10 +1462,8 @@ def softplus(input, beta=1, threshold=20):
 
 
 def softsign(input):
-    from .._functional import abs as _abs, add as _add, div as _div
-    from .._creation import tensor as _tensor
-    one = _tensor(1.0, device=input.device)
-    return _div(input, _add(one, _abs(input)))
+    from .._dispatch import dispatch
+    return dispatch("softsign", input.device.type, input)
 
 
 def threshold(input, threshold, value, inplace=False):

--- a/tests/contract/test_training_core_hard_activation_parity.py
+++ b/tests/contract/test_training_core_hard_activation_parity.py
@@ -1,0 +1,63 @@
+import candle as torch
+
+from .helpers import run_training_core_parity_case
+
+
+def test_hardswish_forward_matches_torch_contract():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="hardswish",
+        candle_fn=lambda x: torch.nn.functional.hardswish(x),
+        torch_fn=lambda x: real_torch.nn.functional.hardswish(x),
+        candle_inputs=lambda: (
+            torch.tensor([-4.0, -3.0, -1.0, 0.0, 2.0, 4.0], dtype=torch.float32),
+        ),
+        torch_inputs=lambda: (
+            real_torch.tensor([-4.0, -3.0, -1.0, 0.0, 2.0, 4.0], dtype=real_torch.float32),
+        ),
+    )
+
+    assert result["dtype_match"] is True
+    assert result["shape_match"] is True
+    assert result["value_match"] is True
+
+
+def test_hardsigmoid_forward_matches_torch_contract():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="hardsigmoid",
+        candle_fn=lambda x: torch.nn.functional.hardsigmoid(x),
+        torch_fn=lambda x: real_torch.nn.functional.hardsigmoid(x),
+        candle_inputs=lambda: (
+            torch.tensor([-4.0, -3.0, -1.0, 0.0, 2.0, 4.0], dtype=torch.float32),
+        ),
+        torch_inputs=lambda: (
+            real_torch.tensor([-4.0, -3.0, -1.0, 0.0, 2.0, 4.0], dtype=real_torch.float32),
+        ),
+    )
+
+    assert result["dtype_match"] is True
+    assert result["shape_match"] is True
+    assert result["value_match"] is True
+
+
+def test_softsign_forward_matches_torch_contract():
+    import torch as real_torch
+
+    result = run_training_core_parity_case(
+        op_name="softsign",
+        candle_fn=lambda x: torch.nn.functional.softsign(x),
+        torch_fn=lambda x: real_torch.nn.functional.softsign(x),
+        candle_inputs=lambda: (
+            torch.tensor([-4.0, -1.0, 0.0, 2.0, 4.0], dtype=torch.float32),
+        ),
+        torch_inputs=lambda: (
+            real_torch.tensor([-4.0, -1.0, 0.0, 2.0, 4.0], dtype=real_torch.float32),
+        ),
+    )
+
+    assert result["dtype_match"] is True
+    assert result["shape_match"] is True
+    assert result["value_match"] is True

--- a/tests/cpu/test_nn_functional.py
+++ b/tests/cpu/test_nn_functional.py
@@ -65,6 +65,99 @@ def test_prelu_cpu():
     assert torch.allclose(result, expected, atol=1e-6)
 
 
+def test_hardswish_matches_torch():
+    import torch as torch_ref
+
+    x = torch.tensor([-4.0, -3.0, -1.0, 0.0, 2.0, 4.0], dtype=torch.float32)
+    out = F.hardswish(x)
+
+    x_ref = torch_ref.tensor([-4.0, -3.0, -1.0, 0.0, 2.0, 4.0], dtype=torch_ref.float32)
+    ref = torch_ref.nn.functional.hardswish(x_ref)
+
+    np.testing.assert_allclose(out.numpy(), ref.detach().numpy(), rtol=1e-6, atol=1e-6)
+
+
+def test_hardsigmoid_matches_torch():
+    import torch as torch_ref
+
+    x = torch.tensor([-4.0, -3.0, -1.0, 0.0, 2.0, 4.0], dtype=torch.float32)
+    out = F.hardsigmoid(x)
+
+    x_ref = torch_ref.tensor([-4.0, -3.0, -1.0, 0.0, 2.0, 4.0], dtype=torch_ref.float32)
+    ref = torch_ref.nn.functional.hardsigmoid(x_ref)
+
+    np.testing.assert_allclose(out.numpy(), ref.detach().numpy(), rtol=1e-6, atol=1e-6)
+
+
+def test_softsign_matches_torch():
+    import torch as torch_ref
+
+    x = torch.tensor([-4.0, -1.0, 0.0, 2.0, 4.0], dtype=torch.float32)
+    out = F.softsign(x)
+
+    x_ref = torch_ref.tensor([-4.0, -1.0, 0.0, 2.0, 4.0], dtype=torch_ref.float32)
+    ref = torch_ref.nn.functional.softsign(x_ref)
+
+    np.testing.assert_allclose(out.numpy(), ref.detach().numpy(), rtol=1e-6, atol=1e-6)
+
+
+def test_hardswish_routes_through_dispatch(monkeypatch):
+    import candle._dispatch as dispatch_mod
+
+    calls = []
+    expected = torch.tensor([42.0], dtype=torch.float32)
+
+    def fake_dispatch(name, dispatch_device, input):
+        calls.append((name, dispatch_device, tuple(input.shape)))
+        return expected
+
+    monkeypatch.setattr(dispatch_mod, "dispatch", fake_dispatch)
+    x = torch.tensor([1.0], dtype=torch.float32)
+
+    out = F.hardswish(x)
+
+    assert out is expected
+    assert calls == [("hardswish", "cpu", (1,))]
+
+
+def test_hardsigmoid_routes_through_dispatch(monkeypatch):
+    import candle._dispatch as dispatch_mod
+
+    calls = []
+    expected = torch.tensor([42.0], dtype=torch.float32)
+
+    def fake_dispatch(name, dispatch_device, input):
+        calls.append((name, dispatch_device, tuple(input.shape)))
+        return expected
+
+    monkeypatch.setattr(dispatch_mod, "dispatch", fake_dispatch)
+    x = torch.tensor([1.0], dtype=torch.float32)
+
+    out = F.hardsigmoid(x)
+
+    assert out is expected
+    assert calls == [("hardsigmoid", "cpu", (1,))]
+
+
+def test_softsign_routes_through_dispatch(monkeypatch):
+    import candle._dispatch as dispatch_mod
+
+    calls = []
+    expected = torch.tensor([42.0], dtype=torch.float32)
+
+    def fake_dispatch(name, dispatch_device, input):
+        calls.append((name, dispatch_device, tuple(input.shape)))
+        return expected
+
+    monkeypatch.setattr(dispatch_mod, "dispatch", fake_dispatch)
+    x = torch.tensor([1.0], dtype=torch.float32)
+
+    out = F.softsign(x)
+
+    assert out is expected
+    assert calls == [("softsign", "cpu", (1,))]
+
+
 # --- Activation Autograd Tests ---
 
 def test_silu_backward():


### PR DESCRIPTION
## Summary
- route `torch.nn.functional.hardswish`, `hardsigmoid`, and `softsign` through their registered backend ops instead of composite Python paths
- add focused CPU regressions for hard-activation forward parity and dispatch routing
- add training-core contract parity coverage for the hard-activation trio

## Testing
- `PYTHONPATH=src pytest tests/cpu/test_nn_functional.py -k "hardswish or hardsigmoid or softsign" -v --tb=short`
- `PYTHONPATH=src pytest tests/contract/test_training_core_hard_activation_parity.py -v --tb=short`
- `PYTHONPATH=src pytest tests/cpu/test_nn_functional.py -v --tb=short`
- `PYTHONPATH=src pytest tests/contract/ -v --tb=short`
- `PYTHONPATH=src pytest tests/cpu/ -v --tb=short`
