### PR TITLE
fix(mps): eliminate remaining numpy fallbacks via GPU composites

### DIFF
--- a/src/candle/_backends/mps/ops/_helpers.py
+++ b/src/candle/_backends/mps/ops/_helpers.py
@@ -95,6 +95,19 @@ def _metal_buf_to_bytes(metal_buf, nbytes):
     return bytes((ctypes.c_char * nbytes).from_address(ptr))
 
 
+def _read_scalar(t):
+    """Read a single scalar from a GPU tensor without numpy.
+
+    Uses buffer_contents + struct.unpack to extract the value directly
+    from the Metal buffer.
+    """
+    from ..runtime import buffer_contents
+    nbytes = _itemsize(t.dtype)
+    ptr = buffer_contents(_metal_buf(t))
+    raw = bytes((ctypes.c_char * nbytes).from_address(ptr))
+    return struct.unpack(_scalar_fmt(t.dtype), raw)[0]
+
+
 def _from_metal_buffer(metal_buf, shape, stride, dtype, device):
     """Wrap an existing Metal buffer into a Tensor without copying data."""
     from ..runtime import buffer_contents
@@ -183,7 +196,7 @@ def _dispatch_binary_gpu(a, b, kernel_base):
                 out_buf, numel, list(a.shape), list(a.stride),
                 list(b.stride), len(a.shape))
     else:
-        raw = float(b) if not isinstance(b, Tensor) else float(_to_numpy(b).ravel()[0])
+        raw = float(b) if not isinstance(b, Tensor) else _read_scalar(b)
         scalar = _scalar_value(raw, a.dtype)
         if a.is_contiguous():
             d.dispatch_binary_scalar(f"{kernel_base}_scalar_{sfx}",

--- a/src/candle/_backends/mps/ops/activation.py
+++ b/src/candle/_backends/mps/ops/activation.py
@@ -264,6 +264,21 @@ def softshrink(a, lambd=0.5):
     _unsupported_dtype("softshrink", a)
 
 def rrelu(a, lower=1.0 / 8, upper=1.0 / 3, training=False):
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
+        from ._helpers import _empty_like
+        from .random import uniform_, fill_
+        from .comparison import ge
+        a_c = a.contiguous() if not a.is_contiguous() else a
+        slope = _empty_like(a_c)
+        if training:
+            uniform_(slope, lower, upper)
+        else:
+            fill_(slope, (lower + upper) / 2.0)
+        mask = ge(a_c, 0)
+        neg = mul(a_c, slope)
+        result = where(mask, a_c, neg)
+        result._rrelu_slope = slope
+        return result
     arr = _to_numpy(a)
     if training:
         slope = np.random.uniform(lower, upper, size=arr.shape).astype(arr.dtype)

--- a/src/candle/_backends/mps/ops/comparison.py
+++ b/src/candle/_backends/mps/ops/comparison.py
@@ -9,7 +9,7 @@ from ._helpers import (
     _alloc_output_buf, _metal_buf_to_bytes, _from_metal_buffer,
     _get_dispatcher, _dispatch_unary_gpu, _dispatch_unary_predicate_gpu,
     _scalar_value, _dispatch_binary_gpu,
-    _to_numpy, _from_numpy,
+    _to_numpy, _from_numpy, _read_scalar,
     _compute_reduce_dims, _reduce_shape, _gpu_reduce_single_dim,
     _normalize_tensor_sequence_args,
     _can_use_blas, _blas_gemm,
@@ -59,8 +59,8 @@ def eq(a, b):
         if isinstance(b, Tensor) and _can_use_gpu(b) and a.shape == b.shape and a.is_contiguous() and b.is_contiguous():
             d.dispatch_comparison(f"eq_{sfx}", _metal_buf(a), _metal_buf(b),
                                   out_buf, numel)
-        elif not isinstance(b, Tensor) or not _can_use_gpu(b):
-            scalar = _scalar_value(float(b) if not isinstance(b, Tensor) else float(_to_numpy(b).ravel()[0]), a.dtype)
+        elif not isinstance(b, Tensor) or not _can_use_gpu(b) or a.shape != b.shape:
+            scalar = _scalar_value(float(b) if not isinstance(b, Tensor) else _read_scalar(b), a.dtype)
             if a.is_contiguous():
                 d.dispatch_comparison_scalar(f"eq_scalar_{sfx}", _metal_buf(a),
                                              scalar, out_buf, numel,
@@ -84,8 +84,8 @@ def ne(a, b):
         if isinstance(b, Tensor) and _can_use_gpu(b) and a.shape == b.shape and a.is_contiguous() and b.is_contiguous():
             d.dispatch_comparison(f"ne_{sfx}", _metal_buf(a), _metal_buf(b),
                                   out_buf, numel)
-        elif not isinstance(b, Tensor) or not _can_use_gpu(b):
-            scalar = _scalar_value(float(b) if not isinstance(b, Tensor) else float(_to_numpy(b).ravel()[0]), a.dtype)
+        elif not isinstance(b, Tensor) or not _can_use_gpu(b) or a.shape != b.shape:
+            scalar = _scalar_value(float(b) if not isinstance(b, Tensor) else _read_scalar(b), a.dtype)
             if a.is_contiguous():
                 d.dispatch_comparison_scalar(f"ne_scalar_{sfx}", _metal_buf(a),
                                              scalar, out_buf, numel,
@@ -109,8 +109,8 @@ def lt(a, b):
         if isinstance(b, Tensor) and _can_use_gpu(b) and a.shape == b.shape and a.is_contiguous() and b.is_contiguous():
             d.dispatch_comparison(f"lt_{sfx}", _metal_buf(a), _metal_buf(b),
                                   out_buf, numel)
-        elif not isinstance(b, Tensor) or not _can_use_gpu(b):
-            scalar = float(b) if not isinstance(b, Tensor) else float(_to_numpy(b).ravel()[0])
+        elif not isinstance(b, Tensor) or not _can_use_gpu(b) or a.shape != b.shape:
+            scalar = float(b) if not isinstance(b, Tensor) else _read_scalar(b)
             if a.is_contiguous():
                 d.dispatch_comparison_scalar(f"lt_scalar_{sfx}", _metal_buf(a),
                                              scalar, out_buf, numel,
@@ -134,8 +134,8 @@ def le(a, b):
         if isinstance(b, Tensor) and _can_use_gpu(b) and a.shape == b.shape and a.is_contiguous() and b.is_contiguous():
             d.dispatch_comparison(f"le_{sfx}", _metal_buf(a), _metal_buf(b),
                                   out_buf, numel)
-        elif not isinstance(b, Tensor) or not _can_use_gpu(b):
-            scalar = float(b) if not isinstance(b, Tensor) else float(_to_numpy(b).ravel()[0])
+        elif not isinstance(b, Tensor) or not _can_use_gpu(b) or a.shape != b.shape:
+            scalar = float(b) if not isinstance(b, Tensor) else _read_scalar(b)
             if a.is_contiguous():
                 d.dispatch_comparison_scalar(f"le_scalar_{sfx}", _metal_buf(a),
                                              scalar, out_buf, numel,
@@ -159,8 +159,8 @@ def gt(a, b):
         if isinstance(b, Tensor) and _can_use_gpu(b) and a.shape == b.shape and a.is_contiguous() and b.is_contiguous():
             d.dispatch_comparison(f"gt_{sfx}", _metal_buf(a), _metal_buf(b),
                                   out_buf, numel)
-        elif not isinstance(b, Tensor) or not _can_use_gpu(b):
-            scalar = float(b) if not isinstance(b, Tensor) else float(_to_numpy(b).ravel()[0])
+        elif not isinstance(b, Tensor) or not _can_use_gpu(b) or a.shape != b.shape:
+            scalar = float(b) if not isinstance(b, Tensor) else _read_scalar(b)
             if a.is_contiguous():
                 d.dispatch_comparison_scalar(f"gt_scalar_{sfx}", _metal_buf(a),
                                              scalar, out_buf, numel,
@@ -184,8 +184,8 @@ def ge(a, b):
         if isinstance(b, Tensor) and _can_use_gpu(b) and a.shape == b.shape and a.is_contiguous() and b.is_contiguous():
             d.dispatch_comparison(f"ge_{sfx}", _metal_buf(a), _metal_buf(b),
                                   out_buf, numel)
-        elif not isinstance(b, Tensor) or not _can_use_gpu(b):
-            scalar = float(b) if not isinstance(b, Tensor) else float(_to_numpy(b).ravel()[0])
+        elif not isinstance(b, Tensor) or not _can_use_gpu(b) or a.shape != b.shape:
+            scalar = float(b) if not isinstance(b, Tensor) else _read_scalar(b)
             if a.is_contiguous():
                 d.dispatch_comparison_scalar(f"ge_scalar_{sfx}", _metal_buf(a),
                                              scalar, out_buf, numel,

--- a/src/candle/_backends/mps/ops/elementwise.py
+++ b/src/candle/_backends/mps/ops/elementwise.py
@@ -164,8 +164,29 @@ def heaviside(a, values):
 
 def diff(a, n=1, dim=-1, prepend=None, append=None):
     """Compute the n-th discrete difference along the given dim."""
-    # NOTE: GPU composite blocked by _metal_buf not handling storage offsets;
-    # narrow views share the underlying buffer so sub() reads wrong data.
+    if _can_use_gpu(a):
+        from .shape import narrow, cat
+        ndim = len(a.shape)
+        d = dim if dim >= 0 else dim + ndim
+        # Handle prepend/append by concatenating on-device
+        src = a
+        if prepend is not None or append is not None:
+            pieces = []
+            if prepend is not None:
+                pieces.append(prepend)
+            pieces.append(src)
+            if append is not None:
+                pieces.append(append)
+            src = cat(pieces, dim=d)
+        # Iterate n times: diff = src[1:] - src[:-1] along dim
+        for _ in range(n):
+            size = src.shape[d]
+            # .contiguous() on narrow views creates separate GPU buffers,
+            # avoiding aliased _metal_buf issues with sub()
+            head = narrow(src, d, 1, size - 1).contiguous()
+            tail = narrow(src, d, 0, size - 1).contiguous()
+            src = sub(head, tail)
+        return src
     arr = _to_numpy(a)
     if prepend is not None or append is not None:
         pieces = []
@@ -220,6 +241,16 @@ def bucketize(a, boundaries, out_int32=False, right=False):
 
 def isin(elements, test_elements):
     """Tests if each element is in test_elements."""
+    if _can_use_gpu(elements):
+        from .comparison import eq, logical_or
+        from ._helpers import _read_scalar
+        # Iterate over test_elements, accumulate eq() with logical_or()
+        te_flat = test_elements.contiguous().reshape((-1,))
+        n_test = te_flat.numel()
+        result = eq(elements, _read_scalar(te_flat[0]) if n_test > 0 else 0)
+        for i in range(1, n_test):
+            result = logical_or(result, eq(elements, _read_scalar(te_flat[i])))
+        return result
     e = _to_numpy(elements)
     te = _to_numpy(test_elements)
     out = np.isin(e, te)
@@ -227,6 +258,12 @@ def isin(elements, test_elements):
 
 def uniform(a):
     """Return tensor of same shape filled with Uniform(0,1) samples."""
+    from ._helpers import _empty_like
+    if _can_use_gpu(a) and a.dtype in (float32_dtype, float16_dtype):
+        from .random import uniform_
+        out = _empty_like(a)
+        uniform_(out, 0.0, 1.0)
+        return out
     from ...._random import _get_cpu_rng
     rng = _get_cpu_rng()
     arr = rng.uniform(0.0, 1.0, _to_numpy(a).shape).astype(_to_numpy(a).dtype)

--- a/src/candle/_backends/mps/ops/random.py
+++ b/src/candle/_backends/mps/ops/random.py
@@ -219,6 +219,15 @@ def fill_(a, value):
     return a
 
 def clamp_(a, min_val=None, max_val=None):
+    if _can_use_gpu(a):
+        from .activation import clamp
+        clamped = clamp(a, min_val, max_val)
+        # Copy result back into a's buffer using identity kernel
+        d = _get_dispatcher()
+        sfx = _kernel_suffix(a.dtype)
+        d.dispatch_unary(f"identity_{sfx}", _metal_buf(clamped),
+                         _metal_buf(a), a.numel())
+        return a
     arr = _to_numpy(a)
     np.clip(arr, min_val, max_val, out=arr)
     return a
@@ -228,7 +237,8 @@ def copy_(a, src):
         d = _get_dispatcher()
         sfx = _kernel_suffix(a.dtype)
         numel = min(a.numel(), src.numel())
-        d.dispatch_copy(f"copy_{sfx}", _metal_buf(src), _metal_buf(a), numel)
+        # Use identity kernel (unary copy) — dispatch_copy has a bug
+        d.dispatch_unary(f"identity_{sfx}", _metal_buf(src), _metal_buf(a), numel)
         return a
     arr = _to_numpy(a)
     src_arr = _to_numpy(src)

--- a/src/candle/_backends/mps/ops/shape.py
+++ b/src/candle/_backends/mps/ops/shape.py
@@ -60,6 +60,12 @@ def flip(a, dims):
     return _from_numpy(np.ascontiguousarray(out), a.dtype, a.device)
 
 def roll(a, shifts, dims=None):
+    # GPU path for dims=None: flatten → roll(flat, shifts, 0) → reshape
+    if _can_use_gpu(a) and dims is None:
+        orig_shape = tuple(a.shape)
+        flat = flatten(a)
+        rolled = roll(flat, shifts, dims=0)
+        return rolled.reshape(orig_shape)
     if (_can_use_gpu(a) and a.is_contiguous()
             and a.dtype in (float32_dtype, float16_dtype, int32_dtype, int64_dtype)
             and len(a.shape) <= 8 and dims is not None):


### PR DESCRIPTION
## Summary

- Eliminate ~8 MPS functions that incorrectly fell through to numpy for GPU tensors, replacing them with native GPU paths using existing Metal kernels
- Add `_read_scalar()` helper to extract scalars from GPU buffers via `struct.unpack` (no numpy)
- Fix `copy_()` GPU path to use `dispatch_unary(identity)` instead of broken `dispatch_copy`
- Fix comparison ops' shape-mismatch routing that caused infinite recursion with scalar tensors

### Ops fixed
| Op | Approach |
|----|----------|
| `eq/ne/lt/le/gt/ge` (scalar tensor) | `_read_scalar()` + fix shape-mismatch routing |
| `roll(dims=None)` | flatten → roll(flat, shifts, 0) → reshape |
| `clamp_()` | `activation.clamp()` + identity copy |
| `copy_()` | `dispatch_unary(identity)` instead of broken `dispatch_copy` |
| `uniform()` | `_empty_like` + Philox `uniform_()` |
| `diff()` | `narrow().contiguous()` + `sub()` loop |
| `isin()` | `eq()` + `logical_or()` accumulation |
| `rrelu()` | `uniform_()/fill_()` + `where()` |

## Test plan
- [x] Pylint passes (10.00/10)
- [x] All 361 MPS tests pass
- [x] All 1647 CPU/contract tests pass (28 skipped)
- [x] Smoke test verifies each fixed op on MPS device

🤖 Generated with [Claude Code](https://claude.com/claude-code)