### PR TITLE
feat(cython): migrate distributed subsystem to Cython for c10d parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,4 @@ compat/*/_transformers/
 compat/*/_pytorch/
 compat/*/_reports/
 compat/pytorch/_pytorch.local/
+*.c

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,18 @@ if platform.system() == "Linux":
                     "candle._cython._fast_ops",
                     ["src/candle/_cython/_fast_ops.pyx"],
                 ),
+                Extension(
+                    "candle.distributed._c10d",
+                    ["src/candle/distributed/_c10d.pyx"],
+                ),
+                Extension(
+                    "candle.distributed._c10d_gloo",
+                    ["src/candle/distributed/_c10d_gloo.pyx"],
+                ),
+                Extension(
+                    "candle.distributed._c10d_hccl",
+                    ["src/candle/distributed/_c10d_hccl.pyx"],
+                ),
             ],
             compiler_directives={
                 "language_level": "3",

--- a/src/candle/distributed/__init__.py
+++ b/src/candle/distributed/__init__.py
@@ -1,11 +1,43 @@
 import os
 from datetime import timedelta
 
-from ._reduce_op import ReduceOp, RedOpType, reduce_op
-from ._work import Work
-from ._process_group import ProcessGroup, ProcessGroupHCCL
-from ._gloo import ProcessGroupGloo
-from ._store import TCPStore
+# Core types: try Cython, fallback to Python
+try:
+    from ._c10d import (  # pylint: disable=no-name-in-module
+        RedOpType, ReduceOp, reduce_op,
+        Work,
+        Store as _CStore, TCPStore, PrefixStore as _CPrefixStore, HashStore,
+        ProcessGroup,
+        AllreduceOptions as _CAllreduceOptions,
+        BroadcastOptions as _CBroadcastOptions,
+        ReduceOptions as _CReduceOptions,
+        AllgatherOptions as _CAllgatherOptions,
+        GatherOptions as _CGatherOptions,
+        ScatterOptions as _CScatterOptions,
+        ReduceScatterOptions as _CReduceScatterOptions,
+        BarrierOptions as _CBarrierOptions,
+        AllToAllOptions as _CAllToAllOptions,
+    )
+    _C10D_CYTHON = True
+except ImportError:
+    from ._reduce_op import ReduceOp, RedOpType, reduce_op
+    from ._work import Work
+    from ._process_group import ProcessGroup
+    from ._store import TCPStore
+    _C10D_CYTHON = False
+
+# HCCL backend: try Cython, fallback to Python
+try:
+    from ._c10d_hccl import ProcessGroupHCCL  # pylint: disable=no-name-in-module
+except ImportError:
+    from ._process_group import ProcessGroupHCCL
+
+# Gloo backend: try Cython, fallback to Python
+try:
+    from ._c10d_gloo import ProcessGroupGloo  # pylint: disable=no-name-in-module
+except ImportError:
+    from ._gloo import ProcessGroupGloo
+
 from ._backend import (
     Backend, GroupMember, Store, PrefixStore,
     is_nccl_available, is_gloo_available, is_mpi_available, is_ucc_available,
@@ -34,16 +66,28 @@ _all_to_all_single_seq = {}
 
 default_pg_timeout = timedelta(minutes=30)
 
-# Placeholder option classes for API compatibility
-AllreduceOptions = object
+# Option classes: use Cython versions if available, else placeholders
+if _C10D_CYTHON:
+    AllreduceOptions = _CAllreduceOptions
+    AllToAllOptions = _CAllToAllOptions
+    BarrierOptions = _CBarrierOptions
+    BroadcastOptions = _CBroadcastOptions
+    GatherOptions = _CGatherOptions
+    ReduceOptions = _CReduceOptions
+    ReduceScatterOptions = _CReduceScatterOptions
+    ScatterOptions = _CScatterOptions
+    AllgatherOptions = _CAllgatherOptions
+else:
+    AllreduceOptions = object
+    AllToAllOptions = object
+    BarrierOptions = object
+    BroadcastOptions = object
+    GatherOptions = object
+    ReduceOptions = object
+    ReduceScatterOptions = object
+    ScatterOptions = object
+    AllgatherOptions = object
 AllreduceCoalescedOptions = object
-AllToAllOptions = object
-BarrierOptions = object
-BroadcastOptions = object
-GatherOptions = object
-ReduceOptions = object
-ReduceScatterOptions = object
-ScatterOptions = object
 DebugLevel = object
 
 

--- a/src/candle/distributed/_c10d.pxd
+++ b/src/candle/distributed/_c10d.pxd
@@ -1,0 +1,143 @@
+# cython: language_level=3
+"""
+Public cdef declarations for _c10d.pyx.
+
+Allows _c10d_gloo.pyx and _c10d_hccl.pyx to ``cimport`` the extension
+types defined here so they can subclass ProcessGroup / Store and access
+cdef fields at C speed.
+"""
+
+
+# ---------------------------------------------------------------------------
+# ReduceOp
+# ---------------------------------------------------------------------------
+
+cdef class ReduceOp:
+    cdef public int _op
+
+
+# ---------------------------------------------------------------------------
+# Options structs
+# ---------------------------------------------------------------------------
+
+cdef class AllreduceOptions:
+    cdef public int reduceOp
+    cdef public double timeout
+    cdef public bint asyncOp
+
+
+cdef class BroadcastOptions:
+    cdef public int rootRank
+    cdef public int rootTensor
+    cdef public double timeout
+    cdef public bint asyncOp
+
+
+cdef class ReduceOptions:
+    cdef public int reduceOp
+    cdef public int rootRank
+    cdef public int rootTensor
+    cdef public double timeout
+    cdef public bint asyncOp
+
+
+cdef class AllgatherOptions:
+    cdef public double timeout
+    cdef public bint asyncOp
+
+
+cdef class GatherOptions:
+    cdef public int rootRank
+    cdef public double timeout
+    cdef public bint asyncOp
+
+
+cdef class ScatterOptions:
+    cdef public int rootRank
+    cdef public double timeout
+    cdef public bint asyncOp
+
+
+cdef class ReduceScatterOptions:
+    cdef public int reduceOp
+    cdef public double timeout
+    cdef public bint asyncOp
+
+
+cdef class BarrierOptions:
+    cdef public double timeout
+    cdef public bint asyncOp
+    cdef public object device_ids
+
+
+cdef class AllToAllOptions:
+    cdef public double timeout
+    cdef public bint asyncOp
+
+
+# ---------------------------------------------------------------------------
+# Work
+# ---------------------------------------------------------------------------
+
+cdef class Work:
+    cdef public bint _completed
+    cdef public object _stream
+    cdef public object _device_id
+    cdef public object _exception
+    cdef public int _source_rank
+    cdef public object _on_wait
+
+    cpdef bint wait(self, timeout=*)
+    cpdef bint is_completed(self)
+    cpdef bint is_success(self)
+
+
+# ---------------------------------------------------------------------------
+# Store hierarchy
+# ---------------------------------------------------------------------------
+
+cdef class Store:
+    cpdef set(self, str key, bytes value)
+    cpdef bytes get(self, str key)
+    cpdef wait(self, list keys, timeout=*)
+    cpdef close(self)
+
+
+cdef class TCPStore(Store):
+    cdef str _host
+    cdef int _port
+    cdef int _world_size
+    cdef double _timeout
+    cdef object _server_inst
+    cdef object _lock
+    cdef object _sock
+
+    cdef object _connect(self, str host, int port, double timeout)
+
+
+cdef class PrefixStore(Store):
+    cdef str _prefix
+    cdef object _store
+
+
+cdef class HashStore(Store):
+    cdef dict _data
+    cdef object _lock
+    cdef object _cond
+
+
+# ---------------------------------------------------------------------------
+# ProcessGroup
+# ---------------------------------------------------------------------------
+
+cdef class ProcessGroup:
+    cdef public int _rank
+    cdef public int _size
+    cdef public str _group_name
+    cdef public str _group_desc
+    cdef public object _ranks
+    cdef public object _bound_device_id
+
+    cpdef int rank(self)
+    cpdef int size(self)
+    cpdef str name(self)

--- a/src/candle/distributed/_c10d.pyx
+++ b/src/candle/distributed/_c10d.pyx
@@ -1,0 +1,613 @@
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""
+Cython implementation of core distributed types for candle.distributed.
+
+Ports the exact logic from:
+  _reduce_op.py  -> RedOpType, ReduceOp, reduce_op
+  _work.py       -> Work
+  _store.py      -> _recvall, _recv_bytes, _send_bytes, _StoreServer, TCPStore
+  _backend.py    -> Store (base), PrefixStore
+  _process_group.py -> ProcessGroup (base class only)
+
+Plus new: HashStore (dict + lock, thread-safe), Options structs.
+"""
+
+import threading
+import socket
+import struct
+import time
+from enum import IntEnum
+
+
+# ---------------------------------------------------------------------------
+# ReduceOp section
+# ---------------------------------------------------------------------------
+
+class RedOpType(IntEnum):
+    SUM = 0
+    PRODUCT = 1
+    MAX = 2
+    MIN = 3
+    BAND = 4
+    BOR = 5
+    BXOR = 6
+    AVG = 7
+    PREMUL_SUM = 8
+    UNUSED = 9
+
+
+cdef class ReduceOp:
+    # cdef fields declared in _c10d.pxd
+
+    SUM = RedOpType.SUM
+    PRODUCT = RedOpType.PRODUCT
+    MAX = RedOpType.MAX
+    MIN = RedOpType.MIN
+    BAND = RedOpType.BAND
+    BOR = RedOpType.BOR
+    BXOR = RedOpType.BXOR
+    AVG = RedOpType.AVG
+    PREMUL_SUM = RedOpType.PREMUL_SUM
+    UNUSED = RedOpType.UNUSED
+
+    RedOpType = RedOpType
+
+    def __init__(self, op=None):
+        if op is not None:
+            self._op = int(RedOpType(op))
+        else:
+            self._op = int(RedOpType.SUM)
+
+    def __int__(self):
+        return self._op
+
+    def __eq__(self, other):
+        if isinstance(other, ReduceOp):
+            return self._op == (<ReduceOp>other)._op
+        if isinstance(other, (int, RedOpType)):
+            return self._op == int(other)
+        return NotImplemented
+
+    def __hash__(self):
+        return hash(self._op)
+
+    def __repr__(self):
+        return f"<ReduceOp.{RedOpType(self._op).name}: {self._op}>"
+
+
+# Deprecated alias matching PyTorch
+class reduce_op:
+    SUM = ReduceOp.SUM
+    PRODUCT = ReduceOp.PRODUCT
+    MAX = ReduceOp.MAX
+    MIN = ReduceOp.MIN
+
+
+# ---------------------------------------------------------------------------
+# Options structs
+# ---------------------------------------------------------------------------
+
+cdef class AllreduceOptions:
+    # cdef fields declared in _c10d.pxd
+
+    def __init__(self, reduceOp=int(RedOpType.SUM), double timeout=300.0,
+                 bint asyncOp=False):
+        self.reduceOp = reduceOp
+        self.timeout = timeout
+        self.asyncOp = asyncOp
+
+
+cdef class BroadcastOptions:
+    # cdef fields declared in _c10d.pxd
+
+    def __init__(self, int rootRank=0, int rootTensor=0, double timeout=300.0,
+                 bint asyncOp=False):
+        self.rootRank = rootRank
+        self.rootTensor = rootTensor
+        self.timeout = timeout
+        self.asyncOp = asyncOp
+
+
+cdef class ReduceOptions:
+    # cdef fields declared in _c10d.pxd
+
+    def __init__(self, reduceOp=int(RedOpType.SUM), int rootRank=0,
+                 int rootTensor=0, double timeout=300.0, bint asyncOp=False):
+        self.reduceOp = reduceOp
+        self.rootRank = rootRank
+        self.rootTensor = rootTensor
+        self.timeout = timeout
+        self.asyncOp = asyncOp
+
+
+cdef class AllgatherOptions:
+    # cdef fields declared in _c10d.pxd
+
+    def __init__(self, double timeout=300.0, bint asyncOp=False):
+        self.timeout = timeout
+        self.asyncOp = asyncOp
+
+
+cdef class GatherOptions:
+    # cdef fields declared in _c10d.pxd
+
+    def __init__(self, int rootRank=0, double timeout=300.0,
+                 bint asyncOp=False):
+        self.rootRank = rootRank
+        self.timeout = timeout
+        self.asyncOp = asyncOp
+
+
+cdef class ScatterOptions:
+    # cdef fields declared in _c10d.pxd
+
+    def __init__(self, int rootRank=0, double timeout=300.0,
+                 bint asyncOp=False):
+        self.rootRank = rootRank
+        self.timeout = timeout
+        self.asyncOp = asyncOp
+
+
+cdef class ReduceScatterOptions:
+    # cdef fields declared in _c10d.pxd
+
+    def __init__(self, reduceOp=int(RedOpType.SUM), double timeout=300.0,
+                 bint asyncOp=False):
+        self.reduceOp = reduceOp
+        self.timeout = timeout
+        self.asyncOp = asyncOp
+
+
+cdef class BarrierOptions:
+    # cdef fields declared in _c10d.pxd
+
+    def __init__(self, double timeout=300.0, bint asyncOp=False,
+                 device_ids=None):
+        self.timeout = timeout
+        self.asyncOp = asyncOp
+        self.device_ids = device_ids if device_ids is not None else []
+
+
+cdef class AllToAllOptions:
+    # cdef fields declared in _c10d.pxd
+
+    def __init__(self, double timeout=300.0, bint asyncOp=False):
+        self.timeout = timeout
+        self.asyncOp = asyncOp
+
+
+# ---------------------------------------------------------------------------
+# Work class
+# ---------------------------------------------------------------------------
+
+cdef class Work:
+    # cdef fields declared in _c10d.pxd
+
+    def __init__(self, stream=None, device_id=None, int source_rank=-1):
+        self._completed = False
+        self._stream = stream
+        self._device_id = device_id
+        self._exception = None
+        self._source_rank = source_rank
+        self._on_wait = None
+
+    cpdef bint wait(self, timeout=None):
+        if not self._completed and self._stream is not None:
+            try:
+                from .._backends.npu import runtime as npu_runtime
+                dev = self._device_id if self._device_id is not None else 0
+                npu_runtime.get_runtime(dev).synchronize_stream(self._stream)
+            except Exception as e:
+                self._exception = e
+                raise
+        if self._on_wait is not None:
+            try:
+                self._on_wait()
+            except Exception as e:
+                self._exception = e
+                raise
+            finally:
+                self._on_wait = None
+        self._completed = True
+        return True
+
+    cpdef bint is_completed(self):
+        return self._completed
+
+    cpdef bint is_success(self):
+        return self._completed and self._exception is None
+
+    def exception(self):
+        return self._exception
+
+    def source_rank(self):
+        return self._source_rank
+
+    def result(self):
+        return []
+
+    def synchronize(self):
+        self.wait()
+
+    def get_future(self):
+        from ..futures import Future
+
+        fut = Future()
+        try:
+            self.wait()
+        except Exception as exc:
+            fut.set_exception(exc)
+            return fut
+
+        fut.set_result(self.result())
+        return fut
+
+
+# ---------------------------------------------------------------------------
+# Store hierarchy
+# ---------------------------------------------------------------------------
+
+# Wire protocol constants
+cdef int _CMD_SET = 0
+cdef int _CMD_GET = 1
+cdef int _CMD_WAIT = 2
+
+cdef int _RESP_OK = 0
+cdef int _RESP_VALUE = 1
+
+cdef double _DEFAULT_TIMEOUT = 300.0
+
+
+# Internal helpers — cdef for C-speed, not callable from Python
+
+cdef bytes _recvall(object sock, int n):
+    cdef bytearray buf = bytearray()
+    cdef bytes chunk
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            return None
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+cdef bytes _recv_bytes(object sock):
+    cdef bytes raw = _recvall(sock, 4)
+    if raw is None:
+        raise ConnectionError("connection closed")
+    cdef int length = struct.unpack("!I", raw)[0]
+    return _recvall(sock, length)
+
+
+cdef void _send_bytes(object sock, bytes data):
+    sock.sendall(struct.pack("!I", len(data)))
+    sock.sendall(data)
+
+
+# --- Store base class ---
+
+cdef class Store:
+    """Base class for distributed stores (API compatibility)."""
+
+    cpdef set(self, str key, bytes value):
+        raise NotImplementedError
+
+    cpdef bytes get(self, str key):
+        raise NotImplementedError
+
+    cpdef wait(self, list keys, timeout=None):
+        raise NotImplementedError
+
+    cpdef close(self):
+        pass
+
+
+# --- _StoreServer (NOT in .pxd, keep cdef fields here) ---
+
+cdef class _StoreServer:
+    cdef dict _data
+    cdef object _lock
+    cdef object _cond
+    cdef int _world_size
+    cdef double _timeout
+    cdef bint _closed
+    cdef object _server
+    cdef object _thread
+
+    def __init__(self, int port, int world_size, double timeout=_DEFAULT_TIMEOUT):
+        self._data = {}
+        self._lock = threading.Lock()
+        self._cond = threading.Condition(self._lock)
+        self._world_size = world_size
+        self._timeout = timeout
+        self._closed = False
+        self._server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._server.bind(("", port))
+        self._server.listen(world_size * 4)
+        self._thread = threading.Thread(target=self._accept_loop, daemon=True)
+        self._thread.start()
+
+    def _accept_loop(self):
+        while not self._closed:
+            try:
+                conn, _ = self._server.accept()
+            except OSError:
+                break
+            t = threading.Thread(target=self._handle, args=(conn,),
+                                 daemon=True)
+            t.start()
+
+    def _handle(self, conn):
+        cdef bytes hdr
+        cdef int cmd
+        cdef str key
+        cdef bytes value
+        cdef bytes raw
+        cdef int n
+        cdef int offset
+        cdef int klen
+        cdef list keys
+        cdef double deadline
+        cdef double remaining
+        cdef str k
+        cdef bint all_present
+        try:
+            while not self._closed:
+                hdr = _recvall(conn, 1)
+                if hdr is None:
+                    break
+                cmd = hdr[0]
+                if cmd == _CMD_SET:
+                    key = _recv_bytes(conn).decode("utf-8")
+                    value = _recv_bytes(conn)
+                    with self._cond:
+                        self._data[key] = value
+                        self._cond.notify_all()
+                    conn.sendall(bytes([_RESP_OK]))
+                elif cmd == _CMD_GET:
+                    key = _recv_bytes(conn).decode("utf-8")
+                    deadline = time.monotonic() + self._timeout
+                    with self._cond:
+                        while key not in self._data:
+                            remaining = deadline - time.monotonic()
+                            if remaining <= 0 or self._closed:
+                                raise TimeoutError(
+                                    f"TCPStore server: GET '{key}' timed out")
+                            self._cond.wait(timeout=min(remaining, 1.0))
+                        value = self._data[key]
+                    conn.sendall(bytes([_RESP_VALUE]))
+                    _send_bytes(conn, value)
+                elif cmd == _CMD_WAIT:
+                    raw = _recv_bytes(conn)
+                    n = struct.unpack("!I", raw[:4])[0]
+                    keys = []
+                    offset = 4
+                    for _ in range(n):
+                        klen = struct.unpack("!I", raw[offset:offset + 4])[0]
+                        offset += 4
+                        keys.append(raw[offset:offset + klen].decode("utf-8"))
+                        offset += klen
+                    deadline = time.monotonic() + self._timeout
+                    with self._cond:
+                        while True:
+                            all_present = True
+                            for k in keys:
+                                if k not in self._data:
+                                    all_present = False
+                                    break
+                            if all_present:
+                                break
+                            remaining = deadline - time.monotonic()
+                            if remaining <= 0 or self._closed:
+                                raise TimeoutError(
+                                    "TCPStore server: WAIT timed out")
+                            self._cond.wait(timeout=min(remaining, 1.0))
+                    conn.sendall(bytes([_RESP_OK]))
+        except (ConnectionError, OSError, TimeoutError):
+            pass
+        finally:
+            conn.close()
+
+    def close(self):
+        self._closed = True
+        with self._cond:
+            self._cond.notify_all()
+        try:
+            self._server.close()
+        except OSError:
+            pass
+
+
+# --- TCPStore ---
+
+cdef class TCPStore(Store):
+    # cdef fields declared in _c10d.pxd
+
+    def __init__(self, str host, int port, int world_size, bint is_master,
+                 double timeout=_DEFAULT_TIMEOUT):
+        self._host = host
+        self._port = port
+        self._world_size = world_size
+        self._timeout = timeout
+        self._server_inst = None
+        self._lock = threading.Lock()
+        if is_master:
+            self._server_inst = _StoreServer(port, world_size, timeout=timeout)
+            time.sleep(0.1)
+        self._sock = self._connect(host, port, timeout)
+
+    cdef object _connect(self, str host, int port, double timeout):
+        cdef double deadline = time.monotonic() + timeout
+        cdef object sock
+        while True:
+            try:
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.settimeout(max(deadline - time.monotonic(), 1.0))
+                sock.connect((host, port))
+                sock.settimeout(self._timeout)
+                return sock
+            except (ConnectionRefusedError, OSError):
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        f"TCPStore: could not connect to {host}:{port} "
+                        f"within {timeout}s"
+                    )
+                time.sleep(0.1)
+
+    cpdef set(self, str key, bytes value):
+        if isinstance(value, str):
+            value = (<str>value).encode("utf-8")
+        with self._lock:
+            self._sock.sendall(bytes([_CMD_SET]))
+            _send_bytes(self._sock, key.encode("utf-8"))
+            _send_bytes(self._sock, value)
+            resp = _recvall(self._sock, 1)
+        if resp is None or resp[0] != _RESP_OK:
+            raise RuntimeError("TCPStore.set failed")
+
+    cpdef bytes get(self, str key):
+        with self._lock:
+            self._sock.sendall(bytes([_CMD_GET]))
+            _send_bytes(self._sock, key.encode("utf-8"))
+            resp = _recvall(self._sock, 1)
+            if resp is None or resp[0] != _RESP_VALUE:
+                raise RuntimeError("TCPStore.get failed")
+            return _recv_bytes(self._sock)
+
+    cpdef wait(self, list keys, timeout=None):
+        cdef bytes buf = struct.pack("!I", len(keys))
+        cdef bytes kb
+        cdef object old_timeout
+        cdef bytes resp
+        for k in keys:
+            kb = k.encode("utf-8")
+            buf += struct.pack("!I", len(kb)) + kb
+        with self._lock:
+            self._sock.sendall(bytes([_CMD_WAIT]))
+            _send_bytes(self._sock, buf)
+            old_timeout = self._sock.gettimeout()
+            if timeout is not None:
+                self._sock.settimeout(timeout)
+            try:
+                resp = _recvall(self._sock, 1)
+                if resp is None or resp[0] != _RESP_OK:
+                    raise RuntimeError("TCPStore.wait failed")
+            finally:
+                self._sock.settimeout(old_timeout)
+
+    cpdef close(self):
+        try:
+            self._sock.close()
+        except OSError:
+            pass
+        if self._server_inst is not None:
+            self._server_inst.close()
+
+
+# --- PrefixStore ---
+
+cdef class PrefixStore(Store):
+    # cdef fields declared in _c10d.pxd
+
+    def __init__(self, str prefix, object store):
+        self._prefix = prefix
+        self._store = store
+
+    cpdef set(self, str key, bytes value):
+        self._store.set(f"{self._prefix}/{key}", value)
+
+    cpdef bytes get(self, str key):
+        return self._store.get(f"{self._prefix}/{key}")
+
+    cpdef wait(self, list keys, timeout=None):
+        self._store.wait([f"{self._prefix}/{k}" for k in keys], timeout)
+
+    cpdef close(self):
+        self._store.close()
+
+
+# --- HashStore ---
+
+cdef class HashStore(Store):
+    # cdef fields declared in _c10d.pxd
+
+    def __init__(self):
+        self._data = {}
+        self._lock = threading.Lock()
+        self._cond = threading.Condition(self._lock)
+
+    cpdef set(self, str key, bytes value):
+        with self._cond:
+            self._data[key] = value
+            self._cond.notify_all()
+
+    cpdef bytes get(self, str key):
+        with self._cond:
+            while key not in self._data:
+                self._cond.wait(timeout=1.0)
+            return self._data[key]
+
+    cpdef wait(self, list keys, timeout=None):
+        cdef double deadline
+        cdef double remaining
+        cdef str k
+        cdef bint all_present
+        if timeout is not None:
+            deadline = time.monotonic() + <double>timeout
+        else:
+            deadline = time.monotonic() + _DEFAULT_TIMEOUT
+        with self._cond:
+            while True:
+                all_present = True
+                for k in keys:
+                    if k not in self._data:
+                        all_present = False
+                        break
+                if all_present:
+                    break
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError(
+                        f"HashStore: WAIT timed out for keys {keys}")
+                self._cond.wait(timeout=min(remaining, 1.0))
+
+    cpdef close(self):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# ProcessGroup base class
+# ---------------------------------------------------------------------------
+
+cdef class ProcessGroup:
+    # cdef fields declared in _c10d.pxd
+
+    def __init__(self, int rank, int size):
+        self._rank = rank
+        self._size = size
+        self._group_name = ""
+        self._group_desc = ""
+        self._ranks = None
+        self._bound_device_id = None
+
+    cpdef int rank(self):
+        return self._rank
+
+    cpdef int size(self):
+        return self._size
+
+    cpdef str name(self):
+        return self._group_name
+
+    @property
+    def group_name(self):
+        return self._group_name
+
+    @property
+    def group_desc(self):
+        return self._group_desc
+
+    @property
+    def bound_device_id(self):
+        return self._bound_device_id

--- a/src/candle/distributed/_c10d_gloo.pyx
+++ b/src/candle/distributed/_c10d_gloo.pyx
@@ -1,0 +1,566 @@
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""Cython Gloo backend: TcpTransport + numpy collectives + ProcessGroupGloo."""
+
+import socket
+import struct
+import threading
+import numpy as np
+from enum import IntEnum
+
+from ._c10d import RedOpType, Work, ProcessGroup
+
+
+# ---------------------------------------------------------------------------
+# Section 1: _recvall helper (from _tcp_transport.py)
+# ---------------------------------------------------------------------------
+
+cdef bytes _recvall(object sock, Py_ssize_t n):
+    """Read exactly *n* bytes from a socket."""
+    cdef bytearray buf = bytearray()
+    cdef bytes chunk
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            raise ConnectionError("peer connection closed")
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+# ---------------------------------------------------------------------------
+# Section 2: Numpy collectives (from _numpy_collectives.py)
+# ---------------------------------------------------------------------------
+
+# ReduceOp int value -> numpy ufunc
+_REDUCE_OPS = {
+    int(RedOpType.SUM): np.add,
+    int(RedOpType.PRODUCT): np.multiply,
+    int(RedOpType.MAX): np.maximum,
+    int(RedOpType.MIN): np.minimum,
+    int(RedOpType.BAND): np.bitwise_and,
+    int(RedOpType.BOR): np.bitwise_or,
+    int(RedOpType.BXOR): np.bitwise_xor,
+    # AVG is handled specially by the caller (sum then divide)
+    int(RedOpType.AVG): np.add,
+}
+
+
+cdef object apply_reduce_op(int op, object a, object b):
+    """Apply a reduce operation element-wise: result = op(a, b)."""
+    cdef int op_int = int(op)
+    fn = _REDUCE_OPS.get(op_int)
+    if fn is None:
+        raise ValueError(f"Unsupported reduce op: {op}")
+    return fn(a, b)
+
+
+cdef bytes serialize_array(object arr):
+    """Serialize a numpy array to bytes.
+
+    Wire format:
+      1 byte  - length of dtype name
+      N bytes - dtype name (ascii)
+      4 bytes - ndim (uint32 big-endian)
+      ndim*8 bytes - shape dims (uint64 big-endian each)
+      rest    - raw data bytes
+    """
+    arr = np.ascontiguousarray(arr)
+    cdef bytes dtype_name = arr.dtype.str.encode("ascii")
+    cdef bytes header = struct.pack("!B", len(dtype_name)) + dtype_name
+    header += struct.pack("!I", arr.ndim)
+    for s in arr.shape:
+        header += struct.pack("!Q", s)
+    return header + arr.tobytes()
+
+
+cdef object deserialize_array(bytes data):
+    """Deserialize bytes back to a numpy array."""
+    cdef Py_ssize_t offset = 0
+    cdef int dtype_len = data[offset]
+    offset += 1
+    cdef bytes dtype_raw = data[offset:offset + dtype_len]
+    cdef str dtype_name = dtype_raw.decode("ascii")
+    offset += dtype_len
+    cdef int ndim = struct.unpack("!I", data[offset:offset + 4])[0]
+    offset += 4
+    cdef list shape = []
+    cdef int i
+    for i in range(ndim):
+        shape.append(struct.unpack("!Q", data[offset:offset + 8])[0])
+        offset += 8
+    cdef bytes body = data[offset:]
+    return np.frombuffer(body, dtype=np.dtype(dtype_name)).reshape(tuple(shape))
+
+
+# ---------------------------------------------------------------------------
+# Section 3: TcpTransport (from _tcp_transport.py)
+# ---------------------------------------------------------------------------
+
+cdef class TcpTransport:
+    """Full-mesh TCP connection manager for peer-to-peer communication."""
+
+    cdef int _rank
+    cdef int _world_size
+    cdef double _timeout
+    cdef bint _closed
+    cdef dict _peers        # peer_rank -> socket
+    cdef dict _locks        # peer_rank -> threading.Lock
+    cdef object _server
+
+    def __init__(self, object store, int rank, int world_size,
+                 str prefix="", double timeout=300):
+        self._rank = rank
+        self._world_size = world_size
+        self._timeout = timeout
+        self._closed = False
+        self._peers = {}
+        self._locks = {}
+
+        if world_size < 2:
+            return
+
+        # Bind ephemeral server socket for accepting incoming connections
+        self._server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._server.settimeout(timeout)
+        self._server.bind(("", 0))
+        self._server.listen(world_size)
+        cdef str host = socket.gethostname()
+        cdef int port = self._server.getsockname()[1]
+
+        # Publish our address to the store so peers can find us
+        cdef str addr_key = f"gloo_addr_rank_{rank}"
+        if prefix:
+            addr_key = f"{prefix}/{addr_key}"
+        store.set(addr_key, f"{host}:{port}".encode("utf-8"))
+
+        # Collect all peer addresses
+        cdef dict peer_addrs = {}
+        cdef str peer_key
+        cdef str addr_str
+        cdef str h
+        cdef str p_str
+        cdef int p
+        cdef int i
+        for i in range(world_size):
+            if i == rank:
+                continue
+            peer_key = f"gloo_addr_rank_{i}"
+            if prefix:
+                peer_key = f"{prefix}/{peer_key}"
+            store.wait([peer_key])
+            raw = store.get(peer_key)
+            addr_str = raw.decode("utf-8") if isinstance(raw, bytes) else raw
+            h, p_str = addr_str.rsplit(":", 1)
+            peer_addrs[i] = (h, int(p_str))
+
+        # Establish connections with deterministic ordering to avoid deadlock:
+        # rank i connects to rank j where j > i;
+        # rank j accepts from rank i where i < j.
+        #
+        # Process lower ranks first (accept from them), then higher ranks
+        # (connect to them).
+
+        cdef object conn
+        cdef bytes peer_rank_bytes
+        cdef int peer_rank
+        cdef object sock
+
+        # Accept connections from ranks < self
+        for i in sorted(r for r in range(world_size) if r < rank):
+            conn, _ = self._server.accept()
+            conn.settimeout(timeout)
+            # Peer sends its rank as a 4-byte int so we know who connected
+            peer_rank_bytes = _recvall(conn, 4)
+            peer_rank = struct.unpack("!I", peer_rank_bytes)[0]
+            self._peers[peer_rank] = conn
+            self._locks[peer_rank] = threading.Lock()
+
+        # Connect to ranks > self
+        cdef int j
+        for j in sorted(r for r in range(world_size) if r > rank):
+            h_j, p_j = peer_addrs[j]
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(timeout)
+            sock.connect((h_j, p_j))
+            # Send our rank so the peer knows who we are
+            sock.sendall(struct.pack("!I", rank))
+            self._peers[j] = sock
+            self._locks[j] = threading.Lock()
+
+    def send_to(self, int rank, bytes data):
+        """Send data bytes to a peer rank. Thread-safe per socket."""
+        cdef object lock = self._locks[rank]
+        cdef object sock = self._peers[rank]
+        with lock:
+            # Wire format: 8-byte big-endian length + data
+            sock.sendall(struct.pack("!Q", len(data)))
+            sock.sendall(data)
+
+    def recv_from(self, int rank):
+        """Receive data bytes from a peer rank. Thread-safe per socket."""
+        cdef object lock = self._locks[rank]
+        cdef object sock = self._peers[rank]
+        cdef bytes length_bytes
+        cdef unsigned long long length
+        with lock:
+            length_bytes = _recvall(sock, 8)
+            length = struct.unpack("!Q", length_bytes)[0]
+            return _recvall(sock, length)
+
+    def close(self):
+        """Close all peer sockets and the server socket."""
+        if self._closed:
+            return
+        self._closed = True
+        for sock in self._peers.values():
+            try:
+                sock.close()
+            except OSError:
+                pass
+        self._peers.clear()
+        self._locks.clear()
+        if hasattr(self, "_server"):
+            try:
+                self._server.close()
+            except OSError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Section 4: ProcessGroupGloo (from _process_group_gloo.py)
+# ---------------------------------------------------------------------------
+
+cdef class ProcessGroupGloo:
+    """Gloo-compatible process group using pure Python TCP transport.
+
+    All collectives are synchronous (gather-to-root + broadcast-from-root).
+    Work objects are returned already completed.
+
+    Standalone cdef class (does not inherit from the Cython ProcessGroup to
+    avoid cross-module inheritance complexity). Provides rank/size methods
+    for API compatibility.
+    """
+
+    cdef int _rank
+    cdef int _size
+    cdef str _group_name
+    cdef object _ranks
+    cdef object _store
+    cdef TcpTransport _transport
+
+    def __init__(self, object store, int rank, int size,
+                 str group_name="", object group_ranks=None):
+        self._rank = rank
+        self._size = size
+        self._group_name = group_name
+        self._ranks = group_ranks
+        self._store = store
+        self._transport = TcpTransport(store, rank, size, prefix=group_name)
+
+    # -- rank / size accessors -----------------------------------------------
+
+    def rank(self):
+        return self._rank
+
+    def size(self):
+        return self._size
+
+    # -- internal helpers ----------------------------------------------------
+
+    def _tensor_to_numpy(self, tensor):
+        """Convert a CPU tensor to a contiguous numpy array."""
+        arr = tensor._numpy_view()
+        return np.ascontiguousarray(arr)
+
+    def _write_numpy_to_tensor(self, arr, tensor):
+        """Write numpy array data back into a tensor in-place."""
+        dst = tensor._numpy_view()
+        np.copyto(dst, arr.reshape(dst.shape))
+
+    def _make_work(self):
+        """Return an already-completed Work object (synchronous collectives)."""
+        work = Work(stream=None)
+        work._completed = True
+        return work
+
+    # -- collective operations -----------------------------------------------
+
+    def allreduce(self, tensor, op=0):
+        """All-reduce: all ranks reduce and receive the result."""
+        if self._size == 1:
+            return self._make_work()
+
+        arr = self._tensor_to_numpy(tensor)
+        serialized = serialize_array(arr)
+
+        # All non-root send to rank 0
+        if self._rank != 0:
+            self._transport.send_to(0, serialized)
+        else:
+            # Rank 0 receives from all peers and reduces
+            result = arr.copy()
+            for peer in range(1, self._size):
+                peer_data = self._transport.recv_from(peer)
+                peer_arr = deserialize_array(peer_data)
+                result = apply_reduce_op(op, result, peer_arr)
+
+            # Handle AVG: divide by world_size
+            if int(op) == int(RedOpType.AVG):
+                result = result / self._size
+
+            # Rank 0 broadcasts result to all
+            result_serialized = serialize_array(result)
+            for peer in range(1, self._size):
+                self._transport.send_to(peer, result_serialized)
+
+            # Write result back into tensor
+            self._write_numpy_to_tensor(result, tensor)
+
+        # Non-root ranks receive the result
+        if self._rank != 0:
+            result_data = self._transport.recv_from(0)
+            result = deserialize_array(result_data)
+            self._write_numpy_to_tensor(result, tensor)
+
+        return self._make_work()
+
+    def broadcast(self, tensor, root=0):
+        """Broadcast: root sends tensor to all other ranks."""
+        if self._size == 1:
+            return self._make_work()
+
+        if self._rank == root:
+            arr = self._tensor_to_numpy(tensor)
+            serialized = serialize_array(arr)
+            for peer in range(self._size):
+                if peer != root:
+                    self._transport.send_to(peer, serialized)
+        else:
+            data = self._transport.recv_from(root)
+            arr = deserialize_array(data)
+            self._write_numpy_to_tensor(arr, tensor)
+
+        return self._make_work()
+
+    def allgather(self, output_tensor, input_tensor):
+        """All-gather: gather input from all ranks, concatenate into output."""
+        if self._size == 1:
+            # Just copy input to output
+            np.copyto(output_tensor._numpy_view(), input_tensor._numpy_view())
+            return self._make_work()
+
+        arr = self._tensor_to_numpy(input_tensor)
+        serialized = serialize_array(arr)
+
+        # All ranks send to rank 0
+        if self._rank != 0:
+            self._transport.send_to(0, serialized)
+        else:
+            # Rank 0 gathers from all
+            gathered = [arr]
+            for peer in range(1, self._size):
+                peer_data = self._transport.recv_from(peer)
+                peer_arr = deserialize_array(peer_data)
+                gathered.append(peer_arr)
+
+            # Concatenate along first dimension
+            result = np.concatenate(gathered, axis=0)
+            result_serialized = serialize_array(result)
+
+            # Rank 0 broadcasts concatenated result
+            for peer in range(1, self._size):
+                self._transport.send_to(peer, result_serialized)
+
+            self._write_numpy_to_tensor(result, output_tensor)
+
+        # Non-root ranks receive the result
+        if self._rank != 0:
+            result_data = self._transport.recv_from(0)
+            result = deserialize_array(result_data)
+            self._write_numpy_to_tensor(result, output_tensor)
+
+        return self._make_work()
+
+    def reduce(self, tensor, dst=0, op=0):
+        """Reduce: all ranks send to dst, dst receives reduced result."""
+        if self._size == 1:
+            return self._make_work()
+
+        arr = self._tensor_to_numpy(tensor)
+        serialized = serialize_array(arr)
+
+        # All non-dst send to dst
+        if self._rank != dst:
+            self._transport.send_to(dst, serialized)
+        else:
+            # dst receives from all and reduces
+            result = arr.copy()
+            for peer in range(self._size):
+                if peer != dst:
+                    peer_data = self._transport.recv_from(peer)
+                    peer_arr = deserialize_array(peer_data)
+                    result = apply_reduce_op(op, result, peer_arr)
+
+            # Handle AVG
+            if int(op) == int(RedOpType.AVG):
+                result = result / self._size
+
+            self._write_numpy_to_tensor(result, tensor)
+
+        return self._make_work()
+
+    def reduce_scatter(self, output_tensor, input_tensor, op=0):
+        """Reduce-scatter: reduce input, split into chunks, scatter to ranks."""
+        if self._size == 1:
+            np.copyto(output_tensor._numpy_view(), input_tensor._numpy_view())
+            return self._make_work()
+
+        arr = self._tensor_to_numpy(input_tensor)
+        serialized = serialize_array(arr)
+
+        # All ranks send to rank 0
+        if self._rank != 0:
+            self._transport.send_to(0, serialized)
+        else:
+            # Rank 0 reduces
+            result = arr.copy()
+            for peer in range(1, self._size):
+                peer_data = self._transport.recv_from(peer)
+                peer_arr = deserialize_array(peer_data)
+                result = apply_reduce_op(op, result, peer_arr)
+
+            # Handle AVG
+            if int(op) == int(RedOpType.AVG):
+                result = result / self._size
+
+            # Split into chunks (split along first dimension)
+            chunk_size = result.shape[0] // self._size
+            chunks = np.split(result, self._size, axis=0)
+
+            # Send chunk i to rank i
+            for peer in range(self._size):
+                chunk_serialized = serialize_array(chunks[peer])
+                if peer == 0:
+                    self._write_numpy_to_tensor(chunks[peer], output_tensor)
+                else:
+                    self._transport.send_to(peer, chunk_serialized)
+
+        # Non-root ranks receive their chunk
+        if self._rank != 0:
+            chunk_data = self._transport.recv_from(0)
+            chunk = deserialize_array(chunk_data)
+            self._write_numpy_to_tensor(chunk, output_tensor)
+
+        return self._make_work()
+
+    def scatter(self, output_tensor, input_tensor, src=0):
+        """Scatter: src splits input into chunks, sends chunk i to rank i."""
+        if self._size == 1:
+            np.copyto(output_tensor._numpy_view(), input_tensor._numpy_view())
+            return self._make_work()
+
+        if self._rank == src:
+            arr = self._tensor_to_numpy(input_tensor)
+            # Split into chunks
+            chunk_size = arr.shape[0] // self._size
+            chunks = np.split(arr, self._size, axis=0)
+
+            # Send chunk i to rank i
+            for peer in range(self._size):
+                chunk_serialized = serialize_array(chunks[peer])
+                if peer == src:
+                    self._write_numpy_to_tensor(chunks[peer], output_tensor)
+                else:
+                    self._transport.send_to(peer, chunk_serialized)
+        else:
+            # Receive chunk from src
+            chunk_data = self._transport.recv_from(src)
+            chunk = deserialize_array(chunk_data)
+            self._write_numpy_to_tensor(chunk, output_tensor)
+
+        return self._make_work()
+
+    def barrier(self):
+        """Barrier: all ranks synchronize."""
+        if self._size == 1:
+            return self._make_work()
+
+        # All ranks send a 1-byte token to rank 0
+        if self._rank != 0:
+            self._transport.send_to(0, b"\x00")
+        else:
+            # Rank 0 waits for all
+            for peer in range(1, self._size):
+                self._transport.recv_from(peer)
+            # Rank 0 sends ack to all
+            for peer in range(1, self._size):
+                self._transport.send_to(peer, b"\x00")
+
+        # Non-root ranks wait for ack
+        if self._rank != 0:
+            self._transport.recv_from(0)
+
+        return self._make_work()
+
+    def send(self, tensor, dst):
+        """Point-to-point send."""
+        arr = self._tensor_to_numpy(tensor)
+        serialized = serialize_array(arr)
+        self._transport.send_to(dst, serialized)
+        return self._make_work()
+
+    def recv(self, tensor, src):
+        """Point-to-point receive."""
+        data = self._transport.recv_from(src)
+        arr = deserialize_array(data)
+        self._write_numpy_to_tensor(arr, tensor)
+        work = self._make_work()
+        work._source_rank = src
+        return work
+
+    def all_to_all(self, output_tensors, input_tensors):
+        """All-to-all: each rank sends tensor i to rank i, receives from all.
+
+        Uses P2P send/recv with deadlock-free ordering:
+        - For peer < rank: recv first, then send
+        - For peer > rank: send first, then recv
+        - For peer == rank: local copy
+        """
+        if self._size == 1:
+            np.copyto(output_tensors[0]._numpy_view(),
+                      input_tensors[0]._numpy_view())
+            return self._make_work()
+
+        # Local copy first (rank sends to itself)
+        np.copyto(output_tensors[self._rank]._numpy_view(),
+                  input_tensors[self._rank]._numpy_view())
+
+        # P2P exchange with deadlock-free ordering
+        for peer in range(self._size):
+            if peer == self._rank:
+                continue
+
+            if self._rank < peer:
+                # Lower rank sends first, then receives
+                arr = self._tensor_to_numpy(input_tensors[peer])
+                serialized = serialize_array(arr)
+                self._transport.send_to(peer, serialized)
+
+                data = self._transport.recv_from(peer)
+                arr = deserialize_array(data)
+                self._write_numpy_to_tensor(arr, output_tensors[peer])
+            else:
+                # Higher rank receives first, then sends
+                data = self._transport.recv_from(peer)
+                arr = deserialize_array(data)
+                self._write_numpy_to_tensor(arr, output_tensors[peer])
+
+                arr = self._tensor_to_numpy(input_tensors[peer])
+                serialized = serialize_array(arr)
+                self._transport.send_to(peer, serialized)
+
+        return self._make_work()
+
+    def destroy(self):
+        """Clean up transport resources."""
+        self._transport.close()

--- a/src/candle/distributed/_c10d_hccl.pyx
+++ b/src/candle/distributed/_c10d_hccl.pyx
@@ -1,0 +1,643 @@
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""Cython HCCL backend: ProcessGroupHCCL with typed hot paths."""
+
+import os
+import ctypes
+
+from ._c10d import Work
+
+
+cdef class ProcessGroupHCCL:
+    """HCCL process group using direct ctypes bindings to libhccl.so.
+
+    Initialization follows torch_npu's pattern:
+    1. Try ranktable path (RANK_TABLE_FILE + HcclCommInitClusterInfoConfig)
+    2. Fall back to root info path (HcclGetRootInfo + HcclCommInitRootInfoConfig)
+
+    HCCL bindings are imported lazily when this class is instantiated, so
+    importing the base ProcessGroup class does not require libhccl.so.
+
+    This class does NOT inherit from ProcessGroup (to avoid cross-module
+    cdef class inheritance). It provides rank()/size() methods directly.
+    """
+
+    cdef public int _rank
+    cdef public int _size
+    cdef public int _device_id
+    cdef public object _comm
+    cdef public str _group_name
+    cdef public object _ranks
+    cdef public object _store
+
+    def __init__(self, store, rank, size, device_id=None, group_name="",
+                 group_ranks=None):
+        self._rank = rank
+        self._size = size
+        if device_id is None:
+            device_id = rank % 8
+        self._device_id = device_id
+        self._comm = None
+        self._group_name = group_name
+        self._ranks = group_ranks
+        self._store = store
+        self._init_hccl(store, group_name)
+
+    def rank(self):
+        return self._rank
+
+    def size(self):
+        return self._size
+
+    @staticmethod
+    def _load_bindings():
+        from ._hccl.hccl_bindings import (
+            get_bindings, HcclRootInfo, HcclCommConfig, HCCL_ROOT_INFO_BYTES,
+            HCCL_COMM_CONFIG_COMM_NAME,
+            hccl_comm_config_init, is_hccl_feature_supported,
+            dtype_to_hccl, _check,
+        )
+        return (get_bindings, HcclRootInfo, HcclCommConfig,
+                HCCL_ROOT_INFO_BYTES, HCCL_COMM_CONFIG_COMM_NAME,
+                hccl_comm_config_init, is_hccl_feature_supported,
+                dtype_to_hccl, _check)
+
+    def _make_config(self):
+        (_, _, HcclCommConfig, _, HCCL_COMM_CONFIG_COMM_NAME,
+         hccl_comm_config_init, is_hccl_feature_supported, _, _) = self._load_bindings()
+        config = HcclCommConfig()
+        hccl_comm_config_init(config)
+        # Old CANN (<=8.3) without COMM_NAME capability needs a truncated
+        # size so the library ignores the (absent) commName field.
+        # New CANN (>=8.5) must keep the full V8 size even when the
+        # capability bit is unset -- overwriting would corrupt the config.
+        from ._hccl.hccl_bindings import _USE_V8
+        if not _USE_V8 and not is_hccl_feature_supported(HCCL_COMM_CONFIG_COMM_NAME):
+            import struct
+            struct.pack_into("<Q", (ctypes.c_ubyte * 8).from_buffer(config), 0, 32)
+        return config
+
+    def _try_init_cluster_info(self):
+        """Try ranktable-based init (preferred for multi-node)."""
+        rank_table = os.environ.get("RANK_TABLE_FILE")
+        if not rank_table or not os.path.isfile(rank_table):
+            return False
+        get_bindings = self._load_bindings()[0]
+        bindings = get_bindings()
+        if bindings.comm_init_cluster_info_config is None:
+            return False
+        config = self._make_config()
+        comm = ctypes.c_void_p()
+        ret = bindings.comm_init_cluster_info_config(
+            rank_table.encode("utf-8"),
+            ctypes.c_uint32(self._rank),
+            ctypes.byref(config),
+            ctypes.byref(comm),
+        )
+        if ret != 0:
+            return False
+        self._comm = comm
+        return True
+
+    def _init_root_info(self, store, prefix=""):
+        """Root info broadcast path (standard NCCL-like init)."""
+        (get_bindings, HcclRootInfo, _, HCCL_ROOT_INFO_BYTES,
+         _, _, _, _, _check) = self._load_bindings()
+        bindings = get_bindings()
+        key = f"{prefix}/hccl_root_info" if prefix else "hccl_root_info"
+
+        if self._rank == 0:
+            root_info = HcclRootInfo()
+            ret = bindings.get_root_info(ctypes.byref(root_info))
+            _check(ret, "HcclGetRootInfo")
+            store.set(key, ctypes.string_at(ctypes.addressof(root_info), HCCL_ROOT_INFO_BYTES))
+        else:
+            store.wait([key])
+
+        raw = store.get(key)
+        if len(raw) != HCCL_ROOT_INFO_BYTES:
+            raise RuntimeError(
+                f"HCCL root info size mismatch: expected {HCCL_ROOT_INFO_BYTES}, got {len(raw)}"
+            )
+        root_info = HcclRootInfo()
+        ctypes.memmove(ctypes.addressof(root_info), raw, HCCL_ROOT_INFO_BYTES)
+
+        config = self._make_config()
+        comm = ctypes.c_void_p()
+        ret = bindings.comm_init_root_info_config(
+            ctypes.c_uint32(self._size),
+            ctypes.byref(root_info),
+            ctypes.c_uint32(self._rank),
+            ctypes.byref(config),
+            ctypes.byref(comm),
+        )
+        _check(ret, "HcclCommInitRootInfoConfig")
+        self._comm = comm
+
+    def _init_hccl(self, store, prefix=""):
+        from .._backends.npu import state as npu_state
+        npu_state.set_device(self._device_id)
+
+        # Try ranktable path first, fall back to root info
+        if not self._try_init_cluster_info():
+            self._init_root_info(store, prefix)
+
+    def _stream(self):
+        from .._backends.npu import state as npu_state
+        return npu_state.current_stream(self._device_id).stream
+
+    def _make_work(self, stream, source_rank=-1):
+        return Work(stream=stream, device_id=self._device_id,
+                    source_rank=source_rank)
+
+    cdef tuple _tensor_args(self, tensor):
+        _, _, _, _, _, _, _, dtype_to_hccl, _ = self._load_bindings()
+        ptr = ctypes.c_void_p(tensor.storage().data_ptr())
+        count = ctypes.c_uint64(tensor.numel())
+        hccl_dtype = ctypes.c_int32(dtype_to_hccl(tensor.dtype))
+        return ptr, count, hccl_dtype
+
+    def allreduce(self, tensor, op=0):
+        get_bindings, _, _, _, _, _, _, _, _check = self._load_bindings()
+        bindings = get_bindings()
+        stream = self._stream()
+        ptr, count, dt = self._tensor_args(tensor)
+        ret = bindings.all_reduce(
+            ptr, ptr, count, dt, ctypes.c_int32(int(op)),
+            self._comm, ctypes.c_void_p(int(stream)),
+        )
+        _check(ret, "HcclAllReduce")
+        return self._make_work(stream)
+
+    def broadcast(self, tensor, root=0):
+        get_bindings, _, _, _, _, _, _, _, _check = self._load_bindings()
+        bindings = get_bindings()
+        stream = self._stream()
+        ptr, count, dt = self._tensor_args(tensor)
+        ret = bindings.broadcast(
+            ptr, count, dt, ctypes.c_uint32(root),
+            self._comm, ctypes.c_void_p(int(stream)),
+        )
+        _check(ret, "HcclBroadcast")
+        return self._make_work(stream)
+
+    def allgather(self, output_tensor, input_tensor):
+        get_bindings, _, _, _, _, _, _, _, _check = self._load_bindings()
+        bindings = get_bindings()
+        stream = self._stream()
+        in_ptr, in_count, dt = self._tensor_args(input_tensor)
+        out_ptr = ctypes.c_void_p(output_tensor.storage().data_ptr())
+        ret = bindings.all_gather(
+            in_ptr, out_ptr, in_count, dt,
+            self._comm, ctypes.c_void_p(int(stream)),
+        )
+        _check(ret, "HcclAllGather")
+        return self._make_work(stream)
+
+    def reduce_scatter(self, output_tensor, input_tensor, op=0):
+        get_bindings, _, _, _, _, _, _, _, _check = self._load_bindings()
+        bindings = get_bindings()
+        stream = self._stream()
+        in_ptr = ctypes.c_void_p(input_tensor.storage().data_ptr())
+        out_ptr, out_count, dt = self._tensor_args(output_tensor)
+        ret = bindings.reduce_scatter(
+            in_ptr, out_ptr, out_count, dt, ctypes.c_int32(int(op)),
+            self._comm, ctypes.c_void_p(int(stream)),
+        )
+        _check(ret, "HcclReduceScatter")
+        return self._make_work(stream)
+
+    def reduce(self, tensor, dst=0, op=0):
+        get_bindings, _, _, _, _, _, _, _, _check = self._load_bindings()
+        bindings = get_bindings()
+        stream = self._stream()
+        ptr, count, dt = self._tensor_args(tensor)
+        ret = bindings.reduce(
+            ptr, ptr, count, dt, ctypes.c_int32(int(op)), ctypes.c_uint32(dst),
+            self._comm, ctypes.c_void_p(int(stream)),
+        )
+        _check(ret, "HcclReduce")
+        return self._make_work(stream)
+
+    def scatter(self, output_tensor, input_tensor, src=0):
+        get_bindings, _, _, _, _, _, _, _, _check = self._load_bindings()
+        bindings = get_bindings()
+        stream = self._stream()
+        in_ptr = ctypes.c_void_p(input_tensor.storage().data_ptr())
+        out_ptr, out_count, dt = self._tensor_args(output_tensor)
+        ret = bindings.scatter(
+            in_ptr, out_ptr, out_count, dt, ctypes.c_uint32(src),
+            self._comm, ctypes.c_void_p(int(stream)),
+        )
+        _check(ret, "HcclScatter")
+        return self._make_work(stream)
+
+    def barrier(self):
+        get_bindings, _, _, _, _, _, _, _, _check = self._load_bindings()
+        bindings = get_bindings()
+        stream = self._stream()
+        ret = bindings.barrier(
+            self._comm, ctypes.c_void_p(int(stream)),
+        )
+        _check(ret, "HcclBarrier")
+        return self._make_work(stream)
+
+    def send(self, tensor, dst):
+        get_bindings, _, _, _, _, _, _, _, _check = self._load_bindings()
+        bindings = get_bindings()
+        stream = self._stream()
+        ptr, count, dt = self._tensor_args(tensor)
+        ret = bindings.send(
+            ptr, count, dt, ctypes.c_uint32(dst),
+            self._comm, ctypes.c_void_p(int(stream)),
+        )
+        _check(ret, "HcclSend")
+        return self._make_work(stream)
+
+    def recv(self, tensor, src):
+        get_bindings, _, _, _, _, _, _, _, _check = self._load_bindings()
+        bindings = get_bindings()
+        stream = self._stream()
+        ptr, count, dt = self._tensor_args(tensor)
+        ret = bindings.recv(
+            ptr, count, dt, ctypes.c_uint32(src),
+            self._comm, ctypes.c_void_p(int(stream)),
+        )
+        _check(ret, "HcclRecv")
+        return self._make_work(stream, source_rank=src)
+
+    def _p2p_exchange(self, send_ptr, recv_ptr, count, hccl_dtype, peer,
+                      stream, bindings, _check, *,
+                      send_count=None, recv_count=None):
+        """Send/recv with a single peer using deadlock-free ordering."""
+        sc = send_count if send_count is not None else count
+        rc = recv_count if recv_count is not None else count
+        if self._rank < peer:
+            if sc > 0:
+                ret = bindings.send(
+                    send_ptr, ctypes.c_uint64(sc), hccl_dtype,
+                    ctypes.c_uint32(peer), self._comm,
+                    ctypes.c_void_p(int(stream)))
+                _check(ret, f"HcclSend to {peer}")
+            if rc > 0:
+                ret = bindings.recv(
+                    recv_ptr, ctypes.c_uint64(rc), hccl_dtype,
+                    ctypes.c_uint32(peer), self._comm,
+                    ctypes.c_void_p(int(stream)))
+                _check(ret, f"HcclRecv from {peer}")
+        else:
+            if rc > 0:
+                ret = bindings.recv(
+                    recv_ptr, ctypes.c_uint64(rc), hccl_dtype,
+                    ctypes.c_uint32(peer), self._comm,
+                    ctypes.c_void_p(int(stream)))
+                _check(ret, f"HcclRecv from {peer}")
+            if sc > 0:
+                ret = bindings.send(
+                    send_ptr, ctypes.c_uint64(sc), hccl_dtype,
+                    ctypes.c_uint32(peer), self._comm,
+                    ctypes.c_void_p(int(stream)))
+                _check(ret, f"HcclSend to {peer}")
+
+    def all_to_all(self, output_tensors, input_tensors):
+        """All-to-all using native HcclAlltoAll/HcclAlltoAllV or P2P fallback.
+
+        CANN >=8.5 (V8): Uses native HcclAlltoAll (equal split) or
+        HcclAlltoAllV (unequal split) for any world size.
+        CANN <=8.3: Falls back to P2P send/recv (preserved for compat).
+        """
+        from ._hccl.hccl_bindings import _USE_V8
+        from .._backends.npu import runtime as npu_runtime
+        get_bindings, _, _, _, _, _, _, dtype_to_hccl, _check = self._load_bindings()
+        bindings = get_bindings()
+        stream = self._stream()
+
+        if _USE_V8:
+            import candle as torch
+            dtype = input_tensors[0].dtype
+            itemsize = dtype.itemsize
+            world_size = self._size
+
+            equal_split = (
+                len({t.numel() for t in input_tensors}) == 1 and
+                len({t.numel() for t in output_tensors}) == 1
+            )
+
+            if equal_split:
+                count_per_rank = input_tensors[0].numel()
+                total_count = count_per_rank * world_size
+
+                send_flat = torch.empty(total_count, dtype=dtype,
+                                        device=input_tensors[0].device)
+                recv_flat = torch.empty(total_count, dtype=dtype,
+                                        device=output_tensors[0].device)
+
+                dst_base = send_flat.storage().data_ptr()
+                for i, t in enumerate(input_tensors):
+                    npu_runtime.memcpy_d2d(
+                        dst_base + i * count_per_rank * itemsize,
+                        count_per_rank * itemsize,
+                        t.storage().data_ptr(),
+                    )
+
+                # Ensure pack memcpy is visible before the collective
+                dev_id = self._device_id if self._device_id is not None else 0
+                npu_runtime.get_runtime(dev_id).synchronize_stream(stream)
+
+                ret = bindings.all_to_all(
+                    ctypes.c_void_p(send_flat.storage().data_ptr()),
+                    ctypes.c_uint64(count_per_rank),
+                    ctypes.c_int32(dtype_to_hccl(dtype)),
+                    ctypes.c_void_p(recv_flat.storage().data_ptr()),
+                    ctypes.c_uint64(count_per_rank),
+                    ctypes.c_int32(dtype_to_hccl(dtype)),
+                    self._comm,
+                    ctypes.c_void_p(int(stream)))
+                _check(ret, "HcclAlltoAll")
+
+                dev_id = self._device_id if self._device_id is not None else 0
+                npu_runtime.get_runtime(dev_id).synchronize_stream(stream)
+
+                src_base = recv_flat.storage().data_ptr()
+                for i, t in enumerate(output_tensors):
+                    npu_runtime.memcpy_d2d(
+                        t.storage().data_ptr(),
+                        count_per_rank * itemsize,
+                        src_base + i * count_per_rank * itemsize,
+                    )
+            else:
+                # Unequal split: pack, use HcclAlltoAllV, unpack
+                send_counts = [t.numel() for t in input_tensors]
+                recv_counts = [t.numel() for t in output_tensors]
+                total_send = sum(send_counts)
+                total_recv = sum(recv_counts)
+
+                send_flat = torch.empty(total_send, dtype=dtype,
+                                        device=input_tensors[0].device)
+                recv_flat = torch.empty(total_recv, dtype=dtype,
+                                        device=output_tensors[0].device)
+
+                # Pack input tensors into send_flat
+                dst_base = send_flat.storage().data_ptr()
+                offset = 0
+                for i, t in enumerate(input_tensors):
+                    nbytes = send_counts[i] * itemsize
+                    npu_runtime.memcpy_d2d(
+                        dst_base + offset, nbytes,
+                        t.storage().data_ptr(),
+                    )
+                    offset += nbytes
+
+                # Ensure pack memcpy is visible before the collective
+                dev_id = self._device_id if self._device_id is not None else 0
+                npu_runtime.get_runtime(dev_id).synchronize_stream(stream)
+
+                # Build counts and displacements (uint64 arrays)
+                ArrayU64 = ctypes.c_uint64 * world_size
+                sc = ArrayU64(*send_counts)
+                rc = ArrayU64(*recv_counts)
+                sd = ArrayU64()
+                rd = ArrayU64()
+                d = 0
+                for i, c in enumerate(send_counts):
+                    sd[i] = d
+                    d += c
+                d = 0
+                for i, c in enumerate(recv_counts):
+                    rd[i] = d
+                    d += c
+
+                hccl_dt = ctypes.c_int32(dtype_to_hccl(dtype))
+                ret = bindings.all_to_all_v(
+                    ctypes.c_void_p(send_flat.storage().data_ptr()),
+                    ctypes.cast(sc, ctypes.c_void_p),
+                    ctypes.cast(sd, ctypes.c_void_p),
+                    hccl_dt,
+                    ctypes.c_void_p(recv_flat.storage().data_ptr()),
+                    ctypes.cast(rc, ctypes.c_void_p),
+                    ctypes.cast(rd, ctypes.c_void_p),
+                    hccl_dt,
+                    self._comm,
+                    ctypes.c_void_p(int(stream)))
+                _check(ret, "HcclAlltoAllV")
+
+                dev_id = self._device_id if self._device_id is not None else 0
+                npu_runtime.get_runtime(dev_id).synchronize_stream(stream)
+
+                # Unpack recv buffer into output tensors
+                src_base = recv_flat.storage().data_ptr()
+                offset = 0
+                for i, t in enumerate(output_tensors):
+                    nbytes = recv_counts[i] * itemsize
+                    npu_runtime.memcpy_d2d(
+                        t.storage().data_ptr(), nbytes,
+                        src_base + offset,
+                    )
+                    offset += nbytes
+
+            return self._make_work(stream)
+
+        # CANN <=8.3: all_gather-based fallback.
+        # P2P send/recv fails with error 6 on 4+ ranks (910A),
+        # and native HcclAlltoAll is a no-op on CANN 8.3.
+        # Strategy: pack -> all_gather -> extract columns.
+        import candle as torch
+        dtype = input_tensors[0].dtype
+        itemsize = dtype.itemsize
+        world_size = self._size
+        dev = input_tensors[0].device
+
+        send_counts = [t.numel() for t in input_tensors]
+        total_send = sum(send_counts)
+
+        # Pack input tensors into a flat send buffer
+        send_flat = torch.empty(total_send, dtype=dtype, device=dev)
+        dst_base = send_flat.storage().data_ptr()
+        offset = 0
+        for t in input_tensors:
+            nb = t.numel() * itemsize
+            npu_runtime.memcpy_d2d(dst_base + offset, nb,
+                                   t.storage().data_ptr())
+            offset += nb
+
+        # all_gather: every rank gets every other rank's send buffer
+        recv_flat = torch.empty(total_send * world_size, dtype=dtype,
+                                device=dev)
+        self.allgather(recv_flat, send_flat).wait()
+
+        # Extract: from rank j's buffer, take the chunk destined for us
+        dev_id = self._device_id if self._device_id is not None else 0
+        rt = npu_runtime.get_runtime(dev_id)
+        rt.synchronize_stream(stream)
+        src_base = recv_flat.storage().data_ptr()
+        for j in range(world_size):
+            # rank j's flat buffer starts at j * total_send elements
+            # within that buffer, chunk for rank self._rank starts at
+            # sum(send_counts[0:self._rank]) elements
+            j_buf_offset = j * total_send * itemsize
+            my_chunk_offset = sum(send_counts[:self._rank]) * itemsize
+            nb = send_counts[self._rank] * itemsize
+            npu_runtime.memcpy_d2d(
+                output_tensors[j].storage().data_ptr(), nb,
+                src_base + j_buf_offset + my_chunk_offset,
+                runtime=rt)
+
+        return self._make_work(stream)
+
+    def all_to_all_single(self, output, input, count_per_rank):
+        """All-to-all on contiguous buffers using native HcclAlltoAll."""
+        from ._hccl.hccl_bindings import _USE_V8
+        get_bindings, _, _, _, _, _, _, dtype_to_hccl, _check = self._load_bindings()
+        bindings = get_bindings()
+        stream = self._stream()
+
+        if _USE_V8:
+            # CANN >=8.5: use native HcclAlltoAll for all world sizes
+            ret = bindings.all_to_all(
+                ctypes.c_void_p(input.storage().data_ptr()),
+                ctypes.c_uint64(count_per_rank),
+                ctypes.c_int32(dtype_to_hccl(input.dtype)),
+                ctypes.c_void_p(output.storage().data_ptr()),
+                ctypes.c_uint64(count_per_rank),
+                ctypes.c_int32(dtype_to_hccl(output.dtype)),
+                self._comm,
+                ctypes.c_void_p(int(stream)))
+            _check(ret, "HcclAlltoAll")
+            return self._make_work(stream)
+
+        # CANN <=8.3: all_gather-based fallback.
+        # P2P send/recv fails with error 6 on 4+ ranks (910A).
+        import candle as torch
+        from .._backends.npu import runtime as npu_runtime
+        total = count_per_rank * self._size
+        recv_flat = torch.empty(total * self._size, dtype=input.dtype,
+                                device=input.device)
+        self.allgather(recv_flat, input).wait()
+
+        dev_id = self._device_id if self._device_id is not None else 0
+        rt = npu_runtime.get_runtime(dev_id)
+        rt.synchronize_stream(stream)
+
+        # From rank j's gathered buffer, pick the chunk destined for us
+        itemsize = input.dtype.itemsize
+        chunk_bytes = count_per_rank * itemsize
+        out_base = output.storage().data_ptr()
+        src_base = recv_flat.storage().data_ptr()
+        for j in range(self._size):
+            # rank j's buffer starts at j * total elements
+            # our chunk within that buffer is at offset self._rank * count_per_rank
+            src_off = (j * total + self._rank * count_per_rank) * itemsize
+            dst_off = j * chunk_bytes
+            npu_runtime.memcpy_d2d(out_base + dst_off, chunk_bytes,
+                                   src_base + src_off, runtime=rt)
+
+        return self._make_work(stream)
+
+    def all_to_all_single_v(self, output, input, input_split_sizes,
+                            output_split_sizes):
+        """All-to-all with variable splits on contiguous buffers.
+
+        Uses HcclAlltoAllV on CANN >=8.5, P2P fallback on older CANN.
+        """
+        from ._hccl.hccl_bindings import _USE_V8
+        get_bindings, _, _, _, _, _, _, dtype_to_hccl, _check = self._load_bindings()
+        bindings = get_bindings()
+        stream = self._stream()
+
+        if _USE_V8:
+            world_size = self._size
+            ArrayU64 = ctypes.c_uint64 * world_size
+
+            sc = ArrayU64(*[int(s) for s in input_split_sizes])
+            rc = ArrayU64(*[int(s) for s in output_split_sizes])
+            sd = ArrayU64()
+            rd = ArrayU64()
+            d = 0
+            for i, s in enumerate(input_split_sizes):
+                sd[i] = d
+                d += int(s)
+            d = 0
+            for i, s in enumerate(output_split_sizes):
+                rd[i] = d
+                d += int(s)
+
+            hccl_dt = ctypes.c_int32(dtype_to_hccl(input.dtype))
+            ret = bindings.all_to_all_v(
+                ctypes.c_void_p(input.storage().data_ptr()),
+                ctypes.cast(sc, ctypes.c_void_p),
+                ctypes.cast(sd, ctypes.c_void_p),
+                hccl_dt,
+                ctypes.c_void_p(output.storage().data_ptr()),
+                ctypes.cast(rc, ctypes.c_void_p),
+                ctypes.cast(rd, ctypes.c_void_p),
+                hccl_dt,
+                self._comm,
+                ctypes.c_void_p(int(stream)))
+            _check(ret, "HcclAlltoAllV")
+            return self._make_work(stream)
+
+        # CANN <=8.3: all_gather-based fallback.
+        # P2P send/recv fails with error 6 on 4+ ranks (910A).
+        import candle as torch
+        from .._backends.npu import runtime as npu_runtime
+        world_size = self._size
+        itemsize = input.dtype.itemsize
+        total_send = input.numel()
+        dev = input.device
+
+        # Step 1: all_gather the split-size vectors so every rank knows
+        # every other rank's input layout.
+        local_splits = torch.tensor([int(s) for s in input_split_sizes],
+                                    dtype=torch.int64, device=dev)
+        all_splits_flat = torch.empty(world_size * world_size,
+                                      dtype=torch.int64, device=dev)
+        self.allgather(all_splits_flat, local_splits).wait()
+
+        dev_id = self._device_id if self._device_id is not None else 0
+        rt = npu_runtime.get_runtime(dev_id)
+        rt.synchronize_stream(stream)
+
+        # all_splits[j] = rank j's input_split_sizes
+        all_splits = all_splits_flat.reshape(world_size, world_size)
+        all_splits_cpu = all_splits.to("cpu")._numpy_view()
+
+        # Step 2: all_gather the data buffers.
+        # Each rank may have a different total_send, so pad to the max.
+        max_send = int(all_splits_cpu.sum(axis=1).max())
+        if total_send < max_send:
+            padded = torch.zeros(max_send, dtype=input.dtype, device=dev)
+            npu_runtime.memcpy_d2d(
+                padded.storage().data_ptr(), total_send * itemsize,
+                input.storage().data_ptr(), runtime=rt)
+            send_buf = padded
+        else:
+            send_buf = input
+
+        recv_flat = torch.empty(max_send * world_size, dtype=input.dtype,
+                                device=dev)
+        self.allgather(recv_flat, send_buf).wait()
+        rt.synchronize_stream(stream)
+
+        # Step 3: extract our column from each rank's gathered buffer.
+        out_base = output.storage().data_ptr()
+        src_base = recv_flat.storage().data_ptr()
+        out_off = 0
+        for j in range(world_size):
+            # Offset within rank j's buffer for the chunk destined to us
+            j_splits = all_splits_cpu[j]
+            my_offset_in_j = int(sum(j_splits[:self._rank]))
+            recv_numel = int(output_split_sizes[j])
+            if recv_numel > 0:
+                src_off = (j * max_send + my_offset_in_j) * itemsize
+                npu_runtime.memcpy_d2d(out_base + out_off,
+                                       recv_numel * itemsize,
+                                       src_base + src_off, runtime=rt)
+            out_off += recv_numel * itemsize
+
+        return self._make_work(stream)
+
+    def destroy(self):
+        if self._comm is not None:
+            get_bindings = self._load_bindings()[0]
+            bindings = get_bindings()
+            bindings.comm_destroy(self._comm)
+            self._comm = None

--- a/tests/distributed/test_c10d_cython.py
+++ b/tests/distributed/test_c10d_cython.py
@@ -1,0 +1,283 @@
+"""Tests for the Cython-compiled candle.distributed._c10d module."""
+
+import random
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# 1. test_cython_modules_importable
+# ---------------------------------------------------------------------------
+
+def test_cython_modules_importable():
+    """All three Cython extension modules should be importable."""
+    from candle.distributed import _c10d
+    from candle.distributed import _c10d_gloo
+    from candle.distributed import _c10d_hccl
+
+    assert _c10d is not None
+    assert _c10d_gloo is not None
+    assert _c10d_hccl is not None
+
+
+# ---------------------------------------------------------------------------
+# 2. test_reduce_op_values
+# ---------------------------------------------------------------------------
+
+def test_reduce_op_values():
+    """ReduceOp class attributes must match the expected integer values."""
+    from candle.distributed._c10d import ReduceOp
+
+    assert ReduceOp.SUM == 0
+    assert ReduceOp.PRODUCT == 1
+    assert ReduceOp.MAX == 2
+    assert ReduceOp.MIN == 3
+    assert ReduceOp.BAND == 4
+    assert ReduceOp.BOR == 5
+    assert ReduceOp.BXOR == 6
+    assert ReduceOp.AVG == 7
+    assert ReduceOp.PREMUL_SUM == 8
+    assert ReduceOp.UNUSED == 9
+
+
+# ---------------------------------------------------------------------------
+# 3. test_reduce_op_equality
+# ---------------------------------------------------------------------------
+
+def test_reduce_op_equality():
+    """ReduceOp equality works with ReduceOp instances and plain ints."""
+    from candle.distributed._c10d import ReduceOp
+
+    op_from_int = ReduceOp(0)
+    op_from_attr = ReduceOp(ReduceOp.SUM)
+    assert op_from_int == op_from_attr
+    assert op_from_int == 0
+
+    op_avg = ReduceOp(7)
+    assert op_avg == ReduceOp(ReduceOp.AVG)
+    assert op_avg == 7
+
+
+# ---------------------------------------------------------------------------
+# 4. test_reduce_op_hash
+# ---------------------------------------------------------------------------
+
+def test_reduce_op_hash():
+    """ReduceOp instances with the same value produce the same hash."""
+    from candle.distributed._c10d import ReduceOp
+
+    a = ReduceOp(0)
+    b = ReduceOp(ReduceOp.SUM)
+    assert hash(a) == hash(b)
+
+    # Different values should (in practice) have different hashes
+    c = ReduceOp(7)
+    assert hash(a) != hash(c)
+
+    # Usable as dict keys
+    d = {a: "sum"}
+    assert d[b] == "sum"
+
+
+# ---------------------------------------------------------------------------
+# 5. test_reduce_op_repr
+# ---------------------------------------------------------------------------
+
+def test_reduce_op_repr():
+    """ReduceOp repr contains the operation name."""
+    from candle.distributed._c10d import ReduceOp
+
+    r = repr(ReduceOp(0))
+    assert "SUM" in r
+
+    r = repr(ReduceOp(7))
+    assert "AVG" in r
+
+
+# ---------------------------------------------------------------------------
+# 6. test_reduce_op_deprecated_alias
+# ---------------------------------------------------------------------------
+
+def test_reduce_op_deprecated_alias():
+    """The deprecated reduce_op class aliases must match ReduceOp values."""
+    from candle.distributed._c10d import ReduceOp, reduce_op
+
+    assert reduce_op.SUM == ReduceOp.SUM
+    assert reduce_op.PRODUCT == ReduceOp.PRODUCT
+    assert reduce_op.MAX == ReduceOp.MAX
+    assert reduce_op.MIN == ReduceOp.MIN
+
+
+# ---------------------------------------------------------------------------
+# 7. test_options_defaults
+# ---------------------------------------------------------------------------
+
+def test_options_defaults():
+    """Options structs should have sensible default values."""
+    from candle.distributed._c10d import AllreduceOptions, BroadcastOptions
+
+    ar = AllreduceOptions()
+    assert ar.reduceOp == 0
+    assert ar.asyncOp is False
+
+    bc = BroadcastOptions()
+    assert bc.rootRank == 0
+    assert bc.rootTensor == 0
+    assert bc.asyncOp is False
+
+
+# ---------------------------------------------------------------------------
+# 8. test_options_custom
+# ---------------------------------------------------------------------------
+
+def test_options_custom():
+    """Options structs accept custom values via constructor."""
+    from candle.distributed._c10d import AllreduceOptions, BroadcastOptions
+
+    bc = BroadcastOptions(rootRank=3)
+    assert bc.rootRank == 3
+
+    ar = AllreduceOptions(reduceOp=7)
+    assert ar.reduceOp == 7
+
+
+# ---------------------------------------------------------------------------
+# 9. test_work_lifecycle
+# ---------------------------------------------------------------------------
+
+def test_work_lifecycle():
+    """Work starts incomplete; wait() marks it completed and successful."""
+    from candle.distributed._c10d import Work
+
+    w = Work()
+    assert not w.is_completed()
+
+    w.wait()
+
+    assert w.is_completed()
+    assert w.is_success()
+
+
+# ---------------------------------------------------------------------------
+# 10. test_work_source_rank
+# ---------------------------------------------------------------------------
+
+def test_work_source_rank():
+    """Work records the source_rank passed at construction."""
+    from candle.distributed._c10d import Work
+
+    w = Work(source_rank=5)
+    assert w.source_rank() == 5
+
+    w_default = Work()
+    assert w_default.source_rank() == -1
+
+
+# ---------------------------------------------------------------------------
+# 11. test_work_result
+# ---------------------------------------------------------------------------
+
+def test_work_result():
+    """Work.result() returns an empty list."""
+    from candle.distributed._c10d import Work
+
+    w = Work()
+    assert w.result() == []
+
+
+# ---------------------------------------------------------------------------
+# 12. test_work_get_future
+# ---------------------------------------------------------------------------
+
+def test_work_get_future():
+    """Work.get_future() returns a Future whose wait() returns []."""
+    from candle.distributed._c10d import Work
+    from candle.futures import Future
+
+    w = Work()
+    fut = w.get_future()
+    assert isinstance(fut, Future)
+    assert fut.wait() == []
+
+
+# ---------------------------------------------------------------------------
+# 13. test_hash_store_basic
+# ---------------------------------------------------------------------------
+
+def test_hash_store_basic():
+    """HashStore set/get round-trip works."""
+    from candle.distributed._c10d import HashStore
+
+    store = HashStore()
+    store.set("key1", b"value1")
+    assert store.get("key1") == b"value1"
+
+
+# ---------------------------------------------------------------------------
+# 14. test_hash_store_overwrite
+# ---------------------------------------------------------------------------
+
+def test_hash_store_overwrite():
+    """HashStore overwrites: the latest set() wins on get()."""
+    from candle.distributed._c10d import HashStore
+
+    store = HashStore()
+    store.set("k", b"old")
+    store.set("k", b"new")
+    assert store.get("k") == b"new"
+
+
+# ---------------------------------------------------------------------------
+# 15. test_prefix_store
+# ---------------------------------------------------------------------------
+
+def test_prefix_store():
+    """PrefixStore delegates to the underlying store with the prefix prepended."""
+    from candle.distributed._c10d import HashStore, PrefixStore
+
+    base = HashStore()
+    ps = PrefixStore("myprefix", base)
+
+    ps.set("key1", b"val1")
+    # The underlying store should contain the prefixed key
+    assert base.get("myprefix/key1") == b"val1"
+    # And the PrefixStore should retrieve it transparently
+    assert ps.get("key1") == b"val1"
+
+
+# ---------------------------------------------------------------------------
+# 16. test_tcp_store_roundtrip
+# ---------------------------------------------------------------------------
+
+def test_tcp_store_roundtrip():
+    """TCPStore as master: set, get, and wait should work over TCP."""
+    from candle.distributed._c10d import TCPStore
+
+    port = random.randint(20000, 60000)
+    store = TCPStore("127.0.0.1", port, 1, True, timeout=5.0)
+    try:
+        store.set("hello", b"world")
+        assert store.get("hello") == b"world"
+
+        store.set("another", b"value")
+        # wait should return without error since both keys exist
+        store.wait(["hello", "another"], timeout=2.0)
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# 17. test_process_group_basic
+# ---------------------------------------------------------------------------
+
+def test_process_group_basic():
+    """ProcessGroup exposes rank, size, name, group_name, group_desc, bound_device_id."""
+    from candle.distributed._c10d import ProcessGroup
+
+    pg = ProcessGroup(rank=2, size=8)
+
+    assert pg.rank() == 2
+    assert pg.size() == 8
+    assert pg.name() == ""
+    assert pg.group_name == ""
+    assert pg.group_desc == ""
+    assert pg.bound_device_id is None


### PR DESCRIPTION
## Summary

Migrate candle's distributed subsystem from pure Python to Cython, aligning with PyTorch's pybind11 `torch._C._distributed_c10d` interface for comparable performance.

## Changes

### New Cython modules

- **`_c10d.pyx`** — Core types: `ReduceOp`, 9 Options structs, `Work`, Store hierarchy (`TCPStore`, `PrefixStore`, `HashStore`), `ProcessGroup` base class
- **`_c10d.pxd`** — Declaration file for cross-module `cimport`
- **`_c10d_gloo.pyx`** — `ProcessGroupGloo`, `TcpTransport`, numpy collectives with typed `serialize_array`/`deserialize_array` hot paths
- **`_c10d_hccl.pyx`** — `ProcessGroupHCCL` with `cdef _tensor_args` hot path, all collectives including `all_to_all` V8/V6 branching

### Performance optimizations

- `cpdef` for frequently called methods (`wait`, `rank`, `size`, `is_completed`)
- `cdef` for internal hot paths (`_recvall`, `serialize_array`, `_tensor_args`, `dtype_to_hccl`)
- Typed variables in tight loops (socket I/O, packing/unpacking)

### Backward compatibility

- Existing Python files preserved as fallback (`try/except ImportError`)
- Zero API changes — all existing tests and callers work unchanged
- Build failure does not block installation

### Modified files

- `setup.py` — 3 new Cython Extension entries
- `distributed/__init__.py` — Fallback import logic

## Testing

17 new tests in `tests/distributed/test_c10d_cython.py` covering:
- Module importability
- ReduceOp values, equality, hashing, repr, deprecated aliases
- Options struct defaults and custom values
- Work lifecycle, source_rank, get_future
- HashStore, PrefixStore, TCPStore round-trip
- ProcessGroup basic properties

## Design Doc

`docs/plans/2026-03-18-distributed-cython-migration-design.md`