### PR TITLE
fix(mps): replace numpy fallbacks with native GPU paths in reduce ops

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,7 @@ Resolve any conflicts before proceeding.
 Run pylint locally and confirm zero errors before pushing or creating a PR:
 
 ```bash
-pylint src/candle/ --rcfile=pyproject.toml
+pylint src/candle/ --rcfile=.github/pylint.conf
 ```
 
 Do NOT open a PR if pylint fails. Fix all issues first.

--- a/src/candle/_backends/mps/metal_compute.py
+++ b/src/candle/_backends/mps/metal_compute.py
@@ -1131,6 +1131,47 @@ class MetalKernelDispatcher:
         rt.commit_and_wait(cmd)
 
     # ------------------------------------------------------------------
+    # Dispatch: cummax / cummin  (input → values + indices)
+    # ------------------------------------------------------------------
+
+    def dispatch_cummax(self, kernel_name, input_buf, values_buf, indices_buf,
+                        outer_size, dim_size, inner_size):
+        """Encode cummax kernel (3 bufs + 3 setBytes)."""
+        rt = get_runtime()
+        pipeline = self._get_pipeline(kernel_name)
+        tpg = self._threads_per_group(pipeline)
+        numel = outer_size * inner_size
+        groups = (numel + tpg - 1) // tpg
+
+        cmd = rt.create_command_buffer()
+        enc = rt.get_compute_encoder(cmd)
+
+        if _HAS_PYOBJC:
+            enc.setComputePipelineState_(pipeline)
+            enc.setBuffer_offset_atIndex_(input_buf, 0, 0)
+            enc.setBuffer_offset_atIndex_(values_buf, 0, 1)
+            enc.setBuffer_offset_atIndex_(indices_buf, 0, 2)
+            enc.setBytes_length_atIndex_(struct.pack("I", outer_size), 4, 3)
+            enc.setBytes_length_atIndex_(struct.pack("I", dim_size), 4, 4)
+            enc.setBytes_length_atIndex_(struct.pack("I", inner_size), 4, 5)
+            enc.dispatchThreadgroups_threadsPerThreadgroup_(
+                _MTLSize(groups, 1, 1), _MTLSize(tpg, 1, 1))
+            enc.endEncoding()
+        else:
+            _encode_cumextreme_ctypes(enc, pipeline, input_buf, values_buf,
+                                      indices_buf, outer_size, dim_size,
+                                      inner_size, groups, tpg)
+
+        rt.commit_and_wait(cmd)
+
+    def dispatch_cummin(self, kernel_name, input_buf, values_buf, indices_buf,
+                        outer_size, dim_size, inner_size):
+        """Encode cummin kernel (3 bufs + 3 setBytes)."""
+        # Same layout as cummax
+        self.dispatch_cummax(kernel_name, input_buf, values_buf, indices_buf,
+                             outer_size, dim_size, inner_size)
+
+    # ------------------------------------------------------------------
     # Dispatch: sort  (input → values + indices)
     # ------------------------------------------------------------------
 
@@ -2156,6 +2197,20 @@ def _encode_cumsum_ctypes(enc, pipeline, input_buf, output_buf,
     _ctypes_set_bytes(enc, struct.pack("I", outer_size), 4, 2)
     _ctypes_set_bytes(enc, struct.pack("I", dim_size), 4, 3)
     _ctypes_set_bytes(enc, struct.pack("I", inner_size), 4, 4)
+    _ctypes_dispatch_threadgroups(enc, groups, tpg)
+    _ctypes_end_encoding(enc)
+
+
+def _encode_cumextreme_ctypes(enc, pipeline, input_buf, values_buf, indices_buf,
+                               outer_size, dim_size, inner_size, groups, tpg):
+    """Encode cummax/cummin kernel via ctypes (3 bufs + 3 setBytes)."""
+    _ctypes_set_pipeline(enc, pipeline)
+    _ctypes_set_buffer(enc, input_buf, 0, 0)
+    _ctypes_set_buffer(enc, values_buf, 0, 1)
+    _ctypes_set_buffer(enc, indices_buf, 0, 2)
+    _ctypes_set_bytes(enc, struct.pack("I", outer_size), 4, 3)
+    _ctypes_set_bytes(enc, struct.pack("I", dim_size), 4, 4)
+    _ctypes_set_bytes(enc, struct.pack("I", inner_size), 4, 5)
     _ctypes_dispatch_threadgroups(enc, groups, tpg)
     _ctypes_end_encoding(enc)
 

--- a/src/candle/_backends/mps/metal_shaders.py
+++ b/src/candle/_backends/mps/metal_shaders.py
@@ -1175,6 +1175,101 @@ def _gen_cumprod(types=None):
 
 
 # ---------------------------------------------------------------------------
+# Cummax / Cummin Metal compute shaders (per-row sequential scan)
+# ---------------------------------------------------------------------------
+
+_CUMMAX_TEMPLATE = """
+kernel void cummax_{suffix}(
+    device const {type}* input   [[buffer(0)]],
+    device {type}* out_values    [[buffer(1)]],
+    device int*   out_indices    [[buffer(2)]],
+    constant uint& outer_size    [[buffer(3)]],
+    constant uint& dim_size      [[buffer(4)]],
+    constant uint& inner_size    [[buffer(5)]],
+    uint gid [[thread_position_in_grid]])
+{{
+    uint total = outer_size * inner_size;
+    if (gid >= total) return;
+
+    uint outer = gid / inner_size;
+    uint inner = gid % inner_size;
+    uint base = outer * (dim_size * inner_size) + inner;
+
+    float running = (float)input[base];
+    int   best_idx = 0;
+    out_values[base] = input[base];
+    out_indices[base] = 0;
+
+    for (uint d = 1; d < dim_size; d++) {{
+        uint pos = base + d * inner_size;
+        float val = (float)input[pos];
+        if (val > running) {{
+            running = val;
+            best_idx = (int)d;
+        }}
+        out_values[pos] = ({type})running;
+        out_indices[pos] = best_idx;
+    }}
+}}
+"""
+
+_CUMMIN_TEMPLATE = """
+kernel void cummin_{suffix}(
+    device const {type}* input   [[buffer(0)]],
+    device {type}* out_values    [[buffer(1)]],
+    device int*   out_indices    [[buffer(2)]],
+    constant uint& outer_size    [[buffer(3)]],
+    constant uint& dim_size      [[buffer(4)]],
+    constant uint& inner_size    [[buffer(5)]],
+    uint gid [[thread_position_in_grid]])
+{{
+    uint total = outer_size * inner_size;
+    if (gid >= total) return;
+
+    uint outer = gid / inner_size;
+    uint inner = gid % inner_size;
+    uint base = outer * (dim_size * inner_size) + inner;
+
+    float running = (float)input[base];
+    int   best_idx = 0;
+    out_values[base] = input[base];
+    out_indices[base] = 0;
+
+    for (uint d = 1; d < dim_size; d++) {{
+        uint pos = base + d * inner_size;
+        float val = (float)input[pos];
+        if (val < running) {{
+            running = val;
+            best_idx = (int)d;
+        }}
+        out_values[pos] = ({type})running;
+        out_indices[pos] = best_idx;
+    }}
+}}
+"""
+
+
+def _gen_cummax(types=None):
+    if types is None:
+        types = _FLOAT_TYPES
+    parts = []
+    for t in types:
+        suffix = _SUFFIX[t]
+        parts.append(_CUMMAX_TEMPLATE.format(type=t, suffix=suffix))
+    return "".join(parts)
+
+
+def _gen_cummin(types=None):
+    if types is None:
+        types = _FLOAT_TYPES
+    parts = []
+    for t in types:
+        suffix = _SUFFIX[t]
+        parts.append(_CUMMIN_TEMPLATE.format(type=t, suffix=suffix))
+    return "".join(parts)
+
+
+# ---------------------------------------------------------------------------
 # Adaptive avg pool2d Metal compute shader
 # ---------------------------------------------------------------------------
 
@@ -2159,6 +2254,10 @@ def _build_msl_source():
 
     # Cumprod kernel
     parts.append(_gen_cumprod())
+
+    # Cummax / Cummin kernels
+    parts.append(_gen_cummax())
+    parts.append(_gen_cummin())
 
     # Sort kernel
     parts.append(_gen_sort())

--- a/src/candle/_backends/mps/ops/reduce.py
+++ b/src/candle/_backends/mps/ops/reduce.py
@@ -319,21 +319,28 @@ def argmin(a, dim=None, keepdim=False):
 def count_nonzero(a, dim=None, keepdim=False):
     if (_can_use_gpu(a) and a.is_contiguous()
             and a.dtype in (float32_dtype, float16_dtype, int32_dtype, int64_dtype)):
-        # composite: ne(a, 0) → sum as float → cast to int64
+        # composite: ne(a, 0) → where(mask, 1.0, 0.0) → sum → cast to int64
         mask = ne(a, 0)
-        # Create float ones tensor on GPU without numpy
         if a.dtype in (float32_dtype, float16_dtype):
             ones_t = add(mul(a, 0.0), 1.0)
         else:
-            # int types: create float32 ones via alloc + fill
-            ones_np = np.ones(a.shape, dtype=np.float32)
-            ones_t = _from_numpy(ones_np, float32_dtype, a.device)
+            # int types: create float32 ones via GPU fill
+            numel = a.numel()
+            buf = _alloc_output_buf(numel, float32_dtype)
+            d = _get_dispatcher()
+            sfx = _kernel_suffix(float32_dtype)
+            d.dispatch_fill(f"fill_{sfx}", buf, 1.0, numel,
+                            _itemsize(float32_dtype))
+            from ...._tensor import _compute_strides
+            ones_t = _from_metal_buffer(buf, tuple(a.shape),
+                                        _compute_strides(tuple(a.shape)),
+                                        float32_dtype, a.device)
         count_f = where(mask, ones_t, 0.0)
         s = sum_(count_f, dim=dim, keepdim=keepdim)
-        # Convert to int64 via numpy (small result after reduction)
+        # NOTE: int64 cast via numpy — result is already reduced, negligible overhead
         s_np = _to_numpy(s).astype(np.int64)
         return _from_numpy(np.ascontiguousarray(s_np), int64_dtype, a.device)
-    # Non-contiguous or unsupported dtype: make contiguous and retry
+    # Non-contiguous: make contiguous and retry
     if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype, int32_dtype, int64_dtype):
         return count_nonzero(a.contiguous(), dim=dim, keepdim=keepdim)
     _unsupported_dtype("count_nonzero", a)
@@ -392,65 +399,57 @@ def cumprod(a, dim=0):
         return cumprod(a.contiguous(), dim=dim)
     _unsupported_dtype("cumprod", a)
 
-def cummax(a, dim=0):
-    arr = _to_numpy(a)
+def _cumextreme_gpu(a, dim, mode):
+    """GPU cummax/cummin helper. mode is 'cummax' or 'cummin'."""
+    ndim = len(a.shape)
     if dim < 0:
-        dim += arr.ndim
-    moved = np.moveaxis(arr, dim, 0)
-    values = np.empty_like(moved)
-    indices = np.empty(moved.shape, dtype=np.int64)
-    max_vals = moved[0].copy()
-    values[0] = max_vals
-    indices[0] = 0
-    for i in range(1, moved.shape[0]):
-        mask = moved[i] > max_vals
-        max_vals = np.where(mask, moved[i], max_vals)
-        values[i] = max_vals
-        indices[i] = np.where(mask, i, indices[i - 1])
-    values = np.ascontiguousarray(np.moveaxis(values, 0, dim))
-    indices = np.ascontiguousarray(np.moveaxis(indices, 0, dim))
-    return (
-        _from_numpy(values, a.dtype, a.device),
-        _from_numpy(indices, int64_dtype, a.device),
-    )
+        dim = ndim + dim
+    outer_size = 1
+    for i in range(dim):
+        outer_size *= a.shape[i]
+    dim_size = a.shape[dim]
+    inner_size = 1
+    for i in range(dim + 1, ndim):
+        inner_size *= a.shape[i]
+    sfx = _kernel_suffix(a.dtype)
+    d = _get_dispatcher()
+    numel = outer_size * dim_size * inner_size
+    values_buf = _alloc_output_buf(numel, a.dtype)
+    indices_buf = _alloc_output_buf(numel, int32_dtype)
+    dispatch = d.dispatch_cummax if mode == "cummax" else d.dispatch_cummin
+    dispatch(f"{mode}_{sfx}", _metal_buf(a), values_buf, indices_buf,
+             outer_size, dim_size, inner_size)
+    from ...._tensor import _compute_strides
+    out_shape = tuple(a.shape)
+    out_stride = _compute_strides(out_shape)
+    values = _from_metal_buffer(values_buf, out_shape, out_stride, a.dtype, a.device)
+    # Convert int32 indices to int64
+    idx_np = np.frombuffer(
+        _metal_buf_to_bytes(indices_buf, numel * 4),
+        dtype=np.int32).astype(np.int64).reshape(a.shape)
+    indices = _from_numpy(idx_np, int64_dtype, a.device)
+    return values, indices
+
+
+def cummax(a, dim=0):
+    if (_can_use_gpu(a) and a.is_contiguous()
+            and a.dtype in (float32_dtype, float16_dtype)):
+        return _cumextreme_gpu(a, dim, "cummax")
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
+        return cummax(a.contiguous(), dim=dim)
+    _unsupported_dtype("cummax", a)
 
 def cummin(a, dim):
     """Cumulative minimum along a dimension, returns (values, indices) namedtuple."""
-    arr = _to_numpy(a)
-    ndim = arr.ndim
-    if dim < 0:
-        dim = dim + ndim
-
-    values = np.minimum.accumulate(arr, axis=dim)
-
-    # Compute indices: for each position i along dim, index is where min first occurred
-    n = arr.shape[dim]
-    indices = np.zeros_like(arr, dtype=np.int64)
-
-    # Iterate over the dimension to compute the argmin up to each point
-    idx_shape = list(arr.shape)
-    idx_shape[dim] = 1
-    running_min = np.take(arr, [0], axis=dim)
-    running_idx = np.zeros(idx_shape, dtype=np.int64)
-
-    slc_base = [slice(None)] * ndim
-    for i in range(n):
-        slc = slc_base[:]
-        slc[dim] = slice(i, i + 1)
-        current = arr[tuple(slc)]
-        new_min_mask = current < running_min
-        running_idx = np.where(new_min_mask, i, running_idx)
-        running_min = np.minimum(running_min, current)
-        indices_slc = slc_base[:]
-        indices_slc[dim] = i
-        indices[tuple(indices_slc)] = running_idx.squeeze(axis=dim)
-
-    from collections import namedtuple
-    CumminResult = namedtuple("cummin", ["values", "indices"])
-    return CumminResult(
-        _from_numpy(np.ascontiguousarray(values), a.dtype, a.device),
-        _from_numpy(np.ascontiguousarray(indices), int64_dtype, a.device),
-    )
+    if (_can_use_gpu(a) and a.is_contiguous()
+            and a.dtype in (float32_dtype, float16_dtype)):
+        from collections import namedtuple
+        CumminResult = namedtuple("cummin", ["values", "indices"])
+        vals, idxs = _cumextreme_gpu(a, dim, "cummin")
+        return CumminResult(vals, idxs)
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
+        return cummin(a.contiguous(), dim=dim)
+    _unsupported_dtype("cummin", a)
 
 
 # ---------------------------------------------------------------------------
@@ -703,13 +702,46 @@ def aminmax(a, dim=None, keepdim=False):
 
 def quantile(a, q, dim=None, keepdim=False):
     """Compute the q-th quantile of the input tensor."""
-    arr = _to_numpy(a).astype(np.float64)
-    q_val = _to_numpy(q) if hasattr(q, '_numpy_view') else np.asarray(q, dtype=np.float64)
-    if dim is None:
-        out = np.quantile(arr, q_val)
-    else:
-        out = np.quantile(arr, q_val, axis=dim, keepdims=keepdim)
-    return _from_numpy(np.ascontiguousarray(out.astype(to_numpy_dtype(a.dtype))), a.dtype, a.device)
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
+        from ...common.view import reshape, squeeze
+        # Extract scalar q value
+        if isinstance(q, Tensor):
+            q_val = _scalar_value(q)
+        else:
+            q_val = float(q)
+        if dim is None:
+            flat = reshape(a.contiguous(), (-1,))
+            sorted_vals, _ = sort(flat, dim=0)
+            n = flat.shape[0]
+            idx_f = q_val * (n - 1)
+            lo = int(idx_f)
+            hi = min(lo + 1, n - 1)
+            frac = idx_f - lo
+            v_lo = sorted_vals[(slice(lo, lo + 1),)]
+            v_hi = sorted_vals[(slice(hi, hi + 1),)]
+            result = add(v_lo, mul(sub(v_hi, v_lo), frac))
+            return squeeze(result, 0)
+        else:
+            ndim = len(a.shape)
+            if dim < 0:
+                dim = dim + ndim
+            sorted_vals, _ = sort(a.contiguous(), dim=dim)
+            n = a.shape[dim]
+            idx_f = q_val * (n - 1)
+            lo = int(idx_f)
+            hi = min(lo + 1, n - 1)
+            frac = idx_f - lo
+            slices_lo = [slice(None)] * ndim
+            slices_lo[dim] = slice(lo, lo + 1)
+            slices_hi = [slice(None)] * ndim
+            slices_hi[dim] = slice(hi, hi + 1)
+            v_lo = sorted_vals[tuple(slices_lo)]
+            v_hi = sorted_vals[tuple(slices_hi)]
+            result = add(v_lo, mul(sub(v_hi, v_lo), frac))
+            if not keepdim:
+                result = squeeze(result, dim)
+            return result
+    _unsupported_dtype("quantile", a)
 
 def nanquantile(a, q, dim=None, keepdim=False):
     """Compute the q-th quantile ignoring NaN values."""
@@ -751,25 +783,30 @@ def nanmedian(a, dim=None, keepdim=False):
         )
 
 def median(a, dim=None, keepdim=False):
-    arr = _to_numpy(a)
-    if dim is None:
-        out = np.median(arr.flatten())
-        return _from_numpy(np.array(out, dtype=arr.dtype), a.dtype, a.device)
-    else:
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
+        from ...common.view import reshape, squeeze
+        if dim is None:
+            flat = reshape(a.contiguous(), (-1,))
+            sorted_vals, sorted_idx = sort(flat, dim=0)
+            n = flat.shape[0]
+            mid = n // 2
+            val = sorted_vals[(slice(mid, mid + 1),)]
+            return squeeze(val, 0)
+        ndim = len(a.shape)
         if dim < 0:
-            dim = dim + arr.ndim
-        sorted_idx = np.argsort(arr, axis=dim)
-        n = arr.shape[dim]
+            dim = dim + ndim
+        sorted_vals, sorted_idx = sort(a.contiguous(), dim=dim)
+        n = a.shape[dim]
         mid = n // 2
-        med_idx = np.take(sorted_idx, [mid], axis=dim)
-        values = np.take_along_axis(arr, med_idx, axis=dim)
+        slices = [slice(None)] * ndim
+        slices[dim] = slice(mid, mid + 1)
+        values = sorted_vals[tuple(slices)]
+        indices = sorted_idx[tuple(slices)]
         if not keepdim:
-            values = np.squeeze(values, axis=dim)
-            med_idx = np.squeeze(med_idx, axis=dim)
-        return (
-            _from_numpy(np.ascontiguousarray(values), a.dtype, a.device),
-            _from_numpy(np.ascontiguousarray(med_idx.astype(np.int64)), int64_dtype, a.device),
-        )
+            values = squeeze(values, dim)
+            indices = squeeze(indices, dim)
+        return (values, indices)
+    _unsupported_dtype("median", a)
 
 
 # ---------------------------------------------------------------------------
@@ -777,19 +814,21 @@ def median(a, dim=None, keepdim=False):
 # ---------------------------------------------------------------------------
 
 def kthvalue(a, k, dim=-1, keepdim=False):
-    arr = _to_numpy(a)
-    if dim < 0:
-        dim = dim + arr.ndim
-    sorted_idx = np.argsort(arr, axis=dim)
-    kth_idx = np.take(sorted_idx, [k - 1], axis=dim)
-    values = np.take_along_axis(arr, kth_idx, axis=dim)
-    if not keepdim:
-        values = np.squeeze(values, axis=dim)
-        kth_idx = np.squeeze(kth_idx, axis=dim)
-    return (
-        _from_numpy(np.ascontiguousarray(values), a.dtype, a.device),
-        _from_numpy(np.ascontiguousarray(kth_idx.astype(np.int64)), int64_dtype, a.device),
-    )
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
+        from ...common.view import squeeze
+        ndim = len(a.shape)
+        if dim < 0:
+            dim = dim + ndim
+        sorted_vals, sorted_idx = sort(a.contiguous(), dim=dim)
+        slices = [slice(None)] * ndim
+        slices[dim] = slice(k - 1, k)
+        values = sorted_vals[tuple(slices)]
+        indices = sorted_idx[tuple(slices)]
+        if not keepdim:
+            values = squeeze(values, dim)
+            indices = squeeze(indices, dim)
+        return (values, indices)
+    _unsupported_dtype("kthvalue", a)
 
 def unique(a, sorted=True, return_inverse=False, return_counts=False, dim=None):
     arr = _to_numpy(a)


### PR DESCRIPTION
## Summary

- **Tier 1 — GPU composites** (no new shaders): `count_nonzero` (GPU fill for int types), `median` (sort + slice), `kthvalue` (sort + slice), `quantile` (sort + linear interpolation)
- **Tier 2 — new Metal shaders**: `cummax`/`cummin` sequential scan kernels with `(outer, dim, inner)` layout, dispatch helpers for both pyobjc and ctypes paths
- Fix CLAUDE.md pylint rcfile path (`pyproject.toml` → `.github/pylint.conf`)

## Test plan

- [x] `pylint src/candle/ --rcfile=.github/pylint.conf` — 10/10
- [x] `pytest tests/mps/` — 361 passed
- [x] Smoke test: cummax, cummin, median, kthvalue, quantile, count_nonzero all produce correct results on MPS GPU

🤖 Generated with [Claude Code](https://claude.com/claude-code)