### PR TITLE
fix: autograd grad accumulation and randint size overload

### DIFF
--- a/src/candle/_creation.py
+++ b/src/candle/_creation.py
@@ -121,6 +121,9 @@ def rand(*shape, dtype=None, device=None, memory_format=None, generator=None, re
 
 
 def randint(low, high=None, size=None, *, dtype=None, device=None, generator=None):
+    if size is None and isinstance(high, (tuple, list)):
+        size = high
+        high = None
     return randint_dispatch(low, high=high, size=size, dtype=dtype, device=device, generator=generator)
 
 

--- a/src/candle/autograd/engine.py
+++ b/src/candle/autograd/engine.py
@@ -118,13 +118,11 @@ class _GraphTask:
         return grad
 
     def _accumulate_node_grad(self, node, grad):
-        existing = self.node_grads.get(node)
-        if existing is None:
-            self.node_grads[node] = grad
-        else:
-            from .._functional import add
-            with self._grad_accum_context():
-                self.node_grads[node] = add(existing, grad)
+        bucket = self.node_grads.get(node)
+        if bucket is None:
+            bucket = []
+            self.node_grads[node] = bucket
+        bucket.append(grad)
         self.received[node] = self.received.get(node, 0) + 1
         if self.received[node] >= self.dependencies.get(node, 0):
             self.ready.append(node)
@@ -132,9 +130,15 @@ class _GraphTask:
     def run(self):
         while self.ready:
             node = self.ready.popleft()
-            grad = self.node_grads.pop(node, None)
-            if grad is None:
+            grads = self.node_grads.pop(node, None)
+            if not grads:
                 continue
+            grad = grads[0]
+            if len(grads) > 1:
+                from .._functional import add
+                with self._grad_accum_context():
+                    for extra in grads[1:]:
+                        grad = add(grad, extra)
             try:
                 with evaluating_node(node):
                     grads = node.backward(grad)
@@ -143,10 +147,21 @@ class _GraphTask:
                 raise
             if grads is None:
                 grads = ()
+            elif not isinstance(grads, (tuple, list)):
+                grads = (grads,)
             _check_anomaly_nan(node, grads)
+            grad_counts = None
+            if grads:
+                from .._tensor import Tensor
+                grad_counts = {}
+                for g in grads:
+                    if isinstance(g, Tensor):
+                        grad_counts[id(g)] = grad_counts.get(id(g), 0) + 1
             for (t, g), (next_fn, _output_nr) in zip(zip(node.inputs, grads), node.next_functions):
                 if g is None:
                     continue
+                if grad_counts is not None and grad_counts.get(id(g), 0) > 1:
+                    g = g.clone()
                 should_visit = (
                     self.inputs is None or next_fn is not None or id(t) in self.input_ids
                 )

--- a/tests/contract/test_autograd_engine_topo.py
+++ b/tests/contract/test_autograd_engine_topo.py
@@ -11,6 +11,20 @@ def test_autograd_engine_accumulates_shared_subgraph():
     assert (a.grad.numpy() == 4).all()
 
 
+def test_autograd_engine_accumulates_reused_leaf():
+    x = torch.randn(5, 5, requires_grad=True)
+    y = (torch.rand(5, 5) + 0.1).requires_grad_(True)
+    z = torch.randn(5, 5, requires_grad=True)
+    grad_output = torch.randn(5, 5)
+
+    term3 = 4 * z**2 * x / y
+    (x + term3).backward(grad_output)
+
+    expected = (4 * z.pow(2) / y + 1) * grad_output
+    assert x.grad is not None
+    torch.testing.assert_close(x.grad, expected)
+
+
 def test_autograd_engine_reentrant_backward():
     # Backward inside backward hook should be supported.
     a = torch.ones((2, 2)).requires_grad_()

--- a/tests/contract/test_randint_overload.py
+++ b/tests/contract/test_randint_overload.py
@@ -1,0 +1,19 @@
+import candle as torch
+import torch as pt
+
+
+def _assert_shape_dtype(out, ref):
+    assert out.shape == ref.shape
+    assert str(out.dtype) == str(ref.dtype)
+
+
+def test_randint_high_size_tuple():
+    out = torch.randint(10, (3,))
+    ref = pt.randint(10, (3,))
+    _assert_shape_dtype(out, ref)
+
+
+def test_randint_high_size_list():
+    out = torch.randint(2, [3, 2])
+    ref = pt.randint(2, [3, 2])
+    _assert_shape_dtype(out, ref)


### PR DESCRIPTION
## Summary
- fix autograd grad accumulation to avoid in-place mutation of shared grad outputs
- normalize backward outputs to tuples and handle repeated grads safely
- support `torch.randint(high, size)` tuple/list overload
- add contract tests for autograd reused-leaf accumulation and randint overload

## Testing
- `pytest tests/contract/test_autograd_engine_topo.py::test_autograd_engine_accumulates_reused_leaf -v --tb=short`
- `pytest tests/contract/test_randint_overload.py -v --tb=short`
- `pytest tests/contract/ -v --tb=short`
- `pylint src/candle/ --rcfile=pyproject.toml` (fails in environment due to astroid/pylint crash: `visit_typealias`)
