### PR TITLE
fix: implement is_causal for MHA need_weights=True path

### DIFF
--- a/src/candle/nn/functional.py
+++ b/src/candle/nn/functional.py
@@ -1020,7 +1020,16 @@ def multi_head_attention_forward(
         # q_scaled = q * sqrt(1/E)
         _, _, E = q.shape
         q_scaled = _mul(q, _tensor(math.sqrt(1.0 / float(E)), device=q.device))
-        assert not (is_causal and attn_mask is None), "FIXME: is_causal not implemented for need_weights"
+        if is_causal and attn_mask is None:
+            from .._creation import ones, tensor as _mk_tensor
+            from .._dtype import bool as _bool_dtype
+            from .._dispatch import dispatch as _disp
+            from .._functional import where as _whr
+            causal = ones((tgt_len, src_len), dtype=_bool_dtype, device=q.device).tril()
+            inv = _disp("eq", q.device.type, causal, False)
+            neg_inf = _mk_tensor(float('-inf'), device=q.device)
+            attn_mask = _whr(inv, neg_inf, _mk_tensor(0.0, device=q.device))
+            attn_mask = attn_mask.unsqueeze(0)
 
         if attn_mask is not None:
             attn_output_weights = _baddbmm(attn_mask, q_scaled, k.transpose(-2, -1))


### PR DESCRIPTION
## Summary

Fixes `MultiheadAttention` crash when called with `is_causal=True` and `need_weights=True`.

Previously this hit `assert not (is_causal and attn_mask is None), "FIXME: is_causal not implemented for need_weights"`. Now generates a causal tril mask and applies it as an additive attention mask, matching the `need_weights=False` SDPA path.

## Test plan

- [x] Manual verification: `mha(x, x, x, is_causal=True, need_weights=True)` produces correct shaped output and attention weights
- [x] Full suite: 1717 passed, 2 pre-existing failures, 2 skipped — zero regressions
- [x] Pylint 10/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)