### PR TITLE
feat(mps): add where broadcast, unique_consecutive, upsample_trilinear3d

### DIFF
--- a/src/candle/__init__.py
+++ b/src/candle/__init__.py
@@ -118,7 +118,7 @@ from ._functional import logical_xor
 from ._functional import baddbmm, trace, cummin, logsumexp, renorm
 from ._functional import bitwise_and, bitwise_or, bitwise_xor, bitwise_not
 from ._functional import unflatten, broadcast_to, movedim, moveaxis, diagonal
-from ._functional import unique, searchsorted, kthvalue, median
+from ._functional import unique, unique_consecutive, searchsorted, kthvalue, median
 # Category A: Export existing functions
 from ._functional import eq, ne, lt, le, gt, ge
 from ._functional import select, expand, masked_fill, unfold
@@ -743,6 +743,7 @@ __all__ = [
     "diagonal",
     # new search ops
     "unique",
+    "unique_consecutive",
     "searchsorted",
     "kthvalue",
     "median",

--- a/src/candle/_backends/cpu/__init__.py
+++ b/src/candle/_backends/cpu/__init__.py
@@ -252,6 +252,7 @@ from .ops import (
     diagonal,
     # New search ops
     unique,
+    unique_consecutive,
     searchsorted,
     kthvalue,
     median,
@@ -552,6 +553,7 @@ registry.register("diagonal", "cpu", diagonal, meta=meta_infer.infer_diagonal)
 
 # Search ops (no meta — output shape is data-dependent or returns tuples)
 registry.register("unique", "cpu", unique)
+registry.register("unique_consecutive", "cpu", unique_consecutive)
 registry.register("searchsorted", "cpu", searchsorted)
 registry.register("kthvalue", "cpu", kthvalue)
 registry.register("median", "cpu", median)
@@ -823,12 +825,14 @@ from .ops import (
     upsample_nearest2d,
     upsample_bilinear2d,
     upsample_bicubic2d,
+    upsample_trilinear3d,
 )
 registry.register("upsample_nearest1d", "cpu", upsample_nearest1d)
 registry.register("upsample_linear1d", "cpu", upsample_linear1d)
 registry.register("upsample_nearest2d", "cpu", upsample_nearest2d)
 registry.register("upsample_bilinear2d", "cpu", upsample_bilinear2d)
 registry.register("upsample_bicubic2d", "cpu", upsample_bicubic2d)
+registry.register("upsample_trilinear3d", "cpu", upsample_trilinear3d)
 
 # 1D pooling ops
 from .ops import max_pool1d, avg_pool1d, adaptive_avg_pool1d, max_unpool1d, max_unpool2d

--- a/src/candle/_backends/cpu/ops.py
+++ b/src/candle/_backends/cpu/ops.py
@@ -2684,6 +2684,56 @@ def unique(a, sorted=True, return_inverse=False, return_counts=False, dim=None):
     return _from_numpy(np.ascontiguousarray(result), a.dtype, a.device)
 
 
+def unique_consecutive(a, return_inverse=False, return_counts=False, dim=None):
+    arr = _to_numpy(a)
+    if dim is None:
+        flat = arr.flatten()
+        # Find where consecutive elements differ
+        if flat.size == 0:
+            mask = np.array([], dtype=bool)
+        else:
+            mask = np.concatenate(([True], flat[1:] != flat[:-1]))
+        output = flat[mask]
+        results = [_from_numpy(np.ascontiguousarray(output), a.dtype, a.device)]
+        if return_inverse:
+            inverse = np.cumsum(mask) - 1
+            results.append(_from_numpy(inverse.astype(np.int64), int64_dtype, a.device))
+        if return_counts:
+            indices = np.concatenate((np.where(mask)[0], [flat.size]))
+            counts = np.diff(indices)
+            results.append(_from_numpy(counts.astype(np.int64), int64_dtype, a.device))
+        return tuple(results) if len(results) > 1 else results[0]
+    # dim-based unique_consecutive
+    d = dim if dim >= 0 else dim + arr.ndim
+    n = arr.shape[d]
+    if n == 0:
+        results = [_from_numpy(np.ascontiguousarray(arr), a.dtype, a.device)]
+        if return_inverse:
+            results.append(_from_numpy(np.array([], dtype=np.int64), int64_dtype, a.device))
+        if return_counts:
+            results.append(_from_numpy(np.array([], dtype=np.int64), int64_dtype, a.device))
+        return tuple(results) if len(results) > 1 else results[0]
+    slices_prev = [slice(None)] * arr.ndim
+    slices_curr = [slice(None)] * arr.ndim
+    mask = [True]
+    for i in range(1, n):
+        slices_prev[d] = i - 1
+        slices_curr[d] = i
+        mask.append(not np.array_equal(arr[tuple(slices_prev)], arr[tuple(slices_curr)]))
+    mask = np.array(mask)
+    indices = np.where(mask)[0]
+    output = np.take(arr, indices, axis=d)
+    results = [_from_numpy(np.ascontiguousarray(output), a.dtype, a.device)]
+    if return_inverse:
+        inverse = np.cumsum(mask) - 1
+        results.append(_from_numpy(inverse.astype(np.int64), int64_dtype, a.device))
+    if return_counts:
+        count_indices = np.concatenate((np.where(mask)[0], [n]))
+        counts = np.diff(count_indices)
+        results.append(_from_numpy(counts.astype(np.int64), int64_dtype, a.device))
+    return tuple(results) if len(results) > 1 else results[0]
+
+
 def searchsorted(sorted_seq, values, out_int32=False, right=False, side=None, sorter=None):
     seq_np = _to_numpy(sorted_seq)
     val_np = _to_numpy(values) if isinstance(values, Tensor) else np.array(values)
@@ -4244,6 +4294,52 @@ def upsample_bilinear2d(a, output_size, align_corners=False, scales_h=None, scal
            arr[:, :, h0[:, None], w1[None, :]] * (1 - wh) * ww +
            arr[:, :, h1[:, None], w0[None, :]] * wh * (1 - ww) +
            arr[:, :, h1[:, None], w1[None, :]] * wh * ww)
+    return _from_numpy(np.ascontiguousarray(out.astype(_to_numpy(a).dtype)), a.dtype, a.device)
+
+
+def upsample_trilinear3d(a, output_size, align_corners=False, scales_d=None, scales_h=None, scales_w=None):
+    """Trilinear 3D upsampling. Input: (N, C, D_in, H_in, W_in) -> (N, C, D_out, H_out, W_out)."""
+    arr = _to_numpy(a).astype(np.float64)
+    D_out, H_out, W_out = output_size
+    D_in, H_in, W_in = arr.shape[2], arr.shape[3], arr.shape[4]
+
+    if align_corners and D_in > 1 and D_out > 1:
+        d = np.linspace(0, D_in - 1, D_out)
+    else:
+        d = (np.arange(D_out, dtype=np.float64) + 0.5) * D_in / D_out - 0.5
+    if align_corners and H_in > 1 and H_out > 1:
+        h = np.linspace(0, H_in - 1, H_out)
+    else:
+        h = (np.arange(H_out, dtype=np.float64) + 0.5) * H_in / H_out - 0.5
+    if align_corners and W_in > 1 and W_out > 1:
+        w = np.linspace(0, W_in - 1, W_out)
+    else:
+        w = (np.arange(W_out, dtype=np.float64) + 0.5) * W_in / W_out - 0.5
+
+    d = np.clip(d, 0, D_in - 1)
+    h = np.clip(h, 0, H_in - 1)
+    w = np.clip(w, 0, W_in - 1)
+
+    d0 = np.floor(d).astype(np.intp)
+    d1 = np.minimum(d0 + 1, D_in - 1)
+    h0 = np.floor(h).astype(np.intp)
+    h1 = np.minimum(h0 + 1, H_in - 1)
+    w0 = np.floor(w).astype(np.intp)
+    w1 = np.minimum(w0 + 1, W_in - 1)
+
+    wd = (d - d0).reshape(1, 1, -1, 1, 1)
+    wh = (h - h0).reshape(1, 1, 1, -1, 1)
+    ww = (w - w0).reshape(1, 1, 1, 1, -1)
+
+    # 8-point trilinear interpolation
+    out = (arr[:, :, d0[:, None, None], h0[None, :, None], w0[None, None, :]] * (1 - wd) * (1 - wh) * (1 - ww) +
+           arr[:, :, d0[:, None, None], h0[None, :, None], w1[None, None, :]] * (1 - wd) * (1 - wh) * ww +
+           arr[:, :, d0[:, None, None], h1[None, :, None], w0[None, None, :]] * (1 - wd) * wh * (1 - ww) +
+           arr[:, :, d0[:, None, None], h1[None, :, None], w1[None, None, :]] * (1 - wd) * wh * ww +
+           arr[:, :, d1[:, None, None], h0[None, :, None], w0[None, None, :]] * wd * (1 - wh) * (1 - ww) +
+           arr[:, :, d1[:, None, None], h0[None, :, None], w1[None, None, :]] * wd * (1 - wh) * ww +
+           arr[:, :, d1[:, None, None], h1[None, :, None], w0[None, None, :]] * wd * wh * (1 - ww) +
+           arr[:, :, d1[:, None, None], h1[None, :, None], w1[None, None, :]] * wd * wh * ww)
     return _from_numpy(np.ascontiguousarray(out.astype(_to_numpy(a).dtype)), a.dtype, a.device)
 
 

--- a/src/candle/_backends/mps/__init__.py
+++ b/src/candle/_backends/mps/__init__.py
@@ -242,6 +242,7 @@ from .ops import (
     diagonal,
     # New search ops
     unique,
+    unique_consecutive,
     searchsorted,
     kthvalue,
     median,
@@ -573,6 +574,7 @@ registry.register("diagonal", "mps", diagonal, meta=meta_infer.infer_diagonal)
 # Search / sort ops
 # ---------------------------------------------------------------------------
 registry.register("unique", "mps", unique)
+registry.register("unique_consecutive", "mps", unique_consecutive)
 registry.register("searchsorted", "mps", searchsorted)
 registry.register("kthvalue", "mps", kthvalue)
 registry.register("median", "mps", median)
@@ -847,12 +849,14 @@ from .ops import (
     upsample_nearest2d,
     upsample_bilinear2d,
     upsample_bicubic2d,
+    upsample_trilinear3d,
 )
 registry.register("upsample_nearest1d", "mps", upsample_nearest1d)
 registry.register("upsample_linear1d", "mps", upsample_linear1d)
 registry.register("upsample_nearest2d", "mps", upsample_nearest2d)
 registry.register("upsample_bilinear2d", "mps", upsample_bilinear2d)
 registry.register("upsample_bicubic2d", "mps", upsample_bicubic2d)
+registry.register("upsample_trilinear3d", "mps", upsample_trilinear3d)
 
 # ---------------------------------------------------------------------------
 # 1D pooling

--- a/src/candle/_backends/mps/ops/__init__.py
+++ b/src/candle/_backends/mps/ops/__init__.py
@@ -145,6 +145,7 @@ from .reduce import (  # noqa: F401
     median,
     kthvalue,
     unique,
+    unique_consecutive,
     searchsorted,
     argwhere,
 )
@@ -312,6 +313,7 @@ from .conv import (  # noqa: F401
     upsample_linear1d,
     upsample_bilinear2d,
     upsample_bicubic2d,
+    upsample_trilinear3d,
     pad,
     im2col,
     col2im,

--- a/src/candle/_backends/mps/ops/conv.py
+++ b/src/candle/_backends/mps/ops/conv.py
@@ -947,6 +947,50 @@ def upsample_bicubic2d(a, output_size, align_corners=False, scales_h=None, scale
                     out[:, :, j, i] += arr[:, :, hh, ww] * weight
     return _from_numpy(np.ascontiguousarray(out.astype(_to_numpy(a).dtype)), a.dtype, a.device)
 
+def upsample_trilinear3d(a, output_size, align_corners=False, scales_d=None, scales_h=None, scales_w=None):
+    """Trilinear 3D upsampling. Input: (N, C, D_in, H_in, W_in) -> (N, C, D_out, H_out, W_out)."""
+    arr = _to_numpy(a).astype(np.float64)
+    D_out, H_out, W_out = output_size
+    D_in, H_in, W_in = arr.shape[2], arr.shape[3], arr.shape[4]
+
+    if align_corners and D_in > 1 and D_out > 1:
+        d = np.linspace(0, D_in - 1, D_out)
+    else:
+        d = (np.arange(D_out, dtype=np.float64) + 0.5) * D_in / D_out - 0.5
+    if align_corners and H_in > 1 and H_out > 1:
+        h = np.linspace(0, H_in - 1, H_out)
+    else:
+        h = (np.arange(H_out, dtype=np.float64) + 0.5) * H_in / H_out - 0.5
+    if align_corners and W_in > 1 and W_out > 1:
+        w = np.linspace(0, W_in - 1, W_out)
+    else:
+        w = (np.arange(W_out, dtype=np.float64) + 0.5) * W_in / W_out - 0.5
+
+    d = np.clip(d, 0, D_in - 1)
+    h = np.clip(h, 0, H_in - 1)
+    w = np.clip(w, 0, W_in - 1)
+
+    d0 = np.floor(d).astype(np.intp)
+    d1 = np.minimum(d0 + 1, D_in - 1)
+    h0 = np.floor(h).astype(np.intp)
+    h1 = np.minimum(h0 + 1, H_in - 1)
+    w0 = np.floor(w).astype(np.intp)
+    w1 = np.minimum(w0 + 1, W_in - 1)
+
+    wd = (d - d0).reshape(1, 1, -1, 1, 1)
+    wh = (h - h0).reshape(1, 1, 1, -1, 1)
+    ww = (w - w0).reshape(1, 1, 1, 1, -1)
+
+    out = (arr[:, :, d0[:, None, None], h0[None, :, None], w0[None, None, :]] * (1 - wd) * (1 - wh) * (1 - ww) +
+           arr[:, :, d0[:, None, None], h0[None, :, None], w1[None, None, :]] * (1 - wd) * (1 - wh) * ww +
+           arr[:, :, d0[:, None, None], h1[None, :, None], w0[None, None, :]] * (1 - wd) * wh * (1 - ww) +
+           arr[:, :, d0[:, None, None], h1[None, :, None], w1[None, None, :]] * (1 - wd) * wh * ww +
+           arr[:, :, d1[:, None, None], h0[None, :, None], w0[None, None, :]] * wd * (1 - wh) * (1 - ww) +
+           arr[:, :, d1[:, None, None], h0[None, :, None], w1[None, None, :]] * wd * (1 - wh) * ww +
+           arr[:, :, d1[:, None, None], h1[None, :, None], w0[None, None, :]] * wd * wh * (1 - ww) +
+           arr[:, :, d1[:, None, None], h1[None, :, None], w1[None, None, :]] * wd * wh * ww)
+    return _from_numpy(np.ascontiguousarray(out.astype(_to_numpy(a).dtype)), a.dtype, a.device)
+
 def pad(a, pad_widths, mode='constant', value=0):
     ndim = len(a.shape)
 

--- a/src/candle/_backends/mps/ops/elementwise.py
+++ b/src/candle/_backends/mps/ops/elementwise.py
@@ -23,7 +23,47 @@ from .math import sub, add, mul, div
 from .comparison import gt, lt, logical_not
 
 
+def _broadcast_contiguous(t, out_shape):
+    """Broadcast tensor to out_shape and return a contiguous copy via unified memory."""
+    arr = _to_numpy(t)
+    arr = np.broadcast_to(arr, out_shape)
+    arr = np.ascontiguousarray(arr)
+    return _from_numpy(arr, t.dtype, t.device)
+
+
 def where(cond, x, y):
+    # Broadcast cond, x, y to the same shape if needed
+    if isinstance(x, Tensor) and isinstance(y, Tensor) and isinstance(cond, Tensor):
+        shapes = [cond.shape, x.shape, y.shape]
+        if not (shapes[0] == shapes[1] == shapes[2]):
+            max_ndim = max(len(s) for s in shapes)
+            padded = [(1,) * (max_ndim - len(s)) + tuple(s) for s in shapes]
+            out_shape = []
+            for dims in zip(*padded):
+                m = max(dims)
+                for d in dims:
+                    if d != 1 and d != m:
+                        raise RuntimeError(
+                            f"where: shape mismatch, cannot broadcast {shapes}")
+                out_shape.append(m)
+            out_shape = tuple(out_shape)
+            if tuple(cond.shape) != out_shape:
+                cond = _broadcast_contiguous(cond, out_shape)
+            if tuple(x.shape) != out_shape:
+                x = _broadcast_contiguous(x, out_shape)
+            if tuple(y.shape) != out_shape:
+                y = _broadcast_contiguous(y, out_shape)
+    elif isinstance(x, Tensor) and not isinstance(y, Tensor) and isinstance(cond, Tensor):
+        if tuple(cond.shape) != tuple(x.shape):
+            max_ndim = max(len(cond.shape), len(x.shape))
+            pc = (1,) * (max_ndim - len(cond.shape)) + tuple(cond.shape)
+            px = (1,) * (max_ndim - len(x.shape)) + tuple(x.shape)
+            out_shape = tuple(max(a, b) for a, b in zip(pc, px))
+            if tuple(cond.shape) != out_shape:
+                cond = _broadcast_contiguous(cond, out_shape)
+            if tuple(x.shape) != out_shape:
+                x = _broadcast_contiguous(x, out_shape)
+
     # GPU path: both cond and x are GPU+contiguous
     if (isinstance(x, Tensor) and _can_use_gpu(x) and x.is_contiguous()
             and isinstance(cond, Tensor) and _can_use_gpu(cond) and cond.is_contiguous()):

--- a/src/candle/_backends/mps/ops/reduce.py
+++ b/src/candle/_backends/mps/ops/reduce.py
@@ -914,6 +914,52 @@ def unique(a, sorted=True, return_inverse=False, return_counts=False, dim=None):
         return tuple(out)
     return _from_numpy(np.ascontiguousarray(result), a.dtype, a.device)
 
+def unique_consecutive(a, return_inverse=False, return_counts=False, dim=None):
+    arr = _to_numpy(a)
+    if dim is None:
+        flat = arr.flatten()
+        if flat.size == 0:
+            mask = np.array([], dtype=bool)
+        else:
+            mask = np.concatenate([[True], flat[1:] != flat[:-1]])
+        unique_vals = flat[mask]
+        result = [_from_numpy(np.ascontiguousarray(unique_vals), a.dtype, a.device)]
+        if return_inverse:
+            inverse = np.cumsum(mask) - 1
+            result.append(_from_numpy(inverse.astype(np.int64), int64_dtype, a.device))
+        if return_counts:
+            indices = np.concatenate([np.where(mask)[0], [len(flat)]])
+            counts = np.diff(indices)
+            result.append(_from_numpy(counts.astype(np.int64), int64_dtype, a.device))
+        return tuple(result) if len(result) > 1 else result[0]
+    # dim-based
+    ndim = arr.ndim
+    d = dim if dim >= 0 else dim + ndim
+    n = arr.shape[d]
+    if n == 0:
+        result = [_from_numpy(np.ascontiguousarray(arr), a.dtype, a.device)]
+        if return_inverse:
+            result.append(_from_numpy(np.array([], dtype=np.int64), int64_dtype, a.device))
+        if return_counts:
+            result.append(_from_numpy(np.array([], dtype=np.int64), int64_dtype, a.device))
+        return tuple(result) if len(result) > 1 else result[0]
+    mask = [True]
+    for i in range(1, n):
+        mask.append(not np.array_equal(
+            np.take(arr, [i], axis=d), np.take(arr, [i - 1], axis=d)))
+    mask = np.array(mask)
+    keep = np.where(mask)[0]
+    unique_arr = np.concatenate([np.take(arr, [k], axis=d) for k in keep], axis=d)
+    result = [_from_numpy(np.ascontiguousarray(unique_arr), a.dtype, a.device)]
+    if return_inverse:
+        inverse = np.cumsum(mask) - 1
+        result.append(_from_numpy(inverse.astype(np.int64), int64_dtype, a.device))
+    if return_counts:
+        indices = np.concatenate([keep, [n]])
+        counts = np.diff(indices)
+        result.append(_from_numpy(counts.astype(np.int64), int64_dtype, a.device))
+    return tuple(result) if len(result) > 1 else result[0]
+
 def searchsorted(sorted_seq, values, out_int32=False, right=False, side=None, sorter=None):
     seq_np = _to_numpy(sorted_seq)
     val_np = _to_numpy(values) if isinstance(values, Tensor) else np.array(values)

--- a/src/candle/_dispatch/schemas.py
+++ b/src/candle/_dispatch/schemas.py
@@ -524,6 +524,7 @@ def register_schemas():
 
     # New search ops
     registry.register_schema("unique", "unique(Tensor input, bool sorted=True, bool return_inverse=False, bool return_counts=False, int? dim=None) -> Any")
+    registry.register_schema("unique_consecutive", "unique_consecutive(Tensor input, bool return_inverse=False, bool return_counts=False, int? dim=None) -> Any")
     registry.register_schema("searchsorted", "searchsorted(Tensor sorted_sequence, Any values, bool out_int32=False, bool right=False, str? side=None, Tensor? sorter=None) -> Tensor")
     registry.register_schema("kthvalue", "kthvalue(Tensor input, int k, int dim=-1, bool keepdim=False) -> (Tensor, Tensor)")
     registry.register_schema("median", "median(Tensor input, int? dim=None, bool keepdim=False) -> Any")
@@ -665,6 +666,7 @@ def register_schemas():
     registry.register_schema("upsample_nearest1d", "upsample_nearest1d(Tensor input, Any output_size) -> Tensor")
     registry.register_schema("upsample_linear1d", "upsample_linear1d(Tensor input, Any output_size, bool align_corners=False, Any scales=None) -> Tensor")
     registry.register_schema("upsample_bicubic2d", "upsample_bicubic2d(Tensor input, Any output_size, bool align_corners=False, Any scales_h=None, Any scales_w=None) -> Tensor")
+    registry.register_schema("upsample_trilinear3d", "upsample_trilinear3d(Tensor input, Any output_size, bool align_corners=False, Any scales_d=None, Any scales_h=None, Any scales_w=None) -> Tensor")
     registry.register_schema("uniform", "uniform(Tensor input) -> Tensor")
     registry.register_schema("ctc_loss", "ctc_loss(Tensor log_probs, Any targets, Any input_lengths, Any target_lengths, int blank=0, str reduction='mean', bool zero_infinity=False) -> Tensor")
     registry.register_schema("adaptive_max_pool2d", "adaptive_max_pool2d(Tensor input, Any output_size, bool return_indices=False) -> Tensor")

--- a/src/candle/_functional.py
+++ b/src/candle/_functional.py
@@ -1295,6 +1295,10 @@ def unique(a, sorted=True, return_inverse=False, return_counts=False, dim=None):
     return dispatch("unique", a.device.type, a, sorted, return_inverse, return_counts, dim)
 
 
+def unique_consecutive(a, return_inverse=False, return_counts=False, dim=None):
+    return dispatch("unique_consecutive", a.device.type, a, return_inverse, return_counts, dim)
+
+
 def searchsorted(sorted_seq, values, out_int32=False, right=False, side=None, sorter=None):
     return dispatch(
         "searchsorted", sorted_seq.device.type,

--- a/src/candle/nn/functional.py
+++ b/src/candle/nn/functional.py
@@ -616,6 +616,22 @@ def interpolate(input, size=None, scale_factor=None, mode='nearest',
             output_size = (int(W * sf),)
         else:
             raise ValueError("either size or scale_factor must be defined")
+    elif ndim == 5:
+        # 3D: (N, C, D, H, W)
+        if size is not None:
+            if isinstance(size, int):
+                output_size = (size, size, size)
+            else:
+                output_size = tuple(size)
+        elif scale_factor is not None:
+            if isinstance(scale_factor, (int, float)):
+                sf_d = sf_h = sf_w = float(scale_factor)
+            else:
+                sf_d, sf_h, sf_w = float(scale_factor[0]), float(scale_factor[1]), float(scale_factor[2])
+            D, H, W = input.shape[2], input.shape[3], input.shape[4]
+            output_size = (int(D * sf_d), int(H * sf_h), int(W * sf_w))
+        else:
+            raise ValueError("either size or scale_factor must be defined")
     else:
         # 2D: (N, C, H, W)
         if size is not None:
@@ -663,6 +679,16 @@ def interpolate(input, size=None, scale_factor=None, mode='nearest',
         else:
             sh, sw = 0.0, 0.0
         return dispatch("upsample_bicubic2d", input.device.type, input, output_size, ac, sh, sw)
+    elif mode == 'trilinear':
+        ac = align_corners if align_corners is not None else False
+        if scale_factor is not None and not recompute_scale_factor:
+            if isinstance(scale_factor, (int, float)):
+                sd = sh = sw = float(scale_factor)
+            else:
+                sd, sh, sw = float(scale_factor[0]), float(scale_factor[1]), float(scale_factor[2])
+        else:
+            sd, sh, sw = 0.0, 0.0, 0.0
+        return dispatch("upsample_trilinear3d", input.device.type, input, output_size, ac, sd, sh, sw)
     else:
         raise NotImplementedError(f"interpolate mode '{mode}' is not yet implemented")
 


### PR DESCRIPTION
## Summary

Close the MPS capability gap with three additions:

- **where() broadcast**: broadcast cond/x/y to common shape before GPU dispatch, fixing multi_margin_loss and other ops that rely on broadcast where
- **unique_consecutive**: CPU + MPS implementation with return_inverse/return_counts/dim support
- **upsample_trilinear3d**: 8-point trilinear interpolation for 5D inputs (CPU + MPS), plus `trilinear` mode in `nn.functional.interpolate()`

## Tests

- 361 MPS tests pass
- 1791 CPU tests pass
- Smoke tested all three new features on MPS device