### PR TITLE
fix(cython): P0 gaps — Store methods, PG collective dispatch, send/recv tag, timedelta

### DIFF
--- a/src/candle/distributed/_c10d.pxd
+++ b/src/candle/distributed/_c10d.pxd
@@ -99,6 +99,11 @@ cdef class Work:
 cdef class Store:
     cpdef set(self, str key, bytes value)
     cpdef bytes get(self, str key)
+    cpdef int add(self, str key, int amount)
+    cpdef bint delete_key(self, str key)
+    cpdef int num_keys(self)
+    cpdef bint check(self, list keys)
+    cpdef bytes compare_set(self, str key, str expected, str desired)
     cpdef wait(self, list keys, timeout=*)
     cpdef close(self)
 

--- a/src/candle/distributed/_c10d.pyx
+++ b/src/candle/distributed/_c10d.pyx
@@ -16,7 +16,17 @@ import threading
 import socket
 import struct
 import time
+from datetime import timedelta
 from enum import IntEnum
+
+
+cdef double _to_seconds(object timeout):
+    """Convert timeout to seconds. Accepts float, int, or timedelta."""
+    if timeout is None:
+        return _DEFAULT_TIMEOUT
+    if isinstance(timeout, timedelta):
+        return (<object>timeout).total_seconds()
+    return <double>timeout
 
 
 # ---------------------------------------------------------------------------
@@ -192,6 +202,8 @@ cdef class Work:
         self._on_wait = None
 
     cpdef bint wait(self, timeout=None):
+        if timeout is not None:
+            _to_seconds(timeout)  # validate timedelta accepted
         if not self._completed and self._stream is not None:
             try:
                 from .._backends.npu import runtime as npu_runtime
@@ -251,6 +263,11 @@ cdef class Work:
 cdef int _CMD_SET = 0
 cdef int _CMD_GET = 1
 cdef int _CMD_WAIT = 2
+cdef int _CMD_ADD = 3
+cdef int _CMD_DELETE = 4
+cdef int _CMD_NUM_KEYS = 5
+cdef int _CMD_CHECK = 6
+cdef int _CMD_COMPARE_SET = 7
 
 cdef int _RESP_OK = 0
 cdef int _RESP_VALUE = 1
@@ -293,6 +310,21 @@ cdef class Store:
         raise NotImplementedError
 
     cpdef bytes get(self, str key):
+        raise NotImplementedError
+
+    cpdef int add(self, str key, int amount):
+        raise NotImplementedError
+
+    cpdef bint delete_key(self, str key):
+        raise NotImplementedError
+
+    cpdef int num_keys(self):
+        raise NotImplementedError
+
+    cpdef bint check(self, list keys):
+        raise NotImplementedError
+
+    cpdef bytes compare_set(self, str key, str expected, str desired):
         raise NotImplementedError
 
     cpdef wait(self, list keys, timeout=None):
@@ -404,6 +436,57 @@ cdef class _StoreServer:
                                     "TCPStore server: WAIT timed out")
                             self._cond.wait(timeout=min(remaining, 1.0))
                     conn.sendall(bytes([_RESP_OK]))
+                elif cmd == _CMD_ADD:
+                    key = _recv_bytes(conn).decode("utf-8")
+                    amount = struct.unpack("!i", _recvall(conn, 4))[0]
+                    with self._cond:
+                        old = 0
+                        if key in self._data:
+                            old = struct.unpack("!i", self._data[key])[0]
+                        new_val = old + amount
+                        self._data[key] = struct.pack("!i", new_val)
+                        self._cond.notify_all()
+                    conn.sendall(struct.pack("!i", new_val))
+                elif cmd == _CMD_DELETE:
+                    key = _recv_bytes(conn).decode("utf-8")
+                    with self._cond:
+                        deleted = key in self._data
+                        if deleted:
+                            del self._data[key]
+                    conn.sendall(struct.pack("!?", deleted))
+                elif cmd == _CMD_NUM_KEYS:
+                    with self._cond:
+                        count = len(self._data)
+                    conn.sendall(struct.pack("!I", count))
+                elif cmd == _CMD_CHECK:
+                    raw = _recv_bytes(conn)
+                    n = struct.unpack("!I", raw[:4])[0]
+                    keys = []
+                    offset = 4
+                    for _ in range(n):
+                        klen = struct.unpack("!I", raw[offset:offset + 4])[0]
+                        offset += 4
+                        keys.append(raw[offset:offset + klen].decode("utf-8"))
+                        offset += klen
+                    with self._cond:
+                        found = True
+                        for k in keys:
+                            if k not in self._data:
+                                found = False
+                                break
+                    conn.sendall(struct.pack("!?", found))
+                elif cmd == _CMD_COMPARE_SET:
+                    key = _recv_bytes(conn).decode("utf-8")
+                    expected = _recv_bytes(conn)
+                    desired = _recv_bytes(conn)
+                    with self._cond:
+                        current = self._data.get(key, b"")
+                        if current == expected:
+                            self._data[key] = desired
+                            self._cond.notify_all()
+                        result_val = self._data.get(key, b"")
+                    conn.sendall(bytes([_RESP_VALUE]))
+                    _send_bytes(conn, result_val)
         except (ConnectionError, OSError, TimeoutError):
             pass
         finally:
@@ -425,17 +508,17 @@ cdef class TCPStore(Store):
     # cdef fields declared in _c10d.pxd
 
     def __init__(self, str host, int port, int world_size, bint is_master,
-                 double timeout=_DEFAULT_TIMEOUT):
+                 timeout=_DEFAULT_TIMEOUT):
         self._host = host
         self._port = port
         self._world_size = world_size
-        self._timeout = timeout
+        self._timeout = _to_seconds(timeout)
         self._server_inst = None
         self._lock = threading.Lock()
         if is_master:
-            self._server_inst = _StoreServer(port, world_size, timeout=timeout)
+            self._server_inst = _StoreServer(port, world_size, timeout=self._timeout)
             time.sleep(0.1)
-        self._sock = self._connect(host, port, timeout)
+        self._sock = self._connect(host, port, self._timeout)
 
     cdef object _connect(self, str host, int port, double timeout):
         cdef double deadline = time.monotonic() + timeout
@@ -480,6 +563,7 @@ cdef class TCPStore(Store):
         cdef bytes kb
         cdef object old_timeout
         cdef bytes resp
+        cdef double t
         for k in keys:
             kb = k.encode("utf-8")
             buf += struct.pack("!I", len(kb)) + kb
@@ -488,13 +572,79 @@ cdef class TCPStore(Store):
             _send_bytes(self._sock, buf)
             old_timeout = self._sock.gettimeout()
             if timeout is not None:
-                self._sock.settimeout(timeout)
+                t = _to_seconds(timeout)
+                self._sock.settimeout(t)
             try:
                 resp = _recvall(self._sock, 1)
                 if resp is None or resp[0] != _RESP_OK:
                     raise RuntimeError("TCPStore.wait failed")
             finally:
                 self._sock.settimeout(old_timeout)
+
+    cpdef int add(self, str key, int amount):
+        cdef bytes resp
+        with self._lock:
+            self._sock.sendall(bytes([_CMD_ADD]))
+            _send_bytes(self._sock, key.encode("utf-8"))
+            self._sock.sendall(struct.pack("!i", amount))
+            resp = _recvall(self._sock, 4)
+        if resp is None:
+            raise RuntimeError("TCPStore.add failed")
+        return struct.unpack("!i", resp)[0]
+
+    cpdef bint delete_key(self, str key):
+        cdef bytes resp
+        with self._lock:
+            self._sock.sendall(bytes([_CMD_DELETE]))
+            _send_bytes(self._sock, key.encode("utf-8"))
+            resp = _recvall(self._sock, 1)
+        if resp is None:
+            raise RuntimeError("TCPStore.delete_key failed")
+        return struct.unpack("!?", resp)[0]
+
+    cpdef int num_keys(self):
+        cdef bytes resp
+        with self._lock:
+            self._sock.sendall(bytes([_CMD_NUM_KEYS]))
+            resp = _recvall(self._sock, 4)
+        if resp is None:
+            raise RuntimeError("TCPStore.num_keys failed")
+        return struct.unpack("!I", resp)[0]
+
+    cpdef bint check(self, list keys):
+        cdef bytes buf = struct.pack("!I", len(keys))
+        cdef bytes kb
+        cdef bytes resp
+        for k in keys:
+            kb = k.encode("utf-8")
+            buf += struct.pack("!I", len(kb)) + kb
+        with self._lock:
+            self._sock.sendall(bytes([_CMD_CHECK]))
+            _send_bytes(self._sock, buf)
+            resp = _recvall(self._sock, 1)
+        if resp is None:
+            raise RuntimeError("TCPStore.check failed")
+        return struct.unpack("!?", resp)[0]
+
+    cpdef bytes compare_set(self, str key, str expected, str desired):
+        cdef bytes resp
+        with self._lock:
+            self._sock.sendall(bytes([_CMD_COMPARE_SET]))
+            _send_bytes(self._sock, key.encode("utf-8"))
+            _send_bytes(self._sock, expected.encode("utf-8"))
+            _send_bytes(self._sock, desired.encode("utf-8"))
+            resp = _recvall(self._sock, 1)
+            if resp is None or resp[0] != _RESP_VALUE:
+                raise RuntimeError("TCPStore.compare_set failed")
+            return _recv_bytes(self._sock)
+
+    @property
+    def host(self):
+        return self._host
+
+    @property
+    def port(self):
+        return self._port
 
     cpdef close(self):
         try:
@@ -520,11 +670,30 @@ cdef class PrefixStore(Store):
     cpdef bytes get(self, str key):
         return self._store.get(f"{self._prefix}/{key}")
 
+    cpdef int add(self, str key, int amount):
+        return self._store.add(f"{self._prefix}/{key}", amount)
+
+    cpdef bint delete_key(self, str key):
+        return self._store.delete_key(f"{self._prefix}/{key}")
+
+    cpdef int num_keys(self):
+        return self._store.num_keys()
+
+    cpdef bint check(self, list keys):
+        return self._store.check([f"{self._prefix}/{k}" for k in keys])
+
+    cpdef bytes compare_set(self, str key, str expected, str desired):
+        return self._store.compare_set(f"{self._prefix}/{key}", expected, desired)
+
     cpdef wait(self, list keys, timeout=None):
         self._store.wait([f"{self._prefix}/{k}" for k in keys], timeout)
 
     cpdef close(self):
         self._store.close()
+
+    @property
+    def underlying_store(self):
+        return self._store
 
 
 # --- HashStore ---
@@ -548,15 +717,53 @@ cdef class HashStore(Store):
                 self._cond.wait(timeout=1.0)
             return self._data[key]
 
+    cpdef int add(self, str key, int amount):
+        cdef int old_val, new_val
+        with self._cond:
+            old_val = 0
+            if key in self._data:
+                old_val = struct.unpack("!i", self._data[key])[0]
+            new_val = old_val + amount
+            self._data[key] = struct.pack("!i", new_val)
+            self._cond.notify_all()
+        return new_val
+
+    cpdef bint delete_key(self, str key):
+        with self._lock:
+            if key in self._data:
+                del self._data[key]
+                return True
+            return False
+
+    cpdef int num_keys(self):
+        with self._lock:
+            return len(self._data)
+
+    cpdef bint check(self, list keys):
+        cdef str k
+        with self._lock:
+            for k in keys:
+                if k not in self._data:
+                    return False
+            return True
+
+    cpdef bytes compare_set(self, str key, str expected, str desired):
+        cdef bytes expected_b = expected.encode("utf-8")
+        cdef bytes desired_b = desired.encode("utf-8")
+        with self._cond:
+            current = self._data.get(key, b"")
+            if current == expected_b:
+                self._data[key] = desired_b
+                self._cond.notify_all()
+            return self._data.get(key, b"")
+
     cpdef wait(self, list keys, timeout=None):
         cdef double deadline
         cdef double remaining
         cdef str k
         cdef bint all_present
-        if timeout is not None:
-            deadline = time.monotonic() + <double>timeout
-        else:
-            deadline = time.monotonic() + _DEFAULT_TIMEOUT
+        cdef double t = _to_seconds(timeout)
+        deadline = time.monotonic() + t
         with self._cond:
             while True:
                 all_present = True
@@ -611,3 +818,52 @@ cdef class ProcessGroup:
     @property
     def bound_device_id(self):
         return self._bound_device_id
+
+    @bound_device_id.setter
+    def bound_device_id(self, value):
+        self._bound_device_id = value
+
+    def _set_group_name(self, str name):
+        self._group_name = name
+
+    def _set_group_desc(self, str desc):
+        self._group_desc = desc
+
+    # --- Collective dispatch (delegate to subclass) ---
+
+    def allreduce(self, tensors, opts=None):
+        raise NotImplementedError(f"{type(self).__name__}.allreduce not implemented")
+
+    def broadcast(self, tensors, opts=None):
+        raise NotImplementedError(f"{type(self).__name__}.broadcast not implemented")
+
+    def allgather(self, output_tensors, input_tensors, opts=None):
+        raise NotImplementedError(f"{type(self).__name__}.allgather not implemented")
+
+    def reduce(self, tensors, opts=None):
+        raise NotImplementedError(f"{type(self).__name__}.reduce not implemented")
+
+    def reduce_scatter(self, output_tensors, input_tensors, opts=None):
+        raise NotImplementedError(f"{type(self).__name__}.reduce_scatter not implemented")
+
+    def gather(self, output_tensors, input_tensors, opts=None):
+        raise NotImplementedError(f"{type(self).__name__}.gather not implemented")
+
+    def scatter(self, output_tensors, input_tensors, opts=None):
+        raise NotImplementedError(f"{type(self).__name__}.scatter not implemented")
+
+    def alltoall(self, output_tensors, input_tensors, opts=None):
+        raise NotImplementedError(f"{type(self).__name__}.alltoall not implemented")
+
+    def alltoall_base(self, output, input, output_split_sizes,
+                      input_split_sizes, opts=None):
+        raise NotImplementedError(f"{type(self).__name__}.alltoall_base not implemented")
+
+    def send(self, tensors, int dst, int tag=0):
+        raise NotImplementedError(f"{type(self).__name__}.send not implemented")
+
+    def recv(self, tensors, int src, int tag=0):
+        raise NotImplementedError(f"{type(self).__name__}.recv not implemented")
+
+    def barrier(self, opts=None):
+        raise NotImplementedError(f"{type(self).__name__}.barrier not implemented")

--- a/src/candle/distributed/_c10d_gloo.pyx
+++ b/src/candle/distributed/_c10d_gloo.pyx
@@ -502,14 +502,14 @@ cdef class ProcessGroupGloo:
 
         return self._make_work()
 
-    def send(self, tensor, dst):
+    def send(self, tensor, dst, int tag=0):
         """Point-to-point send."""
         arr = self._tensor_to_numpy(tensor)
         serialized = serialize_array(arr)
         self._transport.send_to(dst, serialized)
         return self._make_work()
 
-    def recv(self, tensor, src):
+    def recv(self, tensor, src, int tag=0):
         """Point-to-point receive."""
         data = self._transport.recv_from(src)
         arr = deserialize_array(data)

--- a/src/candle/distributed/_c10d_hccl.pyx
+++ b/src/candle/distributed/_c10d_hccl.pyx
@@ -241,7 +241,7 @@ cdef class ProcessGroupHCCL:
         _check(ret, "HcclBarrier")
         return self._make_work(stream)
 
-    def send(self, tensor, dst):
+    def send(self, tensor, dst, int tag=0):
         get_bindings, _, _, _, _, _, _, _, _check = self._load_bindings()
         bindings = get_bindings()
         stream = self._stream()
@@ -253,7 +253,7 @@ cdef class ProcessGroupHCCL:
         _check(ret, "HcclSend")
         return self._make_work(stream)
 
-    def recv(self, tensor, src):
+    def recv(self, tensor, src, int tag=0):
         get_bindings, _, _, _, _, _, _, _, _check = self._load_bindings()
         bindings = get_bindings()
         stream = self._stream()


### PR DESCRIPTION
## Summary

Fixes the P0 API gaps identified in the candle Cython distributed implementation vs PyTorch's c10d interface.

Builds on top of #145 (distributed Cython migration).

## Changes

### Store interface (5 new methods)
- `add(key, amount) -> int` — atomic increment, critical for barrier sequence numbers
- `delete_key(key) -> bool` — key removal
- `num_keys() -> int` — key count
- `check(keys) -> bool` — non-blocking key existence check
- `compare_set(key, expected, desired) -> bytes` — CAS operation for lock-free coordination

Implemented across all Store types:
- `_StoreServer`: 5 new wire protocol commands (ADD=3, DELETE=4, NUM_KEYS=5, CHECK=6, COMPARE_SET=7)
- `TCPStore`: client-side for all 5 new commands
- `HashStore`: thread-safe in-process implementation
- `PrefixStore`: delegates all new methods with prefix, adds `underlying_store` property

### ProcessGroup base class
- Added collective dispatch stubs: `allreduce`, `broadcast`, `allgather`, `reduce`, `reduce_scatter`, `gather`, `scatter`, `alltoall`, `alltoall_base`, `send`, `recv`, `barrier`
- All raise `NotImplementedError` — subclasses override
- Added `bound_device_id` setter, `_set_group_name()`, `_set_group_desc()`

### send/recv tag parameter
- Added `tag=0` parameter to `send()`/`recv()` in both Gloo and HCCL backends

### timedelta timeout support
- `TCPStore` constructor accepts `timedelta` or `float`
- `Work.wait()` accepts `timedelta` timeout
- `HashStore.wait()` accepts `timedelta` timeout
- Added `_to_seconds()` helper for uniform conversion

## Testing

All 17 existing Cython tests pass. P0 fixes verified with additional inline tests covering all new Store methods, ProcessGroup stubs, tag parameters, and timedelta acceptance.