### PR TITLE
feat: add view_as_real/complex var_mean scatter_reduce

### DIFF
--- a/docs/plans/2026-03-15-autograd-step2-implementation-plan.md
+++ b/docs/plans/2026-03-15-autograd-step2-implementation-plan.md
@@ -1,0 +1,189 @@
+# Autograd Step 2 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Implement `view_as_real`, `view_as_complex`, `var_mean`, and `scatter_reduce` with full reduce modes, and add contract tests.
+
+**Architecture:**
+- `view_as_real`/`view_as_complex` are view-like ops. Register schemas with alias sets and implement via backend view helpers.
+- `var_mean` returns `(var, mean)` and uses existing ops.
+- `scatter_reduce` supports reduce modes (`sum`, `prod`, `mean`, `amax`, `amin`) and `include_self` on CPU; other backends raise NotImplemented.
+
+**Tech Stack:** Python, Candle dispatch/registry, pytest.
+
+---
+
+### Task 1: Contract Tests (Red)
+
+**Files:**
+- Create: `tests/contract/test_view_as_real_complex.py`
+- Create: `tests/contract/test_var_mean_contract.py`
+- Create: `tests/contract/test_scatter_reduce_contract.py`
+
+**Step 1: Write failing tests**
+
+```python
+# tests/contract/test_view_as_real_complex.py
+import candle as torch
+import pytest
+
+def test_view_as_real_complex_shape_dtype():
+    x = torch.randn(2, 3, dtype=torch.complex64)
+    y = torch.view_as_real(x)
+    assert y.shape == (2, 3, 2)
+    assert str(y.dtype).startswith('float')
+
+def test_view_as_complex_roundtrip():
+    x = torch.randn(2, 3, dtype=torch.complex64)
+    y = torch.view_as_real(x)
+    z = torch.view_as_complex(y)
+    assert z.shape == x.shape
+    assert str(z.dtype) == str(x.dtype)
+
+def test_view_as_complex_invalid_last_dim():
+    x = torch.randn(2, 3, 4)
+    with pytest.raises(RuntimeError):
+        torch.view_as_complex(x)
+```
+
+```python
+# tests/contract/test_var_mean_contract.py
+import candle as torch
+
+def test_var_mean_returns_tuple():
+    x = torch.randn(2, 3)
+    v, m = torch.var_mean(x)
+    assert v.shape == m.shape
+
+
+def test_var_mean_dim_keepdim():
+    x = torch.randn(2, 3)
+    v, m = torch.var_mean(x, dim=1, keepdim=True)
+    assert v.shape == (2, 1)
+    assert m.shape == (2, 1)
+```
+
+```python
+# tests/contract/test_scatter_reduce_contract.py
+import candle as torch
+
+
+def _make_inputs():
+    base = torch.zeros(3, 5)
+    index = torch.tensor([[0, 1, 2, 0, 1], [1, 2, 0, 1, 2], [2, 0, 1, 2, 0]])
+    src = torch.arange(15).reshape(3, 5)
+    return base, index, src
+
+
+def test_scatter_reduce_sum_include_self():
+    base, index, src = _make_inputs()
+    out = torch.scatter_reduce(base, 0, index, src, reduce="sum", include_self=True)
+    assert out.shape == base.shape
+
+
+def test_scatter_reduce_prod_exclude_self():
+    base, index, src = _make_inputs()
+    out = torch.scatter_reduce(base, 0, index, src, reduce="prod", include_self=False)
+    assert out.shape == base.shape
+
+
+def test_scatter_reduce_mean():
+    base, index, src = _make_inputs()
+    out = torch.scatter_reduce(base, 0, index, src, reduce="mean", include_self=True)
+    assert out.shape == base.shape
+
+
+def test_scatter_reduce_amax_amin():
+    base, index, src = _make_inputs()
+    out_max = torch.scatter_reduce(base, 0, index, src, reduce="amax", include_self=True)
+    out_min = torch.scatter_reduce(base, 0, index, src, reduce="amin", include_self=True)
+    assert out_max.shape == base.shape
+    assert out_min.shape == base.shape
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+- `pytest tests/contract/test_view_as_real_complex.py::test_view_as_real_complex_shape_dtype -v --tb=short`
+- `pytest tests/contract/test_var_mean_contract.py::test_var_mean_returns_tuple -v --tb=short`
+- `pytest tests/contract/test_scatter_reduce_contract.py::test_scatter_reduce_sum_include_self -v --tb=short`
+
+Expected: failures due to missing APIs.
+
+---
+
+### Task 2: Schema + Functional API
+
+**Files:**
+- Modify: `src/candle/_dispatch/schemas.py`
+- Modify: `src/candle/_functional.py`
+- Modify: `src/candle/_tensor.py`
+- Modify: `src/candle/__init__.py`
+
+**Step 1: Register schemas**
+- `view_as_real(Tensor input) -> Tensor`
+- `view_as_complex(Tensor input) -> Tensor`
+- `var_mean(Tensor input, int[]? dim=None, bool unbiased=True, bool keepdim=False) -> (Tensor, Tensor)`
+- `scatter_reduce(Tensor input, int dim, Tensor index, Tensor src, str reduce, bool include_self=True) -> Tensor`
+
+**Step 2: Functional API**
+- Add `view_as_real`, `view_as_complex`, `var_mean`, `scatter_reduce` in `src/candle/_functional.py` dispatching by op name.
+- Add `Tensor.var_mean` in `src/candle/_tensor.py` calling functional.
+- Export top-level in `src/candle/__init__.py`.
+
+---
+
+### Task 3: Backend Implementations
+
+**Files:**
+- Modify: `src/candle/_backends/common/view.py`
+- Modify: `src/candle/_backends/cpu/ops.py`
+- Modify: `src/candle/_backends/cpu/__init__.py`
+- Modify: `src/candle/_backends/meta/__init__.py`
+- Modify: `src/candle/_backends/meta/ops.py`
+
+**Step 1: view_as_real/complex**
+- Implement view helpers in `common/view.py` using `as_strided` to reinterpret shape/stride.
+- Register CPU/meta kernels.
+
+**Step 2: var_mean**
+- Implement via existing `var` + `mean` in CPU/meta where needed; or register composite in autograd/functional.
+
+**Step 3: scatter_reduce**
+- Implement CPU kernel supporting `sum/prod/mean/amax/amin` and `include_self`.
+- Meta kernel infers shape.
+
+---
+
+### Task 4: Tests + Contract Suite Gate
+
+**Step 1:** Run targeted tests again (expect pass).
+**Step 2:** Run `pytest tests/contract/ -v --tb=short`.
+
+---
+
+### Task 5: Pylint Gate
+
+Run: `pylint src/candle/ --rcfile=pyproject.toml`
+
+---
+
+### Task 6: Commit + PR
+
+```bash
+git add tests/contract/test_view_as_real_complex.py tests/contract/test_var_mean_contract.py tests/contract/test_scatter_reduce_contract.py \
+  src/candle/_dispatch/schemas.py src/candle/_functional.py src/candle/_tensor.py src/candle/__init__.py \
+  src/candle/_backends/common/view.py src/candle/_backends/cpu/ops.py src/candle/_backends/cpu/__init__.py \
+  src/candle/_backends/meta/__init__.py src/candle/_backends/meta/ops.py
+
+git commit -m "feat: add view_as_real/complex var_mean scatter_reduce"
+
+git fetch upstream main
+git rebase upstream/main
+
+git push -u origin compat/autograd-pr3
+
+gh pr create -R candle-org/candle --base main --head lvyufeng:compat/autograd-pr3 \
+  --title "feat: add view_as_real/complex var_mean scatter_reduce" \
+  --body-file /tmp/pr_body_pr3.md
+```

--- a/src/candle/__init__.py
+++ b/src/candle/__init__.py
@@ -103,10 +103,10 @@ from ._functional import clamp, clamp_min, clamp_max, relu6, hardtanh
 from ._functional import add_, mul_, relu_, zero_, clamp_, copy_
 from ._functional import min, max, amin, amax, fmin, fmax, where
 from ._functional import atan, atan2, asin, acos, lerp, addcmul, addcdiv
-from ._functional import reshape, transpose
+from ._functional import reshape, transpose, view_as_real, view_as_complex
 from ._functional import logaddexp, logaddexp2, hypot, remainder, fmod
 from ._functional import squeeze, unsqueeze, permute
-from ._functional import var, norm, prod
+from ._functional import var, var_mean, norm, prod
 from ._functional import reciprocal, addmm, einsum
 from ._functional import mm, bmm
 from ._functional import floor_divide
@@ -125,7 +125,7 @@ from ._functional import select, expand, masked_fill, unfold
 from ._functional import sum_to_size
 from ._functional import slice, slice_copy, slice_scatter, expand_copy
 from ._functional import as_strided_, as_strided_copy, as_strided_scatter
-from ._functional import scatter_, scatter_add_
+from ._functional import scatter_, scatter_add_, scatter_reduce
 from ._functional import index_add_, index_copy_, index_fill_
 from ._functional import index_put, index_put_
 from ._functional import masked_fill_, masked_scatter_
@@ -410,10 +410,13 @@ __all__ = [
     "std",
     "reshape",
     "transpose",
+    "view_as_real",
+    "view_as_complex",
     "squeeze",
     "unsqueeze",
     "permute",
     "var",
+    "var_mean",
     "norm",
     "prod",
     "mm",
@@ -541,6 +544,7 @@ __all__ = [
     "unfold",
     "scatter_",
     "scatter_add_",
+    "scatter_reduce",
     "index_add_",
     "index_copy_",
     "index_fill_",

--- a/src/candle/_backends/autograd.py
+++ b/src/candle/_backends/autograd.py
@@ -7398,6 +7398,8 @@ for _entry in (
     ("reshape", lambda: _autograd_view("reshape", _reshape_backward)),
     ("transpose", lambda: _autograd_view("transpose", _transpose_backward)),
     ("view", lambda: _autograd_view("view", _reshape_backward)),
+    ("view_as_real", lambda: _autograd_view("view_as_real", _reshape_backward)),
+    ("view_as_complex", lambda: _autograd_view("view_as_complex", _reshape_backward)),
     ("squeeze", lambda: _autograd_view("squeeze", _squeeze_backward)),
     ("unsqueeze", lambda: _autograd_view("unsqueeze", _unsqueeze_backward)),
     ("expand", lambda: _autograd_view("expand", _expand_backward)),
@@ -7450,6 +7452,7 @@ for _entry in (
     ("unbind", lambda: _autograd_multi_output("unbind", _unbind_backward, save_input=False)),
     # Phase 5: Transformer-critical ops
     ("masked_fill", lambda: _autograd_unary_args("masked_fill", _masked_fill_backward, save_input=False)),
+    ("var_mean", lambda: _autograd_unary_args("var_mean", _var_backward)),
     ("var", lambda: _autograd_unary_args("var", _var_backward)),
     ("std", lambda: _autograd_unary_args("std", _std_backward)),
     ("gather", lambda: _autograd_unary_args("gather", _gather_backward, save_input=False)),

--- a/src/candle/_backends/common/view.py
+++ b/src/candle/_backends/common/view.py
@@ -1,5 +1,6 @@
 from ..._tensor import Tensor
 from ...autograd.grad_mode import current_creation_mode
+from ... import _dtype as _dtype
 
 
 def _get_base(tensor):
@@ -198,3 +199,45 @@ def permute(a, dims):
     stride = [a.stride[d] for d in dims]
     base = _get_base(a)
     return _make_view(base, shape, stride, a.offset, "permute", source=a)
+
+
+def view_as_real(a):
+    if not a.is_complex():
+        raise RuntimeError("view_as_real expects a complex tensor")
+    if a.dtype.itemsize % 2 != 0:
+        raise RuntimeError("view_as_real expects complex dtype with even itemsize")
+    if a.dtype == _dtype.complex64:
+        out_dtype = _dtype.float32
+    elif a.dtype == _dtype.complex128:
+        out_dtype = _dtype.float64
+    elif a.dtype == _dtype.complex32:
+        out_dtype = _dtype.float16
+    else:
+        raise RuntimeError("view_as_real expects a supported complex dtype")
+    shape = tuple(a.shape) + (2,)
+    stride = tuple(s * 2 for s in a.stride) + (1,)
+    base = _get_base(a)
+    view = _make_view(base, shape, stride, a.offset * 2, "view_as_real", source=a)
+    view._storage = base._storage._reinterpret(out_dtype)
+    return view
+
+
+def view_as_complex(a):
+    if a.is_complex():
+        raise RuntimeError("view_as_complex expects a non-complex tensor")
+    if len(a.shape) == 0 or a.shape[-1] != 2:
+        raise RuntimeError("view_as_complex expects last dimension of size 2")
+    if a.dtype == _dtype.float16:
+        out_dtype = _dtype.complex32
+    elif a.dtype == _dtype.float32:
+        out_dtype = _dtype.complex64
+    elif a.dtype == _dtype.float64:
+        out_dtype = _dtype.complex128
+    else:
+        raise RuntimeError("view_as_complex is only supported for half, float and double tensors")
+    shape = tuple(a.shape[:-1])
+    stride = tuple(s // 2 for s in a.stride[:-1])
+    base = _get_base(a)
+    view = _make_view(base, shape, stride, a.offset // 2, "view_as_complex", source=a)
+    view._storage = base._storage._reinterpret(out_dtype)
+    return view

--- a/src/candle/_backends/cpu/__init__.py
+++ b/src/candle/_backends/cpu/__init__.py
@@ -162,6 +162,7 @@ from .ops import (
     masked_select,
     gather,
     scatter,
+    scatter_reduce,
     take,
     take_along_dim,
     index_select,
@@ -202,6 +203,7 @@ from .ops import (
     as_strided_scatter,
     embedding,
     var_,
+    var_mean,
     norm_,
     prod_,
     floor_divide,
@@ -425,6 +427,8 @@ registry.register("erfinv_", "cpu", erfinv_, meta=meta_infer.infer_unary)
 registry.register("sub_", "cpu", sub_, meta=meta_infer.infer_binary)
 registry.register("reshape", "cpu", view_backend.reshape, meta=meta_infer.infer_view)
 registry.register("view", "cpu", view_backend.view, meta=meta_infer.infer_view)
+registry.register("view_as_real", "cpu", view_backend.view_as_real, meta=meta_infer.infer_view)
+registry.register("view_as_complex", "cpu", view_backend.view_as_complex, meta=meta_infer.infer_view)
 registry.register("transpose", "cpu", view_backend.transpose, meta=meta_infer.infer_transpose)
 registry.register("squeeze", "cpu", view_backend.squeeze, meta=meta_infer.infer_view)
 registry.register("unsqueeze", "cpu", view_backend.unsqueeze, meta=meta_infer.infer_view)
@@ -461,6 +465,7 @@ registry.register("index_fill_", "cpu", index_fill_)
 registry.register("index_add_", "cpu", index_add_)
 registry.register("scatter_", "cpu", scatter_)
 registry.register("scatter_add_", "cpu", scatter_add_)
+registry.register("scatter_reduce", "cpu", scatter_reduce, meta=meta_infer.infer_scatter)
 registry.register("masked_scatter_", "cpu", masked_scatter_)
 registry.register("unfold", "cpu", unfold)
 registry.register("slice", "cpu", slice_op)
@@ -472,6 +477,7 @@ registry.register("as_strided_copy", "cpu", as_strided_copy)
 registry.register("as_strided_scatter", "cpu", as_strided_scatter)
 
 registry.register("var", "cpu", var_, meta=meta_infer.infer_sum)
+registry.register("var_mean", "cpu", var_mean)
 registry.register("norm", "cpu", norm_, meta=meta_infer.infer_sum)
 registry.register("prod", "cpu", prod_, meta=meta_infer.infer_sum)
 registry.register("floor_divide", "cpu", floor_divide, meta=meta_infer.infer_binary)

--- a/src/candle/_backends/cpu/ops.py
+++ b/src/candle/_backends/cpu/ops.py
@@ -558,6 +558,74 @@ def scatter(a, dim, index, src):
     return _from_numpy(arr, a.dtype, a.device)
 
 
+def scatter_reduce(a, dim, index, src, reduce, *, include_self=True):
+    arr = _to_numpy(a)
+    idx = _ensure_integer_indices(_to_numpy(index), "index").astype(np.int64, copy=False)
+    if dim < 0:
+        dim += arr.ndim
+    if dim < 0 or dim >= arr.ndim:
+        raise ValueError("dim out of range")
+    if idx.ndim != arr.ndim:
+        raise ValueError("index shape mismatch")
+    for i, size in enumerate(idx.shape):
+        if i != dim and size != arr.shape[i]:
+            raise ValueError("index shape mismatch")
+    _check_index_range(idx, arr.shape[dim])
+
+    if hasattr(src, "shape"):
+        src_arr = _to_numpy(src)
+    else:
+        src_arr = np.array(src, dtype=arr.dtype)
+    src_arr = np.broadcast_to(src_arr, idx.shape)
+
+    reduce = str(reduce)
+    if reduce not in ("sum", "prod", "mean", "amax", "amin"):
+        raise ValueError(f"unsupported reduction '{reduce}'")
+
+    if include_self:
+        out = arr.copy()
+    else:
+        if reduce in ("sum", "mean"):
+            out = np.zeros_like(arr)
+        elif reduce == "prod":
+            out = np.ones_like(arr)
+        elif reduce == "amax":
+            fill = np.finfo(arr.dtype).min if arr.dtype.kind in ("f", "c") else np.iinfo(arr.dtype).min
+            out = np.full_like(arr, fill)
+        else:
+            fill = np.finfo(arr.dtype).max if arr.dtype.kind in ("f", "c") else np.iinfo(arr.dtype).max
+            out = np.full_like(arr, fill)
+
+    if reduce == "mean":
+        counts = np.ones_like(arr, dtype=np.int64) if include_self else np.zeros_like(arr, dtype=np.int64)
+
+    it = np.nditer(idx, flags=['multi_index'])
+    while not it.finished:
+        mi = it.multi_index
+        dst_idx = list(mi)
+        dst_idx[dim] = int(it[0])
+        dst_idx = tuple(dst_idx)
+        value = src_arr[mi]
+        if reduce == "sum":
+            out[dst_idx] += value
+        elif reduce == "prod":
+            out[dst_idx] *= value
+        elif reduce == "mean":
+            out[dst_idx] += value
+            counts[dst_idx] += 1
+        elif reduce == "amax":
+            out[dst_idx] = value if value > out[dst_idx] else out[dst_idx]
+        else:
+            out[dst_idx] = value if value < out[dst_idx] else out[dst_idx]
+        it.iternext()
+
+    if reduce == "mean":
+        with np.errstate(divide="ignore", invalid="ignore"):
+            out = out / np.maximum(counts, 1)
+
+    return _from_numpy(out, a.dtype, a.device)
+
+
 def tril_indices(row, col, offset=0, dtype=None, device=None, layout=None):
     _check_indices_layout(layout)
     if row < 0 or col < 0:
@@ -2028,6 +2096,12 @@ def var_(a, dim=None, unbiased=True, keepdim=False):
         if keepdim:
             out = np.full([1] * arr.ndim, out)
     return _from_numpy(np.ascontiguousarray(np.atleast_1d(out).astype(arr.dtype, copy=False)), a.dtype, a.device)
+
+
+def var_mean(a, dim=None, unbiased=True, keepdim=False):
+    var_out = var_(a, dim=dim, unbiased=unbiased, keepdim=keepdim)
+    mean_out = mean_(a, dim=dim, keepdim=keepdim)
+    return var_out, mean_out
 
 
 def norm_(a, p=2, dim=None, keepdim=False):

--- a/src/candle/_backends/meta/__init__.py
+++ b/src/candle/_backends/meta/__init__.py
@@ -71,6 +71,7 @@ from .ops import (
     _meta_dsplit_meta,
     _meta_unbind_meta,
 )
+from .infer import infer_view_as_real, infer_view_as_complex
 
 registry.register("add", "meta", _meta_binary_meta)
 registry.register("mul", "meta", _meta_binary_meta)
@@ -160,6 +161,7 @@ registry.register("take_along_dim", "meta", _meta_take_along_dim_meta)
 registry.register("index_select", "meta", _meta_index_select_meta)
 registry.register("gather", "meta", _meta_gather_meta)
 registry.register("scatter", "meta", _meta_scatter_meta)
+registry.register("scatter_reduce", "meta", _meta_scatter_meta)
 registry.register("cartesian_prod", "meta", _meta_cartesian_prod_meta)
 registry.register("chunk", "meta", _meta_chunk_meta)
 registry.register("split", "meta", _meta_split_meta)
@@ -188,8 +190,11 @@ registry.register("fmod", "meta", _meta_binary_meta)
 registry.register("contiguous", "meta", _meta_contiguous_meta)
 registry.register("sum", "meta", _meta_sum_meta)
 registry.register("std", "meta", _meta_sum_meta)
+registry.register("var_mean", "meta", _meta_sum_meta)
 registry.register("reshape", "meta", view_backend.reshape, meta=_meta_view_meta)
 registry.register("view", "meta", view_backend.view, meta=_meta_view_meta)
+registry.register("view_as_real", "meta", view_backend.view_as_real, meta=infer_view_as_real)
+registry.register("view_as_complex", "meta", view_backend.view_as_complex, meta=infer_view_as_complex)
 registry.register("transpose", "meta", view_backend.transpose, meta=_meta_transpose_meta)
 registry.register("to", "meta", convert_backend.to_device)
 

--- a/src/candle/_backends/meta/infer.py
+++ b/src/candle/_backends/meta/infer.py
@@ -469,6 +469,44 @@ def infer_view(a, shape):
     return TensorSpec(shape=shape, stride=_contiguous_stride(shape), dtype=a.dtype, offset=a.offset)
 
 
+def infer_view_as_real(a):
+    if not a.dtype.is_complex:
+        raise ValueError("view_as_real expects a complex tensor")
+    if a.dtype.itemsize % 2 != 0:
+        raise ValueError("view_as_real expects complex dtype with even itemsize")
+    from ... import _dtype as _dtype
+    if a.dtype == _dtype.complex64:
+        out_dtype = _dtype.float32
+    elif a.dtype == _dtype.complex128:
+        out_dtype = _dtype.float64
+    elif a.dtype == _dtype.complex32:
+        out_dtype = _dtype.float16
+    else:
+        raise ValueError("view_as_real expects a supported complex dtype")
+    shape = tuple(a.shape) + (2,)
+    stride = tuple(s * 2 for s in a.stride) + (1,)
+    return TensorSpec(shape=shape, stride=stride, dtype=out_dtype, offset=a.offset * 2)
+
+
+def infer_view_as_complex(a):
+    if a.dtype.is_complex:
+        raise ValueError("view_as_complex expects a non-complex tensor")
+    if len(a.shape) == 0 or a.shape[-1] != 2:
+        raise ValueError("view_as_complex expects last dimension of size 2")
+    from ... import _dtype as _dtype
+    if a.dtype == _dtype.float16:
+        out_dtype = _dtype.complex32
+    elif a.dtype == _dtype.float32:
+        out_dtype = _dtype.complex64
+    elif a.dtype == _dtype.float64:
+        out_dtype = _dtype.complex128
+    else:
+        raise ValueError("view_as_complex is only supported for half, float and double tensors")
+    shape = tuple(a.shape[:-1])
+    stride = tuple(s // 2 for s in a.stride[:-1])
+    return TensorSpec(shape=shape, stride=stride, dtype=out_dtype, offset=a.offset // 2)
+
+
 def infer_transpose(a, dim0, dim1):
     shape = list(a.shape)
     stride = list(a.stride)

--- a/src/candle/_dispatch/schemas.py
+++ b/src/candle/_dispatch/schemas.py
@@ -137,6 +137,7 @@ CORE_SCHEMA_OPS = (
     "unsqueeze",
     "permute",
     "var",
+    "var_mean",
     "norm",
     "prod",
     "floor_divide",
@@ -194,6 +195,8 @@ def register_schemas():
         },
     )
     registry.register_schema("view", "view(Tensor(a) input, int[] shape) -> Tensor(a)")
+    registry.register_schema("view_as_real", "view_as_real(Tensor(a) input) -> Tensor(a)")
+    registry.register_schema("view_as_complex", "view_as_complex(Tensor(a) input) -> Tensor(a)")
     registry.register_error_overrides(
         "view",
         {
@@ -331,6 +334,10 @@ def register_schemas():
     registry.register_schema("index_select", "index_select(Tensor input, int dim, Tensor index) -> Tensor")
     registry.register_schema("gather", "gather(Tensor input, int dim, Tensor index) -> Tensor")
     registry.register_schema("scatter", "scatter(Tensor input, int dim, Tensor index, Any src) -> Tensor")
+    registry.register_schema(
+        "scatter_reduce",
+        "scatter_reduce(Tensor input, int dim, Tensor index, Tensor src, str reduce, bool include_self=True) -> Tensor",
+    )
 
     registry.register_schema("tril", "tril(Tensor input, int diagonal=0) -> Tensor")
     registry.register_schema("triu", "triu(Tensor input, int diagonal=0) -> Tensor")
@@ -406,6 +413,10 @@ def register_schemas():
     registry.register_schema("scatter_add_", "scatter_add_(Tensor(a!) self, int dim, Tensor index, Tensor src) -> Tensor")
 
     registry.register_schema("var", "var(Tensor input, int[]? dim=None, bool unbiased=True, bool keepdim=False) -> Tensor")
+    registry.register_schema(
+        "var_mean",
+        "var_mean(Tensor input, int[]? dim=None, bool unbiased=True, bool keepdim=False) -> (Tensor, Tensor)",
+    )
     registry.register_error_overrides(
         "var",
         {

--- a/src/candle/_dtype.py
+++ b/src/candle/_dtype.py
@@ -124,6 +124,10 @@ _NUMPY_DTYPE_MAP = {
     complex32: np.complex64,
     complex64: np.complex64,
     complex128: np.complex128,
+    float16: np.float16,
+    float32: np.float32,
+    float64: np.float64,
+    bfloat16: np.uint16,
 }
 
 # Reverse map: numpy dtype -> DType

--- a/src/candle/_functional.py
+++ b/src/candle/_functional.py
@@ -77,6 +77,14 @@ def reshape(*args, **kwargs):
     return dispatch("reshape", None, *args, **kwargs)
 
 
+def view_as_real(a):
+    return dispatch("view_as_real", a.device.type, a)
+
+
+def view_as_complex(a):
+    return dispatch("view_as_complex", a.device.type, a)
+
+
 def mul(*args, **kwargs):
     r = _handle_torch_function(mul, args, kwargs)
     if r is not NotImplemented:
@@ -375,6 +383,10 @@ def mean(a, dim=None, keepdim=False, *, dtype=None, axis=None):
         a = a.to(dtype=dtype)
     result = dispatch("mean", a.device.type, a, dim=dim, keepdim=keepdim)
     return result
+
+
+def var_mean(a, dim=None, keepdim=False, unbiased=True):
+    return dispatch("var_mean", a.device.type, a, dim=dim, unbiased=unbiased, keepdim=keepdim)
 
 
 def std(a, dim=None, keepdim=False, unbiased=True, *, axis=None):
@@ -985,6 +997,19 @@ def scatter_(a, dim, index, src):
 
 def scatter_add_(a, dim, index, src):
     return dispatch("scatter_add_", a.device.type, a, dim, index, src)
+
+
+def scatter_reduce(a, dim, index, src, reduce, *, include_self=True):
+    return dispatch(
+        "scatter_reduce",
+        a.device.type,
+        a,
+        dim,
+        index,
+        src,
+        reduce,
+        include_self=include_self,
+    )
 
 
 def masked_scatter_(a, mask, source):

--- a/src/candle/_storage.py
+++ b/src/candle/_storage.py
@@ -533,6 +533,31 @@ class TypedStorage:
             return self
         raise NotImplementedError(f"Unsupported device: {self.device}")
 
+    def _reinterpret(self, dtype):
+        if dtype == self.dtype:
+            return self
+        if self.device.type == "cpu":
+            itemsize = np.dtype(to_numpy_dtype(dtype)).itemsize
+            size = int(self.nbytes() // itemsize)
+            data = self._data.view(to_numpy_dtype(dtype))
+            data = data.reshape(size)
+            return TypedStorage(self._untyped, dtype, size, data=data)
+        if self.device.type == "mps":
+            itemsize = np.dtype(to_numpy_dtype(dtype)).itemsize
+            size = int(self.nbytes() // itemsize)
+            data = self._data.view(to_numpy_dtype(dtype))
+            data = data.reshape(size)
+            return TypedStorage(self._untyped, dtype, size, data=data)
+        if self.device.type in ("npu", "cuda"):
+            itemsize = np.dtype(to_numpy_dtype(dtype)).itemsize
+            size = int(self.nbytes() // itemsize)
+            return TypedStorage(self._untyped, dtype, size)
+        if self.device.type == "meta":
+            itemsize = np.dtype(to_numpy_dtype(dtype)).itemsize
+            size = int(self.nbytes() // itemsize)
+            return TypedStorage(self._untyped, dtype, size)
+        raise NotImplementedError(f"Unsupported device: {self.device}")
+
     def resize_(self, new_size):
         itemsize = np.dtype(to_numpy_dtype(self.dtype)).itemsize
         self._untyped.resize_(int(new_size) * itemsize)

--- a/src/candle/_tensor.py
+++ b/src/candle/_tensor.py
@@ -434,6 +434,10 @@ class Tensor:
         """Reshape this tensor to the same shape as other."""
         return self.view(other.shape)
 
+    def var_mean(self, dim=None, keepdim=False, unbiased=True):
+        from ._functional import var_mean
+        return var_mean(self, dim=dim, keepdim=keepdim, unbiased=unbiased)
+
     def new_empty(self, size, *, dtype=None, device=None, requires_grad=False):
         """Create a new empty tensor with the same dtype and device as self."""
         from ._creation import empty

--- a/tests/contract/test_scatter_reduce_contract.py
+++ b/tests/contract/test_scatter_reduce_contract.py
@@ -1,0 +1,45 @@
+import candle as torch
+import torch as real_torch
+
+
+def _make_inputs():
+    base = torch.zeros(3, 5)
+    index = torch.tensor([[0, 1, 2, 0, 1], [1, 2, 0, 1, 2], [2, 0, 1, 2, 0]])
+    src = torch.arange(15).reshape(3, 5)
+    return base, index, src
+
+
+def test_scatter_reduce_sum_include_self():
+    base, index, src = _make_inputs()
+    out = torch.scatter_reduce(base, 0, index, src, reduce="sum", include_self=True)
+    assert out.shape == base.shape
+
+
+def test_scatter_reduce_prod_exclude_self():
+    base, index, src = _make_inputs()
+    out = torch.scatter_reduce(base, 0, index, src, reduce="prod", include_self=False)
+    assert out.shape == base.shape
+
+
+def test_scatter_reduce_mean():
+    base, index, src = _make_inputs()
+    out = torch.scatter_reduce(base, 0, index, src, reduce="mean", include_self=True)
+    assert out.shape == base.shape
+
+
+def test_scatter_reduce_amax_amin():
+    base, index, src = _make_inputs()
+    out_max = torch.scatter_reduce(base, 0, index, src, reduce="amax", include_self=True)
+    out_min = torch.scatter_reduce(base, 0, index, src, reduce="amin", include_self=True)
+    assert out_max.shape == base.shape
+    assert out_min.shape == base.shape
+
+
+def test_scatter_reduce_sum_matches_torch_contract():
+    base, index, src = _make_inputs()
+    out = torch.scatter_reduce(base, 0, index, src, reduce="sum", include_self=True)
+    base_ref = real_torch.zeros(3, 5, dtype=real_torch.int64)
+    index_ref = real_torch.tensor([[0, 1, 2, 0, 1], [1, 2, 0, 1, 2], [2, 0, 1, 2, 0]])
+    src_ref = real_torch.arange(15).reshape(3, 5)
+    out_ref = real_torch.scatter_reduce(base_ref, 0, index_ref, src_ref, reduce="sum", include_self=True)
+    assert tuple(out.shape) == tuple(out_ref.shape)

--- a/tests/contract/test_var_mean_contract.py
+++ b/tests/contract/test_var_mean_contract.py
@@ -1,0 +1,24 @@
+import candle as torch
+import torch as real_torch
+
+
+def test_var_mean_returns_tuple():
+    x = torch.randn(2, 3)
+    v, m = torch.var_mean(x)
+    assert v.shape == m.shape
+
+
+def test_var_mean_dim_keepdim():
+    x = torch.randn(2, 3)
+    v, m = torch.var_mean(x, dim=1, keepdim=True)
+    assert v.shape == (2, 1)
+    assert m.shape == (2, 1)
+
+
+def test_var_mean_matches_torch_contract():
+    x = torch.randn(2, 3)
+    v, m = torch.var_mean(x, dim=1, keepdim=True)
+    x_ref = real_torch.randn(2, 3)
+    v_ref, m_ref = real_torch.var_mean(x_ref, dim=1, keepdim=True)
+    assert tuple(v.shape) == tuple(v_ref.shape)
+    assert tuple(m.shape) == tuple(m_ref.shape)

--- a/tests/contract/test_view_as_real_complex.py
+++ b/tests/contract/test_view_as_real_complex.py
@@ -1,0 +1,48 @@
+import candle as torch
+import pytest
+import torch as real_torch
+
+
+def test_view_as_real_complex_shape_dtype():
+    x = torch.randn(2, 3, dtype=torch.complex64)
+    y = torch.view_as_real(x)
+    assert y.shape == (2, 3, 2)
+    assert "float" in str(y.dtype)
+
+
+def test_view_as_complex_roundtrip():
+    x = torch.randn(2, 3, dtype=torch.complex64)
+    y = torch.view_as_real(x)
+    z = torch.view_as_complex(y)
+    assert z.shape == x.shape
+    assert str(z.dtype) == str(x.dtype)
+
+
+def test_view_as_complex_invalid_last_dim():
+    x = torch.randn(2, 3, 4)
+    with pytest.raises(RuntimeError):
+        torch.view_as_complex(x)
+
+
+def test_view_as_real_stride_matches_torch_contract():
+    x = torch.randn(2, 3, dtype=torch.complex64)
+    y = torch.view_as_real(x)
+    x_ref = real_torch.randn(2, 3, dtype=real_torch.complex64)
+    y_ref = real_torch.view_as_real(x_ref)
+    assert tuple(y.stride) == tuple(y_ref.stride())
+
+
+def test_view_as_real_matches_torch_contract():
+    x = torch.randn(2, 3, dtype=torch.complex64)
+    y = torch.view_as_real(x)
+    x_ref = real_torch.randn(2, 3, dtype=real_torch.complex64)
+    y_ref = real_torch.view_as_real(x_ref)
+    assert tuple(y.shape) == tuple(y_ref.shape)
+
+
+def test_view_as_complex_matches_torch_contract():
+    x = torch.view_as_real(torch.randn(2, 3, dtype=torch.complex64))
+    z = torch.view_as_complex(x)
+    x_ref = real_torch.view_as_real(real_torch.randn(2, 3, dtype=real_torch.complex64))
+    z_ref = real_torch.view_as_complex(x_ref)
+    assert tuple(z.shape) == tuple(z_ref.shape)


### PR DESCRIPTION
## Summary
- add schema/functional exports for `view_as_real`, `view_as_complex`, `var_mean`, `scatter_reduce`
- implement view-as-real/complex dtype reinterpretation + meta inference
- add CPU kernels for `scatter_reduce` (all reduce modes) and `var_mean`
- add contract tests for new ops

## Testing
- `pytest tests/contract/test_view_as_real_complex.py -v --tb=short`
- `pytest tests/contract/test_var_mean_contract.py -v --tb=short`
- `pytest tests/contract/test_scatter_reduce_contract.py -v --tb=short`
- `pytest tests/contract/ -v --tb=short`
- `pylint src/candle/ --rcfile=pyproject.toml` (fails due to astroid/pylint crash on this environment; traceback in PR)


## Pylint Crash (excerpt)
```
************* Module candle.distributed._composable.fsdp._fsdp_common
src/candle/distributed/_composable/fsdp/_fsdp_common.py:1:0: F0002: src/candle/distributed/_composable/fsdp/_fsdp_common.py: Fatal error while checking 'src/candle/distributed/_composable/fsdp/_fsdp_common.py'. Please open an issue in our bug tracker so we address this. There is a pre-filled template that you can use in '/home/lvyufeng/.cache/pylint/pylint-crash-2026-03-16-09-43-31.txt'. (astroid-error)
************* Module candle
src/candle/__init__.py:93:0: C0301: Line too long (158/100) (line-too-long)
src/candle/__init__.py:97:0: C0301: Line too long (565/100) (line-too-long)
src/candle/__init__.py:157:0: C0301: Line too long (103/100) (line-too-long)
src/candle/__init__.py:643:0: C0301: Line too long (109/100) (line-too-long)
src/candle/__init__.py:1:0: C0114: Missing module docstring (missing-module-docstring)
src/candle/__init__.py:214:0: W0622: Redefining built-in 'compile' (redefined-builtin)
src/candle/__init__.py:6:0: W0622: Redefining built-in 'bool' (redefined-builtin)
src/candle/__init__.py:19:0: W0622: Redefining built-in 'float' (redefined-builtin)
src/candle/__init__.py:20:0: W0622: Redefining built-in 'int' (redefined-builtin)
src/candle/__init__.py:93:0: W0622: Redefining built-in 'range' (redefined-builtin)
src/candle/__init__.py:97:0: W0622: Redefining built-in 'sum' (redefined-builtin)
src/candle/__init__.py:97:0: W0622: Redefining built-in 'all' (redefined-builtin)
src/candle/__init__.py:97:0: W0622: Redefining built-in 'any' (redefined-builtin)
src/candle/__init__.py:97:0: W0622: Redefining built-in 'abs' (redefined-builtin)
src/candle/__init__.py:98:0: W0622: Redefining built-in 'round' (redefined-builtin)
src/candle/__init__.py:99:0: W0622: Redefining built-in 'pow' (redefined-builtin)
src/candle/__init__.py:104:0: W0622: Redefining built-in 'min' (redefined-builtin)
src/candle/__init__.py:104:0: W0622: Redefining built-in 'max' (redefined-builtin)
src/candle/__init__.py:126:0: W0622: Redefining built-in 'slice' (redefined-builtin)
src/candle/__init__.py:137:0: W0622: Redefining built-in 'complex' (redefined-builtin)
src/candle/__init__.py:19:0: C0414: Import alias does not rename original package (useless-import-alias)
src/candle/__init__.py:20:0: C0414: Import alias does not rename original package (useless-import-alias)
src/candle/__init__.py:21:0: W0404: Reimport 'DType' (imported line 6) (reimported)
src/candle/__init__.py:22:0: W0404: Reimport 'DType' (imported line 6) (reimported)
src/candle/__init__.py:24:0: W0404: Reimport 'device' (imported line 23) (reimported)
src/candle/__init__.py:40:0: C0116: Missing function or method docstring (missing-function-docstring)
src/candle/__init__.py:40:22: W0621: Redefining name 'dtype' from outer scope (line 21) (redefined-outer-name)
src/candle/__init__.py:43:4: W0603: Using the global statement (global-statement)
src/candle/__init__.py:47:0: C0116: Missing function or method docstring (missing-function-docstring)
src/candle/__init__.py:52:0: C0116: Missing function or method docstring (missing-function-docstring)
src/candle/__init__.py:56:0: C0116: Missing function or method docstring (missing-function-docstring)
src/candle/__init__.py:63:0: C0116: Missing function or method docstring (missing-function-docstring)
src/candle/__init__.py:70:8: W0612: Unused variable 'category' (unused-variable)
src/candle/__init__.py:71:12: W0612: Unused variable 'key' (unused-variable)
src/candle/__init__.py:76:0: C0116: Missing function or method docstring (missing-function-docstring)
src/candle/__init__.py:93:0: C0413: Import "from ._creation import tensor, zeros, ones, empty, arange, linspace, full, logspace, eye, range, randn, rand, randint, randperm, from_numpy, as_tensor, normal" should be placed at the top of the module (wrong-import-position)
src/candle/__init__.py:94:0: C0413: Import "from ._functional import zeros_like" should be placed at the top of the module (wrong-import-position)
src/candle/__init__.py:95:0: C0413: Import "from ._functional import ones_like, empty_like, full_like, randn_like, rand_like, randint_like" should be placed at the top of the module (wrong-import-position)
src/candle/__init__.py:96:0: C0413: Import "from ._storage import UntypedStorage, TypedStorage" should be placed at the top of the module (wrong-import-position)
src/candle/__init__.py:97:0: C0413: Import "from ._functional import add, mul, matmul, relu, sum, all, any, argmax, argmin, count_nonzero, masked_select, flip, roll, rot90, repeat, repeat_interleave, tile, nonzero, allclose, isclose, equal, cumsum, cumprod, cummax, argsort, sort, topk, stack, cat, concat, concatenate, hstack, vstack, row_stack, dstack, column_stack, pad_sequence, block_diag, tril, triu, diag, cartesian_prod, chunk, split, vsplit, hsplit, dsplit, unbind, tril_indices, triu_indices, take, take_along_dim, index_select, gather, scatter, abs, neg, exp, log, sqrt, div, true_divide, mean, std" should be placed at the top of the module (wrong-import-position)
src/candle/__init__.py:98:0: C0413: Import "from ._functional import sin, cos, tan, tanh, sigmoid, floor, ceil, round, trunc, frac" should be placed at the top of the module (wrong-import-position)
src/candle/__init__.py:99:0: C0413: Import "from ._functional import pow, log2, log10, exp2, rsqrt" should be placed at the top of the module (wrong-import-position)
src/candle/__init__.py:100:0: C0413: Import "from ._functional import sign, signbit, isnan, isinf, isfinite" should be placed at the top of the module (wrong-import-position)
src/candle/__init__.py:101:0: C0413: Import "from ._functional import sinh, cosh, asinh, acosh, atanh, erf, erfc, softplus" should be placed at the top of the module (wrong-import-position)
src/candle/__init__.py:102:0: C0413: Import "from ._functional import clamp, clamp_min, clamp_max, relu6, hardtanh" should be placed at the top of the module (wrong-import-position)
src/candle/__init__.py:103:0: C0413: Import "from ._functional import add_, mul_, relu_, zero_, clamp_, copy_" should be placed at the top of the module (wrong-import-position)
src/candle/__init__.py:104:0: C0413: Import "from ._functional import min, max, amin, amax, fmin, fmax, where" should be placed at the top of the module (wrong-import-position)
src/candle/__init__.py:105:0: C0413: Import "from ._functional import atan, atan2, asin, acos, lerp, addcmul, addcdiv" should be placed at the top of the module (wrong-import-position)
src/candle/__init__.py:106:0: C0413: Import "from ._functional import reshape, transpose, view_as_real, view_as_complex" should be placed at the top of the module (wrong-import-position)
src/candle/__init__.py:107:0: C0413: Import "from ._functional import logaddexp, logaddexp2, hypot, remainder, fmod" should be placed at the top of the module (wrong-import-position)
src/candle/__init__.py:108:0: C0413: Import "from ._functional import squeeze, unsqueeze, permute" should be placed at the top of the module (wrong-import-position)
src/candle/__init__.py:109:0: C0413: Import "from ._functional import var, var_mean, norm, prod" should be placed at the top of the module (wrong-import-position)
src/candle/__init__.py:110:0: C0413: Import "from ._functional import reciprocal, addmm, einsum" should be placed at the top of the module (wrong-import-position)
src/candle/__init__.py:111:0: C0413: Import "from ._functional import mm, bmm" should be placed at the top of the module (wrong-import-position)
src/candle/__init__.py:112:0: C0413: Import "from ._functional import floor_divide" should be placed at the top of the module (wrong-import-position)
src/candle/__init__.py:113:0: C0413: Import "from ._functional import narrow, flatten" should be placed at the top of the module (wrong-import-position)
src/candle/__init__.py:114:0: C0413: Import "from ._functional import logical_and, logical_or, logical_not" should be placed at the top of the module (wrong-import-position)
```

Full crash log: /tmp/pylint_crash.txt