### PR TITLE
fix: correct weight initialization for Embedding, RNN, and randint overload

### DIFF
--- a/src/candle/_creation.py
+++ b/src/candle/_creation.py
@@ -121,6 +121,9 @@ def rand(*shape, dtype=None, device=None, memory_format=None, generator=None, re
 
 
 def randint(low, high=None, size=None, *, dtype=None, device=None, generator=None):
+    if size is None and isinstance(high, (tuple, list)):
+        size = high
+        high = None
     return randint_dispatch(low, high=high, size=size, dtype=dtype, device=device, generator=generator)
 
 

--- a/src/candle/nn/modules/rnn.py
+++ b/src/candle/nn/modules/rnn.py
@@ -2,9 +2,10 @@ import math
 
 from ..module import Module
 from ..parameter import Parameter
-from ..._creation import zeros, randn
+from ..._creation import zeros, empty
 from ..._functional import stack, cat
 from .. import functional as F
+from .. import init
 
 
 def _rnn_cell_forward(input, hidden, weight_ih, weight_hh, bias_ih, bias_hh, nonlinearity='tanh'):
@@ -95,15 +96,21 @@ class RNNBase(Module):
                     gate_size *= 4
                 elif mode == 'GRU':
                     gate_size *= 3
-                w_ih = zeros(gate_size, layer_input_size)
-                w_hh = zeros(gate_size, hidden_size)
+                w_ih = empty(gate_size, layer_input_size)
+                w_hh = empty(gate_size, hidden_size)
                 setattr(self, f'weight_ih_l{layer}{suffix}', Parameter(w_ih))
                 setattr(self, f'weight_hh_l{layer}{suffix}', Parameter(w_hh))
                 if bias:
-                    b_ih = zeros(gate_size)
-                    b_hh = zeros(gate_size)
+                    b_ih = empty(gate_size)
+                    b_hh = empty(gate_size)
                     setattr(self, f'bias_ih_l{layer}{suffix}', Parameter(b_ih))
                     setattr(self, f'bias_hh_l{layer}{suffix}', Parameter(b_hh))
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        stdv = 1.0 / math.sqrt(self.hidden_size) if self.hidden_size > 0 else 0
+        for weight in self.parameters():
+            init.uniform_(weight, -stdv, stdv)
 
     def _get_weight(self, name):
         return getattr(self, name)
@@ -239,11 +246,11 @@ class RNNCellBase(Module):
         self.input_size = input_size
         self.hidden_size = hidden_size
         self.bias = bias
-        self.weight_ih = Parameter(zeros(num_chunks * hidden_size, input_size))
-        self.weight_hh = Parameter(zeros(num_chunks * hidden_size, hidden_size))
+        self.weight_ih = Parameter(empty(num_chunks * hidden_size, input_size))
+        self.weight_hh = Parameter(empty(num_chunks * hidden_size, hidden_size))
         if bias:
-            self.bias_ih = Parameter(zeros(num_chunks * hidden_size))
-            self.bias_hh = Parameter(zeros(num_chunks * hidden_size))
+            self.bias_ih = Parameter(empty(num_chunks * hidden_size))
+            self.bias_hh = Parameter(empty(num_chunks * hidden_size))
         else:
             self.register_parameter('bias_ih', None)
             self.register_parameter('bias_hh', None)
@@ -252,8 +259,7 @@ class RNNCellBase(Module):
     def reset_parameters(self):
         stdv = 1.0 / math.sqrt(self.hidden_size) if self.hidden_size > 0 else 0
         for weight in self.parameters():
-            new_data = randn(*weight.data.shape) * stdv
-            weight.data.copy_(new_data)
+            init.uniform_(weight, -stdv, stdv)
 
     def extra_repr(self):
         s = f'{self.input_size}, {self.hidden_size}'

--- a/src/candle/nn/modules/sparse.py
+++ b/src/candle/nn/modules/sparse.py
@@ -1,7 +1,8 @@
 from ..module import Module
 from ..parameter import Parameter
-from ..._creation import tensor
+from ..._creation import empty
 from .. import functional as F
+from .. import init
 
 
 class Embedding(Module):
@@ -19,9 +20,19 @@ class Embedding(Module):
         if _weight is not None:
             self.weight = Parameter(_weight) if not isinstance(_weight, Parameter) else _weight
         else:
-            self.weight = Parameter(tensor([[0.0] * embedding_dim for _ in range(num_embeddings)]))
+            self.weight = Parameter(empty(num_embeddings, embedding_dim))
+            self.reset_parameters()
         if _freeze:
             self.weight.requires_grad = False
+
+    def reset_parameters(self):
+        init.normal_(self.weight)
+        self._fill_padding_idx_with_zero()
+
+    def _fill_padding_idx_with_zero(self):
+        if self.padding_idx is not None:
+            from ..._creation import zeros
+            self.weight.data[self.padding_idx] = zeros(self.embedding_dim)
 
     def forward(self, input):
         return F.embedding(input, self.weight, self.padding_idx, self.max_norm,
@@ -54,7 +65,8 @@ class EmbeddingBag(Module):
         if _weight is not None:
             self.weight = Parameter(_weight)
         else:
-            self.weight = Parameter(tensor([[0.0] * embedding_dim for _ in range(num_embeddings)]))
+            self.weight = Parameter(empty(num_embeddings, embedding_dim))
+            init.normal_(self.weight)
 
     def forward(self, input, offsets=None, per_sample_weights=None):
         return F.embedding_bag(input, self.weight, offsets=offsets,

--- a/tests/cpu/test_module_init.py
+++ b/tests/cpu/test_module_init.py
@@ -1,0 +1,137 @@
+"""Tests for nn.Module weight initialization parity with PyTorch."""
+import numpy as np
+import candle as torch
+
+
+def test_embedding_init_not_zeros():
+    """Embedding weights should be initialized with normal_(0, 1), not zeros."""
+    emb = torch.nn.Embedding(100, 32)
+    w = emb.weight.detach().numpy()
+    assert not np.allclose(w, 0.0), "Embedding weights should not be all zeros"
+    assert np.abs(w).sum() > 0, "Embedding weights should have non-zero values"
+
+
+def test_embedding_init_distribution():
+    """Embedding weights should follow roughly N(0, 1)."""
+    torch.manual_seed(42)
+    emb = torch.nn.Embedding(10000, 64)
+    w = emb.weight.detach().numpy()
+    assert abs(w.mean()) < 0.05, f"Mean should be near 0, got {w.mean()}"
+    assert abs(w.std() - 1.0) < 0.1, f"Std should be near 1.0, got {w.std()}"
+
+
+def test_embedding_padding_idx_zero():
+    """Embedding with padding_idx should have zeros at that index."""
+    torch.manual_seed(42)
+    emb = torch.nn.Embedding(100, 32, padding_idx=0)
+    w = emb.weight.detach().numpy()
+    np.testing.assert_allclose(w[0], 0.0)
+    assert not np.allclose(w[1], 0.0), "Non-padding rows should be non-zero"
+
+
+def test_embedding_from_pretrained_skips_init():
+    """from_pretrained should use provided weights, not re-initialize."""
+    data = torch.randn(10, 8)
+    emb = torch.nn.Embedding.from_pretrained(data)
+    np.testing.assert_allclose(emb.weight.detach().numpy(), data.detach().numpy())
+
+
+def test_embedding_bag_init_not_zeros():
+    """EmbeddingBag weights should be initialized with normal_(0, 1)."""
+    emb = torch.nn.EmbeddingBag(100, 32)
+    w = emb.weight.detach().numpy()
+    assert not np.allclose(w, 0.0), "EmbeddingBag weights should not be all zeros"
+
+
+def test_embedding_init_vs_torch():
+    """Verify Embedding init distribution matches PyTorch's."""
+    import torch as real_torch
+    torch.manual_seed(42)
+    real_torch.manual_seed(42)
+    emb_c = torch.nn.Embedding(1000, 64)
+    emb_t = real_torch.nn.Embedding(1000, 64)
+    w_c = emb_c.weight.detach().numpy()
+    w_t = emb_t.weight.detach().numpy()
+    # Distribution should be similar (both N(0,1))
+    assert abs(w_c.mean() - w_t.mean()) < 0.15
+    assert abs(w_c.std() - w_t.std()) < 0.15
+
+
+def test_lstm_init_not_zeros():
+    """LSTM weights should be initialized with uniform_(-stdv, stdv)."""
+    lstm = torch.nn.LSTM(input_size=32, hidden_size=64, num_layers=1)
+    w_ih = lstm.weight_ih_l0.detach().numpy()
+    w_hh = lstm.weight_hh_l0.detach().numpy()
+    assert not np.allclose(w_ih, 0.0), "LSTM weight_ih should not be all zeros"
+    assert not np.allclose(w_hh, 0.0), "LSTM weight_hh should not be all zeros"
+
+
+def test_lstm_init_distribution():
+    """LSTM weights should follow uniform(-1/sqrt(H), 1/sqrt(H))."""
+    torch.manual_seed(42)
+    hidden_size = 64
+    lstm = torch.nn.LSTM(input_size=32, hidden_size=hidden_size)
+    stdv = 1.0 / np.sqrt(hidden_size)
+    w = lstm.weight_ih_l0.detach().numpy()
+    assert w.min() >= -stdv - 0.01, f"Min {w.min()} should be >= {-stdv}"
+    assert w.max() <= stdv + 0.01, f"Max {w.max()} should be <= {stdv}"
+
+
+def test_gru_init_not_zeros():
+    """GRU weights should be initialized, not zeros."""
+    gru = torch.nn.GRU(input_size=16, hidden_size=32)
+    w = gru.weight_ih_l0.detach().numpy()
+    assert not np.allclose(w, 0.0), "GRU weights should not be all zeros"
+
+
+def test_rnn_init_not_zeros():
+    """RNN weights should be initialized, not zeros."""
+    rnn = torch.nn.RNN(input_size=16, hidden_size=32)
+    w = rnn.weight_ih_l0.detach().numpy()
+    assert not np.allclose(w, 0.0), "RNN weights should not be all zeros"
+
+
+def test_rnn_init_vs_torch():
+    """RNNBase init distribution should match PyTorch's uniform range."""
+    import torch as real_torch
+    hidden_size = 64
+    torch.manual_seed(42)
+    real_torch.manual_seed(42)
+    lstm_c = torch.nn.LSTM(32, hidden_size)
+    lstm_t = real_torch.nn.LSTM(32, hidden_size)
+    stdv = 1.0 / np.sqrt(hidden_size)
+    w_c = lstm_c.weight_ih_l0.detach().numpy()
+    w_t = lstm_t.weight_ih_l0.detach().numpy()
+    # Both should be in [-stdv, stdv]
+    assert w_c.min() >= -stdv - 0.01
+    assert w_c.max() <= stdv + 0.01
+    assert w_t.min() >= -stdv - 0.01
+    assert w_t.max() <= stdv + 0.01
+
+
+def test_rnn_cell_init_not_zeros():
+    """RNNCell/LSTMCell/GRUCell should also be properly initialized."""
+    rnn_cell = torch.nn.RNNCell(16, 32)
+    lstm_cell = torch.nn.LSTMCell(16, 32)
+    gru_cell = torch.nn.GRUCell(16, 32)
+    assert not np.allclose(rnn_cell.weight_ih.detach().numpy(), 0.0)
+    assert not np.allclose(lstm_cell.weight_ih.detach().numpy(), 0.0)
+    assert not np.allclose(gru_cell.weight_ih.detach().numpy(), 0.0)
+
+
+def test_randint_overload():
+    """randint(low, (size,)) should work like randint(low, size=(size,))."""
+    torch.manual_seed(42)
+    a = torch.randint(10, (3, 4))
+    assert a.shape == (3, 4)
+    assert a.dtype == torch.int64
+    assert (a.numpy() >= 0).all()
+    assert (a.numpy() < 10).all()
+
+
+def test_randint_overload_with_high():
+    """randint(low, high, size) should still work."""
+    a = torch.randint(5, 10, (2, 3))
+    assert a.shape == (2, 3)
+    assert (a.numpy() >= 5).all()
+    assert (a.numpy() < 10).all()


### PR DESCRIPTION
## Summary

- **Embedding/EmbeddingBag**: initialize weights with `normal_(0, 1)` instead of zeros, matching PyTorch behavior. Add `reset_parameters()` and `_fill_padding_idx_with_zero()`
- **RNNBase (LSTM/GRU/RNN)**: initialize weights with `uniform_(-1/√H, 1/√H)` via `reset_parameters()`, replacing all-zeros that prevented training convergence
- **RNNCellBase**: use `init.uniform_()` instead of manual `randn * stdv` to match PyTorch's initialization
- **randint**: handle `torch.randint(low, (size,))` calling convention where `high` is omitted and `size` is passed as second positional arg

## Test plan

- [x] 14 new tests covering Embedding init distribution, padding_idx, from_pretrained, EmbeddingBag, LSTM/GRU/RNN/Cell init ranges, vs-torch parity, and randint overloads
- [x] Full CPU + contract suite: 1685 passed (14 new + 1671 existing), 2 pre-existing failures, 2 skipped
- [x] Pylint 10/10 with CI config

🤖 Generated with [Claude Code](https://claude.com/claude-code)