### PR TITLE
feat(mps): add bitwise_left_shift/right_shift dispatch for MPS

### DIFF
--- a/src/candle/_backends/mps/__init__.py
+++ b/src/candle/_backends/mps/__init__.py
@@ -229,6 +229,8 @@ from .ops import (
     bitwise_or,
     bitwise_xor,
     bitwise_not,
+    bitwise_left_shift,
+    bitwise_right_shift,
     # New random in-place op
     randint_,
     random_,
@@ -549,6 +551,8 @@ registry.register("bitwise_and", "mps", bitwise_and, meta=meta_infer.infer_binar
 registry.register("bitwise_or", "mps", bitwise_or, meta=meta_infer.infer_binary)
 registry.register("bitwise_xor", "mps", bitwise_xor, meta=meta_infer.infer_binary)
 registry.register("bitwise_not", "mps", bitwise_not, meta=meta_infer.infer_unary)
+registry.register("bitwise_left_shift", "mps", bitwise_left_shift, meta=meta_infer.infer_binary)
+registry.register("bitwise_right_shift", "mps", bitwise_right_shift, meta=meta_infer.infer_binary)
 
 # ---------------------------------------------------------------------------
 # Random in-place

--- a/src/candle/_backends/mps/ops/__init__.py
+++ b/src/candle/_backends/mps/ops/__init__.py
@@ -74,6 +74,8 @@ from .comparison import (  # noqa: F401
     bitwise_or,
     bitwise_xor,
     bitwise_not,
+    bitwise_left_shift,
+    bitwise_right_shift,
 )
 
 from .activation import (  # noqa: F401

--- a/src/candle/_backends/mps/ops/comparison.py
+++ b/src/candle/_backends/mps/ops/comparison.py
@@ -271,6 +271,20 @@ def bitwise_not(a):
         return _empty_like(a)
     _unsupported_dtype("bitwise_not", a)
 
+def bitwise_left_shift(a, b):
+    if _can_use_gpu(a):
+        return _dispatch_binary_gpu(a, b, "bitwise_left_shift")
+    if a.numel() == 0:
+        return _empty_like(a)
+    _unsupported_dtype("bitwise_left_shift", a)
+
+def bitwise_right_shift(a, b):
+    if _can_use_gpu(a):
+        return _dispatch_binary_gpu(a, b, "bitwise_right_shift")
+    if a.numel() == 0:
+        return _empty_like(a)
+    _unsupported_dtype("bitwise_right_shift", a)
+
 
 # ---------------------------------------------------------------------------
 # Group 4: Random in-place op

--- a/src/candle/_functional.py
+++ b/src/candle/_functional.py
@@ -1259,6 +1259,14 @@ def bitwise_not(a):
     return dispatch("bitwise_not", a.device.type, a)
 
 
+def bitwise_left_shift(a, b):
+    return dispatch("bitwise_left_shift", None, a, b)
+
+
+def bitwise_right_shift(a, b):
+    return dispatch("bitwise_right_shift", None, a, b)
+
+
 def flatten(a, start_dim=0, end_dim=-1):
     return dispatch("flatten", a.device.type, a, start_dim, end_dim)
 


### PR DESCRIPTION
## Summary

Wire up the Metal shaders for `bitwise_left_shift` (`<<`) and `bitwise_right_shift` (`>>`) that were generated in PR #144 but not yet dispatched.

### Changes

- `comparison.py`: GPU dispatch implementations using `_dispatch_binary_gpu`
- `ops/__init__.py`: export the new functions
- `mps/__init__.py`: import + `registry.register` with `infer_binary` meta
- `_functional.py`: dispatch wrappers

### Supported dtypes
- `int32`, `int64`, `bool`

### Testing
- All 361 MPS tests pass
- Pylint 10.00/10
- Manual correctness verification against numpy