### PR TITLE
test: add E2E training tests; fix 4 source bugs they exposed

### DIFF
--- a/src/candle/_backends/cpu/optim_ops.py
+++ b/src/candle/_backends/cpu/optim_ops.py
@@ -17,7 +17,8 @@ def _to_numpy(t):
 
 def _write_back(t, arr):
     """Write numpy array back into a Tensor's storage."""
-    t.storage()._data[:] = arr
+    storage_data = t.storage()._data
+    storage_data[:] = np.asarray(arr).reshape(storage_data.shape)
 
 
 def _sgd_step(param, grad, buf, lr, momentum, dampening, weight_decay, nesterov, maximize):

--- a/src/candle/_creation.py
+++ b/src/candle/_creation.py
@@ -20,14 +20,22 @@ from ._functional import normal as normal_dispatch
 
 def _infer_creation_dtype(data):
     if isinstance(data, (np.ndarray, np.generic)):
-        return bool_dtype if data.dtype == np.bool_ else None
+        if data.dtype == np.bool_:
+            return bool_dtype
+        if np.issubdtype(data.dtype, np.integer):
+            return int64
+        return None
     if hasattr(data, "dtype"):
         return None
     try:
         arr = np.asarray(data)
     except Exception:
         return None
-    return bool_dtype if arr.dtype == np.bool_ else None
+    if arr.dtype == np.bool_:
+        return bool_dtype
+    if np.issubdtype(arr.dtype, np.integer):
+        return int64
+    return None
 
 
 def _get_default_dtype():

--- a/src/candle/nn/module.py
+++ b/src/candle/nn/module.py
@@ -17,6 +17,20 @@ class Module:
         self._next_hook_id = 0
         self.training = True
 
+    def __getattr__(self, name):
+        _parameters = self.__dict__.get('_parameters', {})
+        if name in _parameters:
+            return _parameters[name]
+        _buffers = self.__dict__.get('_buffers', {})
+        if name in _buffers:
+            return _buffers[name]
+        _modules = self.__dict__.get('_modules', {})
+        if name in _modules:
+            return _modules[name]
+        raise AttributeError(
+            f"'{type(self).__name__}' object has no attribute '{name}'"
+        )
+
     def __setattr__(self, name, value):
         if isinstance(value, Parameter):
             self._parameters[name] = value

--- a/src/candle/utils/checkpoint.py
+++ b/src/candle/utils/checkpoint.py
@@ -96,16 +96,14 @@ def checkpoint(function, *args, use_reentrant=True, preserve_rng_state=True, **k
             out_with_grad.append(r)
             grad_outputs.append(grad if len(recomputed) == 1 else None)
 
-        result = _run_backward(
+        _run_backward(
             tuple(out_with_grad), tuple(grad_outputs),
             retain_graph=False, create_graph=False,
-            accumulate_grad=False, inputs=detached,
+            accumulate_grad=True, inputs=None,
             allow_unused=True,
         )
-        # Map back to original tensor_inputs order
-        all_grads = [None] * len(tensor_inputs)
-        for i, g in enumerate(result):
-            all_grads[i] = g
+        # Retrieve grads from the detached input copies
+        all_grads = [d.grad for d in detached]
         return tuple(all_grads)
 
     def _recompute_saved_result():

--- a/tests/cpu/test_amp_e2e.py
+++ b/tests/cpu/test_amp_e2e.py
@@ -1,0 +1,136 @@
+"""End-to-end tests for mixed precision training (AMP).
+
+Tests the autocast context manager and GradScaler workflow on CPU.
+CPU autocast uses bfloat16 by default.
+"""
+import numpy as np
+import candle as torch
+import candle.nn as nn
+import candle.nn.functional as F
+from candle.amp import autocast, GradScaler
+
+
+def test_autocast_cpu_context_manager():
+    """autocast('cpu') should enter and exit without error."""
+    model = nn.Linear(8, 4)
+    x = torch.randn(2, 8)
+    with autocast("cpu"):
+        out = model(x)
+    assert out.shape == (2, 4)
+
+
+def test_autocast_cpu_dtype():
+    """CPU autocast should cast float32 inputs to bfloat16."""
+    x = torch.randn(2, 4)
+    assert x.dtype == torch.float32
+    with autocast("cpu"):
+        # Inside autocast, eligible ops should receive bfloat16 inputs
+        # The autocast state should be enabled
+        from candle.amp.state import is_autocast_enabled
+        assert is_autocast_enabled("cpu")
+    assert not is_autocast_enabled("cpu")
+
+
+def test_autocast_disabled():
+    """autocast with enabled=False should be a no-op."""
+    with autocast("cpu", enabled=False):
+        from candle.amp.state import is_autocast_enabled
+        assert not is_autocast_enabled("cpu")
+
+
+def test_autocast_nesting():
+    """Nested autocast should work correctly."""
+    from candle.amp.state import is_autocast_enabled
+    assert not is_autocast_enabled("cpu")
+    with autocast("cpu"):
+        assert is_autocast_enabled("cpu")
+        with autocast("cpu", enabled=False):
+            assert not is_autocast_enabled("cpu")
+        assert is_autocast_enabled("cpu")
+    assert not is_autocast_enabled("cpu")
+
+
+def test_autocast_as_decorator():
+    """autocast should work as a function decorator."""
+    @autocast("cpu")
+    def forward(x):
+        return x * 2
+
+    out = forward(torch.randn(2, 4))
+    assert out.shape == (2, 4)
+
+
+def test_grad_scaler_basic():
+    """GradScaler basic workflow: scale -> backward -> unscale -> step -> update."""
+    model = nn.Linear(4, 2)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+    scaler = GradScaler(device="cpu")
+
+    x = torch.randn(2, 4)
+    y = torch.randn(2, 2)
+
+    optimizer.zero_grad()
+    with autocast("cpu"):
+        out = model(x)
+        loss = F.mse_loss(out, y)
+
+    scaled_loss = scaler.scale(loss)
+    scaled_loss.backward()
+    scaler.step(optimizer)
+    scaler.update()
+
+    # After step, weights should have been updated
+    assert scaler.get_scale() > 0
+
+
+def test_grad_scaler_disabled():
+    """GradScaler with enabled=False should be a passthrough."""
+    scaler = GradScaler(device="cpu", enabled=False)
+    assert not scaler.is_enabled()
+    assert scaler.get_scale() == 1.0
+
+    x = torch.tensor([3.0])
+    scaled = scaler.scale(x)
+    np.testing.assert_allclose(scaled.numpy(), x.numpy())
+
+
+def test_grad_scaler_state_dict():
+    """GradScaler state_dict should be saveable and loadable."""
+    scaler = GradScaler(device="cpu", init_scale=1024.0)
+    sd = scaler.state_dict()
+    assert "scale" in sd
+    assert sd["scale"] == 1024.0
+
+    scaler2 = GradScaler(device="cpu")
+    scaler2.load_state_dict(sd)
+    assert scaler2.get_scale() == 1024.0
+
+
+def test_amp_training_loop():
+    """Full AMP training loop: autocast + GradScaler over multiple steps."""
+    torch.manual_seed(42)
+    model = nn.Sequential(
+        nn.Linear(8, 16),
+        nn.ReLU(),
+        nn.Linear(16, 4),
+    )
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+    scaler = GradScaler(device="cpu")
+
+    X = torch.randn(16, 8)
+    Y = torch.randn(16, 4)
+
+    losses = []
+    for _ in range(30):
+        optimizer.zero_grad()
+        with autocast("cpu"):
+            out = model(X)
+            loss = F.mse_loss(out, Y)
+        scaled_loss = scaler.scale(loss)
+        scaled_loss.backward()
+        scaler.step(optimizer)
+        scaler.update()
+        losses.append(loss.item())
+
+    assert losses[-1] < losses[0], \
+        f"AMP training should reduce loss: {losses[0]:.4f} -> {losses[-1]:.4f}"

--- a/tests/cpu/test_dtype_device.py
+++ b/tests/cpu/test_dtype_device.py
@@ -3,8 +3,11 @@ import candle as torch
 
 def test_default_dtype_and_device():
     x = torch.tensor([1, 2, 3])
-    assert x.dtype == torch.float32
+    assert x.dtype == torch.int64  # PyTorch infers int64 from integer data
     assert x.device.type == "cpu"
+    # Float data should infer the default dtype (float32)
+    y = torch.tensor([1.0, 2.0, 3.0])
+    assert y.dtype == torch.float32
 
 
 def test_default_device_set_get_affects_creation():

--- a/tests/cpu/test_gradient_checkpoint.py
+++ b/tests/cpu/test_gradient_checkpoint.py
@@ -1,0 +1,135 @@
+"""Tests for gradient checkpointing (torch.utils.checkpoint).
+
+Verifies that checkpointed forward passes produce correct outputs and
+gradients, trading memory for compute.
+"""
+import numpy as np
+import candle as torch
+import candle.nn as nn
+import candle.nn.functional as F
+from candle.utils.checkpoint import checkpoint, checkpoint_sequential
+
+
+def _make_mlp():
+    """Create a small MLP for testing."""
+    torch.manual_seed(42)
+    return nn.Sequential(
+        nn.Linear(8, 16),
+        nn.ReLU(),
+        nn.Linear(16, 8),
+        nn.ReLU(),
+        nn.Linear(8, 4),
+    )
+
+
+def test_checkpoint_output_matches():
+    """Checkpointed output should match non-checkpointed output."""
+    torch.manual_seed(42)
+    model = _make_mlp()
+    x = torch.randn(4, 8)
+    x.requires_grad = True
+
+    out_normal = model(x)
+    out_ckpt = checkpoint(model, x)
+
+    np.testing.assert_allclose(
+        out_normal.detach().numpy(),
+        out_ckpt.detach().numpy(),
+        atol=1e-6,
+    )
+
+
+def test_checkpoint_gradients_match():
+    """Gradients through checkpoint should match non-checkpointed gradients."""
+    torch.manual_seed(42)
+    model_a = _make_mlp()
+
+    torch.manual_seed(42)
+    model_b = _make_mlp()
+
+    torch.manual_seed(0)
+    x_data = torch.randn(4, 8).detach().numpy()
+
+    # Non-checkpointed
+    x_a = torch.tensor(x_data)
+    x_a.requires_grad = True
+    out_a = model_a(x_a)
+    out_a.sum().backward()
+
+    # Checkpointed
+    x_b = torch.tensor(x_data)
+    x_b.requires_grad = True
+    out_b = checkpoint(model_b, x_b)
+    out_b.sum().backward()
+
+    np.testing.assert_allclose(
+        x_a.grad.numpy(), x_b.grad.numpy(), atol=1e-5,
+        err_msg="Input gradients should match"
+    )
+
+    for (name_a, p_a), (name_b, p_b) in zip(
+        model_a.named_parameters(), model_b.named_parameters()
+    ):
+        assert p_a.grad is not None, f"{name_a} has no grad (normal)"
+        assert p_b.grad is not None, f"{name_b} has no grad (checkpoint)"
+        np.testing.assert_allclose(
+            p_a.grad.numpy(), p_b.grad.numpy(), atol=1e-5,
+            err_msg=f"Gradient mismatch for {name_a}"
+        )
+
+
+def test_checkpoint_no_grad_input():
+    """checkpoint with non-grad input should still produce correct output."""
+    model = _make_mlp()
+    x = torch.randn(4, 8)  # requires_grad=False
+    out = checkpoint(model, x)
+    assert out.shape == (4, 4)
+
+
+def test_checkpoint_with_custom_function():
+    """checkpoint should work with arbitrary callables, not just nn.Module."""
+    def my_fn(x):
+        return x * 2 + 1
+
+    x = torch.randn(4, 8)
+    x.requires_grad = True
+    out = checkpoint(my_fn, x)
+    out.sum().backward()
+    np.testing.assert_allclose(x.grad.numpy(), np.full((4, 8), 2.0), atol=1e-6)
+
+
+def test_checkpoint_sequential_basic():
+    """checkpoint_sequential should split modules into segments."""
+    torch.manual_seed(42)
+    layers = [nn.Linear(8, 8), nn.ReLU(), nn.Linear(8, 4)]
+    x = torch.randn(4, 8)
+    x.requires_grad = True
+
+    out = checkpoint_sequential(layers, 2, x)
+    assert out.shape == (4, 4)
+    out.sum().backward()
+    assert x.grad is not None
+    assert x.grad.shape == (4, 8)
+
+
+def test_checkpoint_training_convergence():
+    """Training with checkpoint should converge like normal training."""
+    torch.manual_seed(42)
+    X = torch.randn(16, 8)
+    X.requires_grad = True
+    Y = torch.randn(16, 4)
+
+    model = _make_mlp()
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+
+    losses = []
+    for _ in range(100):
+        optimizer.zero_grad()
+        out = checkpoint(model, X)
+        loss = F.mse_loss(out, Y)
+        loss.backward()
+        optimizer.step()
+        losses.append(loss.item())
+
+    assert losses[-1] < losses[0] * 0.5, \
+        f"Checkpointed training should converge: {losses[0]:.4f} -> {losses[-1]:.4f}"

--- a/tests/cpu/test_save_load_roundtrip.py
+++ b/tests/cpu/test_save_load_roundtrip.py
@@ -1,0 +1,217 @@
+"""Tests for model save/load round-trip correctness.
+
+Verify that saving a candle model and loading it back produces
+identical forward outputs and preserves all state.
+"""
+import os
+import tempfile
+import numpy as np
+import candle as torch
+import candle.nn as nn
+
+
+def _assert_state_dicts_equal(sd1, sd2, msg=""):
+    """Assert two state dicts have identical keys and values."""
+    assert set(sd1.keys()) == set(sd2.keys()), \
+        f"{msg} Key mismatch: {set(sd1.keys())} vs {set(sd2.keys())}"
+    for key in sd1:
+        np.testing.assert_allclose(
+            sd1[key].numpy(), sd2[key].numpy(), atol=1e-6,
+            err_msg=f"{msg} Value mismatch for key '{key}'"
+        )
+
+
+def test_linear_save_load_roundtrip():
+    """Linear model: save -> load -> forward should be identical."""
+    torch.manual_seed(42)
+    model = nn.Linear(8, 4)
+    x = torch.randn(2, 8)
+    out_before = model(x).detach().numpy().copy()
+
+    with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+        path = f.name
+    try:
+        torch.save(model.state_dict(), path)
+        model2 = nn.Linear(8, 4)
+        model2.load_state_dict(torch.load(path))
+        out_after = model2(x).detach().numpy()
+        np.testing.assert_allclose(out_before, out_after, atol=1e-6)
+    finally:
+        os.unlink(path)
+
+
+def test_sequential_save_load_roundtrip():
+    """Sequential model with multiple layers: round-trip preserves output."""
+    torch.manual_seed(42)
+    model = nn.Sequential(
+        nn.Linear(8, 16),
+        nn.ReLU(),
+        nn.Linear(16, 4),
+    )
+    x = torch.randn(2, 8)
+    out_before = model(x).detach().numpy().copy()
+
+    with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+        path = f.name
+    try:
+        torch.save(model.state_dict(), path)
+        model2 = nn.Sequential(
+            nn.Linear(8, 16),
+            nn.ReLU(),
+            nn.Linear(16, 4),
+        )
+        model2.load_state_dict(torch.load(path))
+        out_after = model2(x).detach().numpy()
+        np.testing.assert_allclose(out_before, out_after, atol=1e-6)
+    finally:
+        os.unlink(path)
+
+
+def test_layernorm_save_load_roundtrip():
+    """LayerNorm state (weight + bias) should survive round-trip."""
+    torch.manual_seed(42)
+    ln = nn.LayerNorm(8)
+    x = torch.randn(2, 8)
+    out_before = ln(x).detach().numpy().copy()
+
+    with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+        path = f.name
+    try:
+        torch.save(ln.state_dict(), path)
+        ln2 = nn.LayerNorm(8)
+        ln2.load_state_dict(torch.load(path))
+        out_after = ln2(x).detach().numpy()
+        np.testing.assert_allclose(out_before, out_after, atol=1e-6)
+    finally:
+        os.unlink(path)
+
+
+def test_embedding_save_load_roundtrip():
+    """Embedding weights should survive round-trip."""
+    torch.manual_seed(42)
+    emb = nn.Embedding(100, 32)
+    idx = torch.tensor([0, 5, 99])
+    out_before = emb(idx).detach().numpy().copy()
+
+    with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+        path = f.name
+    try:
+        torch.save(emb.state_dict(), path)
+        emb2 = nn.Embedding(100, 32)
+        emb2.load_state_dict(torch.load(path))
+        out_after = emb2(idx).detach().numpy()
+        np.testing.assert_allclose(out_before, out_after, atol=1e-6)
+    finally:
+        os.unlink(path)
+
+
+def test_mha_save_load_roundtrip():
+    """MultiheadAttention state should survive round-trip."""
+    torch.manual_seed(42)
+    mha = nn.MultiheadAttention(embed_dim=8, num_heads=2, batch_first=True)
+    x = torch.randn(2, 4, 8)
+    out_before, _ = mha(x, x, x)
+    out_before = out_before.detach().numpy().copy()
+
+    with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+        path = f.name
+    try:
+        torch.save(mha.state_dict(), path)
+        mha2 = nn.MultiheadAttention(embed_dim=8, num_heads=2, batch_first=True)
+        mha2.load_state_dict(torch.load(path))
+        out_after, _ = mha2(x, x, x)
+        out_after = out_after.detach().numpy()
+        np.testing.assert_allclose(out_before, out_after, atol=1e-5)
+    finally:
+        os.unlink(path)
+
+
+def test_state_dict_keys_match():
+    """state_dict keys should be identical before save and after load."""
+    torch.manual_seed(42)
+    model = nn.Sequential(
+        nn.Linear(4, 8),
+        nn.LayerNorm(8),
+        nn.Linear(8, 2),
+    )
+    sd_original = model.state_dict()
+
+    with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+        path = f.name
+    try:
+        torch.save(sd_original, path)
+        sd_loaded = torch.load(path)
+        assert set(sd_original.keys()) == set(sd_loaded.keys())
+    finally:
+        os.unlink(path)
+
+
+def test_optimizer_state_save_load():
+    """Optimizer state should survive save/load round-trip."""
+    torch.manual_seed(42)
+    model = nn.Linear(4, 2)
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+
+    # Run a few steps to populate optimizer state
+    for _ in range(5):
+        optimizer.zero_grad()
+        loss = model(torch.randn(2, 4)).sum()
+        loss.backward()
+        optimizer.step()
+
+    opt_state = optimizer.state_dict()
+
+    with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+        path = f.name
+    try:
+        torch.save(opt_state, path)
+        loaded_state = torch.load(path)
+        assert loaded_state["param_groups"][0]["lr"] == 0.01
+        assert len(loaded_state["state"]) == len(opt_state["state"])
+    finally:
+        os.unlink(path)
+
+
+def test_full_training_checkpoint_resume():
+    """Save model + optimizer mid-training, load, and resume — loss continues dropping."""
+    torch.manual_seed(42)
+    X = torch.randn(32, 4)
+    Y = torch.randn(32, 2)
+
+    # Phase 1: train for 50 steps
+    model = nn.Linear(4, 2)
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+    for _ in range(50):
+        optimizer.zero_grad()
+        loss = ((model(X) - Y) ** 2).mean()
+        loss.backward()
+        optimizer.step()
+    loss_at_checkpoint = loss.item()
+
+    # Save
+    with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+        ckpt_path = f.name
+    try:
+        torch.save({
+            "model": model.state_dict(),
+            "optimizer": optimizer.state_dict(),
+        }, ckpt_path)
+
+        # Phase 2: load and resume training
+        model2 = nn.Linear(4, 2)
+        ckpt = torch.load(ckpt_path)
+        model2.load_state_dict(ckpt["model"])
+        optimizer2 = torch.optim.Adam(model2.parameters(), lr=0.01)
+        optimizer2.load_state_dict(ckpt["optimizer"])
+
+        for _ in range(50):
+            optimizer2.zero_grad()
+            loss = ((model2(X) - Y) ** 2).mean()
+            loss.backward()
+            optimizer2.step()
+        loss_after_resume = loss.item()
+
+        assert loss_after_resume < loss_at_checkpoint, \
+            f"Loss should continue decreasing after resume: {loss_at_checkpoint:.4f} -> {loss_after_resume:.4f}"
+    finally:
+        os.unlink(ckpt_path)

--- a/tests/cpu/test_training_convergence.py
+++ b/tests/cpu/test_training_convergence.py
@@ -1,0 +1,193 @@
+"""Multi-step training convergence tests.
+
+Verify that loss actually decreases over multiple optimizer steps on toy
+problems — something a single forward+backward step cannot prove.
+"""
+import numpy as np
+import candle as torch
+import candle.nn as nn
+import candle.nn.functional as F
+
+
+def test_mlp_xor_convergence():
+    """A 2-layer MLP should learn XOR in < 500 steps."""
+    torch.manual_seed(42)
+    # XOR dataset
+    X = torch.tensor([[0, 0], [0, 1], [1, 0], [1, 1]], dtype=torch.float32)
+    Y = torch.tensor([[0], [1], [1], [0]], dtype=torch.float32)
+
+    model = nn.Sequential(
+        nn.Linear(2, 16),
+        nn.ReLU(),
+        nn.Linear(16, 1),
+        nn.Sigmoid(),
+    )
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+
+    losses = []
+    for _ in range(500):
+        optimizer.zero_grad()
+        out = model(X)
+        loss = F.mse_loss(out, Y)
+        loss.backward()
+        optimizer.step()
+        losses.append(loss.item())
+
+    assert losses[-1] < losses[0] * 0.1, \
+        f"Loss should decrease significantly: {losses[0]:.4f} -> {losses[-1]:.4f}"
+    assert losses[-1] < 0.05, f"Final loss {losses[-1]:.4f} should be < 0.05"
+
+
+def test_linear_regression_convergence():
+    """Linear regression on y = 2x + 1 should converge with SGD."""
+    torch.manual_seed(42)
+    X = torch.randn(100, 1)
+    Y = 2.0 * X + 1.0
+
+    model = nn.Linear(1, 1)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+
+    initial_loss = None
+    final_loss = None
+    for step in range(200):
+        optimizer.zero_grad()
+        pred = model(X)
+        loss = F.mse_loss(pred, Y)
+        loss.backward()
+        optimizer.step()
+        if step == 0:
+            initial_loss = loss.item()
+        final_loss = loss.item()
+
+    assert final_loss < initial_loss * 0.01, \
+        f"Loss should drop 100x: {initial_loss:.4f} -> {final_loss:.4f}"
+    # Check learned parameters
+    w = model.weight.detach().numpy().item()
+    b = model.bias.detach().numpy().item()
+    assert abs(w - 2.0) < 0.1, f"Weight should be ~2.0, got {w:.3f}"
+    assert abs(b - 1.0) < 0.1, f"Bias should be ~1.0, got {b:.3f}"
+
+
+def test_transformer_encoder_convergence():
+    """A small transformer encoder should reduce loss on a toy sequence task."""
+    torch.manual_seed(42)
+    batch, seq_len, d_model, nhead = 4, 8, 16, 2
+
+    encoder_layer = nn.TransformerEncoderLayer(
+        d_model=d_model, nhead=nhead, dim_feedforward=32, batch_first=True
+    )
+    encoder = nn.TransformerEncoder(encoder_layer, num_layers=1)
+    head = nn.Linear(d_model, d_model)
+
+    params = list(encoder.parameters()) + list(head.parameters())
+    optimizer = torch.optim.Adam(params, lr=0.001)
+
+    losses = []
+    for _ in range(50):
+        optimizer.zero_grad()
+        src = torch.randn(batch, seq_len, d_model)
+        target = torch.randn(batch, seq_len, d_model)
+        out = head(encoder(src))
+        loss = F.mse_loss(out, target)
+        loss.backward()
+        optimizer.step()
+        losses.append(loss.item())
+
+    # With random targets, loss should still decrease (model fits noise)
+    avg_first_5 = np.mean(losses[:5])
+    avg_last_5 = np.mean(losses[-5:])
+    assert avg_last_5 < avg_first_5, \
+        f"Loss should decrease: first5={avg_first_5:.4f}, last5={avg_last_5:.4f}"
+
+
+def test_gradient_accumulation():
+    """Gradient accumulation should produce same result as large batch."""
+    torch.manual_seed(42)
+    X = torch.randn(8, 4)
+    Y = torch.randn(8, 2)
+
+    # Single large batch
+    model_a = nn.Linear(4, 2)
+    model_a_w = model_a.weight.detach().numpy().copy()
+    model_a_b = model_a.bias.detach().numpy().copy()
+    optimizer_a = torch.optim.SGD(model_a.parameters(), lr=0.1)
+    optimizer_a.zero_grad()
+    loss_a = F.mse_loss(model_a(X), Y)
+    loss_a.backward()
+    optimizer_a.step()
+
+    # Gradient accumulation over 4 micro-batches of size 2
+    model_b = nn.Linear(4, 2)
+    # Copy same initial weights
+    model_b.weight = nn.Parameter(torch.tensor(model_a_w))
+    model_b.bias = nn.Parameter(torch.tensor(model_a_b))
+    optimizer_b = torch.optim.SGD(model_b.parameters(), lr=0.1)
+
+    accum_steps = 4
+    optimizer_b.zero_grad()
+    for i in range(accum_steps):
+        micro_x = X[i * 2:(i + 1) * 2]
+        micro_y = Y[i * 2:(i + 1) * 2]
+        micro_loss = F.mse_loss(model_b(micro_x), micro_y)
+        (micro_loss / accum_steps).backward()
+    optimizer_b.step()
+
+    # Weights should be very close
+    np.testing.assert_allclose(
+        model_a.weight.detach().numpy(),
+        model_b.weight.detach().numpy(),
+        atol=1e-5,
+    )
+    np.testing.assert_allclose(
+        model_a.bias.detach().numpy(),
+        model_b.bias.detach().numpy(),
+        atol=1e-5,
+    )
+
+
+def test_adamw_weight_decay():
+    """AdamW decoupled weight decay should shrink weights toward zero."""
+    torch.manual_seed(42)
+    model = nn.Linear(4, 2, bias=False)
+    initial_norm = np.linalg.norm(model.weight.detach().numpy())
+    optimizer = torch.optim.AdamW(model.parameters(), lr=0.01, weight_decay=0.1)
+
+    for _ in range(100):
+        optimizer.zero_grad()
+        x = torch.randn(8, 4)
+        # Zero target — loss drives outputs to zero, decay drives weights to zero
+        loss = (model(x) ** 2).mean()
+        loss.backward()
+        optimizer.step()
+
+    final_norm = np.linalg.norm(model.weight.detach().numpy())
+    assert final_norm < initial_norm * 0.5, \
+        f"Weight decay should shrink weights: {initial_norm:.4f} -> {final_norm:.4f}"
+
+
+def test_grad_clipping_during_training():
+    """Gradient clipping should cap gradient norms."""
+    torch.manual_seed(42)
+    model = nn.Linear(4, 2)
+    optimizer = torch.optim.SGD(model.parameters(), lr=1.0)
+
+    x = torch.randn(2, 4) * 100  # Large input to create large gradients
+    y = torch.randn(2, 2)
+
+    optimizer.zero_grad()
+    loss = F.mse_loss(model(x), y)
+    loss.backward()
+
+    # Clip gradients
+    max_norm = 1.0
+    total_norm = nn.utils.clip_grad_norm_(model.parameters(), max_norm)
+    assert total_norm > max_norm, "Pre-clip norm should exceed max_norm"
+
+    # After clipping, each parameter's grad norm should be scaled down
+    clipped_norm = 0.0
+    for p in model.parameters():
+        if p.grad is not None:
+            clipped_norm += (p.grad.detach().numpy() ** 2).sum()
+    clipped_norm = np.sqrt(clipped_norm)
+    assert abs(clipped_norm - max_norm) < 0.01, \
+        f"Clipped norm should be ~{max_norm}, got {clipped_norm:.4f}"


### PR DESCRIPTION
## Summary

Adds 29 end-to-end training tests across 4 new test files, which exposed and fixed 4 source bugs.

### New Tests

- **Training convergence** (6 tests): MLP XOR, linear regression, transformer encoder, gradient accumulation, AdamW weight decay, gradient clipping
- **Gradient checkpointing** (6 tests): output parity, gradient parity, custom function, sequential, no-grad input, convergence
- **Model save/load round-trip** (8 tests): Linear, Sequential, LayerNorm, Embedding, MHA, state_dict keys, optimizer state, full checkpoint-resume
- **Mixed precision E2E** (9 tests): autocast context/nesting/decorator/disabled, GradScaler basic/disabled/state_dict, full AMP training loop

### Source Bugs Fixed

| Bug | File | Fix |
|-----|------|-----|
| `checkpoint` doesn't propagate grads to model params | `utils/checkpoint.py` | Use `accumulate_grad=True, inputs=None` so leaf parameter grads propagate through recomputed graph |
| `Sequential.load_state_dict` fails with numeric keys | `nn/module.py` | Add `__getattr__` fallback to `_parameters`/`_buffers`/`_modules` dicts (matches PyTorch) |
| `torch.tensor([1,2,3])` returns float32 instead of int64 | `_creation.py` | Infer int64 from integer data in `_infer_creation_dtype` |
| Optimizer step crashes after deserialization | `cpu/optim_ops.py` | Reshape result to match storage shape in `_write_back` |

## Test plan

- [x] 29 new tests all pass
- [x] Full suite: 1717 passed, 2 pre-existing failures, 2 skipped — zero regressions
- [x] Pylint 10/10 with CI config

🤖 Generated with [Claude Code](https://claude.com/claude-code)