### PR TITLE
docs: enforce worktree isolation, pylint gate, and post-merge cleanup rules

### DIFF
--- a/.codex/skills/candle-fork-upstream-pr/SKILL.md
+++ b/.codex/skills/candle-fork-upstream-pr/SKILL.md
@@ -13,9 +13,11 @@ description: "Enforce Candle contribution flow: never modify main directly, alwa
 
 ## Mandatory Rules
 
-- Never modify `main` directly.
+- Never modify `main` directly. `main` is read-only during development.
 - Never open the final PR to `lvyufeng/candle`.
-- Always run verification tests before push/PR.
+- Always run verification tests AND pylint before push/PR.
+- Always rebase upstream before PR.
+- Only clean up your own worktrees and branches after merge.
 
 ## Step 1: Safety Gate (Before Any Edit)
 
@@ -33,12 +35,13 @@ If branch is `main` and working tree is dirty:
 3. Move in-progress edits into worktree.
 4. Restore `main` to clean state for those files.
 
-## Step 2: Create Isolated Worktree Branch
+## Step 2: Create Isolated Worktree Branch (Sync Upstream)
 
-Preferred location in this repo: `.worktrees/`.
+Always sync upstream before starting:
 
 ```bash
-git worktree add .worktrees/<branch-name> -b <branch-name>
+git fetch upstream main
+git worktree add .worktrees/<branch-name> -b <branch-name> upstream/main
 cd .worktrees/<branch-name>
 ```
 
@@ -74,7 +77,28 @@ git commit -m "<type>: <summary>"
 
 Use small, logical commits.
 
-## Step 5: Push to Fork (origin)
+## Step 5: Rebase Upstream Before PR
+
+Before pushing, always rebase onto the latest upstream main:
+
+```bash
+git fetch upstream main
+git rebase upstream/main
+```
+
+Resolve any conflicts before proceeding.
+
+## Step 6: Pylint Gate
+
+Run pylint and confirm zero errors before pushing:
+
+```bash
+pylint src/candle/ --rcfile=pyproject.toml
+```
+
+Do NOT proceed if pylint fails. Fix all issues first.
+
+## Step 7: Push to Fork (origin)
 
 ```bash
 git push -u origin <branch-name>
@@ -82,7 +106,7 @@ git push -u origin <branch-name>
 
 `origin` for this repo must be `https://github.com/lvyufeng/candle`.
 
-## Step 6: Create PR to Upstream
+## Step 8: Create PR to Upstream
 
 Always create PR to upstream repo explicitly:
 
@@ -97,7 +121,7 @@ gh pr create \
 
 Do not omit `-R candle-org/candle`.
 
-## Step 7: Validate PR Target and Link
+## Step 9: Validate PR Target and Link
 
 Verify PR exists in upstream:
 
@@ -107,7 +131,26 @@ gh pr list -R candle-org/candle --head lvyufeng:<branch-name> --state open
 
 Report upstream PR URL.
 
-## Step 8: Optional Cleanup of Accidental Fork PR
+## Step 10: Cleanup After Merge
+
+After a PR is merged, delete ONLY the worktree and branch YOU created:
+
+```bash
+# From the repo root (not inside the worktree)
+git worktree remove .worktrees/<your-branch-name>
+git branch -d <your-branch-name>
+git push origin --delete <your-branch-name>
+```
+
+NEVER touch worktrees or branches created by other agents or contributors.
+
+Then sync main:
+
+```bash
+git checkout main && git pull upstream main && git push origin main
+```
+
+## Step 11: Optional Cleanup of Accidental Fork PR
 
 If an accidental PR was opened in fork repo:
 
@@ -122,12 +165,18 @@ gh pr close -R lvyufeng/candle <pr-number>
 - Pushing commits only to local branch without fork push.
 - Creating PR without explicit upstream repo (`-R candle-org/candle`).
 - Claiming completion without test output.
+- Opening PR without passing pylint.
+- Opening PR without rebasing upstream.
+- Deleting worktrees or branches that belong to other agents.
 
 ## Completion Checklist
 
 - [ ] Branch is non-`main` and in `.worktrees/`.
 - [ ] `main` has no accidental edits from this task.
 - [ ] Tests for changed behavior pass.
+- [ ] Pylint passes with zero errors.
+- [ ] Rebased on latest `upstream/main`.
 - [ ] Branch pushed to `origin` (`lvyufeng/candle`).
 - [ ] PR opened to `candle-org/candle:main`.
 - [ ] Upstream PR URL confirmed.
+- [ ] After merge: worktree and branch cleaned up (own only).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,15 +58,59 @@ pytest tests/mps/ -v --tb=short
 - Match PyTorch dispatch semantics first (schema binding, error class, dispatch path), then optimize implementation.
 - Error message wording can differ slightly unless a contract test requires exact match.
 
-## Branch Rule
+## Worktree & Branch Rules (Mandatory)
 
-- Always develop on a feature branch from latest `main`.
-- Rebase before opening PR to avoid conflicts.
+These rules apply to Claude Code, Codex, and all coding agents. No exceptions.
+
+### 1. Always use a worktree
+
+Before making ANY code change, create an isolated worktree and sync upstream:
 
 ```bash
-git checkout main && git pull upstream main
-git checkout -b feat/<name>
+git fetch upstream main
+git worktree add .worktrees/<branch-name> -b <branch-name> upstream/main
+cd .worktrees/<branch-name>
 ```
+
+Never edit files on `main` directly. If you find yourself on `main` with uncommitted changes, stop immediately, create a worktree, and move the changes there.
+
+### 2. Never modify main
+
+The `main` branch is read-only during development. All commits go on feature branches inside `.worktrees/`. If a command would alter `main`, abort it.
+
+### 3. Rebase upstream before PR
+
+Before pushing and opening a PR, rebase onto the latest upstream main:
+
+```bash
+git fetch upstream main
+git rebase upstream/main
+```
+
+Resolve any conflicts before proceeding.
+
+### 4. Pylint gate before PR
+
+Run pylint locally and confirm zero errors before pushing or creating a PR:
+
+```bash
+pylint src/candle/ --rcfile=pyproject.toml
+```
+
+Do NOT open a PR if pylint fails. Fix all issues first.
+
+### 5. Clean up after merge
+
+After a PR is merged (manually or via command), delete ONLY the worktree and branch YOU created:
+
+```bash
+# From the repo root (not inside the worktree)
+git worktree remove .worktrees/<your-branch-name>
+git branch -d <your-branch-name>
+git push origin --delete <your-branch-name>
+```
+
+NEVER touch worktrees or branches created by other agents or contributors.
 
 ## GPU/NPU Kernel Fallback Policy (Mandatory)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,27 +131,77 @@ When using option 3 as a workaround for a broken native kernel:
 - **origin**: `lvyufeng/candle` (fork, push target)
 - **upstream**: `candle-org/candle` (upstream, PR target)
 
+### Worktree & Branch Rules (Mandatory)
+
+These rules apply to Claude Code, Codex, and all coding agents. No exceptions.
+
+#### 1. Always use a worktree
+
+Before making ANY code change, create an isolated worktree and sync upstream:
+
+```bash
+git fetch upstream main
+git worktree add .worktrees/<branch-name> -b <branch-name> upstream/main
+cd .worktrees/<branch-name>
+```
+
+Never edit files on `main` directly. If you find yourself on `main` with uncommitted changes, stop immediately, create a worktree, and move the changes there.
+
+#### 2. Never modify main
+
+The `main` branch is read-only during development. All commits go on feature branches inside `.worktrees/`. If a command would alter `main`, abort it.
+
+#### 3. Rebase upstream before PR
+
+Before pushing and opening a PR, rebase onto the latest upstream main:
+
+```bash
+git fetch upstream main
+git rebase upstream/main
+```
+
+Resolve any conflicts before proceeding.
+
+#### 4. Pylint gate before PR
+
+Run pylint locally and confirm zero errors before pushing or creating a PR:
+
+```bash
+pylint src/candle/ --rcfile=pyproject.toml
+```
+
+Do NOT open a PR if pylint fails. Fix all issues first.
+
+#### 5. Clean up after merge
+
+After a PR is merged (manually or via command), delete ONLY the worktree and branch YOU created:
+
+```bash
+# From the repo root (not inside the worktree)
+git worktree remove .worktrees/<your-branch-name>
+git branch -d <your-branch-name>
+git push origin --delete <your-branch-name>
+```
+
+NEVER touch worktrees or branches created by other agents or contributors.
+
 ### PR Workflow
 
 ```bash
-# 1. Create feature branch from main
-git checkout -b feat/<name>
+# Push to origin
+git push -u origin <branch-name>
 
-# 2. Push to origin
-git push -u origin feat/<name>
-
-# 3. Create PR to upstream
-gh pr create --repo candle-org/candle --head lvyufeng:feat/<name> --base main
+# Create PR to upstream
+gh pr create --repo candle-org/candle --head lvyufeng:<branch-name> --base main
 ```
 
 ### Merge Convention
 
 - Squash merge PRs into main
-- After merge: sync local main, delete feature branch
+- After merge: clean up worktree and branch (Rule 5 above), then sync main:
 
 ```bash
 git checkout main && git pull upstream main && git push origin main
-git branch -d feat/<name> && git push origin --delete feat/<name>
 ```
 
 ---


### PR DESCRIPTION
Add five mandatory rules for all coding agents (Claude Code, Codex):

1. Always create a worktree and sync upstream before editing
2. Never modify main directly
3. Rebase upstream before opening PR
4. Pass pylint locally before PR
5. Only clean up your own worktree/branch after merge

Updated in CLAUDE.md, AGENTS.md, and .codex/skills/candle-fork-upstream-pr/SKILL.md.