### PR TITLE
fix(mps): route string ords to matrix_norm in linalg_norm GPU path

### DIFF
--- a/src/candle/_backends/mps/ops/linalg.py
+++ b/src/candle/_backends/mps/ops/linalg.py
@@ -347,6 +347,9 @@ def linalg_norm(a, ord=None, dim=None, keepdim=False):
         if isinstance(dim, (list, tuple)) and len(dim) == 2:
             return linalg_matrix_norm(a, ord=ord if ord is not None else 'fro',
                                       dim=dim, keepdim=keepdim)
+        # String ords ('fro', 'nuc') are matrix norms — route to matrix_norm for 2D
+        if isinstance(ord, str) and len(a.shape) == 2:
+            return linalg_matrix_norm(a, ord=ord, dim=(-2, -1), keepdim=keepdim)
         # vector norm: ord=None means ord=2
         return linalg_vector_norm(a, ord=ord if ord is not None else 2,
                                   dim=dim, keepdim=keepdim)


### PR DESCRIPTION
## Problem

`linalg_norm` with `ord='fro'` and `dim=None` on a 2D MPS tensor was falling through to `linalg_vector_norm`, which cannot handle string ords — causing a `ValueError: could not convert string to float: 'fro'`.

## Fix

Route string ords (`'fro'`, `'nuc'`) on 2D inputs to `linalg_matrix_norm` before reaching the `linalg_vector_norm` fallback. 3-line change.

## Verification

- Smoke test: all batch 3 ops pass on MPS (cross, trace, dist, cdist, linalg_norm, multi_dot, einsum, diag, fftshift/ifftshift)
- CPU/contract tests: 1693 passed
- MPS tests: 361 passed
- Pylint: 10.00/10