### PR TITLE
fix(mps): fix pad reflect/replicate crash and RNN/LSTM/GRU device mismatch

### DIFF
--- a/src/candle/_backends/mps/ops/conv.py
+++ b/src/candle/_backends/mps/ops/conv.py
@@ -989,8 +989,7 @@ def pad(a, pad_widths, mode='constant', value=0):
                 fill_bytes = struct.pack("f", float(value))
                 fill_size = 4
             else:
-                import numpy as np
-                fill_bytes = np.float16(value).tobytes()
+                fill_bytes = struct.pack("e", float(value))
                 fill_size = 2
             d.dispatch_pad_constant(
                 f"pad_constant_{sfx}", _metal_buf(a), out_buf,

--- a/src/candle/nn/modules/rnn.py
+++ b/src/candle/nn/modules/rnn.py
@@ -127,10 +127,13 @@ class RNNBase(Module):
         # Initialize hidden state
         if hx is None:
             if self.mode == 'LSTM':
-                h_zeros = zeros(self.num_layers * num_directions, batch_size, self.hidden_size)
-                hx = (h_zeros, zeros(self.num_layers * num_directions, batch_size, self.hidden_size))
+                h_zeros = zeros(self.num_layers * num_directions, batch_size, self.hidden_size,
+                                dtype=input.dtype, device=input.device)
+                hx = (h_zeros, zeros(self.num_layers * num_directions, batch_size, self.hidden_size,
+                                     dtype=input.dtype, device=input.device))
             else:
-                hx = zeros(self.num_layers * num_directions, batch_size, self.hidden_size)
+                hx = zeros(self.num_layers * num_directions, batch_size, self.hidden_size,
+                           dtype=input.dtype, device=input.device)
 
         # Split hidden state per layer and direction
         if self.mode == 'LSTM':
@@ -280,7 +283,8 @@ class RNNCell(RNNCellBase):
 
     def forward(self, input, hx=None):
         if hx is None:
-            hx = zeros(input.shape[0], self.hidden_size)
+            hx = zeros(input.shape[0], self.hidden_size,
+                       dtype=input.dtype, device=input.device)
         gate = F.linear(input, self.weight_ih, self.bias_ih) + \
                F.linear(hx, self.weight_hh, self.bias_hh)
         if self.nonlinearity == 'tanh':
@@ -309,8 +313,10 @@ class LSTMCell(RNNCellBase):
     def forward(self, input, hx=None):
         if hx is None:
             hx = (
-                zeros(input.shape[0], self.hidden_size),
-                zeros(input.shape[0], self.hidden_size),
+                zeros(input.shape[0], self.hidden_size,
+                      dtype=input.dtype, device=input.device),
+                zeros(input.shape[0], self.hidden_size,
+                      dtype=input.dtype, device=input.device),
             )
         h, c = hx
         gates = F.linear(input, self.weight_ih, self.bias_ih) + \
@@ -337,7 +343,8 @@ class GRUCell(RNNCellBase):
 
     def forward(self, input, hx=None):
         if hx is None:
-            hx = zeros(input.shape[0], self.hidden_size)
+            hx = zeros(input.shape[0], self.hidden_size,
+                       dtype=input.dtype, device=input.device)
         # Compute input gates (all 3 at once)
         gates_x = F.linear(input, self.weight_ih, self.bias_ih)
         gates_h = F.linear(hx, self.weight_hh, self.bias_hh)


### PR DESCRIPTION
## Summary

Two MPS backend bugs fixed:

### Bug 1: `F.pad(mode='reflect'/'replicate')` crash

**Symptom:** `UnboundLocalError: local variable 'np' referenced before assignment`

**Root cause:** In `_backends/mps/ops/conv.py`, the GPU constant-pad path had a conditional `import numpy as np` (line 992, inside the float16 branch). Python treats `np` as a local variable for the entire function scope, shadowing the module-level `import numpy as np` at line 4. When the CPU fallback path (reflect/replicate/circular) tried to use `np.pad()`, it hit the unbound local.

**Fix:** Replace `np.float16(value).tobytes()` with `struct.pack('e', float(value))`, eliminating the local import that caused the shadowing.

### Bug 2: RNN/LSTM/GRU device mismatch on MPS

**Symptom:** `RuntimeError: Tensor on device mps:0 is not on the expected device cpu`

**Root cause:** When `hx=None` (default), hidden states were initialized via `zeros(...)` without `device` or `dtype` arguments, defaulting to CPU. This affected:
- `RNNBase.forward()` (RNN, LSTM, GRU modules)
- `RNNCell.forward()`
- `LSTMCell.forward()`
- `GRUCell.forward()`

**Fix:** Pass `dtype=input.dtype, device=input.device` to all `zeros()` calls.

## Testing

- All 361 MPS tests pass
- All 1760 CPU + contract tests pass
- Pylint 10.00/10
- Manual verification of all 10 affected ops (pad constant/reflect/replicate/circular, RNN, LSTM, GRU, RNNCell, LSTMCell, GRUCell)