### PR TITLE
feat(npu): Cython-ize _binary_op helper layer (Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,4 @@ compat/*/_transformers/
 compat/*/_pytorch/
 compat/*/_reports/
 compat/pytorch/_pytorch.local/
+src/candle/_backends/npu/_npu_ops_fast.c

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,10 @@ if platform.system() == "Linux":
                     ["src/candle/_backends/npu/_aclnn_ffi.pyx"],
                     libraries=["dl"],
                 ),
+                Extension(
+                    "candle._backends.npu._npu_ops_fast",
+                    ["src/candle/_backends/npu/_npu_ops_fast.pyx"],
+                ),
             ],
             compiler_directives={
                 "language_level": "3",

--- a/src/candle/_backends/npu/_npu_ops_fast.pyx
+++ b/src/candle/_backends/npu/_npu_ops_fast.pyx
@@ -1,0 +1,197 @@
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""Cython fast-path for _binary_op helper.
+
+Replaces Python-level shape computation (broadcast, stride, numel) with
+C-level loops, reducing per-op overhead by ~0.05-0.10ms on the hot path.
+
+The heavy operations (device malloc, aclnn kernel, output wrapping) remain
+in Python — this module only accelerates the metadata computation.
+"""
+
+from libc.stdint cimport int64_t
+
+DEF MAX_NDIM = 16
+
+# ---------------------------------------------------------------------------
+# C-level shape utilities (nogil)
+# ---------------------------------------------------------------------------
+
+cdef int c_broadcast_shape(
+    const int64_t* a, int a_ndim,
+    const int64_t* b, int b_ndim,
+    int64_t* out) except -1 nogil:
+    """Compute broadcast shape into *out*.  Returns out_ndim.
+
+    Raises ValueError (via except -1) on shape mismatch.
+    """
+    cdef int out_ndim = a_ndim if a_ndim > b_ndim else b_ndim
+    cdef int i
+    cdef int64_t a_dim, b_dim
+    # Fill from the right (index out_ndim-1 down to 0)
+    for i in range(out_ndim):
+        a_dim = a[a_ndim - 1 - i] if i < a_ndim else 1
+        b_dim = b[b_ndim - 1 - i] if i < b_ndim else 1
+        if a_dim == b_dim:
+            out[out_ndim - 1 - i] = a_dim
+        elif a_dim == 1:
+            out[out_ndim - 1 - i] = b_dim
+        elif b_dim == 1:
+            out[out_ndim - 1 - i] = a_dim
+        else:
+            with gil:
+                raise ValueError("matmul shape mismatch")
+            return -1  # unreachable, keeps compiler happy
+    return out_ndim
+
+
+cdef void c_contiguous_stride(
+    const int64_t* shape, int ndim, int64_t* out) noexcept nogil:
+    """Compute contiguous strides in-place."""
+    cdef int64_t acc = 1
+    cdef int i, j
+    # Iterate forward using (ndim - 1 - j) to avoid negative index
+    for j in range(ndim):
+        i = ndim - 1 - j
+        out[i] = acc
+        acc = acc * shape[i]
+
+
+cdef int64_t c_numel(const int64_t* shape, int ndim) nogil:
+    """Product of shape dims."""
+    cdef int64_t n = 1
+    cdef int i
+    for i in range(ndim):
+        n = n * shape[i]
+    return n
+
+
+# ---------------------------------------------------------------------------
+# dtype itemsize (C switch, no dict lookup)
+# ---------------------------------------------------------------------------
+
+cdef int c_dtype_itemsize(object dtype):
+    """Return byte size from a candle dtype object."""
+    cdef object size = getattr(dtype, "itemsize", None)
+    if size is not None:
+        return <int>size
+    cdef str name = getattr(dtype, "name", None)
+    if name is None:
+        s = str(dtype)
+        parts = s.split(".")
+        name = parts[len(parts) - 1]
+    if name == "float32" or name == "int32":
+        return 4
+    if name == "float64" or name == "int64":
+        return 8
+    if name == "float16" or name == "bfloat16" or name == "int16":
+        return 2
+    if name == "int8" or name == "uint8" or name == "bool":
+        return 1
+    return 4  # fallback
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+cdef inline void _fill_shape(object py_tuple, int64_t* buf, int ndim):
+    """Copy Python tuple of ints into a C array."""
+    cdef int i
+    for i in range(ndim):
+        buf[i] = <int64_t>py_tuple[i]
+
+
+cdef inline tuple _to_tuple(const int64_t* arr, int n):
+    """Convert C int64 array to Python tuple."""
+    return tuple([arr[i] for i in range(n)])
+
+
+# ---------------------------------------------------------------------------
+# fast_binary_op — drop-in replacement for _binary_op in _helpers.py
+# ---------------------------------------------------------------------------
+
+def fast_binary_op(a, b, fn, str name):
+    """Drop-in replacement for _binary_op in _helpers.py.
+
+    Does shape/stride/numel computation in C, then calls Python for:
+    - runtime/stream lookup (dict + TLS)
+    - allocator (complex caching + GC)
+    - aclnn kernel (already Cython-ized)
+    - output tensor wrapping (weakref + Python objects)
+    """
+    # Import heavy Python deps (cached after first call by Python)
+    from . import runtime as npu_runtime
+    from . import state as npu_state
+    from ..._storage import npu_typed_storage_from_ptr
+    from ..._tensor import Tensor
+
+    # 1. Validate device/dtype (direct attribute access)
+    a_dev = a.device
+    b_dev = b.device
+    if a_dev.type != "npu" or b_dev.type != "npu":
+        raise ValueError(f"NPU {name} expects NPU tensors")
+    a_dtype = a.dtype
+    if a_dtype != b.dtype:
+        raise ValueError(f"NPU {name} requires matching dtypes")
+
+    # 2. Get runtime + stream (Python — dict + TLS)
+    cdef int dev_idx = a_dev.index or 0
+    runtime = npu_runtime.get_runtime(dev_idx)
+    stream = npu_state.current_stream(dev_idx)
+
+    # 3. Extract shapes into C arrays
+    py_a_shape = a.shape
+    py_b_shape = b.shape
+    cdef int a_ndim = len(py_a_shape)
+    cdef int b_ndim = len(py_b_shape)
+
+    if a_ndim > MAX_NDIM or b_ndim > MAX_NDIM:
+        raise ValueError(f"ndim exceeds MAX_NDIM ({MAX_NDIM})")
+
+    cdef int64_t[MAX_NDIM] a_shape_buf, b_shape_buf
+    cdef int64_t[MAX_NDIM] out_shape_buf, out_stride_buf
+
+    _fill_shape(py_a_shape, a_shape_buf, a_ndim)
+    _fill_shape(py_b_shape, b_shape_buf, b_ndim)
+
+    # 4. C-level shape computation (nogil)
+    cdef int out_ndim
+    cdef int64_t n
+    with nogil:
+        out_ndim = c_broadcast_shape(
+            a_shape_buf, a_ndim, b_shape_buf, b_ndim, out_shape_buf)
+        c_contiguous_stride(out_shape_buf, out_ndim, out_stride_buf)
+        n = c_numel(out_shape_buf, out_ndim)
+
+    # 5. Convert to Python tuples (one allocation each)
+    out_shape = _to_tuple(out_shape_buf, out_ndim)
+    out_stride = _to_tuple(out_stride_buf, out_ndim)
+
+    # 6. Allocate output (Python — allocator is complex)
+    cdef int isize = c_dtype_itemsize(a_dtype)
+    out_ptr = npu_runtime._alloc_device(n * isize, runtime=runtime)
+
+    # 7. Get data pointers via storage (need _unwrap_storage validation)
+    a_storage = a.storage()
+    b_storage = b.storage()
+
+    # 8. Call aclnn (Python — already Cython-ized internally)
+    fn(
+        a_storage.data_ptr(),
+        b_storage.data_ptr(),
+        out_ptr,
+        py_a_shape,
+        a.stride,
+        py_b_shape,
+        b.stride,
+        out_shape,
+        out_stride,
+        a_dtype,
+        runtime,
+        stream=stream.stream,
+    )
+
+    # 9. Wrap output (Python — involves GC weak references)
+    out_storage = npu_typed_storage_from_ptr(
+        out_ptr, n, a_dtype, device=a_dev)
+    return Tensor(out_storage, out_shape, out_stride)

--- a/src/candle/_backends/npu/_npu_ops_fast_fallback.py
+++ b/src/candle/_backends/npu/_npu_ops_fast_fallback.py
@@ -1,0 +1,111 @@
+"""Pure-Python fallback for _npu_ops_fast (identical API).
+
+Used when Cython is not available (e.g. CI without CANN, pip install
+without a compiler).  The fast_binary_op function here is functionally
+identical to the Cython version but runs in pure Python.
+"""
+
+_MAX_NDIM = 16
+
+
+def _broadcast_shape(a_shape, b_shape):
+    """Broadcast two shapes, return result tuple."""
+    a_ndim = len(a_shape)
+    b_ndim = len(b_shape)
+    out_ndim = max(a_ndim, b_ndim)
+    out = [0] * out_ndim
+    for i in range(out_ndim):
+        a_dim = a_shape[a_ndim - 1 - i] if i < a_ndim else 1
+        b_dim = b_shape[b_ndim - 1 - i] if i < b_ndim else 1
+        if a_dim == b_dim:
+            out[out_ndim - 1 - i] = a_dim
+        elif a_dim == 1:
+            out[out_ndim - 1 - i] = b_dim
+        elif b_dim == 1:
+            out[out_ndim - 1 - i] = a_dim
+        else:
+            raise ValueError("matmul shape mismatch")
+    return tuple(out)
+
+
+def _contiguous_stride(shape):
+    """Compute contiguous strides."""
+    ndim = len(shape)
+    stride = [0] * ndim
+    acc = 1
+    for i in range(ndim - 1, -1, -1):
+        stride[i] = acc
+        acc *= shape[i]
+    return tuple(stride)
+
+
+def _numel(shape):
+    """Product of shape dims."""
+    n = 1
+    for d in shape:
+        n *= d
+    return n
+
+
+def _dtype_itemsize(dtype):
+    """Return byte size from a candle dtype object."""
+    size = getattr(dtype, "itemsize", None)
+    if size is not None:
+        return int(size)
+    name = getattr(dtype, "name", None)
+    if name is None:
+        name = str(dtype).rsplit(".", 1)[-1]
+    _map = {
+        "float32": 4, "int32": 4, "float64": 8, "int64": 8,
+        "float16": 2, "bfloat16": 2, "int16": 2,
+        "int8": 1, "uint8": 1, "bool": 1,
+    }
+    return _map.get(name, 4)
+
+
+def fast_binary_op(a, b, fn, name):
+    """Drop-in replacement for _binary_op in _helpers.py (pure Python)."""
+    from . import runtime as npu_runtime
+    from . import state as npu_state
+    from ..._storage import npu_typed_storage_from_ptr
+    from ..._tensor import Tensor
+
+    a_dev = a.device
+    b_dev = b.device
+    if a_dev.type != "npu" or b_dev.type != "npu":
+        raise ValueError(f"NPU {name} expects NPU tensors")
+    a_dtype = a.dtype
+    if a_dtype != b.dtype:
+        raise ValueError(f"NPU {name} requires matching dtypes")
+
+    dev_idx = a_dev.index or 0
+    runtime = npu_runtime.get_runtime(dev_idx)
+    stream = npu_state.current_stream(dev_idx)
+
+    out_shape = _broadcast_shape(a.shape, b.shape)
+    out_stride = _contiguous_stride(out_shape)
+    n = _numel(out_shape)
+    isize = _dtype_itemsize(a_dtype)
+    out_ptr = npu_runtime._alloc_device(n * isize, runtime=runtime)
+
+    a_storage = a.storage()
+    b_storage = b.storage()
+
+    fn(
+        a_storage.data_ptr(),
+        b_storage.data_ptr(),
+        out_ptr,
+        a.shape,
+        a.stride,
+        b.shape,
+        b.stride,
+        out_shape,
+        out_stride,
+        a_dtype,
+        runtime,
+        stream=stream.stream,
+    )
+
+    out_storage = npu_typed_storage_from_ptr(
+        out_ptr, n, a_dtype, device=a_dev)
+    return Tensor(out_storage, out_shape, out_stride)

--- a/src/candle/_backends/npu/ops/_helpers.py
+++ b/src/candle/_backends/npu/ops/_helpers.py
@@ -13,6 +13,16 @@ from .. import runtime as npu_runtime
 from .. import state as npu_state
 from .. import ops_soc
 
+try:
+    from .._npu_ops_fast import fast_binary_op as _fast_binary_op  # pylint: disable=no-name-in-module
+    _HAS_FAST_OPS = True
+except ImportError:
+    try:
+        from .._npu_ops_fast_fallback import fast_binary_op as _fast_binary_op
+        _HAS_FAST_OPS = True
+    except ImportError:
+        _HAS_FAST_OPS = False
+
 
 def _unwrap_storage(tensor):
     if tensor.storage().device.type != "npu":
@@ -289,6 +299,8 @@ def _unary_op(a, fn, name, out_dtype=None):
 
 
 def _binary_op(a, b, fn, name):
+    if _HAS_FAST_OPS:
+        return _fast_binary_op(a, b, fn, name)
     runtime = npu_runtime.get_runtime((a.device.index or 0))
     stream = npu_state.current_stream((a.device.index or 0))
     if a.device.type != "npu" or b.device.type != "npu":


### PR DESCRIPTION
## Summary

Cython-ize the `_binary_op` helper in `ops/_helpers.py`, which accounts for ~41% of the `torch.add` overhead on NPU. Replaces Python-level shape computation (broadcast, stride, numel, dtype itemsize) with C-level loops.

### Performance context

```
torch_npu.add:           0.065ms  (target)
candle torch.add:        0.364ms  (current)
├─ functional layer:     0.016ms  (5%)
├─ dispatcher routing:   0.081ms  (22%)
├─ _binary_op helper:    0.150ms  (41%)  ← THIS PR
└─ aclnn.add (FFI):      0.117ms  (32%)
```

### Changes

- **`_npu_ops_fast.pyx`** (new): Cython module with `fast_binary_op()` entry point. C-level `c_broadcast_shape`, `c_contiguous_stride`, `c_numel` run in `nogil` sections. Heavy operations (device malloc, aclnn kernel, output wrapping) remain in Python.
- **`_npu_ops_fast_fallback.py`** (new): Pure-Python fallback with identical API for environments without Cython.
- **`ops/_helpers.py`**: Auto-selects Cython fast path → fallback → original inline code.
- **`setup.py`**: Added new Cython extension alongside existing `_aclnn_ffi`.

### Testing

- 266 NPU tests pass
- 1782 CPU/contract tests pass
- Pylint 10.00/10