### PR TITLE
fix(mps): eliminate numpy fallbacks in linalg and shape ops via GPU composites

### DIFF
--- a/src/candle/_backends/mps/ops/linalg.py
+++ b/src/candle/_backends/mps/ops/linalg.py
@@ -18,7 +18,7 @@ from ._helpers import (
     mps_typed_storage_from_numpy, _MPSUntypedStorage, TypedStorage,
     _accel,
 )
-from .math import mul, add
+from .math import mul, add, abs as gpu_abs, sqrt as gpu_sqrt, pow as gpu_pow
 
 
 def matmul(a, b):
@@ -41,6 +41,17 @@ def matmul(a, b):
                     out_stride = _compute_strides(out_shape)
                     return _from_metal_buffer(out_buf, out_shape, out_stride,
                                              a.dtype, a.device)
+    # GPU path: 3D batched matmul — loop GPU 2D matmul per batch, then stack
+    if (_can_use_gpu(a) and _can_use_gpu(b)
+            and len(a.shape) == 3 and len(b.shape) == 3):
+        from .shape import stack as gpu_stack, select
+        batch = a.shape[0]
+        slices = []
+        for i in range(batch):
+            ai = select(a, 0, i)  # a[i] — 2D view
+            bi = select(b, 0, i)  # b[i] — 2D view
+            slices.append(matmul(ai, bi))
+        return gpu_stack(slices, dim=0)
     # CPU path (Accelerate BLAS or numpy)
     a_np = _to_numpy(a)
     b_np = _to_numpy(b)
@@ -71,6 +82,11 @@ def bmm(a, b):
 def dot(a, b):
     if a.dtype != b.dtype:
         raise RuntimeError("dot: expected both vectors to have same dtype")
+    # GPU composite: sum(mul(a, b))
+    if _can_use_gpu(a) and _can_use_gpu(b):
+        from .reduce import sum_
+        return sum_(mul(a, b))
+    # CPU path (Accelerate BLAS or numpy)
     a_np = np.ascontiguousarray(_to_numpy(a))
     b_np = np.ascontiguousarray(_to_numpy(b))
     if _can_use_blas(a_np) and _can_use_blas(b_np):
@@ -83,12 +99,22 @@ def dot(a, b):
     return _from_numpy(np.dot(a_np, b_np), a.dtype, a.device)
 
 def outer(a, b):
+    # GPU composite: matmul(a.reshape(-1,1), b.reshape(1,-1))
+    if _can_use_gpu(a) and _can_use_gpu(b):
+        return matmul(a.reshape(-1, 1), b.reshape(1, -1))
     return _from_numpy(np.outer(_to_numpy(a), _to_numpy(b)), a.dtype, a.device)
 
 def inner(a, b):
+    # GPU composite: for 1D tensors, same as dot
+    if _can_use_gpu(a) and _can_use_gpu(b) and len(a.shape) == 1 and len(b.shape) == 1:
+        return dot(a, b)
     return _from_numpy(np.inner(_to_numpy(a), _to_numpy(b)), a.dtype, a.device)
 
 def mv(a, b):
+    # GPU composite: matmul(a, b.reshape(-1,1)).reshape(-1)
+    if _can_use_gpu(a) and _can_use_gpu(b) and len(a.shape) == 2 and len(b.shape) == 1:
+        return matmul(a, b.reshape(-1, 1)).reshape(-1)
+    # CPU path (Accelerate BLAS or numpy)
     a_np = np.ascontiguousarray(_to_numpy(a))
     b_np = np.ascontiguousarray(_to_numpy(b))
     if a_np.ndim == 2 and b_np.ndim == 1 and _can_use_blas(a_np) and _can_use_blas(b_np):
@@ -115,6 +141,35 @@ def cross(a, b, dim=-1):
 def tensordot(a, b, dims=2):
     if a.dtype != b.dtype:
         raise RuntimeError("tensordot: expected both inputs to have same dtype")
+    # GPU composite for integer dims: reshape to 2D → matmul → reshape
+    if isinstance(dims, int) and _can_use_gpu(a) and _can_use_gpu(b):
+        ndim_a = len(a.shape)
+        ndim_b = len(b.shape)
+        # Contract last `dims` of a with first `dims` of b
+        a_free = a.shape[:ndim_a - dims]
+        a_contract = a.shape[ndim_a - dims:]
+        b_contract = b.shape[:dims]
+        b_free = b.shape[dims:]
+        if a_contract != b_contract:
+            raise RuntimeError("tensordot: contraction dimensions mismatch")
+        contract_size = 1
+        for s in a_contract:
+            contract_size *= s
+        a_rows = 1
+        for s in a_free:
+            a_rows *= s
+        b_cols = 1
+        for s in b_free:
+            b_cols *= s
+        a_2d = a.contiguous().reshape(a_rows, contract_size)
+        b_2d = b.contiguous().reshape(contract_size, b_cols)
+        result_2d = matmul(a_2d, b_2d)
+        out_shape = a_free + b_free
+        if not out_shape:
+            out_shape = (1,)
+            return result_2d.reshape(out_shape).squeeze(0)
+        return result_2d.reshape(out_shape)
+    # CPU/numpy fallback (also handles axis-list dims)
     a_np = _to_numpy(a)
     b_np = _to_numpy(b)
     if isinstance(dims, int):
@@ -217,6 +272,23 @@ def linalg_inv(a):
 
 def linalg_vector_norm(a, ord=2, dim=None, keepdim=False):
     """Vector norm."""
+    # GPU composite for common orders
+    if _can_use_gpu(a) and ord != 0:
+        from .reduce import sum_, amax, amin
+        abs_a = gpu_abs(a)
+        if ord == 2:
+            return gpu_sqrt(sum_(mul(a, a), dim=dim, keepdim=keepdim))
+        if ord == 1:
+            return sum_(abs_a, dim=dim, keepdim=keepdim)
+        if ord == float('inf'):
+            return amax(abs_a, dim=dim, keepdim=keepdim)
+        if ord == float('-inf'):
+            return amin(abs_a, dim=dim, keepdim=keepdim)
+        # General p-norm: pow(sum(pow(abs(a), p), dim), 1/p)
+        powered = gpu_pow(abs_a, ord)
+        summed = sum_(powered, dim=dim, keepdim=keepdim)
+        return gpu_pow(summed, 1.0 / ord)
+    # CPU/numpy fallback (also handles ord=0)
     arr = _to_numpy(a).astype(np.float64)
     if dim is not None:
         if isinstance(dim, (list, tuple)):

--- a/src/candle/_backends/mps/ops/shape.py
+++ b/src/candle/_backends/mps/ops/shape.py
@@ -155,6 +155,27 @@ def repeat(a, repeats):
     return _from_numpy(np.ascontiguousarray(out), a.dtype, a.device)
 
 def repeat_interleave(a, repeats, dim=None):
+    # GPU composite for integer repeats: unsqueeze → expand → reshape
+    if _can_use_gpu(a) and isinstance(repeats, int):
+        if dim is None:
+            # Flatten first, then repeat along dim=0
+            flat = flatten(a)
+            n = flat.shape[0]
+            # unsqueeze to (n, 1), expand to (n, repeats), reshape to (n*repeats,)
+            return expand(flat.unsqueeze(1), (n, repeats)).contiguous().reshape(-1)
+        d = dim if dim >= 0 else dim + len(a.shape)
+        shape = list(a.shape)
+        n = shape[d]
+        # Insert a new dim after d: unsqueeze at d+1
+        unsq = a.unsqueeze(d + 1)
+        # Expand that new dim to repeats
+        exp_shape = list(unsq.shape)
+        exp_shape[d + 1] = repeats
+        expanded = expand(unsq, tuple(exp_shape))
+        # Reshape: merge dims d and d+1
+        new_shape = shape[:d] + [n * repeats] + shape[d + 1:]
+        return expanded.contiguous().reshape(new_shape)
+    # CPU/numpy fallback (also handles tensor repeats)
     arr = _to_numpy(a)
     axis = None if dim is None else dim
     out = np.repeat(arr, repeats, axis=axis)
@@ -821,6 +842,21 @@ def masked_fill(a, mask, value):
     return _from_numpy(arr, a.dtype, a.device)
 
 def masked_fill_(a, mask, value):
+    # GPU path: use non-inplace masked_fill (has Metal kernel), then copy back
+    if (_can_use_gpu(a) and a.is_contiguous()
+            and isinstance(mask, Tensor) and _can_use_gpu(mask)):
+        # Broadcast mask to a's shape if needed
+        if mask.shape != a.shape:
+            mask = broadcast_to(mask, a.shape).contiguous()
+        result = masked_fill(a, mask, value)
+        # Copy result buffer back into a's storage via identity kernel
+        if result.numel() > 0:
+            d = _get_dispatcher()
+            sfx = _kernel_suffix(a.dtype)
+            d.dispatch_unary(f"identity_{sfx}", _metal_buf(result),
+                             _metal_buf(a), a.numel())
+        return a
+    # CPU/numpy fallback
     arr = _to_numpy(a)
     m = _to_numpy(mask).astype(bool)
     arr[m] = value
@@ -924,6 +960,33 @@ def masked_scatter_(a, mask, source):
     return a
 
 def unfold(a, dimension, size, step):
+    # GPU composite: narrow windows → stack
+    if _can_use_gpu(a):
+        ndim = len(a.shape)
+        d = dimension if dimension >= 0 else dimension + ndim
+        dim_size = a.shape[d]
+        n_windows = max(0, (dim_size - size) // step + 1)
+        if n_windows == 0:
+            new_shape = list(a.shape)
+            new_shape[d] = 0
+            new_shape.append(size)
+            return _from_numpy(np.empty(new_shape, dtype=to_numpy_dtype(a.dtype)),
+                               a.dtype, a.device)
+        windows = []
+        for i in range(n_windows):
+            # narrow along dim d: start=i*step, length=size
+            win = narrow(a, d, i * step, size)
+            # Move the window dim to the end: transpose d with last, but we
+            # need to keep other dims intact. Use movedim equivalent.
+            # Actually, we need to move dim d to the last position.
+            # permute: move d to end
+            perm = list(range(ndim))
+            perm.pop(d)
+            perm.append(d)
+            win = win.permute(*perm)
+            windows.append(win)
+        return stack(windows, dim=d)
+    # CPU/numpy fallback
     arr = _to_numpy(a)
     d = dimension if dimension >= 0 else dimension + arr.ndim
     dim_size = arr.shape[d]
@@ -1028,6 +1091,37 @@ def movedim(a, source, destination):
     return a.permute(*order)
 
 def diagonal(a, offset=0, dim1=0, dim2=1):
+    # GPU composite: select along dim1 and dim2 in loop, then stack
+    if _can_use_gpu(a):
+        ndim = len(a.shape)
+        d1 = dim1 if dim1 >= 0 else dim1 + ndim
+        d2 = dim2 if dim2 >= 0 else dim2 + ndim
+        size1 = a.shape[d1]
+        size2 = a.shape[d2]
+        if offset >= 0:
+            diag_len = max(0, min(size1, size2 - offset))
+        else:
+            diag_len = max(0, min(size1 + offset, size2))
+        if diag_len == 0:
+            # Empty diagonal
+            out_shape = [s for i, s in enumerate(a.shape) if i not in (d1, d2)] + [0]
+            return _from_numpy(np.empty(out_shape, dtype=to_numpy_dtype(a.dtype)),
+                               a.dtype, a.device)
+        elements = []
+        for i in range(diag_len):
+            row = i if offset >= 0 else i - offset
+            col = i + offset if offset >= 0 else i
+            # Select along the higher dim first to keep lower dim index valid
+            if d1 < d2:
+                t = select(a, d1, row)
+                t = select(t, d2 - 1, col)  # d2 shifts by -1 after removing d1
+            else:
+                t = select(a, d2, col)
+                t = select(t, d1 - 1, row)  # d1 shifts by -1 after removing d2
+            elements.append(t)
+        # Stack along last dim (PyTorch convention: diagonal goes to last dim)
+        return stack(elements, dim=-1)
+    # CPU/numpy fallback
     arr = _to_numpy(a)
     out = np.diagonal(arr, offset=offset, axis1=dim1, axis2=dim2)
     return _from_numpy(np.ascontiguousarray(out), a.dtype, a.device)


### PR DESCRIPTION
## Summary

- Replace unconditional numpy/CPU fallbacks with on-device GPU composites for 11 high-impact MPS ops across linalg and shape modules
- **Linalg ops**: `dot` (sum·mul), `outer` (matmul reshape), `inner` (→dot for 1D), `mv` (matmul reshape), `matmul` 3D batched (loop GPU 2D matmul + stack), `linalg_vector_norm` (ord=1/2/inf/-inf/p), `tensordot` integer dims (reshape→matmul→reshape)
- **Shape ops**: `repeat_interleave` (unsqueeze+expand+reshape), `unfold` (narrow+permute+stack), `diagonal` (select loop+stack), `masked_fill_` (delegate to GPU masked_fill + identity copy-back)
- All GPU paths fall back to existing numpy/BLAS paths for non-GPU tensors, ensuring no regressions

## Test plan

- [x] Pylint: 10.00/10
- [x] MPS tests: 361 passed
- [x] CPU + contract tests: 1664 passed, 28 skipped
- [x] Smoke test covering all 11 ops on MPS device

🤖 Generated with [Claude Code](https://claude.com/claude-code)