### PR TITLE
fix(mps): fix setitem crash when value is MPS tensor

### DIFF
--- a/src/candle/_backends/mps/ops/shape.py
+++ b/src/candle/_backends/mps/ops/shape.py
@@ -784,8 +784,8 @@ def getitem(tensor, key):
 def setitem(tensor, key, value):
     arr = _to_numpy(tensor)
     norm_key = _normalize_index_key(key)
-    if hasattr(value, 'numpy'):
-        arr[norm_key] = value.numpy()
+    if hasattr(value, '_numpy_view'):
+        arr[norm_key] = _to_numpy(value)
     else:
         arr[norm_key] = value
     return tensor


### PR DESCRIPTION
## Summary

`setitem()` crashed with `RuntimeError: numpy() is only available for CPU tensors` when assigning an MPS tensor to another MPS tensor via `put_()` or `tensor[key] = mps_tensor`.

### Root cause

`setitem()` in `mps/ops/shape.py` called `value.numpy()`, which has an explicit CPU-only guard in `Tensor.numpy()`. The tensor data (`arr = _to_numpy(tensor)`) was already correctly using `_numpy_view()` (which works on MPS via unified memory), but the value side wasn't.

### Fix

Changed `value.numpy()` → `_to_numpy(value)` which goes through `_numpy_view()` and works with MPS unified memory. Also changed the guard from `hasattr(value, 'numpy')` to `hasattr(value, '_numpy_view')` for consistency.

### Testing
- All 361 MPS tests pass
- Pylint 10.00/10
- Manual verification: `put_()`, `tensor[idx] = tensor`, `tensor[slice] = tensor`, scalar assignment