### PR TITLE
fix(mps): eliminate numpy fallbacks in linalg, shape, and FFT ops via GPU composites

### DIFF
--- a/src/candle/_backends/mps/ops/linalg.py
+++ b/src/candle/_backends/mps/ops/linalg.py
@@ -18,7 +18,7 @@ from ._helpers import (
     mps_typed_storage_from_numpy, _MPSUntypedStorage, TypedStorage,
     _accel,
 )
-from .math import mul, add, abs as gpu_abs, sqrt as gpu_sqrt, pow as gpu_pow
+from .math import mul, add, sub, abs as gpu_abs, sqrt as gpu_sqrt, pow as gpu_pow, div
 
 
 def matmul(a, b):
@@ -132,6 +132,21 @@ def mv(a, b):
 def cross(a, b, dim=-1):
     if a.dtype != b.dtype:
         raise RuntimeError("cross: expected both inputs to have same dtype")
+    # GPU composite: extract 3 components via narrow, compute cross product
+    if _can_use_gpu(a) and _can_use_gpu(b):
+        from .shape import narrow, cat
+        ndim = len(a.shape)
+        d = dim if dim >= 0 else dim + ndim
+        a0 = narrow(a, d, 0, 1)
+        a1 = narrow(a, d, 1, 1)
+        a2 = narrow(a, d, 2, 1)
+        b0 = narrow(b, d, 0, 1)
+        b1 = narrow(b, d, 1, 1)
+        b2 = narrow(b, d, 2, 1)
+        c0 = sub(mul(a1, b2), mul(a2, b1))
+        c1 = sub(mul(a2, b0), mul(a0, b2))
+        c2 = sub(mul(a0, b1), mul(a1, b0))
+        return cat([c0, c1, c2], dim=d)
     a_np = np.moveaxis(_to_numpy(a), dim, -1)
     b_np = np.moveaxis(_to_numpy(b), dim, -1)
     out = np.cross(a_np, b_np)
@@ -183,6 +198,19 @@ def tensordot(a, b, dims=2):
 def einsum(equation, *operands):
     if len(operands) == 1 and isinstance(operands[0], (list, tuple)):
         operands = operands[0]
+    # GPU composite for common 2-operand patterns
+    if len(operands) == 2 and _can_use_gpu(operands[0]) and _can_use_gpu(operands[1]):
+        from .reduce import sum_
+        a, b = operands
+        eq = equation.replace(' ', '')
+        if eq in ('ij,jk->ik', 'bij,bjk->bik'):
+            return matmul(a, b)
+        if eq == 'ij,ij->ij':
+            return mul(a, b)
+        if eq == 'ij,ij->':
+            return sum_(mul(a, b))
+        if eq == 'ij,ij->i':
+            return sum_(mul(a, b), dim=-1)
     ops_np = [_to_numpy(op) for op in operands]
     out = np.einsum(equation, *ops_np)
     return _from_numpy(np.ascontiguousarray(out), operands[0].dtype, operands[0].device)
@@ -314,6 +342,14 @@ def linalg_vector_norm(a, ord=2, dim=None, keepdim=False):
 
 def linalg_norm(a, ord=None, dim=None, keepdim=False):
     """Vector or matrix norm."""
+    # GPU composite: delegate to vector_norm or matrix_norm
+    if _can_use_gpu(a):
+        if isinstance(dim, (list, tuple)) and len(dim) == 2:
+            return linalg_matrix_norm(a, ord=ord if ord is not None else 'fro',
+                                      dim=dim, keepdim=keepdim)
+        # vector norm: ord=None means ord=2
+        return linalg_vector_norm(a, ord=ord if ord is not None else 2,
+                                  dim=dim, keepdim=keepdim)
     arr = _to_numpy(a).astype(np.float64)
     if dim is not None:
         if isinstance(dim, (list, tuple)):
@@ -327,6 +363,10 @@ def linalg_norm(a, ord=None, dim=None, keepdim=False):
 
 def linalg_matrix_norm(a, ord='fro', dim=(-2, -1), keepdim=False):
     """Matrix norm."""
+    # GPU composite for Frobenius norm
+    if _can_use_gpu(a) and ord == 'fro':
+        from .reduce import sum_
+        return gpu_sqrt(sum_(mul(a, a), dim=list(dim), keepdim=keepdim))
     arr = _to_numpy(a).astype(np.float64)
     if isinstance(dim, (list, tuple)) and len(dim) == 2:
         axis = tuple(dim)
@@ -342,7 +382,13 @@ def linalg_matrix_norm(a, ord='fro', dim=(-2, -1), keepdim=False):
     return _from_numpy(np.ascontiguousarray(np.atleast_1d(out).astype(to_numpy_dtype(a.dtype))), a.dtype, a.device)
 
 def linalg_multi_dot(tensors):
-    """Efficiently multiply 2+ matrices using np.linalg.multi_dot."""
+    """Efficiently multiply 2+ matrices using chained matmul."""
+    # GPU composite: left-to-right chain of GPU matmul
+    if all(_can_use_gpu(t) for t in tensors):
+        result = tensors[0]
+        for t in tensors[1:]:
+            result = matmul(result, t)
+        return result
     arrays = [_to_numpy(t).astype(np.float64) for t in tensors]
     out = np.linalg.multi_dot(arrays)
     dt = tensors[0].dtype
@@ -617,16 +663,26 @@ def det(a):
 
 def trace(a):
     """Sum of diagonal elements (2D only)."""
-    arr = _to_numpy(a)
-    if arr.ndim != 2:
+    arr_ndim = len(a.shape)
+    if arr_ndim != 2:
         raise RuntimeError(
-            f"trace: expected a matrix (2-D tensor), but got {arr.ndim}-D tensor"
+            f"trace: expected a matrix (2-D tensor), but got {arr_ndim}-D tensor"
         )
+    # GPU composite: sum(diagonal(a))
+    if _can_use_gpu(a):
+        from .shape import diagonal
+        from .reduce import sum_
+        return sum_(diagonal(a))
+    arr = _to_numpy(a)
     out = np.trace(arr)
     return _from_numpy(np.array(out, dtype=arr.dtype), a.dtype, a.device)
 
 def dist(a, b, p=2):
     """p-norm distance between two tensors (flattened)."""
+    # GPU composite: linalg_vector_norm(flatten(a) - flatten(b), p)
+    if _can_use_gpu(a) and _can_use_gpu(b):
+        from .shape import flatten
+        return linalg_vector_norm(sub(flatten(a), flatten(b)), ord=p)
     a_np = _to_numpy(a)
     b_np = _to_numpy(b)
     diff = a_np.ravel() - b_np.ravel()
@@ -635,6 +691,27 @@ def dist(a, b, p=2):
 
 def cdist(x1, x2, p=2.0):
     """Batched pairwise distance between two sets of vectors."""
+    # GPU composite via broadcasting
+    if _can_use_gpu(x1) and _can_use_gpu(x2):
+        from .reduce import sum_, amax
+        ndim = len(x1.shape)
+        if ndim == 2:
+            # (M, D) → (M, 1, D) - (1, N, D) → (M, N, D)
+            diff = sub(x1.unsqueeze(1), x2.unsqueeze(0))
+        elif ndim == 3:
+            # (B, M, D) → (B, M, 1, D) - (B, 1, N, D) → (B, M, N, D)
+            diff = sub(x1.unsqueeze(2), x2.unsqueeze(1))
+        else:
+            diff = None
+        if diff is not None:
+            if p == 2.0:
+                return gpu_sqrt(sum_(mul(diff, diff), dim=-1))
+            if p == 1.0:
+                return sum_(gpu_abs(diff), dim=-1)
+            if p == float('inf'):
+                return amax(gpu_abs(diff), dim=-1)
+            # General p
+            return gpu_pow(sum_(gpu_pow(gpu_abs(diff), p), dim=-1), 1.0 / p)
     a = _to_numpy(x1).astype(np.float64)
     b = _to_numpy(x2).astype(np.float64)
     if a.ndim == 2:

--- a/src/candle/_backends/mps/ops/shape.py
+++ b/src/candle/_backends/mps/ops/shape.py
@@ -366,11 +366,14 @@ def triu(a, diagonal=0):
     out = np.triu(_to_numpy(a), k=diagonal)
     return _from_numpy(out, a.dtype, a.device)
 
-def diag(a, diagonal=0):
+def diag(a, diagonal_offset=0):
+    # GPU composite for 2D input: delegate to diagonal()
+    if _can_use_gpu(a) and len(a.shape) == 2:
+        return diagonal(a, offset=diagonal_offset)
     arr = _to_numpy(a)
     if arr.ndim not in (1, 2):
         raise ValueError("diag expects 1D or 2D tensor")
-    out = np.diag(arr, k=diagonal).copy()
+    out = np.diag(arr, k=diagonal_offset).copy()
     return _from_numpy(out, a.dtype, a.device)
 
 def cartesian_prod(*tensors):

--- a/src/candle/_backends/mps/ops/special.py
+++ b/src/candle/_backends/mps/ops/special.py
@@ -280,6 +280,18 @@ def fft_ihfft(a, n=None, dim=-1, norm=None):
 
 def fft_fftshift(a, dim=None):
     """Shift zero-frequency component to center."""
+    # GPU composite: roll by n//2 per dim
+    if _can_use_gpu(a):
+        from .shape import roll
+        ndim = len(a.shape)
+        if dim is None:
+            dims = list(range(ndim))
+        elif isinstance(dim, int):
+            dims = [dim]
+        else:
+            dims = list(dim)
+        shifts = [a.shape[d if d >= 0 else d + ndim] // 2 for d in dims]
+        return roll(a, shifts, dims)
     arr = _to_numpy(a)
     axes = None if dim is None else (tuple(dim) if isinstance(dim, (list, tuple)) else (dim,))
     out = np.fft.fftshift(arr, axes=axes)
@@ -287,6 +299,18 @@ def fft_fftshift(a, dim=None):
 
 def fft_ifftshift(a, dim=None):
     """Inverse of fftshift."""
+    # GPU composite: roll by -(n//2) per dim
+    if _can_use_gpu(a):
+        from .shape import roll
+        ndim = len(a.shape)
+        if dim is None:
+            dims = list(range(ndim))
+        elif isinstance(dim, int):
+            dims = [dim]
+        else:
+            dims = list(dim)
+        shifts = [-(a.shape[d if d >= 0 else d + ndim] // 2) for d in dims]
+        return roll(a, shifts, dims)
     arr = _to_numpy(a)
     axes = None if dim is None else (tuple(dim) if isinstance(dim, (list, tuple)) else (dim,))
     out = np.fft.ifftshift(arr, axes=axes)


### PR DESCRIPTION
## Summary

Batch 3 of MPS numpy fallback elimination. Replaces unconditional numpy paths with GPU composite implementations built from existing on-device primitives.

Follows PR #98 (batch 1: comparison/elementwise/activation/random) and PR #101 (batch 2: dot/outer/inner/mv/matmul3D/vector_norm/tensordot/repeat_interleave/unfold/diagonal/masked_fill_).

## Changes

### `linalg.py` — 8 ops
| Op | Composite strategy |
|----|--------------------|
| `cross` | `narrow` → `mul`/`sub` → `cat` |
| `trace` | `sum_(diagonal(a))` |
| `dist` | `linalg_vector_norm(sub(flatten(a), flatten(b)), p)` |
| `cdist` | Broadcasting `unsqueeze` + `sub` → p-norm reduction |
| `linalg_norm` | Delegates to `linalg_vector_norm` or `linalg_matrix_norm` |
| `linalg_matrix_norm` (fro) | `sqrt(sum(mul(a, a), dim))` |
| `linalg_multi_dot` | Left-to-right chain of GPU `matmul` |
| `einsum` | Pattern-match common 2-op equations (`ij,jk->ik`, `bij,bjk->bik`, `ij,ij->ij`, `ij,ij->`, `ij,ij->i`) |

### `shape.py` — 1 op
| Op | Composite strategy |
|----|--------------------|
| `diag` (2D input) | Delegates to GPU `diagonal(a, offset=k)` |

### `special.py` — 2 ops
| Op | Composite strategy |
|----|--------------------|
| `fft_fftshift` | `roll` by `n//2` per dim |
| `fft_ifftshift` | `roll` by `-(n//2)` per dim |

## Not in scope
- LAPACK ops (QR, SVD, inv, eig, solve, det, cholesky) — need Metal shaders
- scipy special functions (digamma, bessel, erfinv) — need special-function Metal shaders
- FFT kernels (fft, ifft, rfft) — need Metal FFT implementation
- `diag` 1D→2D — requires GPU scatter
- `einsum` uncommon/ND patterns

## Testing
- Pylint: 10.00/10
- MPS tests: 361 passed
- CPU + contract tests: 1664 passed, 28 skipped