### PR TITLE
fix(mps): replace numpy fallbacks with GPU composites across math/comparison/elementwise/reduce/activation

### DIFF
--- a/src/candle/_backends/mps/ops/activation.py
+++ b/src/candle/_backends/mps/ops/activation.py
@@ -103,10 +103,9 @@ def prelu(a, weight):
     if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
         a_c = a.contiguous() if not a.is_contiguous() else a
         mask = gt(a_c, 0)
-        w_np = _to_numpy(weight)
-        # Broadcast weight to match a's shape
-        w_expanded = _from_numpy(
-            np.broadcast_to(w_np, a_c.shape).copy(), a.dtype, a.device)
+        # Broadcast weight to match a's shape via GPU expand (zero-copy view)
+        from .shape import expand
+        w_expanded = expand(weight, tuple(a_c.shape))
         neg = mul(a_c, w_expanded)
         return where(mask, a_c, neg)
     _unsupported_dtype("prelu", a)

--- a/src/candle/_backends/mps/ops/comparison.py
+++ b/src/candle/_backends/mps/ops/comparison.py
@@ -21,26 +21,34 @@ from ._helpers import (
 )
 
 def allclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
-    return np.allclose(
-        _to_numpy(a),
-        _to_numpy(b),
-        rtol=rtol,
-        atol=atol,
-        equal_nan=equal_nan,
-    )
+    # GPU composite: all(isclose(a, b))
+    close = isclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan)
+    # all_ returns a scalar tensor; extract Python bool
+    from .reduce import all_
+    return bool(all_(close).item())
 
 def isclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
-    out = np.isclose(
-        _to_numpy(a),
-        _to_numpy(b),
-        rtol=rtol,
-        atol=atol,
-        equal_nan=equal_nan,
-    )
-    return _from_numpy(out, bool_dtype, a.device)
+    # GPU composite: |a - b| <= atol + rtol * |b|
+    if _can_use_gpu(a) and isinstance(b, Tensor) and _can_use_gpu(b):
+        from .math import abs as _abs, sub, mul, add
+        diff = _abs(sub(a, b))
+        tol = add(_dispatch_binary_gpu(_abs(b), float(rtol), "mul"), float(atol))
+        close = le(diff, tol)
+        if equal_nan:
+            from .math import isnan
+            both_nan = logical_and(isnan(a), isnan(b))
+            close = logical_or(close, both_nan)
+        return close
+    _unsupported_dtype("isclose", a)
 
 def equal(a, b):
-    return np.array_equal(_to_numpy(a), _to_numpy(b))
+    # GPU composite: all(eq(a, b))
+    if _can_use_gpu(a) and isinstance(b, Tensor) and _can_use_gpu(b):
+        if a.shape != b.shape:
+            return False
+        from .reduce import all_
+        return bool(all_(eq(a, b)).item())
+    _unsupported_dtype("equal", a)
 
 def eq(a, b):
     if _can_use_gpu(a):

--- a/src/candle/_backends/mps/ops/elementwise.py
+++ b/src/candle/_backends/mps/ops/elementwise.py
@@ -33,9 +33,8 @@ def where(cond, x, y):
         out_buf = _alloc_output_buf(numel, x.dtype)
         # Ensure condition is uint8 (uchar) for the shader
         if cond.dtype != bool_dtype:
-            cond_u8 = _from_numpy(
-                _to_numpy(cond).astype(np.bool_).astype(np.uint8),
-                bool_dtype, cond.device)
+            from .comparison import ne
+            cond_u8 = ne(cond, 0)
         else:
             cond_u8 = cond
         cond_buf = _metal_buf(cond_u8)
@@ -79,35 +78,27 @@ def lerp(a, b, weight):
 def addcmul(a, b, c, value=1.0):
     if _can_use_gpu(a) and _can_use_gpu(b) and _can_use_gpu(c):
         return add(a, mul(mul(b, c), value))
-    return _from_numpy(
-        _to_numpy(a) + value * (_to_numpy(b) * _to_numpy(c)),
-        a.dtype,
-        a.device,
-    )
+    _unsupported_dtype("addcmul", a)
 
 def addcdiv(a, b, c, value=1.0):
     if _can_use_gpu(a) and _can_use_gpu(b) and _can_use_gpu(c):
         return add(a, mul(div(b, c), value))
-    return _from_numpy(
-        _to_numpy(a) + value * (_to_numpy(b) / _to_numpy(c)),
-        a.dtype,
-        a.device,
-    )
+    _unsupported_dtype("addcdiv", a)
 
 def logaddexp(a, b):
     if isinstance(a, Tensor) and isinstance(b, Tensor) and _can_use_gpu(a) and _can_use_gpu(b):
         return _dispatch_binary_gpu(a, b, "logaddexp")
-    return _from_numpy(np.logaddexp(_to_numpy(a), _to_numpy(b)), a.dtype, a.device)
+    _unsupported_dtype("logaddexp", a if isinstance(a, Tensor) else b)
 
 def logaddexp2(a, b):
     if isinstance(a, Tensor) and isinstance(b, Tensor) and _can_use_gpu(a) and _can_use_gpu(b):
         return _dispatch_binary_gpu(a, b, "logaddexp2")
-    return _from_numpy(np.logaddexp2(_to_numpy(a), _to_numpy(b)), a.dtype, a.device)
+    _unsupported_dtype("logaddexp2", a if isinstance(a, Tensor) else b)
 
 def hypot(a, b):
     if isinstance(a, Tensor) and isinstance(b, Tensor) and _can_use_gpu(a) and _can_use_gpu(b):
         return _dispatch_binary_gpu(a, b, "hypot")
-    return _from_numpy(np.hypot(_to_numpy(a), _to_numpy(b)), a.dtype, a.device)
+    _unsupported_dtype("hypot", a if isinstance(a, Tensor) else b)
 
 def remainder(a, b):
     if isinstance(a, Tensor) and _can_use_gpu(a):
@@ -119,15 +110,12 @@ def remainder(a, b):
             d.dispatch_binary(f"remainder_{sfx}", _metal_buf(a), _metal_buf(b),
                               out_buf, numel)
         else:
-            scalar = float(b) if not isinstance(b, Tensor) else float(_to_numpy(b).ravel()[0])
+            scalar = float(b) if not isinstance(b, Tensor) else float(b.item())
             d.dispatch_binary_scalar(f"remainder_scalar_{sfx}", _metal_buf(a),
                                      scalar, out_buf, numel,
                                      scalar_fmt=_scalar_fmt(a.dtype))
         return _from_metal_buffer(out_buf, a.shape, a.stride, a.dtype, a.device)
-    a_np = _to_numpy(a) if isinstance(a, Tensor) else a
-    b_np = _to_numpy(b) if isinstance(b, Tensor) else b
-    ref = a if isinstance(a, Tensor) else b
-    return _from_numpy(np.remainder(a_np, b_np), ref.dtype, ref.device)
+    _unsupported_dtype("remainder", a if isinstance(a, Tensor) else b)
 
 def fmod(a, b):
     if _can_use_gpu(a) and isinstance(b, Tensor) and _can_use_gpu(b):
@@ -138,7 +126,7 @@ def fmod(a, b):
         d.dispatch_binary(f"fmod_{sfx}", _metal_buf(a), _metal_buf(b),
                           out_buf, numel)
         return _from_metal_buffer(out_buf, a.shape, a.stride, a.dtype, a.device)
-    return _from_numpy(np.fmod(_to_numpy(a), _to_numpy(b)), a.dtype, a.device)
+    _unsupported_dtype("fmod", a)
 
 def heaviside(a, values):
     """Heaviside step function."""
@@ -159,10 +147,15 @@ def heaviside(a, values):
         # Step 3: where a<0, set to 0.0 → where(~neg_mask, out, 0.0)
         not_neg = logical_not(neg_mask)
         return where(not_neg, out, 0.0)
-    a_np = _to_numpy(a)
-    v_np = _to_numpy(values)
-    out = np.heaviside(a_np, v_np)
-    return _from_numpy(np.ascontiguousarray(out.astype(to_numpy_dtype(a.dtype))), a.dtype, a.device)
+    # Non-contiguous: make contiguous and retry
+    if _can_use_gpu(a) and isinstance(values, Tensor) and _can_use_gpu(values):
+        a_c = a.contiguous() if not a.is_contiguous() else a
+        v_c = values.contiguous() if not values.is_contiguous() else values
+        from .shape import expand
+        if a_c.shape != v_c.shape:
+            v_c = expand(v_c, tuple(a_c.shape))
+        return heaviside(a_c, v_c)
+    _unsupported_dtype("heaviside", a)
 
 
 # ---------------------------------------------------------------------------

--- a/src/candle/_backends/mps/ops/math.py
+++ b/src/candle/_backends/mps/ops/math.py
@@ -1,7 +1,6 @@
 import math
 import ctypes
 import struct
-import numpy as np
 
 from ._helpers import (
     _can_use_gpu, _empty_like, _unsupported_dtype,
@@ -174,7 +173,7 @@ def pow(a, b):
             d.dispatch_binary(f"pow_{sfx}", _metal_buf(a), _metal_buf(b),
                               out_buf, numel)
         else:
-            scalar = float(b) if not isinstance(b, Tensor) else float(_to_numpy(b).ravel()[0])
+            scalar = float(b) if not isinstance(b, Tensor) else float(b.item())
             d.dispatch_binary_scalar(f"pow_scalar_{sfx}", _metal_buf(a),
                                      scalar, out_buf, numel,
                                      scalar_fmt=_scalar_fmt(a.dtype))
@@ -229,11 +228,9 @@ def square(a):
 def signbit(a):
     if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
         return _dispatch_unary_predicate_gpu(a, "signbit")
-    # Integer types: signbit is always False for unsigned, check sign for signed
+    # Integer types: check sign via GPU comparison
     if _can_use_gpu(a) and a.dtype in (int32_dtype, int64_dtype):
         from .comparison import lt
-        from ...._tensor import _compute_strides
-        zero_buf = _alloc_output_buf(a.numel(), a.dtype)
         return lt(a, 0)
     if a.numel() == 0:
         return _empty_like(a)
@@ -242,10 +239,10 @@ def signbit(a):
 def isnan(a):
     if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
         return _dispatch_unary_predicate_gpu(a, "isnan")
-    # Integer/bool types: never NaN
+    # Integer/bool types: never NaN → ne(a, a) is always False
     if _can_use_gpu(a) and a.dtype in (int32_dtype, int64_dtype, bool_dtype):
-        out = np.zeros(a.shape, dtype=np.uint8)
-        return _from_numpy(out, bool_dtype, a.device)
+        from .comparison import ne
+        return ne(a, a)
     if a.numel() == 0:
         return _empty_like(a)
     _unsupported_dtype("isnan", a)
@@ -253,10 +250,10 @@ def isnan(a):
 def isinf(a):
     if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
         return _dispatch_unary_predicate_gpu(a, "isinf")
-    # Integer/bool types: never inf
+    # Integer/bool types: never inf → ne(a, a) is always False
     if _can_use_gpu(a) and a.dtype in (int32_dtype, int64_dtype, bool_dtype):
-        out = np.zeros(a.shape, dtype=np.uint8)
-        return _from_numpy(out, bool_dtype, a.device)
+        from .comparison import ne
+        return ne(a, a)
     if a.numel() == 0:
         return _empty_like(a)
     _unsupported_dtype("isinf", a)
@@ -264,10 +261,10 @@ def isinf(a):
 def isfinite(a):
     if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
         return _dispatch_unary_predicate_gpu(a, "isfinite")
-    # Integer/bool types: always finite
+    # Integer/bool types: always finite → eq(a, a) is always True
     if _can_use_gpu(a) and a.dtype in (int32_dtype, int64_dtype, bool_dtype):
-        out = np.ones(a.shape, dtype=np.uint8)
-        return _from_numpy(out, bool_dtype, a.device)
+        from .comparison import eq
+        return eq(a, a)
     if a.numel() == 0:
         return _empty_like(a)
     _unsupported_dtype("isfinite", a)
@@ -276,9 +273,10 @@ def isneginf(a):
     """Returns a bool tensor indicating negative infinity."""
     if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
         return _dispatch_unary_predicate_gpu(a, "isneginf")
+    # Integer/bool types: never -inf → ne(a, a) is always False
     if _can_use_gpu(a) and a.dtype in (int32_dtype, int64_dtype, bool_dtype):
-        out = np.zeros(a.shape, dtype=np.uint8)
-        return _from_numpy(out, bool_dtype, a.device)
+        from .comparison import ne
+        return ne(a, a)
     if a.numel() == 0:
         return _empty_like(a)
     _unsupported_dtype("isneginf", a)
@@ -287,19 +285,23 @@ def isposinf(a):
     """Returns a bool tensor indicating positive infinity."""
     if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
         return _dispatch_unary_predicate_gpu(a, "isposinf")
+    # Integer/bool types: never +inf → ne(a, a) is always False
     if _can_use_gpu(a) and a.dtype in (int32_dtype, int64_dtype, bool_dtype):
-        out = np.zeros(a.shape, dtype=np.uint8)
-        return _from_numpy(out, bool_dtype, a.device)
+        from .comparison import ne
+        return ne(a, a)
     if a.numel() == 0:
         return _empty_like(a)
     _unsupported_dtype("isposinf", a)
 
 def isreal(a):
     """Returns a bool tensor indicating real-valued elements."""
-    # Candle has no complex dtype support; all tensors are real
-    from ...._tensor import _compute_strides
-    ones = np.ones(a.shape, dtype=np.uint8)
-    return _from_numpy(ones, bool_dtype, a.device)
+    # Candle has no complex dtype support; all tensors are real → eq(a, a)
+    if _can_use_gpu(a):
+        from .comparison import eq
+        return eq(a, a)
+    if a.numel() == 0:
+        return _empty_like(a)
+    _unsupported_dtype("isreal", a)
 
 def sinh(a):
     if _can_use_gpu(a):

--- a/src/candle/_backends/mps/ops/reduce.py
+++ b/src/candle/_backends/mps/ops/reduce.py
@@ -275,8 +275,11 @@ def argmax(a, dim=None, keepdim=False):
         from ..runtime import buffer_contents
         ptr = buffer_contents(out_buf)
         idx_val = struct.unpack("I", (ctypes.c_char * 4).from_address(ptr))[0]
-        out = np.array(int(idx_val), dtype=np.int64)
-        return _from_numpy(out, int64_dtype, a.device)
+        # Write int64 value into a Metal buffer (no numpy)
+        i64_buf = _alloc_output_buf(1, int64_dtype)
+        i64_ptr = buffer_contents(i64_buf)
+        struct.pack_into("q", (ctypes.c_char * 8).from_address(i64_ptr), 0, int(idx_val))
+        return _from_metal_buffer(i64_buf, (), (), int64_dtype, a.device)
 
     # GPU path: axis argmax (dim specified)
     if dim is not None and _can_use_gpu(a) and a.is_contiguous():
@@ -298,8 +301,11 @@ def argmin(a, dim=None, keepdim=False):
         from ..runtime import buffer_contents
         ptr = buffer_contents(out_buf)
         idx_val = struct.unpack("I", (ctypes.c_char * 4).from_address(ptr))[0]
-        out = np.array(int(idx_val), dtype=np.int64)
-        return _from_numpy(out, int64_dtype, a.device)
+        # Write int64 value into a Metal buffer (no numpy)
+        i64_buf = _alloc_output_buf(1, int64_dtype)
+        i64_ptr = buffer_contents(i64_buf)
+        struct.pack_into("q", (ctypes.c_char * 8).from_address(i64_ptr), 0, int(idx_val))
+        return _from_metal_buffer(i64_buf, (), (), int64_dtype, a.device)
 
     # GPU path: axis argmin (dim specified)
     if dim is not None and _can_use_gpu(a) and a.is_contiguous():
@@ -315,12 +321,16 @@ def count_nonzero(a, dim=None, keepdim=False):
             and a.dtype in (float32_dtype, float16_dtype, int32_dtype, int64_dtype)):
         # composite: ne(a, 0) → sum as float → cast to int64
         mask = ne(a, 0)
-        # Need float for sum — use where(mask, 1.0, 0.0) with a float tensor
-        ones_np = np.ones(a.shape, dtype=np.float32)
-        ones_t = _from_numpy(ones_np, float32_dtype, a.device)
+        # Create float ones tensor on GPU without numpy
+        if a.dtype in (float32_dtype, float16_dtype):
+            ones_t = add(mul(a, 0.0), 1.0)
+        else:
+            # int types: create float32 ones via alloc + fill
+            ones_np = np.ones(a.shape, dtype=np.float32)
+            ones_t = _from_numpy(ones_np, float32_dtype, a.device)
         count_f = where(mask, ones_t, 0.0)
         s = sum_(count_f, dim=dim, keepdim=keepdim)
-        # Convert to int64 via numpy (small result)
+        # Convert to int64 via numpy (small result after reduction)
         s_np = _to_numpy(s).astype(np.int64)
         return _from_numpy(np.ascontiguousarray(s_np), int64_dtype, a.device)
     # Non-contiguous or unsupported dtype: make contiguous and retry
@@ -642,17 +652,12 @@ def renorm(a, p, dim, maxnorm):
         n = norm_(a_c, p=p, dim=dim, keepdim=True)
         # scale = where(norm > maxnorm, maxnorm / (norm + eps), 1.0)
         eps_t = _dispatch_binary_gpu(n, 1e-7, "add")
-        ratio = _dispatch_binary_gpu(
-            _from_numpy(np.array(float(maxnorm), dtype=np.float32), float32_dtype, a.device),
-            eps_t, "div") if a.dtype == float32_dtype else _dispatch_binary_gpu(
-            _from_numpy(np.array(float(maxnorm), dtype=np.float32), float32_dtype, a.device),
-            eps_t, "div")
+        from .math import reciprocal
+        ratio = mul(reciprocal(eps_t), float(maxnorm))
         from .comparison import gt
         cond = gt(n, float(maxnorm))
-        ones_shape = tuple(n.shape)
-        ones_np = np.ones(ones_shape, dtype=to_numpy_dtype(a.dtype))
-        ones_t = _from_numpy(ones_np, a.dtype, a.device)
-        scale = where(cond, ratio, ones_t)
+        # Use where with scalar y=1.0 (no numpy ones tensor needed)
+        scale = where(cond, ratio, 1.0)
         return mul(a_c, scale)
     _unsupported_dtype("renorm", a)
 


### PR DESCRIPTION
## Summary

Eliminates ~25 numpy fallback points across 5 MPS ops files, replacing them with GPU-native composites or on-device operations.

## Changes

**math.py**
- `isnan`/`isinf`/`isfinite`/`isneginf`/`isposinf` for int/bool types: `np.zeros`/`np.ones` → `ne(a,a)`/`eq(a,a)` GPU composites
- `isreal`: `np.ones` → `eq(a,a)` GPU composite
- `signbit`: remove unused `_alloc_output_buf` call
- `pow`: `_to_numpy(b).ravel()[0]` → `b.item()`
- Remove `import numpy as np` (no longer needed)

**comparison.py**
- `allclose`: `np.allclose` → `isclose` + `all_` GPU composite
- `isclose`: `np.isclose` → `abs(sub(a,b)) <= atol + rtol*abs(b)` GPU composite
- `equal`: `np.array_equal` → `eq` + `all_` GPU composite

**elementwise.py**
- `where` cond cast: numpy `astype` → `ne(cond, 0)` GPU comparison
- `addcmul`/`addcdiv`/`logaddexp`/`logaddexp2`/`hypot`/`remainder`/`fmod`: numpy fallbacks → `_unsupported_dtype` (GPU paths already handle all valid inputs)
- `heaviside`: numpy fallback → contiguous retry + GPU composite path

**reduce.py**
- `argmax`/`argmin` dim=None: `np.array(int64)` → `struct.pack_into` directly to Metal buffer
- `count_nonzero`: `np.ones` → `mul(a, 0.0) + 1.0` GPU composite for float types
- `renorm`: `np.array(maxnorm)` → `reciprocal` + scalar `mul`; `np.ones` → `where(..., 1.0)` scalar path

**activation.py**
- `prelu`: `np.broadcast_to(weight)` → GPU `expand(weight, shape)`

## Testing

- All 361 MPS tests pass
- All 1631 CPU + contract tests pass (28 skipped)
- Pylint 10.00/10 with CI config