### PR TITLE
feat(mps): eliminate numpy fallbacks in special, RNG, and linalg ops via GPU composites (#batch4)

### DIFF
--- a/src/candle/_backends/mps/ops/linalg.py
+++ b/src/candle/_backends/mps/ops/linalg.py
@@ -400,12 +400,30 @@ def linalg_multi_dot(tensors):
 
 def linalg_matrix_power(a, n):
     """Matrix raised to integer power n."""
+    # GPU composite for n > 0: binary exponentiation via matmul
+    if _can_use_gpu(a) and n > 0:
+        result = None
+        base = a
+        exp = n
+        while exp > 0:
+            if exp % 2 == 1:
+                result = matmul(result, base) if result is not None else base
+            base = matmul(base, base) if exp > 1 else base
+            exp //= 2
+        return result
+    # n==0 (identity) and n<0 (inverse) fall through to numpy
     arr = _to_numpy(a).astype(np.float64)
     out = np.linalg.matrix_power(arr, n)
     return _from_numpy(np.ascontiguousarray(out.astype(to_numpy_dtype(a.dtype))), a.dtype, a.device)
 
 def linalg_vander(x, N=None):
     """Vandermonde matrix."""
+    # GPU composite: build columns x^0..x^(N-1) via pow, then stack
+    if _can_use_gpu(x):
+        from .shape import stack as gpu_stack
+        n = N if N is not None else x.shape[0]
+        cols = [gpu_pow(x, i) for i in range(n)]
+        return gpu_stack(cols, dim=-1)
     arr = _to_numpy(x)
     n = N if N is not None else len(arr)
     out = np.vander(arr, N=n, increasing=True)

--- a/src/candle/_backends/mps/ops/random.py
+++ b/src/candle/_backends/mps/ops/random.py
@@ -180,6 +180,13 @@ def bernoulli_(a, p=0.5, generator=None):
     return a
 
 def exponential_(a, lambd=1.0, generator=None):
+    # GPU composite: uniform_(a) → -log(a)/λ → copy back
+    if _can_use_gpu(a) and a.is_contiguous() and a.dtype in (float32_dtype, float16_dtype):
+        from .math import neg, log, div
+        uniform_(a, 0.0, 1.0, generator=generator)
+        result = div(neg(log(a)), lambd)
+        copy_(a, result)
+        return a
     from ...._random import _get_cpu_rng
     rng = generator._rng if (generator is not None and hasattr(generator, '_rng') and generator._rng is not None) else _get_cpu_rng()
     arr = _to_numpy(a)
@@ -187,6 +194,13 @@ def exponential_(a, lambd=1.0, generator=None):
     return a
 
 def log_normal_(a, mean=1.0, std=2.0, generator=None):
+    # GPU composite: normal_(a,0,1) → exp(a*σ + μ) → copy back
+    if _can_use_gpu(a) and a.is_contiguous() and a.dtype in (float32_dtype, float16_dtype):
+        from .math import mul, add, exp
+        normal_(a, 0.0, 1.0, generator=generator)
+        result = exp(add(mul(a, std), mean))
+        copy_(a, result)
+        return a
     from ...._random import _get_cpu_rng
     rng = generator._rng if (generator is not None and hasattr(generator, '_rng') and generator._rng is not None) else _get_cpu_rng()
     arr = _to_numpy(a)
@@ -194,6 +208,14 @@ def log_normal_(a, mean=1.0, std=2.0, generator=None):
     return a
 
 def cauchy_(a, median=0.0, sigma=1.0, generator=None):
+    # GPU composite: uniform_(a) → median + σ*tan(π*(a-0.5)) → copy back
+    if _can_use_gpu(a) and a.is_contiguous() and a.dtype in (float32_dtype, float16_dtype):
+        import math as _math
+        from .math import mul, add, sub, tan
+        uniform_(a, 0.0, 1.0, generator=generator)
+        result = add(median, mul(sigma, tan(mul(_math.pi, sub(a, 0.5)))))
+        copy_(a, result)
+        return a
     from ...._random import _get_cpu_rng
     rng = generator._rng if (generator is not None and hasattr(generator, '_rng') and generator._rng is not None) else _get_cpu_rng()
     arr = _to_numpy(a)
@@ -201,6 +223,14 @@ def cauchy_(a, median=0.0, sigma=1.0, generator=None):
     return a
 
 def geometric_(a, p, generator=None):
+    # GPU composite: uniform_(a) → ceil(log(1-a)/log(1-p)) → copy back
+    if _can_use_gpu(a) and a.is_contiguous() and a.dtype in (float32_dtype, float16_dtype):
+        import math as _math
+        from .math import sub, log, div, ceil
+        uniform_(a, 0.0, 1.0, generator=generator)
+        result = ceil(div(log(sub(1.0, a)), _math.log(1.0 - p)))
+        copy_(a, result)
+        return a
     from ...._random import _get_cpu_rng
     rng = generator._rng if (generator is not None and hasattr(generator, '_rng') and generator._rng is not None) else _get_cpu_rng()
     arr = _to_numpy(a)

--- a/src/candle/_backends/mps/ops/special.py
+++ b/src/candle/_backends/mps/ops/special.py
@@ -28,6 +28,15 @@ def special_digamma(a):
 
 def special_entr(a):
     """Entropy: -x * ln(x), 0 for x=0, -inf for x<0."""
+    # GPU composite
+    if _can_use_gpu(a):
+        from .math import mul, neg, log
+        from .comparison import gt, ge
+        from .activation import clamp_min
+        from .elementwise import where
+        pos_result = neg(mul(a, log(clamp_min(a, 1e-20))))
+        result = where(gt(a, 0), pos_result, 0.0)
+        return where(ge(a, 0), result, float('-inf'))
     arr = _to_numpy(a).astype(np.float64)
     out = np.where(arr > 0, -arr * np.log(arr), np.where(arr == 0, 0.0, -np.inf))
     return _from_numpy(np.ascontiguousarray(out.astype(to_numpy_dtype(a.dtype))), a.dtype, a.device)
@@ -106,6 +115,14 @@ def special_log_ndtr(a):
 
 def special_logit(a, eps=None):
     """Logit function: log(x / (1 - x))."""
+    # GPU composite: clamp then log(a) - log(1-a)
+    if _can_use_gpu(a):
+        from .math import log, sub
+        from .activation import clamp
+        x = a
+        if eps is not None:
+            x = clamp(x, min_val=eps, max_val=1.0 - eps)
+        return sub(log(x), log(sub(1.0, x)))
     arr = _to_numpy(a).astype(np.float64)
     if eps is not None:
         arr = np.clip(arr, eps, 1.0 - eps)
@@ -122,6 +139,10 @@ def special_multigammaln(a, p):
 
 def special_ndtr(a):
     """Area under the standard Gaussian PDF from -inf to x (normal CDF)."""
+    # GPU composite: 0.5 * (1 + erf(a / sqrt(2)))
+    if _can_use_gpu(a):
+        from .math import mul, add, div, erf
+        return mul(0.5, add(1.0, erf(div(a, math.sqrt(2.0)))))
     from scipy import special as sp
     arr = _to_numpy(a).astype(np.float64)
     out = sp.ndtr(arr)
@@ -143,12 +164,26 @@ def special_polygamma(n, a):
 
 def special_sinc(a):
     """Normalized sinc function: sin(pi*x) / (pi*x)."""
+    # GPU composite: where(a==0, 1, sin(π*a) / (π*a))
+    if _can_use_gpu(a):
+        from .math import mul, sin, div
+        from .comparison import ne
+        from .elementwise import where
+        pi_a = mul(a, math.pi)
+        sinc_val = div(sin(pi_a), pi_a)
+        return where(ne(a, 0), sinc_val, 1.0)
     arr = _to_numpy(a).astype(np.float64)
     out = np.sinc(arr)  # np.sinc already computes sin(pi*x)/(pi*x)
     return _from_numpy(np.ascontiguousarray(out.astype(to_numpy_dtype(a.dtype))), a.dtype, a.device)
 
 def special_xlog1py(a, b):
     """x * log1p(y), with 0 when x=0."""
+    # GPU composite: where(eq(a, 0), 0, a * log1p(b))
+    if _can_use_gpu(a) and _can_use_gpu(b):
+        from .math import mul, log1p
+        from .comparison import ne
+        from .elementwise import where
+        return where(ne(a, 0), mul(a, log1p(b)), 0.0)
     from scipy import special as sp
     a_np = _to_numpy(a).astype(np.float64)
     b_np = _to_numpy(b).astype(np.float64)
@@ -157,6 +192,12 @@ def special_xlog1py(a, b):
 
 def special_xlogy(a, b):
     """x * log(y), with 0 when x=0."""
+    # GPU composite: where(eq(a, 0), 0, a * log(b))
+    if _can_use_gpu(a) and _can_use_gpu(b):
+        from .math import mul, log
+        from .comparison import ne
+        from .elementwise import where
+        return where(ne(a, 0), mul(a, log(b)), 0.0)
     from scipy import special as sp
     a_np = _to_numpy(a).astype(np.float64)
     b_np = _to_numpy(b).astype(np.float64)


### PR DESCRIPTION
## Summary

Batch 4 of MPS numpy fallback elimination. 12 ops now stay on GPU via composites of existing primitives.

### special.py (6 ops)
- `sinc`: `where(a≠0, sin(πa)/(πa), 1)`
- `logit`: `log(a) - log(1-a)` with optional clamp
- `entr`: `where(a>0, -a·log(a), where(a≥0, 0, -inf))`
- `ndtr`: `0.5·(1 + erf(a/√2))`
- `xlogy`: `where(a≠0, a·log(b), 0)`
- `xlog1py`: `where(a≠0, a·log1p(b), 0)`

### random.py (4 in-place RNG ops)
- `exponential_`: `uniform_ → -log(a)/λ → copy_`
- `log_normal_`: `normal_ → exp(a·σ+μ) → copy_`
- `cauchy_`: `uniform_ → med+σ·tan(π·(a-0.5)) → copy_`
- `geometric_`: `uniform_ → ceil(log(1-a)/log(1-p)) → copy_`

### linalg.py (2 ops)
- `linalg_vander`: `pow + stack`
- `linalg_matrix_power` (n>0): binary exponentiation via `matmul`

## Verification
- Pylint: 10.00/10
- MPS tests: 361 passed
- CPU/contract tests: 1694 passed
- Smoke test: all 12 ops verified on MPS device