### PR TITLE
fix(mps): replay Philox RNG in dropout backward

### DIFF
--- a/src/candle/_backends/autograd.py
+++ b/src/candle/_backends/autograd.py
@@ -1033,6 +1033,24 @@ def _autograd_dropout():
                     out_storage = npu_typed_storage_from_ptr(out_ptr, max(out_numel, 1),
                                                             grad.dtype, device=grad.device)
                     return (_wrap_tensor(out_storage, out_shape, out_stride),)
+                if backward_data is not None and grad.device.type == "mps":
+                    from .mps.ops._helpers import (
+                        _metal_buf, _alloc_output_buf, _kernel_suffix,
+                        _get_dispatcher, _from_metal_buffer,
+                    )
+                    bd = backward_data
+                    numel = grad.numel()
+                    sfx = _kernel_suffix(grad.dtype)
+                    out_buf = _alloc_output_buf(numel, grad.dtype)
+                    _get_dispatcher().dispatch_philox_dropout(
+                        f"philox_dropout_{sfx}", _metal_buf(grad), out_buf,
+                        bd['p'], bd['scale'],
+                        bd['seed_lo'], bd['seed_hi'], bd['offset'], numel,
+                    )
+                    return (_from_metal_buffer(
+                        out_buf, grad.shape, tuple(grad.stride()),
+                        grad.dtype, grad.device,
+                    ),)
                 # CPU fallback: apply mask * scale
                 from .cpu.ops import _to_numpy, _from_numpy
                 import numpy as _np

--- a/src/candle/_backends/mps/ops/activation.py
+++ b/src/candle/_backends/mps/ops/activation.py
@@ -376,7 +376,15 @@ def dropout(a, p=0.5, training=True):
             f"philox_dropout_{sfx}", _metal_buf(a), out_buf,
             float(p), float(scale), seed_lo, seed_hi, offset, numel)
         stride = tuple(a.stride())
-        return _from_metal_buffer(out_buf, tuple(a.shape), stride, a.dtype, a.device)
+        result = _from_metal_buffer(out_buf, tuple(a.shape), stride, a.dtype, a.device)
+        result._backward_data = {
+            'seed_lo': seed_lo,
+            'seed_hi': seed_hi,
+            'offset': offset,
+            'p': float(p),
+            'scale': float(scale),
+        }
+        return result
     from ...._random import _get_cpu_rng
     rng = _get_cpu_rng()
     arr = _to_numpy(a)


### PR DESCRIPTION
## Summary

- **Refactor**: Split monolithic `mps/ops.py` (6400+ lines) into categorized submodules under `mps/ops/` for maintainability
- **Fix**: Replace broken dropout backward that inferred mask from output (`out != 0`) with deterministic Philox RNG replay on GPU — saves seed/offset in forward, re-runs the same Metal kernel on the gradient in backward
- **Bug**: The old approach was incorrect when input contained zeros (can't distinguish dropped zeros from kept zeros) and violated the no-CPU-fallback rule

## Test plan

- [x] MPS tests: 361 passed
- [x] CPU + contract tests: 1591 passed, 28 skipped
- [x] Manual smoke test: dropout backward on zero-valued inputs produces correct gradients (only 0.0 and scale values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)