### PR TITLE
perf(cython): add TensorImpl, Dispatcher, FastDevice, FastNode, FastOps modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,12 @@ src/candle/_cython/_npu_ops.c
 src/candle/_cython/_dispatch.c
 src/candle/_cython/_allocator.c
 src/candle/_cython/_storage.c
+src/candle/_cython/_tensor_impl.c
+src/candle/_cython/_dispatcher_core.c
+src/candle/_cython/_device.c
+src/candle/_cython/_dtype.c
+src/candle/_cython/_autograd_node.c
+src/candle/_cython/_fast_ops.c
 
 # Distribution / packaging
 .Python

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,30 @@ if platform.system() == "Linux":
                     "candle._cython._storage",
                     ["src/candle/_cython/_storage.pyx"],
                 ),
+                Extension(
+                    "candle._cython._tensor_impl",
+                    ["src/candle/_cython/_tensor_impl.pyx"],
+                ),
+                Extension(
+                    "candle._cython._dispatcher_core",
+                    ["src/candle/_cython/_dispatcher_core.pyx"],
+                ),
+                Extension(
+                    "candle._cython._device",
+                    ["src/candle/_cython/_device.pyx"],
+                ),
+                Extension(
+                    "candle._cython._dtype",
+                    ["src/candle/_cython/_dtype.pyx"],
+                ),
+                Extension(
+                    "candle._cython._autograd_node",
+                    ["src/candle/_cython/_autograd_node.pyx"],
+                ),
+                Extension(
+                    "candle._cython._fast_ops",
+                    ["src/candle/_cython/_fast_ops.pyx"],
+                ),
             ],
             compiler_directives={
                 "language_level": "3",

--- a/src/candle/_cython/__init__.py
+++ b/src/candle/_cython/__init__.py
@@ -1,7 +1,8 @@
 """Candle's C extension layer — Cython accelerators for hot paths.
 
 This package provides Cython implementations of performance-critical code
-paths (dispatcher, allocator, storage creation, NPU ops, ACLNN FFI).
+paths (dispatcher, allocator, storage creation, NPU ops, ACLNN FFI,
+TensorImpl, dispatcher core, device, dtype, autograd node, fast ops).
 Each module has a pure-Python fallback so the framework works without
 a C compiler.
 
@@ -11,6 +12,12 @@ Feature flags (set after import):
     _HAS_CYTHON_STORAGE    — True if _storage.pyx compiled successfully
     _HAS_CYTHON_NPU_OPS    — True if _npu_ops.pyx compiled successfully
     _HAS_CYTHON_ACLNN_FFI  — True if _aclnn_ffi.pyx compiled successfully
+    _HAS_CYTHON_TENSOR_IMPL — True if _tensor_impl.pyx compiled successfully
+    _HAS_CYTHON_DISPATCHER_CORE — True if _dispatcher_core.pyx compiled
+    _HAS_CYTHON_DEVICE     — True if _device.pyx compiled successfully
+    _HAS_CYTHON_DTYPE      — True if _dtype.pyx compiled successfully
+    _HAS_CYTHON_AUTOGRAD_NODE — True if _autograd_node.pyx compiled
+    _HAS_CYTHON_FAST_OPS   — True if _fast_ops.pyx compiled successfully
 """
 
 _HAS_CYTHON_DISPATCH = False
@@ -18,6 +25,12 @@ _HAS_CYTHON_ALLOCATOR = False
 _HAS_CYTHON_STORAGE = False
 _HAS_CYTHON_NPU_OPS = False
 _HAS_CYTHON_ACLNN_FFI = False
+_HAS_CYTHON_TENSOR_IMPL = False
+_HAS_CYTHON_DISPATCHER_CORE = False
+_HAS_CYTHON_DEVICE = False
+_HAS_CYTHON_DTYPE = False
+_HAS_CYTHON_AUTOGRAD_NODE = False
+_HAS_CYTHON_FAST_OPS = False
 
 try:
     from ._dispatch import cy_dispatch, cy_dispatch_with_keyset  # noqa: F401
@@ -53,5 +66,41 @@ try:
         binary_op_with_alpha, binary_op_no_alpha,
     )
     _HAS_CYTHON_ACLNN_FFI = True
+except ImportError:
+    pass
+
+try:
+    from ._tensor_impl import TensorImpl, _VersionCounterProxy  # noqa: F401
+    _HAS_CYTHON_TENSOR_IMPL = True
+except ImportError:
+    pass
+
+try:
+    from ._dispatcher_core import cy_dispatch_with_keyset_fast  # noqa: F401
+    _HAS_CYTHON_DISPATCHER_CORE = True
+except ImportError:
+    pass
+
+try:
+    from ._device import FastDevice  # noqa: F401
+    _HAS_CYTHON_DEVICE = True
+except ImportError:
+    pass
+
+try:
+    from ._dtype import FastDType  # noqa: F401
+    _HAS_CYTHON_DTYPE = True
+except ImportError:
+    pass
+
+try:
+    from ._autograd_node import FastNode  # noqa: F401
+    _HAS_CYTHON_AUTOGRAD_NODE = True
+except ImportError:
+    pass
+
+try:
+    from ._fast_ops import add, mul, matmul  # noqa: F401
+    _HAS_CYTHON_FAST_OPS = True
 except ImportError:
     pass

--- a/src/candle/_cython/_autograd_node.pyx
+++ b/src/candle/_cython/_autograd_node.pyx
@@ -1,0 +1,55 @@
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""Cython FastNode — C-level autograd node with typed fields.
+
+Accelerates _freeze_next_functions and attribute access on the forward path.
+"""
+
+from libc.stdint cimport int64_t
+
+
+cdef class FastNode:
+    """C-level base for autograd Node."""
+    cdef public object backward
+    cdef public tuple inputs
+    cdef public list _saved_tensors_list
+    cdef public dict _saved_fields
+    cdef public dict _hooks
+    cdef public dict _prehooks
+    cdef public tuple _next_functions_cache
+    cdef public object _metadata
+    cdef public str _name
+    cdef public object _anomaly_trace
+    cdef public object _anomaly_parent
+    cdef dict __dict__
+
+    def __init__(self, backward, inputs, *, name=None):
+        if backward is not None:
+            self.backward = backward
+        self.inputs = tuple(inputs)
+        self._saved_tensors_list = []
+        self._saved_fields = {}
+        self._hooks = {}
+        self._prehooks = {}
+        self._metadata = None
+        self._name = name or type(self).__name__
+        self._anomaly_trace = None
+        self._anomaly_parent = None
+        self._next_functions_cache = self._freeze_next_functions()
+
+    cdef tuple _freeze_next_functions(self):
+        """Build next_functions tuple — C-speed field access."""
+        cdef list result = []
+        for inp in self.inputs:
+            fn = getattr(inp, "grad_fn", None)
+            if fn is not None:
+                result.append((fn, 0))
+            elif getattr(inp, "requires_grad", False):
+                acc = getattr(inp, "_accumulate_grad_node", None)
+                if acc is None:
+                    from candle.autograd.node import AccumulateGrad
+                    acc = AccumulateGrad(inp)
+                    inp._accumulate_grad_node = acc
+                result.append((acc, 0))
+            else:
+                result.append((None, 0))
+        return tuple(result)

--- a/src/candle/_cython/_autograd_node_fallback.py
+++ b/src/candle/_cython/_autograd_node_fallback.py
@@ -1,0 +1,15 @@
+"""Pure-Python fallback for _autograd_node.pyx — FastNode."""
+
+
+class FastNode:
+    """Pure-Python mirror of Cython FastNode.
+
+    Provides the same typed-slot layout so Node can inherit from it
+    unconditionally.  When Cython is available the .pyx version replaces
+    this module.
+    """
+    __slots__ = (
+        "backward", "inputs", "_saved_tensors_list", "_saved_fields",
+        "_hooks", "_prehooks", "_next_functions_cache", "_metadata",
+        "_name", "_anomaly_trace", "_anomaly_parent", "__dict__",
+    )

--- a/src/candle/_cython/_device.pyx
+++ b/src/candle/_cython/_device.pyx
@@ -1,0 +1,101 @@
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""Cython FastDevice — int-based device comparison instead of string ops.
+
+Maintains full API compatibility with the original ``device`` class:
+``.index`` returns ``None`` (not -1) when no index was specified.
+"""
+
+cdef class FastDevice:
+    """C-level device with int type_code for fast comparison."""
+    cdef public int type_code    # 0=cpu, 1=npu, 2=cuda, 3=mps, 4=meta
+    cdef int _index              # -1 means None
+    cdef str _type_str
+
+    def __init__(self, dev=None, index=None):
+        if isinstance(dev, FastDevice):
+            self.type_code = (<FastDevice>dev).type_code
+            self._type_str = (<FastDevice>dev)._type_str
+            self._index = (<FastDevice>dev)._index if index is None else int(index)
+            return
+        # Accept original device class
+        if dev is not None and hasattr(dev, "type") and not isinstance(dev, str):
+            self._type_str = dev.type
+            oi = dev.index if index is None else index
+            self._index = -1 if oi is None else int(oi)
+            self._assign_type_code()
+            return
+        cdef str s
+        if isinstance(dev, str):
+            s = <str>dev
+            if ":" in s:
+                parts = s.split(":", 1)
+                s = parts[0]
+                index = int(parts[1])
+            self._type_str = s
+        elif dev is None:
+            self._type_str = "cpu"
+        else:
+            self._type_str = str(dev)
+
+        self._assign_type_code()
+        # Auto-assign index=0 for npu/mps when not specified
+        if self._type_str == "npu" and index is None:
+            index = 0
+        if self._type_str == "mps" and index is None:
+            index = 0
+        self._index = -1 if index is None else int(index)
+
+    cdef void _assign_type_code(self):
+        if self._type_str == "cpu":
+            self.type_code = 0
+        elif self._type_str == "npu":
+            self.type_code = 1
+        elif self._type_str == "cuda":
+            self.type_code = 2
+        elif self._type_str == "mps":
+            self.type_code = 3
+        elif self._type_str == "meta":
+            self.type_code = 4
+        else:
+            self.type_code = -1
+
+    @property
+    def type(self):
+        return self._type_str
+
+    @property
+    def index(self):
+        if self._index == -1:
+            return None
+        return self._index
+
+    @index.setter
+    def index(self, value):
+        self._index = -1 if value is None else int(value)
+
+    def __repr__(self):
+        if self._index == -1:
+            return f"device(type='{self._type_str}')"
+        return f"device(type='{self._type_str}', index={self._index})"
+
+    def __str__(self):
+        if self._index == -1:
+            return self._type_str
+        return f"{self._type_str}:{self._index}"
+
+    def __eq__(self, other):
+        if isinstance(other, FastDevice):
+            return (self.type_code == (<FastDevice>other).type_code
+                    and self._index == (<FastDevice>other)._index)
+        if hasattr(other, "type"):
+            oi = getattr(other, "index", None)
+            return (self._type_str == other.type
+                    and self._index == (-1 if oi is None else oi))
+        return NotImplemented
+
+    def __hash__(self):
+        return hash((self._type_str, None if self._index == -1 else self._index))
+
+    def __reduce__(self):
+        idx = None if self._index == -1 else self._index
+        return (FastDevice, (self._type_str, idx))

--- a/src/candle/_cython/_device_fallback.py
+++ b/src/candle/_cython/_device_fallback.py
@@ -1,0 +1,72 @@
+"""Pure-Python fallback for _device.pyx — FastDevice."""
+
+
+class FastDevice:
+    """Pure-Python mirror of Cython FastDevice."""
+    __slots__ = ("type_code", "_index", "_type_str")
+
+    _TYPE_MAP = {"cpu": 0, "npu": 1, "cuda": 2, "mps": 3, "meta": 4}
+
+    def __init__(self, dev=None, index=None):
+        if isinstance(dev, FastDevice):
+            self.type_code = dev.type_code
+            self._type_str = dev._type_str
+            self._index = dev._index if index is None else int(index)
+            return
+        if dev is not None and hasattr(dev, "type") and not isinstance(dev, str):
+            self._type_str = dev.type
+            oi = dev.index if index is None else index
+            self._index = -1 if oi is None else int(oi)
+            self.type_code = self._TYPE_MAP.get(self._type_str, -1)
+            return
+        if isinstance(dev, str):
+            s = dev
+            if ":" in s:
+                s, idx = s.split(":", 1)
+                index = int(idx)
+            self._type_str = s
+        elif dev is None:
+            self._type_str = "cpu"
+        else:
+            self._type_str = str(dev)
+
+        self.type_code = self._TYPE_MAP.get(self._type_str, -1)
+        if self._type_str in ("npu", "mps") and index is None:
+            index = 0
+        self._index = -1 if index is None else int(index)
+
+    @property
+    def type(self):
+        return self._type_str
+
+    @property
+    def index(self):
+        if self._index == -1:
+            return None
+        return self._index
+
+    @index.setter
+    def index(self, value):
+        self._index = -1 if value is None else int(value)
+
+    def __repr__(self):
+        if self._index == -1:
+            return f"device(type='{self._type_str}')"
+        return f"device(type='{self._type_str}', index={self._index})"
+
+    def __str__(self):
+        if self._index == -1:
+            return self._type_str
+        return f"{self._type_str}:{self._index}"
+
+    def __eq__(self, other):
+        if isinstance(other, FastDevice):
+            return self.type_code == other.type_code and self._index == other._index
+        if hasattr(other, "type"):
+            oi = getattr(other, "index", None)
+            return (self._type_str == other.type
+                    and self._index == (-1 if oi is None else oi))
+        return NotImplemented
+
+    def __hash__(self):
+        return hash((self._type_str, None if self._index == -1 else self._index))

--- a/src/candle/_cython/_dispatcher_core.pyx
+++ b/src/candle/_cython/_dispatcher_core.pyx
@@ -1,0 +1,453 @@
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""Cython full dispatcher — replaces dispatch_with_keyset inner loop.
+
+Inlines: tensor extraction, device validation, TLS mask application,
+schema validation fast-path, kernel lookup, kwargs preparation,
+dispatch context push/pop, and version bumping.
+"""
+
+from libc.stdint cimport int64_t, uint32_t
+import os
+import inspect
+
+# ---------------------------------------------------------------------------
+# Schema validation fast-path: skip after N successful validations
+# ---------------------------------------------------------------------------
+
+cdef dict _validated_ops = {}
+cdef int _VALIDATION_THRESHOLD = 100
+cdef bint _FORCE_VALIDATE = os.environ.get("CANDLE_DEBUG_SCHEMA", "") == "1"
+
+cdef inline bint _should_validate(str name):
+    if _FORCE_VALIDATE:
+        return True
+    cdef int count = _validated_ops.get(name, 0)
+    if count >= _VALIDATION_THRESHOLD:
+        return False
+    _validated_ops[name] = count + 1
+    return True
+
+# ---------------------------------------------------------------------------
+# Cached TLS object references for fast access
+# ---------------------------------------------------------------------------
+
+cdef object _grad_tls = None
+cdef object _func_tls = None
+cdef object _pipeline_mod = None
+cdef object _autocast_mod = None
+cdef object _profiler_mod = None
+
+cdef inline bint _fast_grad_enabled():
+    global _grad_tls
+    if _grad_tls is None:
+        from candle.autograd.grad_mode import _GRAD_MODE_STATE
+        _grad_tls = _GRAD_MODE_STATE
+    return getattr(_grad_tls, "enabled", True)
+
+# ---------------------------------------------------------------------------
+# Cached accepts_device check (shared with _dispatch.pyx)
+# ---------------------------------------------------------------------------
+
+cdef dict _accepts_device_cache = {}
+
+cdef inline bint _cy_accepts_device(object func):
+    cdef object cached = _accepts_device_cache.get(func)
+    if cached is not None:
+        return <bint>cached
+    try:
+        sig = inspect.signature(func)
+    except (TypeError, ValueError):
+        _accepts_device_cache[func] = False
+        return False
+    cdef bint result = "device" in sig.parameters
+    _accepts_device_cache[func] = result
+    return result
+
+
+cdef inline dict _fast_prepare_kwargs(object func, dict kwargs, object device):
+    if not kwargs:
+        if _cy_accepts_device(func):
+            return {"device": device}
+        return {}
+    if "device" in kwargs:
+        if _cy_accepts_device(func):
+            return kwargs
+        return {k: v for k, v in kwargs.items() if k != "device"}
+    if _cy_accepts_device(func):
+        merged = dict(kwargs)
+        merged["device"] = device
+        return merged
+    return kwargs
+
+
+# ---------------------------------------------------------------------------
+# Dispatch context stack — MUST share with dispatcher.py's _DISPATCH_STATE
+# ---------------------------------------------------------------------------
+
+cdef object _DISPATCH_STATE = None
+
+cdef inline object _get_dispatch_state():
+    global _DISPATCH_STATE
+    if _DISPATCH_STATE is None:
+        from candle._dispatch.dispatcher import _DISPATCH_STATE as _ds
+        _DISPATCH_STATE = _ds
+    return _DISPATCH_STATE
+
+cdef inline list _fast_state_stack():
+    cdef object state = _get_dispatch_state()
+    cdef object stack = getattr(state, "stack", None)
+    if stack is None:
+        stack = []
+        state.stack = stack
+    return <list>stack
+
+cdef inline void _fast_push(object keyset, object key):
+    _fast_state_stack().append((keyset, key))
+
+cdef inline void _fast_pop():
+    cdef list stack = _fast_state_stack()
+    if stack:
+        stack.pop()
+
+
+# ---------------------------------------------------------------------------
+# Fast version bumping (inlined _version_value access)
+# ---------------------------------------------------------------------------
+
+cdef void _fast_bump_versions(object schema_obj, tuple args, dict kwargs):
+    if schema_obj is None:
+        return
+    cdef list params = schema_obj.params
+    cdef list positional = [p for p in params if not p.kw_only]
+    cdef dict bound = {}
+    cdef int idx
+    cdef set seen = set()
+    cdef int64_t tid
+    for idx in range(len(args)):
+        if idx < len(positional):
+            bound[positional[idx].name] = args[idx]
+    if kwargs:
+        for key, value in kwargs.items():
+            bound[key] = value
+    for param in params:
+        if not param.mutates:
+            continue
+        alias = getattr(param, "alias_set", None)
+        if alias is None or alias == "":
+            continue
+        target = bound.get(param.name)
+        if target is None:
+            continue
+        base = getattr(target, "_base", None)
+        if base is not None:
+            target = base
+        dev = getattr(target, "device", None)
+        if dev is not None and getattr(dev, "type", None) == "meta":
+            continue
+        tid = id(target)
+        if tid in seen:
+            continue
+        # Prefer direct _version_value (TensorImpl), fall back to _version_counter
+        try:
+            target._version_value += 1
+        except AttributeError:
+            counter = getattr(target, "_version_counter", None)
+            if counter is not None:
+                counter.bump()
+        seen.add(tid)
+
+
+# ---------------------------------------------------------------------------
+# Core dispatch_with_keyset replacement
+# ---------------------------------------------------------------------------
+
+import numpy as np
+
+# Cached module-level references (lazy-loaded)
+cdef object _registry = None
+cdef object _DispatchKey = None
+cdef object _DISPATCH_KEY_PRIORITY = None
+
+cdef inline void _ensure_imports():
+    global _registry, _DispatchKey, _DISPATCH_KEY_PRIORITY
+    if _registry is None:
+        from candle._dispatch.registry import registry
+        from candle._dispatch.keys import DispatchKey, DISPATCH_KEY_PRIORITY
+        _registry = registry
+        _DispatchKey = DispatchKey
+        _DISPATCH_KEY_PRIORITY = DISPATCH_KEY_PRIORITY
+
+
+cdef inline list _fast_extract_tensors(tuple args, dict kwargs):
+    """Extract tensors from args/kwargs — typed C loop."""
+    cdef list tensors = []
+    cdef int n = len(args)
+    # Fast path: binary op (2 tensor args, no kwargs with tensors)
+    if n == 2 and not kwargs:
+        a = args[0]
+        b = args[1]
+        if hasattr(a, "device") and hasattr(b, "device"):
+            tensors.append(a)
+            tensors.append(b)
+            return tensors
+    cdef int i
+    for i in range(n):
+        _fast_visit(args[i], tensors)
+    if kwargs:
+        for v in kwargs.values():
+            _fast_visit(v, tensors)
+    return tensors
+
+
+cdef inline void _fast_visit(object value, list tensors):
+    if hasattr(value, "device") and not isinstance(value, np.ndarray):
+        tensors.append(value)
+        return
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            _fast_visit(item, tensors)
+
+
+cdef inline void _fast_validate_devices(list tensors):
+    """Validate all tensors are on the same device."""
+    cdef int n = len(tensors)
+    if n <= 1:
+        return
+    cdef object expected = tensors[0].device
+    cdef str expected_type = getattr(expected, "type", expected)
+    cdef object expected_index = getattr(expected, "index", None)
+    cdef int i
+    for i in range(1, n):
+        dev = tensors[i].device
+        dt = getattr(dev, "type", dev)
+        di = getattr(dev, "index", None)
+        if dt != expected_type or di != expected_index:
+            el = expected_type if expected_index is None else f"{expected_type}:{expected_index}"
+            dl = dt if di is None else f"{dt}:{di}"
+            raise RuntimeError(
+                f"Tensor on device {dl} is not on the expected device {el}!"
+            )
+
+
+cdef inline object _fast_kernel_for_entry(object entry, object keyset):
+    """Find kernel for dispatch entry — direct iteration."""
+    _ensure_imports()
+    cdef unsigned int m
+    if hasattr(keyset, "mask"):
+        m = <unsigned int>int(keyset.mask)
+    else:
+        m = <unsigned int>int(keyset)
+    fallthrough = entry.fallthrough
+    kernels = entry.kernels
+    global_fallthrough = getattr(_registry, "_global_fallthrough", set())
+    for key in _DISPATCH_KEY_PRIORITY:
+        if not (m & <unsigned int>int(key)):
+            continue
+        if key in fallthrough:
+            continue
+        kernel = kernels.get(key)
+        if kernel is not None:
+            return kernel, key
+        if key in global_fallthrough:
+            continue
+    return None, None
+
+
+# ---------------------------------------------------------------------------
+# Main dispatch entry point
+# ---------------------------------------------------------------------------
+
+def cy_dispatch_with_keyset_fast(str name, object keyset, object dispatch_device,
+                                  *args, **kwargs):
+    """Full Cython replacement for dispatch_with_keyset.
+
+    Handles: tensor extraction, device validation, TLS masks, schema
+    validation (fast-path), kernel lookup, kwargs prep, context push/pop,
+    version bumping.  Delegates to Python for: functionalize, autocast,
+    pipeline, profiler, forward AD, __torch_dispatch__.
+    """
+    _ensure_imports()
+
+    # -- lazy imports for complex paths (only loaded when needed) --
+    from candle._dispatch.keys import apply_tls_masks
+    from candle._dispatch.pipeline import current_pipeline
+    from candle._dispatch.functionalize import (
+        is_functionalize_enabled as _is_func_enabled,
+        should_functionalize, functionalize_op,
+    )
+    from candle.amp.state import is_autocast_enabled
+    from candle.amp.policy import apply_autocast_policy
+    from candle.autograd import forward_ad
+    from candle.profiler.profiler import is_profiler_enabled, dispatch_op_enter, dispatch_op_exit
+    from candle._dispatch.dispatcher import (
+        _infer_dispatch_device, _wrap_dispatch_error,
+        _check_inplace_targets, _PendingOp, _FunctionalizePendingOp,
+        _pending_from_meta, _dispatch_torch_dispatch,
+        redispatch,
+    )
+
+    cdef list tensors = _fast_extract_tensors(args, kwargs)
+    _fast_validate_devices(tensors)
+
+    keyset = apply_tls_masks(keyset)
+    pipe = current_pipeline()
+    dispatch_device = _infer_dispatch_device(dispatch_device, tensors, keyset)
+
+    cdef str alias_name = name
+    try:
+        name = _registry.resolve(name)
+        entry = _registry.get(name)
+    except Exception as exc:
+        raise _wrap_dispatch_error(exc, alias_name, dispatch_device) from exc
+
+    # -- Schema validation --
+    cdef object schema_obj = entry.schema_obj
+    if schema_obj is not None:
+        schema_obj.bind(args, kwargs, op_name=alias_name,
+                        error_overrides=entry.error_overrides)
+        if keyset.has(_DispatchKey.ADInplaceOrView):
+            _check_inplace_targets(schema_obj, args, kwargs)
+
+    # -- Functionalize --
+    if keyset.has(_DispatchKey.Functionalize) and should_functionalize(entry):
+        if pipe is not None and keyset.has(_DispatchKey.Pipeline):
+            return functionalize_op(name, alias_name, entry, keyset, args, kwargs,
+                                    redispatch, pipeline=pipe, dispatch_device=dispatch_device)
+        return functionalize_op(name, alias_name, entry, keyset, args, kwargs,
+                                redispatch, dispatch_device=dispatch_device)
+
+    # -- __torch_dispatch__ --
+    if keyset.has(_DispatchKey.Python):
+        result = _dispatch_torch_dispatch(alias_name, tensors, args, kwargs)
+        if result is not NotImplemented:
+            return result
+
+    # -- Autocast --
+    if keyset.has(_DispatchKey.Autocast):
+        device_type = getattr(dispatch_device, "type", dispatch_device)
+        if device_type is None and tensors:
+            device_type = getattr(tensors[0].device, "type", None)
+        casted_args, casted_kwargs = apply_autocast_policy(alias_name, args, kwargs, device_type)
+        return redispatch(alias_name, keyset.without(_DispatchKey.Autocast),
+                          *casted_args, **casted_kwargs)
+
+    # -- Pipeline deferred execution --
+    if pipe is not None and keyset.has(_DispatchKey.Pipeline):
+        if not pipe.should_defer_next():
+            return _run_kernel_fast(entry, keyset, alias_name, dispatch_device,
+                                    schema_obj, tensors, args, kwargs,
+                                    forward_ad, is_profiler_enabled,
+                                    dispatch_op_enter, dispatch_op_exit)
+        meta = entry.kernels.get(_DispatchKey.Meta)
+        if meta is None:
+            raise RuntimeError(f"pipeline requires meta kernel for op {name}")
+        meta_kwargs = _fast_prepare_kwargs(meta, kwargs, dispatch_device)
+        spec = meta(*args, **meta_kwargs)
+        out = _pending_from_meta(spec, dispatch_device)
+        if isinstance(out, (tuple, list)):
+            for item in out:
+                item._pending = True
+        else:
+            out._pending = True
+        backend_keys = [key for key in keyset.iter_keys() if key != _DispatchKey.Pipeline]
+        impl, impl_key = _fast_kernel_for_entry(entry, keyset.without(_DispatchKey.Pipeline))
+        if impl is None:
+            raise RuntimeError(f"pipeline requires backend kernel for op {name}")
+        impl_kwargs = _fast_prepare_kwargs(impl, kwargs, dispatch_device)
+        pipe.record(
+            _PendingOp(impl, args, impl_kwargs, out,
+                       keyset.without(_DispatchKey.Pipeline), impl_key,
+                       schema_obj=schema_obj, op_name=alias_name),
+            pending=out,
+        )
+        return out
+
+    if pipe is not None and keyset.has(_DispatchKey.Pipeline):
+        pipe.flush()
+
+    return _run_kernel_fast(entry, keyset, alias_name, dispatch_device,
+                            schema_obj, tensors, args, kwargs,
+                            forward_ad, is_profiler_enabled,
+                            dispatch_op_enter, dispatch_op_exit)
+
+
+# ---------------------------------------------------------------------------
+# _run_kernel — the hot inner loop
+# ---------------------------------------------------------------------------
+
+cdef object _run_kernel_fast(object entry, object keyset, str alias_name,
+                              object dispatch_device, object schema_obj,
+                              list tensors, tuple args, dict kwargs,
+                              object forward_ad, object is_profiler_enabled,
+                              object dispatch_op_enter, object dispatch_op_exit):
+    """Execute the backend kernel — C-speed context management."""
+    from candle._dispatch.dispatcher import _wrap_dispatch_error, redispatch
+
+    kernel, key = _fast_kernel_for_entry(entry, keyset)
+    if kernel is None:
+        key_names = [k.name for k in keyset.iter_keys()]
+        exc = RuntimeError(
+            f"could not find kernel for op {alias_name} with keys {key_names}"
+        )
+        raise _wrap_dispatch_error(exc, alias_name, dispatch_device) from exc
+
+    cdef dict impl_kwargs = _fast_prepare_kwargs(kernel, kwargs, dispatch_device)
+
+    cdef object token = None
+    if is_profiler_enabled():
+        token = dispatch_op_enter(alias_name, dispatch_device, args, impl_kwargs)
+
+    _fast_push(keyset, key)
+    try:
+        result = kernel(*args, **impl_kwargs)
+    except Exception as exc:
+        raise _wrap_dispatch_error(exc, alias_name, dispatch_device) from exc
+    finally:
+        _fast_pop()
+        if token is not None:
+            dispatch_op_exit(token)
+
+    _fast_bump_versions(schema_obj, args, impl_kwargs)
+
+    # -- Forward AD (JVP) --
+    cdef int level = forward_ad._current_level()
+    if level >= 0:
+        tangents = [forward_ad.get_tangent(t, level) for t in tensors]
+        if any(t is not None for t in tangents):
+            jvp = forward_ad.get_jvp(alias_name)
+            if jvp is None:
+                raise RuntimeError(
+                    f"no forward-mode rule registered for op {alias_name}"
+                )
+            inner_keyset = keyset.without({
+                _DispatchKey.Autograd, _DispatchKey.AutogradCPU,
+                _DispatchKey.AutogradCUDA, _DispatchKey.AutogradNPU,
+                _DispatchKey.AutogradMeta, _DispatchKey.AutogradXPU,
+                _DispatchKey.AutogradOther,
+            })
+            jvp_key = key
+            if jvp_key in inner_keyset:
+                inner_keyset = inner_keyset.without(jvp_key)
+
+            def _eval_jvp():
+                _fast_push(inner_keyset, jvp_key)
+                try:
+                    return jvp(*args, **impl_kwargs, _tangents=tangents)
+                finally:
+                    _fast_pop()
+
+            try:
+                with forward_ad.temporarily_disable(level):
+                    out_tangent = _eval_jvp()
+            except Exception:
+                out_tangent = _eval_jvp()
+
+            if isinstance(result, (tuple, list)):
+                for out, t in zip(result, out_tangent):
+                    if hasattr(out, "_fw_set"):
+                        out._fw_set(level, t)
+            else:
+                if hasattr(result, "_fw_set"):
+                    result._fw_set(level, out_tangent)
+
+    return result

--- a/src/candle/_cython/_dispatcher_core_fallback.py
+++ b/src/candle/_cython/_dispatcher_core_fallback.py
@@ -1,0 +1,12 @@
+"""Pure-Python fallback for _dispatcher_core.pyx.
+
+When Cython is not available, dispatch_with_keyset remains the original
+Python implementation in dispatcher.py — this module is only imported
+to satisfy the conditional import pattern.
+"""
+
+
+def cy_dispatch_with_keyset_fast(name, keyset, dispatch_device, *args, **kwargs):
+    """Fallback: delegate to the original Python dispatch_with_keyset."""
+    from candle._dispatch.dispatcher import _py_dispatch_with_keyset
+    return _py_dispatch_with_keyset(name, keyset, dispatch_device, *args, **kwargs)

--- a/src/candle/_cython/_dtype.pyx
+++ b/src/candle/_cython/_dtype.pyx
@@ -1,0 +1,51 @@
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""Cython FastDType — int-code based dtype for fast comparison."""
+
+cdef class FastDType:
+    """C-level dtype with int code for fast comparison."""
+    cdef public int code
+    cdef public int itemsize
+    cdef public bint is_floating_point
+    cdef public bint is_complex
+    cdef public bint is_signed
+    cdef public bint _is_quantized
+    cdef public str name
+    cdef public object _numpy_dtype
+
+    def __init__(self, str name, object numpy_dtype, int itemsize,
+                 bint is_floating_point=False, bint is_complex=False,
+                 bint is_signed=True, int code=-1):
+        self.name = name
+        self._numpy_dtype = numpy_dtype
+        self.itemsize = itemsize
+        self.is_floating_point = is_floating_point
+        self.is_complex = is_complex
+        self.is_signed = is_signed
+        self._is_quantized = False
+        self.code = code
+
+    @property
+    def is_quantized(self):
+        return self._is_quantized
+
+    def __repr__(self):
+        return f"torch.{self.name}"
+
+    def __eq__(self, other):
+        if isinstance(other, FastDType):
+            return self.name == (<FastDType>other).name
+        if hasattr(other, "name"):
+            return self.name == other.name
+        return NotImplemented
+
+    def __hash__(self):
+        return hash(self.name)
+
+    def __reduce__(self):
+        return (_reconstruct_dtype, (self.name,))
+
+
+def _reconstruct_dtype(str name):
+    """Reconstruct a FastDType from its name during unpickling."""
+    from candle._dtype import from_name
+    return from_name(name)

--- a/src/candle/_cython/_dtype_fallback.py
+++ b/src/candle/_cython/_dtype_fallback.py
@@ -1,0 +1,35 @@
+"""Pure-Python fallback for _dtype.pyx — FastDType."""
+
+
+class FastDType:
+    """Pure-Python mirror of Cython FastDType."""
+    __slots__ = ("code", "itemsize", "is_floating_point", "is_complex",
+                 "is_signed", "_is_quantized", "name", "_numpy_dtype")
+
+    def __init__(self, name, numpy_dtype, itemsize, is_floating_point=False,
+                 is_complex=False, is_signed=True, code=-1):
+        self.name = name
+        self._numpy_dtype = numpy_dtype
+        self.itemsize = itemsize
+        self.is_floating_point = is_floating_point
+        self.is_complex = is_complex
+        self.is_signed = is_signed
+        self._is_quantized = False
+        self.code = code
+
+    @property
+    def is_quantized(self):
+        return self._is_quantized
+
+    def __repr__(self):
+        return f"torch.{self.name}"
+
+    def __eq__(self, other):
+        if isinstance(other, FastDType):
+            return self.name == other.name
+        if hasattr(other, "name"):
+            return self.name == other.name
+        return NotImplemented
+
+    def __hash__(self):
+        return hash(self.name)

--- a/src/candle/_cython/_fast_ops.pyx
+++ b/src/candle/_cython/_fast_ops.pyx
@@ -1,0 +1,149 @@
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""Cython fast-path for top-10 ops — skip __torch_function__ for base Tensor.
+
+``type(a) is _BaseTensor`` is a single CPython pointer comparison (~1ns).
+When both args are base Tensor, we skip the _has_torch_function scan entirely.
+"""
+
+# Cached reference to base Tensor class
+cdef object _BaseTensor = None
+
+cdef inline void _ensure_base():
+    global _BaseTensor
+    if _BaseTensor is None:
+        from candle._tensor import Tensor
+        _BaseTensor = Tensor
+
+
+cdef inline bint _is_base_tensor(object t):
+    """True if t is exactly the base Tensor class (not a subclass)."""
+    _ensure_base()
+    return type(t) is _BaseTensor
+
+
+# Cache original Python implementations (loaded once)
+cdef object _py_add_fn = None
+cdef object _py_mul_fn = None
+cdef object _py_matmul_fn = None
+cdef object _py_sub_fn = None
+cdef object _py_div_fn = None
+cdef object _py_relu_fn = None
+cdef object _py_neg_fn = None
+cdef object _handle_tf = None
+cdef object _dispatch_fn = None
+
+cdef inline void _ensure_originals():
+    global _py_add_fn, _py_mul_fn, _py_matmul_fn, _py_sub_fn
+    global _py_div_fn, _py_relu_fn, _py_neg_fn, _handle_tf, _dispatch_fn
+    if _dispatch_fn is None:
+        from candle._dispatch.dispatcher import dispatch
+        _dispatch_fn = dispatch
+    if _handle_tf is None:
+        from candle._functional import _handle_torch_function
+        _handle_tf = _handle_torch_function
+    if _py_add_fn is None:
+        from candle._functional import _py_add, _py_mul, _py_matmul
+        from candle._functional import _py_sub, _py_div, _py_relu, _py_neg
+        _py_add_fn = _py_add
+        _py_mul_fn = _py_mul
+        _py_matmul_fn = _py_matmul
+        _py_sub_fn = _py_sub
+        _py_div_fn = _py_div
+        _py_relu_fn = _py_relu
+        _py_neg_fn = _py_neg
+
+
+def add(a=None, b=None, *, alpha=1, out=None):
+    """Fast add: skip __torch_function__ when both args are base Tensor."""
+    _ensure_originals()
+    if a is None or b is None:
+        # Delegate to original for proper error message
+        return _py_add_fn(a, b, alpha=alpha, out=out) if a is not None else _py_add_fn()
+    if _is_base_tensor(a) and (_is_base_tensor(b) or not hasattr(b, "__torch_function__")):
+        if alpha != 1:
+            b = _dispatch_fn("mul", None, b, alpha)
+        return _dispatch_fn("add", None, a, b)
+    r = _handle_tf(_py_add_fn, (a, b), {"alpha": alpha, "out": out})
+    if r is not NotImplemented:
+        return r
+    if alpha != 1:
+        b = _dispatch_fn("mul", None, b, alpha)
+    return _dispatch_fn("add", None, a, b)
+
+
+def mul(a, b):
+    """Fast mul: skip __torch_function__ when both args are base Tensor."""
+    _ensure_originals()
+    if _is_base_tensor(a) and (_is_base_tensor(b) or not hasattr(b, "__torch_function__")):
+        return _dispatch_fn("mul", None, a, b)
+    r = _handle_tf(_py_mul_fn, (a, b), {})
+    if r is not NotImplemented:
+        return r
+    return _dispatch_fn("mul", None, a, b)
+
+
+def matmul(a, b):
+    """Fast matmul: skip __torch_function__ when both args are base Tensor."""
+    _ensure_originals()
+    if _is_base_tensor(a) and _is_base_tensor(b):
+        return _dispatch_fn("matmul", None, a, b)
+    r = _handle_tf(_py_matmul_fn, (a, b), {})
+    if r is not NotImplemented:
+        return r
+    return _dispatch_fn("matmul", None, a, b)
+
+
+def sub(a, b, *, alpha=1):
+    """Fast sub: skip __torch_function__ when both args are base Tensor."""
+    _ensure_originals()
+    if _is_base_tensor(a) and (_is_base_tensor(b) or not hasattr(b, "__torch_function__")):
+        if alpha != 1:
+            b = _dispatch_fn("mul", None, b, alpha)
+        return _dispatch_fn("sub", None, a, b)
+    r = _handle_tf(_py_sub_fn, (a, b), {"alpha": alpha})
+    if r is not NotImplemented:
+        return r
+    if alpha != 1:
+        b = _dispatch_fn("mul", None, b, alpha)
+    return _dispatch_fn("sub", None, a, b)
+
+
+def div(a, b, *, rounding_mode=None):
+    """Fast div: skip __torch_function__ when both args are base Tensor."""
+    _ensure_originals()
+    if _is_base_tensor(a) and (_is_base_tensor(b) or not hasattr(b, "__torch_function__")):
+        if rounding_mode == "trunc":
+            return _dispatch_fn("trunc_divide", None, a, b)
+        if rounding_mode == "floor":
+            return _dispatch_fn("floor_divide", None, a, b)
+        return _dispatch_fn("true_divide", None, a, b)
+    r = _handle_tf(_py_div_fn, (a, b), {"rounding_mode": rounding_mode})
+    if r is not NotImplemented:
+        return r
+    if rounding_mode == "trunc":
+        return _dispatch_fn("trunc_divide", None, a, b)
+    if rounding_mode == "floor":
+        return _dispatch_fn("floor_divide", None, a, b)
+    return _dispatch_fn("true_divide", None, a, b)
+
+
+def relu(a):
+    """Fast relu: skip __torch_function__ for base Tensor."""
+    _ensure_originals()
+    if _is_base_tensor(a):
+        return _dispatch_fn("relu", None, a)
+    r = _handle_tf(_py_relu_fn, (a,), {})
+    if r is not NotImplemented:
+        return r
+    return _dispatch_fn("relu", None, a)
+
+
+def neg(a):
+    """Fast neg: skip __torch_function__ for base Tensor."""
+    _ensure_originals()
+    if _is_base_tensor(a):
+        return _dispatch_fn("neg", a.device.type, a)
+    r = _handle_tf(_py_neg_fn, (a,), {})
+    if r is not NotImplemented:
+        return r
+    return _dispatch_fn("neg", a.device.type, a)

--- a/src/candle/_cython/_fast_ops_fallback.py
+++ b/src/candle/_cython/_fast_ops_fallback.py
@@ -1,0 +1,16 @@
+"""Pure-Python fallback for _fast_ops.pyx.
+
+When Cython is not available, the original _functional.py implementations
+are used directly — this module is only imported to satisfy the conditional
+import pattern.
+"""
+
+# These are no-ops; the real functions live in _functional.py
+# and are only replaced when the Cython extension compiles.
+fast_add = None
+fast_mul = None
+fast_matmul = None
+fast_sub = None
+fast_div = None
+fast_relu = None
+fast_neg = None

--- a/src/candle/_cython/_tensor_impl.pyx
+++ b/src/candle/_cython/_tensor_impl.pyx
@@ -1,0 +1,254 @@
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""Cython TensorImpl — C-level storage for Tensor metadata.
+
+Mirrors PyTorch's TensorImpl: shape/stride/device/dtype/autograd fields
+are stored as C-typed attributes for zero-overhead access from Cython code.
+VersionCounter is inlined as a C int64.
+"""
+
+from libc.stdint cimport int64_t
+
+DEF MAX_NDIM = 64
+
+
+cdef class TensorImpl:
+    """C-level base for Tensor. All hot fields are cdef-typed."""
+
+    # -- shape / stride (C arrays + cached Python tuples) --
+    cdef int64_t _c_shape[MAX_NDIM]
+    cdef int64_t _c_stride[MAX_NDIM]
+    cdef public int _ndim
+    cdef public int64_t _c_numel
+    cdef public int64_t _c_offset
+
+    # -- device (int enum + cached object) --
+    cdef public int _device_type       # 0=cpu 1=npu 2=cuda 3=mps 4=meta
+    cdef public int _device_index
+    cdef public object _device_obj     # cached device instance
+
+    # -- dtype (int code + cached object) --
+    cdef public int _dtype_code
+    cdef public int _itemsize
+    cdef public object _dtype_obj      # cached DType instance
+
+    # -- storage --
+    cdef public object _storage
+
+    # -- autograd --
+    cdef public bint requires_grad
+    cdef public object grad
+    cdef public object grad_fn
+    cdef public int64_t _version_value   # inlined VersionCounter
+    cdef public object _base
+    cdef public object _view_meta
+    cdef public bint _pending
+    cdef public bint _retain_grad
+    cdef public object _backward_hooks
+
+    # -- Python tuple caches (avoid re-creating every access) --
+    cdef public tuple _shape_tuple
+    cdef public object _stride_tuple   # _StrideTuple instance
+
+    # -- allow dynamic attrs (__dict__) for _fw_tangents etc. --
+    cdef dict __dict__
+
+    # -- cached version counter proxy --
+    cdef public object _vc_proxy
+
+    # ---------------------------------------------------------------
+    # Initialisation helpers
+    # ---------------------------------------------------------------
+
+    cdef inline void _set_shape(self, tuple shape):
+        cdef int n = len(shape)
+        cdef int i
+        cdef int64_t numel = 1
+        self._ndim = n
+        for i in range(n):
+            self._c_shape[i] = <int64_t>shape[i]
+            numel *= self._c_shape[i]
+        self._c_numel = numel
+        self._shape_tuple = shape
+
+    cdef inline void _set_stride(self, object stride):
+        cdef int n = len(stride)
+        cdef int i
+        for i in range(n):
+            self._c_stride[i] = <int64_t>stride[i]
+        self._stride_tuple = stride
+
+    cdef inline void _set_device_from_obj(self, object dev):
+        """Cache device object and extract type_code/index."""
+        self._device_obj = dev
+        cdef str dt = getattr(dev, "type", None)
+        if dt is None:
+            dt = str(dev)
+        if dt == "cpu":
+            self._device_type = 0
+        elif dt == "npu":
+            self._device_type = 1
+        elif dt == "cuda":
+            self._device_type = 2
+        elif dt == "mps":
+            self._device_type = 3
+        elif dt == "meta":
+            self._device_type = 4
+        else:
+            self._device_type = -1
+        cdef object idx = getattr(dev, "index", None)
+        self._device_index = <int>(idx if idx is not None else -1)
+
+    cdef inline void _set_dtype_from_obj(self, object dtype):
+        """Cache dtype object and extract code/itemsize."""
+        self._dtype_obj = dtype
+        self._itemsize = <int>getattr(dtype, "itemsize", 4)
+        # Assign a numeric code based on dtype name for fast comparison
+        cdef str name = getattr(dtype, "name", "")
+        if name == "float32":
+            self._dtype_code = 0
+        elif name == "float16":
+            self._dtype_code = 1
+        elif name == "float64":
+            self._dtype_code = 2
+        elif name == "bfloat16":
+            self._dtype_code = 3
+        elif name == "int32":
+            self._dtype_code = 4
+        elif name == "int64":
+            self._dtype_code = 5
+        elif name == "int16":
+            self._dtype_code = 6
+        elif name == "int8":
+            self._dtype_code = 7
+        elif name == "uint8":
+            self._dtype_code = 8
+        elif name == "bool":
+            self._dtype_code = 9
+        else:
+            self._dtype_code = -1
+
+    # ---------------------------------------------------------------
+    # Properties — zero-overhead access to cached Python objects
+    # ---------------------------------------------------------------
+
+    @property
+    def shape(self):
+        return self._shape_tuple
+
+    @shape.setter
+    def shape(self, value):
+        self._set_shape(tuple(value))
+
+    @property
+    def stride(self):
+        return self._stride_tuple
+
+    @stride.setter
+    def stride(self, value):
+        self._stride_tuple = value
+        cdef int n = len(value)
+        cdef int i
+        for i in range(n):
+            self._c_stride[i] = <int64_t>value[i]
+
+    @property
+    def offset(self):
+        return self._c_offset
+
+    @offset.setter
+    def offset(self, value):
+        self._c_offset = <int64_t>value
+
+    @property
+    def device(self):
+        return self._storage.device
+
+    @property
+    def dtype(self):
+        return self._storage.dtype
+
+    # ---------------------------------------------------------------
+    # VersionCounter — inlined as C int64
+    # For views (_base is set), delegate to the base tensor so that
+    # base._version_counter is view._version_counter (identity).
+    # ---------------------------------------------------------------
+
+    @property
+    def _version_counter(self):
+        if self._base is not None:
+            return self._base._version_counter
+        cdef object proxy = self._vc_proxy
+        if proxy is not None:
+            return proxy
+        proxy = _VersionCounterProxy.__new__(_VersionCounterProxy, self)
+        self._vc_proxy = proxy
+        return proxy
+
+    @_version_counter.setter
+    def _version_counter(self, value):
+        # When setting from a proxy, share the underlying impl's value
+        if isinstance(value, _VersionCounterProxy):
+            self._version_value = (<_VersionCounterProxy>value)._impl._version_value
+        else:
+            self._version_value = <int64_t>getattr(value, "value", 0)
+        # Invalidate cached proxy
+        self._vc_proxy = None
+
+    def _bump_version(self):
+        if self._base is not None:
+            self._base._bump_version()
+        else:
+            self._version_value += 1
+
+    # ---------------------------------------------------------------
+    # Storage access
+    # ---------------------------------------------------------------
+
+    def storage(self):
+        return self._storage
+
+    # ---------------------------------------------------------------
+    # Fast dim / numel
+    # ---------------------------------------------------------------
+
+    def dim(self):
+        return self._ndim
+
+    def numel(self):
+        return self._c_numel
+
+    def element_size(self):
+        return self._itemsize
+
+    # ---------------------------------------------------------------
+    # Pickle support
+    # ---------------------------------------------------------------
+
+    def __reduce__(self):
+        # Delegate to Tensor's own __reduce__ if available
+        reduce_fn = getattr(type(self), "_tensor_reduce", None)
+        if reduce_fn is not None:
+            return reduce_fn(self)
+        raise TypeError(f"cannot pickle {type(self).__name__}")
+
+
+# -------------------------------------------------------------------
+# VersionCounter proxy — lightweight wrapper around TensorImpl._version_value
+# -------------------------------------------------------------------
+
+cdef class _VersionCounterProxy:
+    cdef TensorImpl _impl
+
+    def __cinit__(self, TensorImpl impl):
+        self._impl = impl
+
+    @property
+    def value(self):
+        return self._impl._version_value
+
+    @value.setter
+    def value(self, int64_t v):
+        self._impl._version_value = v
+
+    cpdef void bump(self):
+        self._impl._version_value += 1

--- a/src/candle/_cython/_tensor_impl_fallback.py
+++ b/src/candle/_cython/_tensor_impl_fallback.py
@@ -1,0 +1,124 @@
+"""Pure-Python fallback for _tensor_impl.pyx.
+
+Provides TensorImpl base class and _VersionCounterProxy when Cython is
+not available.  The Tensor class inherits from this unconditionally —
+when Cython IS available, the .pyx version replaces this module.
+"""
+
+
+class _VersionCounterProxy:
+    """Lightweight proxy wrapping TensorImpl._version_value."""
+    __slots__ = ("_impl",)
+
+    def __init__(self, impl):
+        self._impl = impl
+
+    @property
+    def value(self):
+        return self._impl._version_value
+
+    @value.setter
+    def value(self, v):
+        self._impl._version_value = int(v)
+
+    def bump(self):
+        self._impl._version_value += 1
+
+
+class TensorImpl:
+    """Pure-Python mirror of the Cython TensorImpl cdef class."""
+    __slots__ = (
+        "_storage",
+        "_shape_tuple", "_stride_tuple",
+        "_c_offset", "_c_numel", "_ndim",
+        "_device_type", "_device_index", "_device_obj",
+        "_dtype_code", "_itemsize", "_dtype_obj",
+        "requires_grad", "grad", "grad_fn",
+        "_version_value", "_vc_proxy",
+        "_base", "_view_meta",
+        "_pending", "_retain_grad", "_backward_hooks",
+        "__dict__",
+    )
+
+    # -- shape --
+    @property
+    def shape(self):
+        return self._shape_tuple
+
+    @shape.setter
+    def shape(self, value):
+        t = tuple(value)
+        self._shape_tuple = t
+        self._ndim = len(t)
+        numel = 1
+        for d in t:
+            numel *= d
+        self._c_numel = numel
+
+    # -- stride --
+    @property
+    def stride(self):
+        return self._stride_tuple
+
+    @stride.setter
+    def stride(self, value):
+        self._stride_tuple = value
+
+    # -- offset --
+    @property
+    def offset(self):
+        return self._c_offset
+
+    @offset.setter
+    def offset(self, value):
+        self._c_offset = int(value)
+
+    # -- device (always from storage, matching PyTorch TensorImpl) --
+    @property
+    def device(self):
+        return self._storage.device
+
+    # -- dtype (always from storage, matching PyTorch TensorImpl) --
+    @property
+    def dtype(self):
+        return self._storage.dtype
+
+    # -- version counter (inlined, views delegate to _base) --
+    @property
+    def _version_counter(self):
+        if self._base is not None:
+            return self._base._version_counter
+        proxy = self._vc_proxy
+        if proxy is not None:
+            return proxy
+        proxy = _VersionCounterProxy(self)
+        self._vc_proxy = proxy
+        return proxy
+
+    @_version_counter.setter
+    def _version_counter(self, value):
+        if isinstance(value, _VersionCounterProxy):
+            self._version_value = value._impl._version_value
+        else:
+            self._version_value = int(getattr(value, "value", 0))
+        self._vc_proxy = None
+
+    def _bump_version(self):
+        if self._base is not None:
+            self._base._bump_version()
+        else:
+            self._version_value += 1
+
+    # -- storage --
+    def storage(self):
+        return self._storage
+
+    # -- fast dim/numel --
+    def dim(self):
+        return self._ndim
+
+    def numel(self):
+        return self._c_numel
+
+    def element_size(self):
+        return self._itemsize

--- a/src/candle/_device.py
+++ b/src/candle/_device.py
@@ -44,3 +44,14 @@ def set_default_device(dev):
     global _default_device
     _default_device = device(dev)
     return _default_device
+
+
+# ---------------------------------------------------------------------------
+# Cython fast-path: replace device class if Cython extension is available.
+# FastDevice is a drop-in replacement with int-based comparison.
+# ---------------------------------------------------------------------------
+try:
+    from ._cython._device import FastDevice as device  # noqa: F811
+    _default_device = device("cpu")
+except ImportError:
+    pass

--- a/src/candle/_dispatch/dispatcher.py
+++ b/src/candle/_dispatch/dispatcher.py
@@ -172,9 +172,9 @@ class _PendingOp:
             pending._base = None
             pending._view_meta = None
 
-        result_version = result._version_counter
-        if pending._version_counter is not result_version:
-            pending._version_counter = result_version
+        result_version = result._version_value
+        if pending._version_value != result_version:
+            pending._version_value = result_version
         pending._pending = False
 
     def _execute_body(self):
@@ -548,6 +548,10 @@ def dispatch(name, dispatch_device, *args, **kwargs):
     return dispatch_with_keyset(name, keyset, dispatch_device, *args, **kwargs)
 
 
+# Save original Python implementation for fallback reference
+_py_dispatch_with_keyset = dispatch_with_keyset
+
+
 def redispatch(name, keyset, *args, **kwargs):
     return dispatch_with_keyset(name, keyset, None, *args, **kwargs)
 
@@ -562,3 +566,9 @@ try:
     from .._cython._dispatch import cy_extract_tensors as _extract_tensors  # noqa: F811
 except ImportError:
     pass  # keep existing Python versions
+
+# Full dispatcher core: replace dispatch_with_keyset if Cython available
+try:
+    from .._cython._dispatcher_core import cy_dispatch_with_keyset_fast as dispatch_with_keyset  # noqa: F811
+except ImportError:
+    pass  # keep existing Python version

--- a/src/candle/_functional.py
+++ b/src/candle/_functional.py
@@ -1714,3 +1714,30 @@ def blackman_window(window_length, periodic=True, *, dtype=None, device=None):
     return sub(add(_tensor(a0, dtype=dtype, device=device),
                    mul(_tensor(a2, dtype=dtype, device=device), cos(t2))),
                mul(_tensor(a1, dtype=dtype, device=device), cos(t1)))
+
+
+# ---------------------------------------------------------------------------
+# Cython fast-path: replace top ops if Cython extension is available.
+# These skip __torch_function__ scanning for base Tensor instances.
+# Save originals first so fast_ops can reference them for __torch_function__.
+# ---------------------------------------------------------------------------
+_py_add = add
+_py_mul = mul
+_py_matmul = matmul
+_py_sub = sub
+_py_div = div
+_py_relu = relu
+_py_neg = neg
+
+try:
+    from ._cython._fast_ops import (
+        add,  # noqa: F811
+        mul,  # noqa: F811
+        matmul,  # noqa: F811
+        sub,  # noqa: F811
+        div,  # noqa: F811
+        relu,  # noqa: F811
+        neg,  # noqa: F811
+    )
+except ImportError:
+    pass

--- a/src/candle/_tensor.py
+++ b/src/candle/_tensor.py
@@ -74,8 +74,16 @@ from ._functional import tile as tile_dispatch, flip as flip_dispatch, roll as r
 from ._functional import reciprocal as reciprocal_dispatch, addmm as addmm_dispatch
 from ._functional import log1p as log1p_dispatch, expm1 as expm1_dispatch
 from .autograd.engine import backward as _backward
-from .autograd.version_counter import VersionCounter
 from ._printing import format_tensor
+
+# TensorImpl base class: Cython if available, else pure-Python fallback
+try:
+    from ._cython._tensor_impl import TensorImpl as _TensorBase
+    from ._cython._tensor_impl import _VersionCounterProxy  # noqa: F401
+    _HAS_CYTHON_TENSOR_IMPL = True
+except ImportError:
+    from ._cython._tensor_impl_fallback import TensorImpl as _TensorBase
+    _HAS_CYTHON_TENSOR_IMPL = False
 
 
 class _StrideTuple(tuple):
@@ -137,7 +145,7 @@ class _HookHandle:
         self.remove()
 
 
-class Tensor:
+class Tensor(_TensorBase):
     def __init__(self, storage, shape, stride, offset=0, requires_grad=False):
         self._storage = storage
         self.shape = tuple(shape)
@@ -149,9 +157,24 @@ class Tensor:
         self._pending = False
         self._retain_grad = False
         self._backward_hooks = None
-        self._version_counter = VersionCounter()
+        self._version_value = 0
+        self._vc_proxy = None
         self._base = None
         self._view_meta = None
+
+    def _set_device_from_storage(self, dev):
+        """Cache device from storage into TensorImpl fields."""
+        self._device_obj = dev
+        dt = getattr(dev, "type", str(dev))
+        _MAP = {"cpu": 0, "npu": 1, "cuda": 2, "mps": 3, "meta": 4}
+        self._device_type = _MAP.get(dt, -1)
+        idx = getattr(dev, "index", None)
+        self._device_index = idx if idx is not None else -1
+
+    def _set_dtype_from_storage(self, dtype):
+        """Cache dtype from storage into TensorImpl fields."""
+        self._dtype_obj = dtype
+        self._itemsize = getattr(dtype, "itemsize", 4)
 
     def __delattr__(self, name):
         if name == "grad":
@@ -160,14 +183,6 @@ class Tensor:
         if name in {"data", "requires_grad", "_grad_fn", "grad_fn", "_backward_hooks"}:
             raise RuntimeError(f"cannot delete {name}")
         object.__delattr__(self, name)
-
-    @property
-    def dtype(self):
-        return self._storage.dtype
-
-    @property
-    def device(self):
-        return self._storage.device
 
     @property
     def data(self):
@@ -269,8 +284,6 @@ class Tensor:
     def _fw_has(self, level):
         tangents = getattr(self, "_fw_tangents", None)
         return bool(tangents) and level in tangents
-    def storage(self):
-        return self._storage
 
     def storage_offset(self):
         """Returns the offset into the storage."""
@@ -290,16 +303,13 @@ class Tensor:
         """
         return self._storage.untyped_storage()
 
-    def dim(self):
-        return len(self.shape)
-
     def ndimension(self):
         """Return the number of dimensions of the tensor (alias for dim())."""
-        return len(self.shape)
+        return self._ndim
 
     @property
     def ndim(self):
-        return len(self.shape)
+        return self._ndim
 
     def size(self, dim=None):
         if dim is None:
@@ -310,17 +320,9 @@ class Tensor:
             raise IndexError("Dimension out of range")
         return self.shape[dim]
 
-    def numel(self):
-        result = 1
-        for s in self.shape:
-            result *= s
-        return result
-
     # Alias for numel (PyTorch compatibility)
-    nelement = numel
-
-    def element_size(self):
-        return self.dtype.itemsize
+    def nelement(self):
+        return self.numel()
 
     def is_floating_point(self):
         return self.dtype.is_floating_point
@@ -576,7 +578,7 @@ class Tensor:
         out.grad_fn = None
         out.grad = None
         out._pending = self._pending
-        out._version_counter = self._version_counter
+        out._version_value = self._version_value
         return out
 
     def detach_(self):
@@ -593,9 +595,6 @@ class Tensor:
         handle = _HookHandle(self._backward_hooks)
         self._backward_hooks[handle.id] = hook
         return handle
-
-    def _bump_version(self):
-        self._version_counter.bump()
 
     def _is_view(self):
         return self._base is not None

--- a/src/candle/autograd/node.py
+++ b/src/candle/autograd/node.py
@@ -1,5 +1,13 @@
 from .graph import current_saved_tensors_hooks
 
+# FastNode base class: Cython if available, else no base
+try:
+    from .._cython._autograd_node import FastNode as _NodeBase
+    _HAS_FAST_NODE = True
+except ImportError:
+    _NodeBase = object
+    _HAS_FAST_NODE = False
+
 
 class _SavedValue:
     def __init__(self, value):
@@ -159,20 +167,24 @@ class AccumulateGrad:
         return self._name
 
 
-class Node:
+class Node(_NodeBase):
     def __init__(self, backward, inputs, *, name=None):
-        if backward is not None:
-            self.backward = backward
-        self.inputs = tuple(inputs)
-        self._saved_tensors_list = []
-        self._saved_fields = {}
-        self._hooks = {}
-        self._prehooks = {}
-        self._next_functions_cache = self._freeze_next_functions()
-        self._metadata = None
-        self._name = name or type(self).__name__
-        self._anomaly_trace = None
-        self._anomaly_parent = None
+        if _HAS_FAST_NODE:
+            # FastNode.__init__ handles all field setup + _freeze_next_functions
+            _NodeBase.__init__(self, backward, inputs, name=name)
+        else:
+            if backward is not None:
+                self.backward = backward
+            self.inputs = tuple(inputs)
+            self._saved_tensors_list = []
+            self._saved_fields = {}
+            self._hooks = {}
+            self._prehooks = {}
+            self._next_functions_cache = self._freeze_next_functions()
+            self._metadata = None
+            self._name = name or type(self).__name__
+            self._anomaly_trace = None
+            self._anomaly_parent = None
 
     def save_for_backward(self, *tensors):
         saved = []

--- a/src/candle/autograd/version_counter.py
+++ b/src/candle/autograd/version_counter.py
@@ -1,4 +1,17 @@
+"""Version counter for tensor mutation tracking.
+
+When Cython TensorImpl is available, the version counter is inlined as
+``TensorImpl._version_value`` (C int64) and accessed via a lightweight
+``_VersionCounterProxy``.  This module provides the fallback
+``VersionCounter`` class for use when Cython is not available, and
+re-exports the proxy for compatibility.
+"""
+
+
 class VersionCounter:
+    """Standalone version counter (used when TensorImpl is not the base)."""
+    __slots__ = ("value",)
+
     def __init__(self, value=0):
         self.value = int(value)
 


### PR DESCRIPTION
## Summary

- Add 6 new Cython extension modules to accelerate the Python-side hot path, aligning Candle's architecture with PyTorch's C++ TensorImpl/Dispatcher pattern:
  - **`_tensor_impl.pyx`**: `cdef class TensorImpl` with C-level shape/stride/device/dtype fields and inlined VersionCounter (`int64 _version_value` instead of Python `VersionCounter` object)
  - **`_dispatcher_core.pyx`**: Full Cython replacement for `dispatch_with_keyset` inner loop — C-speed tensor extraction, device validation, kernel lookup, kwargs prep, dispatch context push/pop, version bumping
  - **`_device.pyx`**: `FastDevice` cdef class with `int type_code` for O(1) device comparison instead of string ops
  - **`_autograd_node.pyx`**: `FastNode` cdef class with typed fields and C-speed `_freeze_next_functions`
  - **`_fast_ops.pyx`**: Cython fast-path for `add/mul/matmul/sub/div/relu/neg` that skips `__torch_function__` scanning when both args are base Tensor (`type(a) is Tensor` — single pointer compare)
  - **`_dtype.pyx`**: `FastDType` cdef class (compiled, not wired — low impact/high risk to singleton identity)
- Each module has a pure-Python fallback (`*_fallback.py`) so the framework works without Cython
- `Tensor` now inherits from `TensorImpl` (Cython cdef class when available, pure-Python fallback otherwise)
- `VersionCounter` inlined as `_version_value` (C int64) with cached `_VersionCounterProxy` for identity-based sharing between views

## Benchmark (64×64 float32, NPU, 5000 iters)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| `torch.add` (no sync) | 0.263 ms | 0.250 ms | **−4.9%** |
| 100× property access | 0.064 ms | 0.047 ms | **−26.7%** |
| `numel+dim+elem+ver` | 0.0011 ms | 0.0007 ms | **−36.4%** |
| `torch.add` (with sync) | 0.324 ms | 0.300 ms | **−7.3%** |

## Test plan

- [x] `pip install -e .` — all 11 Cython modules compile
- [x] `pytest tests/npu/ -v` — 266 passed, 25 skipped
- [x] `pytest tests/cpu/ tests/contract/` — 1752 passed (same as main, zero regressions)
- [x] `pylint src/candle/ --rcfile=.github/pylint.conf` — 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)