### PR TITLE
fix(npu): add executor high-water-mark flush to prevent 561103 pool exhaustion

### DIFF
--- a/src/candle/_backends/npu/aclnn.py
+++ b/src/candle/_backends/npu/aclnn.py
@@ -35,6 +35,7 @@ _BINDINGS = None
 _ACLNN_INITIALIZED = False
 _ACLNN_FINALIZED = False
 _DEFERRED_EXECUTORS = []
+_EXECUTOR_HWM = 64  # flush when executor count reaches this threshold
 _CLEANUP_REGISTERED = False
 
 
@@ -4194,6 +4195,8 @@ def _defer_executor(executor):
         return
     _register_cleanup()
     _DEFERRED_EXECUTORS.append(executor)
+    if len(_DEFERRED_EXECUTORS) >= _EXECUTOR_HWM:
+        flush_deferred_executors()
 
 
 def flush_deferred_executors():

--- a/src/candle/npu.py
+++ b/src/candle/npu.py
@@ -110,10 +110,10 @@ def synchronize(device=None):
     dev = _normalize_npu_device(device)
     runtime = npu_runtime.get_runtime(dev.index or 0)
     _set_initialized()
-    if hasattr(runtime, "synchronize_device"):
-        runtime.synchronize_device()
-    else:
-        runtime.synchronize()
+    # Use runtime.synchronize() which also flushes deferred ACLNN executors.
+    # synchronize_device() only waits for device completion but does NOT
+    # reclaim executor handles, leading to pool exhaustion (561103).
+    runtime.synchronize()
 
 
 def _set_initialized():


### PR DESCRIPTION
## Summary

Every ACLNN kernel call appends an executor handle to `_DEFERRED_EXECUTORS` via `_defer_executor()`. Previously, these handles were only reclaimed during `runtime.synchronize()` or at process exit (`atexit`). In long-running workloads (training loops, large test suites), the deferred list grows unbounded and exhausts the CANN executor pool, triggering error 561103.

## Changes

### 1. High-water-mark auto-flush in `_defer_executor()` (`aclnn.py`)

```python
_EXECUTOR_HWM = 64

def _defer_executor(executor):
    ...
    _DEFERRED_EXECUTORS.append(executor)
    if len(_DEFERRED_EXECUTORS) >= _EXECUTOR_HWM:
        flush_deferred_executors()
```

When the deferred list reaches 64 entries, it auto-flushes by destroying all accumulated executor handles. This caps memory/handle usage regardless of sync frequency.

### 2. Fix `npu.synchronize()` to call `runtime.synchronize()` (`npu.py`)

`npu.synchronize()` previously preferred `synchronize_device()` which only waits for device completion but does **not** flush deferred ACLNN executors. Now it calls `runtime.synchronize()` which includes the executor flush, ensuring explicit sync points also reclaim handles.

## Testing

- SoC policy tests pass
- The fix is a strict superset of the executor flush already in `runtime.synchronize()` (added in #78)