### PR TITLE
feat(mps): eliminate numpy fallbacks in erfinv_, instance_norm, and diag 1D ops

### DIFF
--- a/src/candle/_backends/mps/ops/norm.py
+++ b/src/candle/_backends/mps/ops/norm.py
@@ -257,22 +257,26 @@ def instance_norm(input, weight=None, bias=None, running_mean=None, running_var=
             and len(input.shape) >= 2):
         C = input.shape[1]
         result = group_norm(input, num_groups=C, weight=weight, bias=bias, eps=eps)
-        # Update running stats if needed
+        # Update running stats on GPU — only read back small (C,) results
         if use_input_stats and (running_mean is not None or running_var is not None):
-            arr = _to_numpy(input)
-            ndim = len(arr.shape)
-            N = arr.shape[0]
-            spatial_axes = tuple(range(2, ndim))
-            mean = arr.mean(axis=spatial_axes, keepdims=True)
-            var = arr.var(axis=spatial_axes, keepdims=True)
+            from .reduce import mean_, var_
+            from ...common.view import reshape
+            ndim = len(input.shape)
+            N = input.shape[0]
+            spatial_axes = list(range(2, ndim))
             if running_mean is not None:
-                rm = _to_numpy(running_mean)
-                batch_mean = mean.reshape(N, C).mean(axis=0)
-                rm[:] = (1 - momentum) * rm + momentum * batch_mean
+                # GPU reduce over spatial dims, then average over batch
+                mean_gpu = mean_(input, dim=spatial_axes, keepdim=True)
+                batch_mean = mean_(reshape(mean_gpu, (N, C)), dim=[0], keepdim=False)
+                rm = running_mean._storage.data.ravel()
+                bm = _to_numpy(batch_mean)
+                rm[:] = ((1 - momentum) * rm + momentum * bm).astype(rm.dtype)
             if running_var is not None:
-                rv = _to_numpy(running_var)
-                batch_var = var.reshape(N, C).mean(axis=0)
-                rv[:] = (1 - momentum) * rv + momentum * batch_var
+                var_gpu = var_(input, dim=spatial_axes, unbiased=False, keepdim=True)
+                batch_var = mean_(reshape(var_gpu, (N, C)), dim=[0], keepdim=False)
+                rv = running_var._storage.data.ravel()
+                bv = _to_numpy(batch_var)
+                rv[:] = ((1 - momentum) * rv + momentum * bv).astype(rv.dtype)
         return result
 
     arr = _to_numpy(input)

--- a/src/candle/_backends/mps/ops/random.py
+++ b/src/candle/_backends/mps/ops/random.py
@@ -289,6 +289,50 @@ def copy_(a, src):
     return a
 
 def erfinv_(a):
+    # GPU composite: Beasley-Springer-Moro rational approximation on-device
+    if _can_use_gpu(a) and a.is_contiguous() and a.dtype in (float32_dtype, float16_dtype):
+        from .math import mul, add, sub, div, sqrt, log, neg, abs as abs_
+        from .comparison import le, ge, gt, lt
+        from .elementwise import where
+        _sqrt2 = 1.4142135623730951
+        # Map erfinv domain [-1,1] to probit domain [0,1]: p = (a+1)/2
+        p = div(add(a, 1.0), 2.0)
+        q = sub(p, 0.5)
+        abs_q = abs_(q)
+        central_mask = le(abs_q, 0.425)
+        # --- Central region: rational approx in q ---
+        r2 = mul(q, q)
+        # num = ((a3*r2 + a2)*r2 + a1)*r2 + a0
+        t = add(mul(r2, -25.44106049637), 41.39119773534)
+        t = add(mul(t, r2), -18.61500062529)
+        num = add(mul(t, r2), 2.50662823884)
+        # den = (((b3*r2 + b2)*r2 + b1)*r2 + b0)*r2 + 1
+        t = add(mul(r2, 3.13082909833), -21.06224101826)
+        t = add(mul(t, r2), 23.08336743743)
+        t = add(mul(t, r2), -8.47351093090)
+        den = add(mul(t, r2), 1.0)
+        central_val = div(mul(q, num), den)
+        # --- Tail region ---
+        one_minus_p = add(neg(p), 1.0)  # 1 - p
+        p_lt_half = le(p, 0.5)
+        pp = where(p_lt_half, p, one_minus_p)
+        r = sqrt(mul(log(pp), -2.0))
+        # t_num = (c2*r + c1)*r + c0
+        t = add(mul(r, 0.010328), 0.802853)
+        t_num = add(mul(t, r), 2.515517)
+        # t_den = ((d2*r + d1)*r + d0)*r + 1
+        t = add(mul(r, 0.001308), 0.189269)
+        t = add(mul(t, r), 1.432788)
+        t_den = add(mul(t, r), 1.0)
+        tail_abs = sub(r, div(t_num, t_den))
+        tail_val = where(p_lt_half, neg(tail_abs), tail_abs)
+        # Combine central + tail, scale by 1/sqrt(2)
+        result = div(where(central_mask, central_val, tail_val), _sqrt2)
+        # Boundary: erfinv(-1)=-inf, erfinv(1)=inf (scalar must be y in where)
+        result = where(gt(a, -1.0), result, float('-inf'))
+        result = where(lt(a, 1.0), result, float('inf'))
+        copy_(a, result)
+        return a
     arr = _to_numpy(a)
     arr[:] = _ndtr_inv((arr + 1.0) / 2.0) / np.sqrt(2.0)
     return a

--- a/src/candle/_backends/mps/ops/shape.py
+++ b/src/candle/_backends/mps/ops/shape.py
@@ -370,6 +370,25 @@ def diag(a, diagonal_offset=0):
     # GPU composite for 2D input: delegate to diagonal()
     if _can_use_gpu(a) and len(a.shape) == 2:
         return diagonal(a, offset=diagonal_offset)
+    # GPU composite for 1D input: create diagonal matrix on MPS
+    if _can_use_gpu(a) and len(a.shape) == 1:
+        n = a.shape[0]
+        sz = n + (diagonal_offset if diagonal_offset >= 0 else -diagonal_offset)
+        total = sz * sz
+        out_buf = _alloc_output_buf(total, a.dtype)
+        from ...._tensor import _compute_strides
+        out_shape = (sz, sz)
+        out_stride = _compute_strides(out_shape)
+        out = _from_metal_buffer(out_buf, out_shape, out_stride, a.dtype, a.device)
+        # Write via unified memory (storage.data is the metal buffer numpy view)
+        out_data = out._storage.data.reshape(sz, sz)
+        out_data[:] = 0
+        src_data = a._storage.data
+        row_off = max(-diagonal_offset, 0)
+        col_off = max(diagonal_offset, 0)
+        for i in range(n):
+            out_data[row_off + i, col_off + i] = src_data[i]
+        return out
     arr = _to_numpy(a)
     if arr.ndim not in (1, 2):
         raise ValueError("diag expects 1D or 2D tensor")


### PR DESCRIPTION
## Summary

Batch 6 of MPS numpy fallback elimination. Replaces three reachable numpy fallbacks with GPU composites/unified-memory paths.

### Changes

**`erfinv_`** (random.py): GPU composite using Beasley-Springer-Moro rational approximation with on-device primitives (`mul`, `add`, `sub`, `div`, `sqrt`, `log`, `neg`, `abs`, `where`). Piecewise: central region (`|p-0.5| <= 0.425`) uses one rational polynomial, tail region uses another. Boundary values (-1→-inf, 1→inf) handled via `where`.

**`instance_norm` running stats** (norm.py): The GPU branch was pulling the full input tensor to CPU via `_to_numpy(input)` to compute running stats. Now uses GPU `mean_`/`var_` reduce over spatial axes, then reads back only the small `(C,)`-sized batch stats for the EMA update. Same pattern as `batch_norm`.

**`diag` 1D→2D** (shape.py): Creates the output matrix on MPS via `_alloc_output_buf`, then writes zeros and diagonal values through the unified-memory `storage.data` numpy view. No GPU dispatch needed since MPS uses shared memory.

### Verification

- Pylint: 10.00/10
- MPS tests: 361 passed
- CPU/contract tests: 1694 passed, 28 skipped