### PR TITLE
fix(mps): eliminate numpy fallbacks for strided comparisons & activation composites

### DIFF
--- a/src/candle/_backends/mps/ops/activation.py
+++ b/src/candle/_backends/mps/ops/activation.py
@@ -19,6 +19,8 @@ from ._helpers import (
     _accel,
 )
 from .math import add, sub, mul, div, log
+from .comparison import gt
+from .elementwise import where
 from .shape import _ensure_integer_indices
 
 
@@ -96,6 +98,15 @@ def mish(a):
     return _from_numpy(out, a.dtype, a.device)
 
 def prelu(a, weight):
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
+        a_c = a.contiguous() if not a.is_contiguous() else a
+        mask = gt(a_c, 0)
+        w_np = _to_numpy(weight)
+        # Broadcast weight to match a's shape
+        w_expanded = _from_numpy(
+            np.broadcast_to(w_np, a_c.shape).copy(), a.dtype, a.device)
+        neg = mul(a_c, w_expanded)
+        return where(mask, a_c, neg)
     arr = _to_numpy(a)
     weight_arr = _to_numpy(weight)
     out = np.where(arr > 0, arr, arr * weight_arr)
@@ -227,16 +238,33 @@ def celu(a, alpha=1.0):
     return _from_numpy(out, a.dtype, a.device)
 
 def threshold(a, threshold_val, value):
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
+        a_c = a.contiguous() if not a.is_contiguous() else a
+        mask = gt(a_c, threshold_val)
+        fill = mul(add(mul(a_c, 0.0), 1.0), value)
+        return where(mask, a_c, fill)
     arr = _to_numpy(a)
     out = np.where(arr > threshold_val, arr, value)
     return _from_numpy(out, a.dtype, a.device)
 
 def hardshrink(a, lambd=0.5):
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
+        a_c = a.contiguous() if not a.is_contiguous() else a
+        abs_a = _dispatch_unary_gpu(a_c, "abs")
+        mask = gt(abs_a, lambd)
+        return where(mask, a_c, mul(a_c, 0.0))
     arr = _to_numpy(a)
     out = np.where(np.abs(arr) > lambd, arr, 0.0)
     return _from_numpy(out, a.dtype, a.device)
 
 def softshrink(a, lambd=0.5):
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
+        a_c = a.contiguous() if not a.is_contiguous() else a
+        s = _dispatch_unary_gpu(a_c, "sign")
+        abs_a = _dispatch_unary_gpu(a_c, "abs")
+        shifted = sub(abs_a, lambd)
+        clamped = clamp(shifted, 0.0, None)
+        return mul(s, clamped)
     arr = _to_numpy(a)
     out = np.sign(arr) * np.maximum(np.abs(arr) - lambd, 0.0)
     return _from_numpy(out, a.dtype, a.device)

--- a/src/candle/_backends/mps/ops/comparison.py
+++ b/src/candle/_backends/mps/ops/comparison.py
@@ -57,9 +57,9 @@ def eq(a, b):
                                              scalar, out_buf, numel,
                                              scalar_fmt=_scalar_fmt(a.dtype))
             else:
-                return _from_numpy(np.equal(_to_numpy(a), scalar), bool_dtype, a.device)
+                return eq(a.contiguous(), b)
         else:
-            return _from_numpy(np.equal(_to_numpy(a), _to_numpy(b)), bool_dtype, a.device)
+            return eq(a.contiguous(), b.contiguous() if isinstance(b, Tensor) else b)
         from ...._tensor import _compute_strides
         return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape), bool_dtype, a.device)
     b_np = _to_numpy(b) if isinstance(b, Tensor) else b
@@ -81,9 +81,9 @@ def ne(a, b):
                                              scalar, out_buf, numel,
                                              scalar_fmt=_scalar_fmt(a.dtype))
             else:
-                return _from_numpy(np.not_equal(_to_numpy(a), scalar), bool_dtype, a.device)
+                return ne(a.contiguous(), b)
         else:
-            return _from_numpy(np.not_equal(_to_numpy(a), _to_numpy(b)), bool_dtype, a.device)
+            return ne(a.contiguous(), b.contiguous() if isinstance(b, Tensor) else b)
         from ...._tensor import _compute_strides
         return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape), bool_dtype, a.device)
     b_np = _to_numpy(b) if isinstance(b, Tensor) else b
@@ -105,9 +105,9 @@ def lt(a, b):
                                              scalar, out_buf, numel,
                                              scalar_fmt=_scalar_fmt(a.dtype))
             else:
-                return _from_numpy(np.less(_to_numpy(a), scalar), bool_dtype, a.device)
+                return lt(a.contiguous(), b)
         else:
-            return _from_numpy(np.less(_to_numpy(a), _to_numpy(b)), bool_dtype, a.device)
+            return lt(a.contiguous(), b.contiguous() if isinstance(b, Tensor) else b)
         from ...._tensor import _compute_strides
         return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape), bool_dtype, a.device)
     b_np = _to_numpy(b) if isinstance(b, Tensor) else b
@@ -129,9 +129,9 @@ def le(a, b):
                                              scalar, out_buf, numel,
                                              scalar_fmt=_scalar_fmt(a.dtype))
             else:
-                return _from_numpy(np.less_equal(_to_numpy(a), scalar), bool_dtype, a.device)
+                return le(a.contiguous(), b)
         else:
-            return _from_numpy(np.less_equal(_to_numpy(a), _to_numpy(b)), bool_dtype, a.device)
+            return le(a.contiguous(), b.contiguous() if isinstance(b, Tensor) else b)
         from ...._tensor import _compute_strides
         return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape), bool_dtype, a.device)
     b_np = _to_numpy(b) if isinstance(b, Tensor) else b
@@ -153,9 +153,9 @@ def gt(a, b):
                                              scalar, out_buf, numel,
                                              scalar_fmt=_scalar_fmt(a.dtype))
             else:
-                return _from_numpy(np.greater(_to_numpy(a), scalar), bool_dtype, a.device)
+                return gt(a.contiguous(), b)
         else:
-            return _from_numpy(np.greater(_to_numpy(a), _to_numpy(b)), bool_dtype, a.device)
+            return gt(a.contiguous(), b.contiguous() if isinstance(b, Tensor) else b)
         from ...._tensor import _compute_strides
         return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape), bool_dtype, a.device)
     b_np = _to_numpy(b) if isinstance(b, Tensor) else b
@@ -177,17 +177,17 @@ def ge(a, b):
                                              scalar, out_buf, numel,
                                              scalar_fmt=_scalar_fmt(a.dtype))
             else:
-                return _from_numpy(np.greater_equal(_to_numpy(a), scalar), bool_dtype, a.device)
+                return ge(a.contiguous(), b)
         else:
-            return _from_numpy(np.greater_equal(_to_numpy(a), _to_numpy(b)), bool_dtype, a.device)
+            return ge(a.contiguous(), b.contiguous() if isinstance(b, Tensor) else b)
         from ...._tensor import _compute_strides
         return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape), bool_dtype, a.device)
     b_np = _to_numpy(b) if isinstance(b, Tensor) else b
     return _from_numpy(np.greater_equal(_to_numpy(a), b_np), bool_dtype, a.device)
 
 def logical_and(a, b):
-    if (_can_use_gpu(a) and a.is_contiguous()
-            and isinstance(b, Tensor) and _can_use_gpu(b) and b.is_contiguous()):
+    if (_can_use_gpu(a)
+            and isinstance(b, Tensor) and _can_use_gpu(b)):
         # ne(a,0) returns bool(uint8), ne(b,0) returns bool(uint8), mul gives AND
         a_bool = ne(a, 0)
         b_bool = ne(b, 0)
@@ -197,8 +197,8 @@ def logical_and(a, b):
     return _from_numpy(np.logical_and(a_np, b_np), bool_dtype, a.device)
 
 def logical_or(a, b):
-    if (_can_use_gpu(a) and a.is_contiguous()
-            and isinstance(b, Tensor) and _can_use_gpu(b) and b.is_contiguous()):
+    if (_can_use_gpu(a)
+            and isinstance(b, Tensor) and _can_use_gpu(b)):
         # ne(a,0) | ne(b,0) = ne(a_bool + b_bool, 0)
         a_bool = ne(a, 0)
         b_bool = ne(b, 0)
@@ -209,13 +209,13 @@ def logical_or(a, b):
     return _from_numpy(np.logical_or(a_np, b_np), bool_dtype, a.device)
 
 def logical_not(a):
-    if _can_use_gpu(a) and a.is_contiguous():
+    if _can_use_gpu(a):
         return eq(a, 0)
     return _from_numpy(np.logical_not(_to_numpy(a)), bool_dtype, a.device)
 
 def logical_xor(a, b):
-    if (_can_use_gpu(a) and a.is_contiguous()
-            and isinstance(b, Tensor) and _can_use_gpu(b) and b.is_contiguous()):
+    if (_can_use_gpu(a)
+            and isinstance(b, Tensor) and _can_use_gpu(b)):
         a_bool = ne(a, 0)
         b_bool = ne(b, 0)
         return ne(a_bool, b_bool)

--- a/src/candle/_backends/mps/ops/math.py
+++ b/src/candle/_backends/mps/ops/math.py
@@ -243,11 +243,10 @@ def isposinf(a):
 
 def isreal(a):
     """Returns a bool tensor indicating real-valued elements."""
-    arr = _to_numpy(a)
-    out = np.isreal(arr)
-    if out.ndim == 0:
-        out = np.array(out)
-    return _from_numpy(np.ascontiguousarray(out.astype(np.bool_)), bool_dtype, a.device)
+    # Candle has no complex dtype support; all tensors are real
+    from ...._tensor import _compute_strides
+    ones = np.ones(a.shape, dtype=np.uint8)
+    return _from_numpy(ones, bool_dtype, a.device)
 
 def sinh(a):
     if _can_use_gpu(a):


### PR DESCRIPTION
## Summary

- **Comparison ops** (eq/ne/lt/le/gt/ge): Replace 12 numpy fallback points for strided GPU tensors with `.contiguous()` + GPU re-dispatch, keeping all computation on Metal
- **Logical ops** (and/or/not/xor): Remove `is_contiguous()` guard since underlying comparisons now handle strided inputs
- **Activation ops**: Add GPU composite paths for `prelu`, `threshold`, `hardshrink`, and `softshrink` using existing on-device ops (`gt`, `where`, `mul`, `abs`, `sign`, `clamp`, `sub`)
- **isreal**: Return all-true directly without reading tensor data (candle has no complex dtypes)

## Test plan

- [x] Full MPS test suite passes (361 passed)
- [x] Full CPU + contract test suite passes (1591 passed, 28 skipped)
- [x] Strided comparison ops stay on GPU (no numpy round-trip)
- [x] Activation composites produce correct results via existing GPU ops

🤖 Generated with [Claude Code](https://claude.com/claude-code)