### PR TITLE
feat: rewrite futures with thread-safe generic Future[T] and add collect_all

### DIFF
--- a/docs/plans/2026-03-17-futures-pure-python-design.md
+++ b/docs/plans/2026-03-17-futures-pure-python-design.md
@@ -1,0 +1,67 @@
+# Pure Python `torch.futures` Implementation
+
+**Date:** 2026-03-17
+**Status:** Approved
+
+## Goal
+
+Replace the minimal synchronous `Future` in `src/candle/futures.py` with a full-featured, thread-safe, generic `Future[T]` class and add `collect_all`, matching the PyTorch `torch.futures` API without any C++ dependencies.
+
+## Background
+
+PyTorch's `torch.futures.Future` wraps `torch._C.Future` (C++ binding) and `torch._C._collect_all`. Candle needs a pure Python equivalent that:
+
+- Supports real async waiting (threads can block on `wait()` until another thread calls `set_result`)
+- Is generic (`Future[T]`) for type-checker compatibility
+- Provides `collect_all` for aggregating multiple futures
+- Remains backward-compatible with existing DDP comm hooks and `Work.get_future()`
+
+## Design
+
+### `Future[T]` Class
+
+```python
+class Future(Generic[T]):
+    def __init__(self, *, devices=None)
+    def set_result(self, result: T) -> None
+    def set_exception(self, exception: BaseException) -> None
+    def wait(self) -> T
+    def value(self) -> T                    # alias for wait()
+    def done(self) -> bool
+    def then(self, cb: Callable[[Future[T]], S]) -> Future[S]
+    def add_done_callback(self, cb: Callable[[Future[T]], None]) -> None
+```
+
+Key internals:
+- `threading.Event` — `wait()` blocks until `set_result`/`set_exception` signals the event
+- `threading.Lock` — protects state mutations and callback registration against races
+- `then()` returns a new `Future[S]`; exceptions propagate automatically
+- `add_done_callback()` fires immediately if already done, otherwise queued
+
+### `collect_all` Function
+
+```python
+def collect_all(futures: List[Future]) -> Future[List[Future]]
+```
+
+- Uses `add_done_callback` on each input future (no extra threads)
+- Atomic counter tracks remaining futures under a lock
+- Resolves the aggregate future when all inputs complete
+- Propagates the first exception encountered (after all futures finish)
+
+## Impact on Existing Code
+
+| Caller | Impact |
+|--------|--------|
+| `Work.get_future()` | None — `set_result`/`set_exception` API unchanged |
+| DDP comm hooks | None — `Future()` + `set_result()` pattern unchanged |
+| `distributed.py` `.wait()` calls | None — `wait()` semantics unchanged |
+| `.value()` | Semantics change from `[result]` to `result`, but zero callers exist |
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/candle/futures.py` | Rewrite `Future[T]`, add `collect_all` |
+
+No other files require modification.

--- a/src/candle/futures.py
+++ b/src/candle/futures.py
@@ -1,61 +1,141 @@
-"""Minimal Future implementation for DDP communication hooks."""
+"""Thread-safe Future[T] and collect_all, pure-Python replacement for torch._C.Future."""
+
+import threading
+from typing import TypeVar, Generic, Optional, List, Callable
+
+T = TypeVar("T")
+S = TypeVar("S")
 
 
-class Future:
-    """A simple Future class for async operations.
+class Future(Generic[T]):
+    """A thread-safe generic Future compatible with the PyTorch torch.futures.Future API.
 
-    This is a synchronous implementation that immediately resolves.
-    Sufficient for DDP comm hooks since our allreduce is synchronous.
+    Supports real async waiting: ``wait()`` blocks until another thread calls
+    ``set_result`` or ``set_exception``.
     """
 
-    def __init__(self):
-        self._result = None
-        self._exception = None
+    def __init__(self, *, devices=None):
+        self._result: Optional[T] = None
+        self._exception: Optional[BaseException] = None
         self._done = False
-        self._callbacks = []
+        self._event = threading.Event()
+        self._lock = threading.Lock()
+        self._done_callbacks: List[Callable] = []
+        self._devices = devices
 
-    def set_result(self, result):
-        """Set the result and mark as done."""
-        self._result = result
-        self._done = True
-        # Execute callbacks
-        for callback in self._callbacks:
-            self._result = callback(self)
+    # ---- producers ----
 
-    def wait(self):
-        """Wait for the future to complete and return result."""
+    def set_result(self, result: T) -> None:
+        """Set the result, wake waiters, and fire done-callbacks."""
+        with self._lock:
+            if self._done:
+                raise RuntimeError("Future already completed")
+            self._result = result
+            self._done = True
+            self._event.set()
+            callbacks = list(self._done_callbacks)
+        for cb in callbacks:
+            cb(self)
+
+    def set_exception(self, exception: BaseException) -> None:
+        """Set an exception, wake waiters, and fire done-callbacks."""
+        with self._lock:
+            if self._done:
+                raise RuntimeError("Future already completed")
+            self._exception = exception
+            self._done = True
+            self._event.set()
+            callbacks = list(self._done_callbacks)
+        for cb in callbacks:
+            cb(self)
+
+    # ---- consumers ----
+
+    def wait(self) -> T:
+        """Block until the future completes and return the result.
+
+        Raises the stored exception if one was set.
+        """
+        self._event.wait()
         if self._exception is not None:
             raise self._exception
-        return self._result
+        return self._result  # type: ignore[return-value]
 
-    def set_exception(self, exc):
-        """Set an exception result and mark as done."""
-        self._exception = exc
-        self._done = True
+    def value(self) -> T:
+        """Alias for ``wait()``."""
+        return self.wait()
 
-    def value(self):
-        """Return result as a list (PyTorch compatibility)."""
-        return [self._result]
+    def done(self) -> bool:
+        """Return ``True`` if the future has completed."""
+        return self._done
 
-    def then(self, callback):
-        """Chain a callback to execute after completion.
+    # ---- chaining ----
 
-        Args:
-            callback: Function that takes a Future and returns a new result
+    def then(self, callback: Callable[["Future[T]"], S]) -> "Future[S]":
+        """Register *callback* and return a new ``Future[S]`` for its result.
 
-        Returns:
-            A new Future with the callback result
+        *callback* receives this future (already completed) and should return
+        a value of type *S*.  If *callback* raises, the returned future gets
+        the exception instead.
         """
-        new_future = Future()
-        if self._done:
-            # Already done, execute immediately
-            result = callback(self)
-            new_future.set_result(result)
-        else:
-            # Store callback to execute when done
-            self._callbacks.append(lambda fut: callback(fut))
+        new_future: "Future[S]" = Future()
+
+        def _run(source: "Future[T]") -> None:
+            try:
+                new_future.set_result(callback(source))
+            except Exception as exc:  # pylint: disable=broad-except
+                new_future.set_exception(exc)
+
+        with self._lock:
+            if self._done:
+                _run(self)
+            else:
+                self._done_callbacks.append(_run)
         return new_future
 
-    def done(self):
-        """Check if the future is done."""
-        return self._done
+    def add_done_callback(self, callback: Callable[["Future[T]"], None]) -> None:
+        """Register a callback that fires when this future completes.
+
+        If the future is already done the callback runs immediately (in the
+        caller's thread).
+        """
+        with self._lock:
+            if self._done:
+                callback(self)
+            else:
+                self._done_callbacks.append(callback)
+
+
+def collect_all(futures: List[Future]) -> "Future[List[Future]]":
+    """Return a future that completes when every future in *futures* completes.
+
+    The result is the original list of (now-completed) futures.  If any input
+    future has an exception, the aggregate future propagates the first one.
+    """
+    result_future: Future[List[Future]] = Future()
+
+    if not futures:
+        result_future.set_result([])
+        return result_future
+
+    remaining = len(futures)
+    lock = threading.Lock()
+    first_exception: List[Optional[BaseException]] = [None]  # mutable cell
+
+    def _on_done(fut: Future) -> None:
+        nonlocal remaining
+        with lock:
+            if fut._exception is not None and first_exception[0] is None:  # pylint: disable=protected-access
+                first_exception[0] = fut._exception  # pylint: disable=protected-access
+            remaining -= 1
+            all_done = remaining == 0
+        if all_done:
+            if first_exception[0] is not None:
+                result_future.set_exception(first_exception[0])
+            else:
+                result_future.set_result(futures)
+
+    for f in futures:
+        f.add_done_callback(_on_done)
+
+    return result_future


### PR DESCRIPTION
## Summary

Replace the minimal synchronous `Future` with a full-featured, thread-safe, pure-Python implementation that matches the `torch.futures` API without any C++ dependencies (`torch._C.Future`, `torch._C._collect_all`).

## Changes

- **`Future[T]`** — `threading.Event`-based blocking `wait()`, `threading.Lock` for thread safety, `Generic[T]` type annotations
- **`collect_all(futures)`** — aggregates multiple futures, resolves when all complete, propagates first exception
- **`add_done_callback()`** — new method for registering completion callbacks
- **`then()`** — now properly propagates exceptions to the chained future
- **`value()`** — fixed to alias `wait()` (was incorrectly returning `[result]`)

## Backward Compatibility

Zero breaking changes for existing callers:
- `Work.get_future()`, DDP comm hooks, and all `.wait()` / `.set_result()` / `.set_exception()` call sites are fully compatible
- `value()` had zero callers in the codebase

## Design Doc

`docs/plans/2026-03-17-futures-pure-python-design.md`