### PR TITLE
feat(cython): compiled Future / collect_all with Python fallback

### DIFF
--- a/docs/plans/2026-03-19-future-cython-alignment.md
+++ b/docs/plans/2026-03-19-future-cython-alignment.md
@@ -1,0 +1,373 @@
+# Futures Cython Migration Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Move candle's `Future` / `collect_all` implementation onto a compiled Cython fast path while preserving the existing `candle.futures` import surface and compatibility with `distributed.Work.get_future()`.
+
+**Architecture:** Add `src/candle/_cython/_future.pyx` as the compiled primary implementation of `Future` and `collect_all`. Keep `src/candle/futures.py` as a fast-path loader plus pure-Python fallback, following the same pattern already used for stream alignment. Existing callers continue importing from `candle.futures` unchanged.
+
+**Tech Stack:** Cython >= 3.0, Python 3.11, `threading`, `typing`, setuptools extensions, pytest
+
+---
+
+### Task 1: Add failing Future fast-path and compatibility tests
+
+**Files:**
+- Modify: `tests/cpu/test_futures.py`
+- Create if missing: `tests/cpu/test_futures.py`
+- Test: `tests/cpu/test_futures.py`
+
+**Step 1: Write the failing tests**
+
+Create `tests/cpu/test_futures.py` with these tests:
+
+```python
+import threading
+
+from candle.futures import Future, collect_all
+
+
+def test_future_basic_result():
+    fut = Future()
+    fut.set_result(42)
+    assert fut.done() is True
+    assert fut.wait() == 42
+    assert fut.value() == 42
+
+
+def test_future_exception_propagates():
+    fut = Future()
+    fut.set_exception(RuntimeError("boom"))
+
+    try:
+        fut.wait()
+        assert False, "expected exception"
+    except RuntimeError as exc:
+        assert str(exc) == "boom"
+
+
+def test_future_then_chains_result():
+    fut = Future()
+    chained = fut.then(lambda src: src.wait() * 2)
+    fut.set_result(21)
+    assert chained.wait() == 42
+
+
+def test_future_add_done_callback_after_completion_runs_immediately():
+    fut = Future()
+    seen = []
+    fut.set_result("ok")
+    fut.add_done_callback(lambda f: seen.append(f.wait()))
+    assert seen == ["ok"]
+
+
+def test_collect_all_returns_original_futures_in_order():
+    futures = [Future(), Future(), Future()]
+    agg = collect_all(futures)
+    futures[0].set_result("a")
+    futures[1].set_result("b")
+    futures[2].set_result("c")
+    assert agg.wait() == futures
+
+
+def test_collect_all_propagates_first_exception_after_all_done():
+    futures = [Future(), Future()]
+    agg = collect_all(futures)
+    futures[0].set_exception(ValueError("bad"))
+    futures[1].set_result("ok")
+
+    try:
+        agg.wait()
+        assert False, "expected exception"
+    except ValueError as exc:
+        assert str(exc) == "bad"
+
+
+def test_future_wait_blocks_until_other_thread_sets_result():
+    fut = Future()
+    seen = []
+
+    def waiter():
+        seen.append(fut.wait())
+
+    thread = threading.Thread(target=waiter)
+    thread.start()
+    fut.set_result("threaded")
+    thread.join(timeout=2)
+    assert seen == ["threaded"]
+```
+
+**Step 2: Run test to verify it fails only after we add the new compiled-surface check**
+
+Append this additional red test at the bottom:
+
+```python
+def test_future_module_reports_compiled_fast_path():
+    import candle.futures as futures_mod
+
+    assert hasattr(futures_mod, "_FUTURE_CYTHON")
+    assert futures_mod._FUTURE_CYTHON is True
+```
+
+Run:
+```bash
+python -m pytest tests/cpu/test_futures.py::test_future_module_reports_compiled_fast_path -v --tb=short
+```
+
+Expected: FAIL because `_FUTURE_CYTHON` does not exist yet.
+
+**Step 3: Commit**
+
+```bash
+git add tests/cpu/test_futures.py
+git commit -m "test: add futures Cython fast-path checks"
+```
+
+---
+
+### Task 2: Add the new Cython extension to `setup.py`
+
+**Files:**
+- Modify: `setup.py`
+- Test: `python setup.py build_ext --inplace`
+
+**Step 1: Add the extension entry**
+
+In `setup.py`, add this extension near the other `_cython` modules, right after `_stream`:
+
+```python
+                Extension(
+                    "candle._cython._future",
+                    ["src/candle/_cython/_future.pyx"],
+                ),
+```
+
+The relevant block should become:
+
+```python
+                Extension(
+                    "candle._cython._stream",
+                    ["src/candle/_cython/_stream.pyx"],
+                ),
+                Extension(
+                    "candle._cython._future",
+                    ["src/candle/_cython/_future.pyx"],
+                ),
+                Extension(
+                    "candle.distributed._c10d",
+                    ["src/candle/distributed/_c10d.pyx"],
+                ),
+```
+
+**Step 2: Run build to verify target inclusion**
+
+Run:
+```bash
+python setup.py build_ext --inplace
+```
+
+Expected: output includes `building 'candle._cython._future' extension`.
+
+**Step 3: Commit**
+
+```bash
+git add setup.py
+git commit -m "build: add Cython future extension"
+```
+
+---
+
+### Task 3: Create `_cython/_future.pyx`
+
+**Files:**
+- Create: `src/candle/_cython/_future.pyx`
+- Source reference: `src/candle/futures.py`
+- Test: `python -m cython src/candle/_cython/_future.pyx`
+
+**Step 1: Implement the compiled primary Future path**
+
+Create `src/candle/_cython/_future.pyx` with this header:
+
+```cython
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""Compiled primary implementation of candle Future / collect_all.
+
+This module mirrors the public API exposed by `candle.futures` while serving as
+its compiled fast path.
+"""
+```
+
+Then port the full current implementation from `src/candle/futures.py`, preserving these public names exactly:
+- `T = TypeVar("T")`
+- `S = TypeVar("S")`
+- `class Future(Generic[T])`
+- `def collect_all(futures)`
+
+Use the current behavior exactly:
+- `Future.__init__(*, devices=None)`
+- `_result`, `_exception`, `_done`, `_event`, `_lock`, `_done_callbacks`, `_devices`
+- `set_result`, `set_exception`, `wait`, `value`, `done`, `then`, `add_done_callback`
+- `collect_all` propagates the first exception after all futures complete
+
+Keep the initial implementation close to the current Python logic; it is acceptable for the first `.pyx` version to remain Python-style internally.
+
+**Step 2: Run syntax verification**
+
+Run:
+```bash
+python -m cython src/candle/_cython/_future.pyx
+```
+
+Expected: no compile errors.
+
+**Step 3: Commit**
+
+```bash
+git add src/candle/_cython/_future.pyx
+git commit -m "feat(cython): add compiled future implementation"
+```
+
+---
+
+### Task 4: Convert `futures.py` into fast-path loader + Python fallback
+
+**Files:**
+- Modify: `src/candle/futures.py`
+- Test: import smoke test
+
+**Step 1: Add compiled fast path import block**
+
+At the top of `src/candle/futures.py`, add:
+
+```python
+try:
+    from ._cython._future import Future, collect_all  # pylint: disable=no-name-in-module
+    _FUTURE_CYTHON = True
+except ModuleNotFoundError as exc:
+    if exc.name in {"candle._cython", "candle._cython._future"}:
+        _FUTURE_CYTHON = False
+    else:
+        raise
+except ImportError:
+    raise
+```
+
+Then wrap the existing pure-Python implementation under:
+
+```python
+if not _FUTURE_CYTHON:
+    # existing current futures.py body, indented under this block
+```
+
+Do not leave duplicate top-level definitions active when the compiled module imports successfully.
+
+**Step 2: Run import smoke test**
+
+Run:
+```bash
+PYTHONPATH="/home/lvyufeng/lvyufeng/candle/.worktrees/feat/future-cython/src" python -c "import candle.futures as f; print(f._FUTURE_CYTHON); print(f.Future); print(f.collect_all)"
+```
+
+Expected before build: `False`, then Python classes/functions.
+
+**Step 3: Commit**
+
+```bash
+git add src/candle/futures.py
+git commit -m "feat: route futures module through Cython fast path with Python fallback"
+```
+
+---
+
+### Task 5: Build and verify end-to-end
+
+**Files:**
+- Modify if needed: `tests/cpu/test_futures.py`
+- Test: build + futures tests + import smoke tests
+
+**Step 1: Build the extension**
+
+Run:
+```bash
+python setup.py build_ext --inplace
+```
+
+Expected: output includes `building 'candle._cython._future' extension`.
+
+**Step 2: Run the focused futures tests**
+
+Run:
+```bash
+python -m pytest tests/cpu/test_futures.py -v --tb=short
+```
+
+Expected: PASS.
+
+**Step 3: Verify compiled fast path is active**
+
+Run:
+```bash
+PYTHONPATH="/home/lvyufeng/lvyufeng/candle/.worktrees/feat/future-cython/src" python -c "import candle.futures as f; print(f._FUTURE_CYTHON); fut = f.Future(); fut.set_result(1); print(fut.wait())"
+```
+
+Expected:
+- `_FUTURE_CYTHON == True`
+- `fut.wait()` prints `1`
+
+**Step 4: Verify distributed compatibility**
+
+Run:
+```bash
+PYTHONPATH="/home/lvyufeng/lvyufeng/candle/.worktrees/feat/future-cython/src" python -c "from candle.distributed._work import Work; w = Work(); fut = w.get_future(); print(type(fut).__name__); print(fut.wait())"
+```
+
+Expected:
+- prints `Future`
+- prints `[]`
+
+**Step 5: Run pylint on touched files**
+
+Run:
+```bash
+pylint src/candle/futures.py src/candle/_cython/_future.pyx --rcfile=.github/pylint.conf
+```
+
+Expected: no new pylint errors.
+
+**Step 6: Commit final fixes if any**
+
+```bash
+git add src/candle/futures.py src/candle/_cython/_future.pyx setup.py tests/cpu/test_futures.py
+git commit -m "test: verify Cython future alignment end-to-end"
+```
+
+---
+
+### Task 6: Clarify module comments and fallback semantics
+
+**Files:**
+- Modify: `src/candle/futures.py`
+- Modify: `src/candle/_cython/_future.pyx`
+
+**Step 1: Update docstrings/comments**
+
+Make sure:
+- `src/candle/_cython/_future.pyx` clearly states it is the compiled primary implementation
+- `src/candle/futures.py` clearly states it is the public import surface and Python fallback
+- the fallback import logic is easy to understand and mirrors the pattern already used in `_stream.py`
+
+**Step 2: Run import smoke test again**
+
+Run:
+```bash
+PYTHONPATH="/home/lvyufeng/lvyufeng/candle/.worktrees/feat/future-cython/src" python -c "import candle.futures as f; print(f._FUTURE_CYTHON); print(f.Future); print(f.collect_all)"
+```
+
+Expected: `True`, then compiled symbols.
+
+**Step 3: Commit**
+
+```bash
+git add src/candle/futures.py src/candle/_cython/_future.pyx
+git commit -m "docs: clarify Cython future fallback semantics"
+```

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,10 @@ if platform.system() == "Linux":
                     ["src/candle/_cython/_stream.pyx"],
                 ),
                 Extension(
+                    "candle._cython._future",
+                    ["src/candle/_cython/_future.pyx"],
+                ),
+                Extension(
                     "candle.distributed._c10d",
                     ["src/candle/distributed/_c10d.pyx"],
                 ),

--- a/src/candle/_cython/_future.pyx
+++ b/src/candle/_cython/_future.pyx
@@ -1,0 +1,142 @@
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""Thread-safe Future[T] and collect_all, pure-Python replacement for torch._C.Future."""
+
+import threading
+from typing import TypeVar, Generic, Optional, List, Callable
+
+T = TypeVar("T")
+S = TypeVar("S")
+
+
+class Future(Generic[T]):
+    """A thread-safe generic Future compatible with the PyTorch torch.futures.Future API.
+
+    Supports real async waiting: ``wait()`` blocks until another thread calls
+    ``set_result`` or ``set_exception``.
+    """
+
+    def __init__(self, *, devices=None):
+        self._result: Optional[T] = None
+        self._exception: Optional[BaseException] = None
+        self._done = False
+        self._event = threading.Event()
+        self._lock = threading.Lock()
+        self._done_callbacks: List[Callable] = []
+        self._devices = devices
+
+    # ---- producers ----
+
+    def set_result(self, result: T) -> None:
+        """Set the result, wake waiters, and fire done-callbacks."""
+        with self._lock:
+            if self._done:
+                raise RuntimeError("Future already completed")
+            self._result = result
+            self._done = True
+            self._event.set()
+            callbacks = list(self._done_callbacks)
+        for cb in callbacks:
+            cb(self)
+
+    def set_exception(self, exception: BaseException) -> None:
+        """Set an exception, wake waiters, and fire done-callbacks."""
+        with self._lock:
+            if self._done:
+                raise RuntimeError("Future already completed")
+            self._exception = exception
+            self._done = True
+            self._event.set()
+            callbacks = list(self._done_callbacks)
+        for cb in callbacks:
+            cb(self)
+
+    # ---- consumers ----
+
+    def wait(self) -> T:
+        """Block until the future completes and return the result.
+
+        Raises the stored exception if one was set.
+        """
+        self._event.wait()
+        if self._exception is not None:
+            raise self._exception
+        return self._result  # type: ignore[return-value]
+
+    def value(self) -> T:
+        """Alias for ``wait()``."""
+        return self.wait()
+
+    def done(self) -> bool:
+        """Return ``True`` if the future has completed."""
+        return self._done
+
+    # ---- chaining ----
+
+    def then(self, callback: Callable[["Future[T]"], S]) -> "Future[S]":
+        """Register *callback* and return a new ``Future[S]`` for its result.
+
+        *callback* receives this future (already completed) and should return
+        a value of type *S*.  If *callback* raises, the returned future gets
+        the exception instead.
+        """
+        new_future: "Future[S]" = Future()
+
+        def _run(source: "Future[T]") -> None:
+            try:
+                new_future.set_result(callback(source))
+            except Exception as exc:  # pylint: disable=broad-except
+                new_future.set_exception(exc)
+
+        with self._lock:
+            if self._done:
+                _run(self)
+            else:
+                self._done_callbacks.append(_run)
+        return new_future
+
+    def add_done_callback(self, callback: Callable[["Future[T]"], None]) -> None:
+        """Register a callback that fires when this future completes.
+
+        If the future is already done the callback runs immediately (in the
+        caller's thread).
+        """
+        with self._lock:
+            if self._done:
+                callback(self)
+            else:
+                self._done_callbacks.append(callback)
+
+
+def collect_all(futures: List[Future]) -> "Future[List[Future]]":
+    """Return a future that completes when every future in *futures* completes.
+
+    The result is the original list of (now-completed) futures.  If any input
+    future has an exception, the aggregate future propagates the first one.
+    """
+    result_future: Future[List[Future]] = Future()
+
+    if not futures:
+        result_future.set_result([])
+        return result_future
+
+    remaining = len(futures)
+    lock = threading.Lock()
+    first_exception: List[Optional[BaseException]] = [None]  # mutable cell
+
+    def _on_done(fut: Future) -> None:
+        nonlocal remaining
+        with lock:
+            if fut._exception is not None and first_exception[0] is None:  # pylint: disable=protected-access
+                first_exception[0] = fut._exception  # pylint: disable=protected-access
+            remaining -= 1
+            all_done = remaining == 0
+        if all_done:
+            if first_exception[0] is not None:
+                result_future.set_exception(first_exception[0])
+            else:
+                result_future.set_result(futures)
+
+    for f in futures:
+        f.add_done_callback(_on_done)
+
+    return result_future

--- a/src/candle/futures.py
+++ b/src/candle/futures.py
@@ -1,141 +1,154 @@
-"""Thread-safe Future[T] and collect_all, pure-Python replacement for torch._C.Future."""
+"""Public Future/collect_all surface with Cython fast path and Python fallback."""
 
-import threading
-from typing import TypeVar, Generic, Optional, List, Callable
+try:
+    from ._cython._future import Future, collect_all  # pylint: disable=no-name-in-module
+    _FUTURE_CYTHON = True
+except ModuleNotFoundError as exc:
+    if exc.name in {"candle._cython", "candle._cython._future"}:
+        _FUTURE_CYTHON = False
+    else:
+        raise
+except ImportError:
+    raise
 
-T = TypeVar("T")
-S = TypeVar("S")
+
+if not _FUTURE_CYTHON:
+    import threading
+    from typing import TypeVar, Generic, Optional, List, Callable
+
+    T = TypeVar("T")
+    S = TypeVar("S")
 
 
-class Future(Generic[T]):
-    """A thread-safe generic Future compatible with the PyTorch torch.futures.Future API.
+    class Future(Generic[T]):
+        """A thread-safe generic Future compatible with the PyTorch torch.futures.Future API.
 
-    Supports real async waiting: ``wait()`` blocks until another thread calls
-    ``set_result`` or ``set_exception``.
-    """
-
-    def __init__(self, *, devices=None):
-        self._result: Optional[T] = None
-        self._exception: Optional[BaseException] = None
-        self._done = False
-        self._event = threading.Event()
-        self._lock = threading.Lock()
-        self._done_callbacks: List[Callable] = []
-        self._devices = devices
-
-    # ---- producers ----
-
-    def set_result(self, result: T) -> None:
-        """Set the result, wake waiters, and fire done-callbacks."""
-        with self._lock:
-            if self._done:
-                raise RuntimeError("Future already completed")
-            self._result = result
-            self._done = True
-            self._event.set()
-            callbacks = list(self._done_callbacks)
-        for cb in callbacks:
-            cb(self)
-
-    def set_exception(self, exception: BaseException) -> None:
-        """Set an exception, wake waiters, and fire done-callbacks."""
-        with self._lock:
-            if self._done:
-                raise RuntimeError("Future already completed")
-            self._exception = exception
-            self._done = True
-            self._event.set()
-            callbacks = list(self._done_callbacks)
-        for cb in callbacks:
-            cb(self)
-
-    # ---- consumers ----
-
-    def wait(self) -> T:
-        """Block until the future completes and return the result.
-
-        Raises the stored exception if one was set.
+        Supports real async waiting: ``wait()`` blocks until another thread calls
+        ``set_result`` or ``set_exception``.
         """
-        self._event.wait()
-        if self._exception is not None:
-            raise self._exception
-        return self._result  # type: ignore[return-value]
 
-    def value(self) -> T:
-        """Alias for ``wait()``."""
-        return self.wait()
+        def __init__(self, *, devices=None):
+            self._result: Optional[T] = None
+            self._exception: Optional[BaseException] = None
+            self._done = False
+            self._event = threading.Event()
+            self._lock = threading.Lock()
+            self._done_callbacks: List[Callable] = []
+            self._devices = devices
 
-    def done(self) -> bool:
-        """Return ``True`` if the future has completed."""
-        return self._done
+        # ---- producers ----
 
-    # ---- chaining ----
+        def set_result(self, result: T) -> None:
+            """Set the result, wake waiters, and fire done-callbacks."""
+            with self._lock:
+                if self._done:
+                    raise RuntimeError("Future already completed")
+                self._result = result
+                self._done = True
+                self._event.set()
+                callbacks = list(self._done_callbacks)
+            for cb in callbacks:
+                cb(self)
 
-    def then(self, callback: Callable[["Future[T]"], S]) -> "Future[S]":
-        """Register *callback* and return a new ``Future[S]`` for its result.
+        def set_exception(self, exception: BaseException) -> None:
+            """Set an exception, wake waiters, and fire done-callbacks."""
+            with self._lock:
+                if self._done:
+                    raise RuntimeError("Future already completed")
+                self._exception = exception
+                self._done = True
+                self._event.set()
+                callbacks = list(self._done_callbacks)
+            for cb in callbacks:
+                cb(self)
 
-        *callback* receives this future (already completed) and should return
-        a value of type *S*.  If *callback* raises, the returned future gets
-        the exception instead.
+        # ---- consumers ----
+
+        def wait(self) -> T:
+            """Block until the future completes and return the result.
+
+            Raises the stored exception if one was set.
+            """
+            self._event.wait()
+            if self._exception is not None:
+                raise self._exception
+            return self._result  # type: ignore[return-value]
+
+        def value(self) -> T:
+            """Alias for ``wait()``."""
+            return self.wait()
+
+        def done(self) -> bool:
+            """Return ``True`` if the future has completed."""
+            return self._done
+
+        # ---- chaining ----
+
+        def then(self, callback: Callable[["Future[T]"], S]) -> "Future[S]":
+            """Register *callback* and return a new ``Future[S]`` for its result.
+
+            *callback* receives this future (already completed) and should return
+            a value of type *S*.  If *callback* raises, the returned future gets
+            the exception instead.
+            """
+            new_future: "Future[S]" = Future()
+
+            def _run(source: "Future[T]") -> None:
+                try:
+                    new_future.set_result(callback(source))
+                except Exception as exc:  # pylint: disable=broad-except
+                    new_future.set_exception(exc)
+
+            with self._lock:
+                if self._done:
+                    _run(self)
+                else:
+                    self._done_callbacks.append(_run)
+            return new_future
+
+        def add_done_callback(self, callback: Callable[["Future[T]"], None]) -> None:
+            """Register a callback that fires when this future completes.
+
+            If the future is already done the callback runs immediately (in the
+            caller's thread).
+            """
+            with self._lock:
+                if self._done:
+                    callback(self)
+                else:
+                    self._done_callbacks.append(callback)
+
+
+    def collect_all(futures: List[Future]) -> "Future[List[Future]]":
+        """Return a future that completes when every future in *futures* completes.
+
+        The result is the original list of (now-completed) futures.  If any input
+        future has an exception, the aggregate future propagates the first one.
         """
-        new_future: "Future[S]" = Future()
+        result_future: Future[List[Future]] = Future()
 
-        def _run(source: "Future[T]") -> None:
-            try:
-                new_future.set_result(callback(source))
-            except Exception as exc:  # pylint: disable=broad-except
-                new_future.set_exception(exc)
+        if not futures:
+            result_future.set_result([])
+            return result_future
 
-        with self._lock:
-            if self._done:
-                _run(self)
-            else:
-                self._done_callbacks.append(_run)
-        return new_future
+        remaining = len(futures)
+        lock = threading.Lock()
+        first_exception: List[Optional[BaseException]] = [None]  # mutable cell
 
-    def add_done_callback(self, callback: Callable[["Future[T]"], None]) -> None:
-        """Register a callback that fires when this future completes.
+        def _on_done(fut: Future) -> None:
+            nonlocal remaining
+            with lock:
+                if fut._exception is not None and first_exception[0] is None:  # pylint: disable=protected-access
+                    first_exception[0] = fut._exception  # pylint: disable=protected-access
+                remaining -= 1
+                all_done = remaining == 0
+            if all_done:
+                if first_exception[0] is not None:
+                    result_future.set_exception(first_exception[0])
+                else:
+                    result_future.set_result(futures)
 
-        If the future is already done the callback runs immediately (in the
-        caller's thread).
-        """
-        with self._lock:
-            if self._done:
-                callback(self)
-            else:
-                self._done_callbacks.append(callback)
+        for f in futures:
+            f.add_done_callback(_on_done)
 
-
-def collect_all(futures: List[Future]) -> "Future[List[Future]]":
-    """Return a future that completes when every future in *futures* completes.
-
-    The result is the original list of (now-completed) futures.  If any input
-    future has an exception, the aggregate future propagates the first one.
-    """
-    result_future: Future[List[Future]] = Future()
-
-    if not futures:
-        result_future.set_result([])
         return result_future
-
-    remaining = len(futures)
-    lock = threading.Lock()
-    first_exception: List[Optional[BaseException]] = [None]  # mutable cell
-
-    def _on_done(fut: Future) -> None:
-        nonlocal remaining
-        with lock:
-            if fut._exception is not None and first_exception[0] is None:  # pylint: disable=protected-access
-                first_exception[0] = fut._exception  # pylint: disable=protected-access
-            remaining -= 1
-            all_done = remaining == 0
-        if all_done:
-            if first_exception[0] is not None:
-                result_future.set_exception(first_exception[0])
-            else:
-                result_future.set_result(futures)
-
-    for f in futures:
-        f.add_done_callback(_on_done)
-
-    return result_future

--- a/tests/cpu/test_futures.py
+++ b/tests/cpu/test_futures.py
@@ -1,0 +1,80 @@
+import threading
+
+from candle.futures import Future, collect_all
+
+
+def test_future_basic_result():
+    fut = Future()
+    fut.set_result(42)
+    assert fut.done() is True
+    assert fut.wait() == 42
+    assert fut.value() == 42
+
+
+def test_future_exception_propagates():
+    fut = Future()
+    fut.set_exception(RuntimeError("boom"))
+
+    try:
+        fut.wait()
+        assert False, "expected exception"
+    except RuntimeError as exc:
+        assert str(exc) == "boom"
+
+
+def test_future_then_chains_result():
+    fut = Future()
+    chained = fut.then(lambda src: src.wait() * 2)
+    fut.set_result(21)
+    assert chained.wait() == 42
+
+
+def test_future_add_done_callback_after_completion_runs_immediately():
+    fut = Future()
+    seen = []
+    fut.set_result("ok")
+    fut.add_done_callback(lambda f: seen.append(f.wait()))
+    assert seen == ["ok"]
+
+
+def test_collect_all_returns_original_futures_in_order():
+    futures = [Future(), Future(), Future()]
+    agg = collect_all(futures)
+    futures[0].set_result("a")
+    futures[1].set_result("b")
+    futures[2].set_result("c")
+    assert agg.wait() == futures
+
+
+def test_collect_all_propagates_first_exception_after_all_done():
+    futures = [Future(), Future()]
+    agg = collect_all(futures)
+    futures[0].set_exception(ValueError("bad"))
+    futures[1].set_result("ok")
+
+    try:
+        agg.wait()
+        assert False, "expected exception"
+    except ValueError as exc:
+        assert str(exc) == "bad"
+
+
+def test_future_wait_blocks_until_other_thread_sets_result():
+    fut = Future()
+    seen = []
+
+    def waiter():
+        seen.append(fut.wait())
+
+    thread = threading.Thread(target=waiter)
+    thread.start()
+    fut.set_result("threaded")
+    thread.join(timeout=2)
+    assert seen == ["threaded"]
+
+
+def test_future_module_reports_compiled_fast_path():
+    import candle.futures as futures_mod
+
+    assert hasattr(futures_mod, "_FUTURE_CYTHON")
+    assert futures_mod._FUTURE_CYTHON is True


### PR DESCRIPTION
## Summary

This PR moves candle's `Future` / `collect_all` implementation onto a compiled Cython fast path while preserving the existing `candle.futures` import surface and the pure-Python fallback.

The public API stays the same:
- `Future.__init__(*, devices=None)`
- `set_result`
- `set_exception`
- `wait`
- `value`
- `done`
- `then`
- `add_done_callback`
- `collect_all`

## What changed

### 1. Added compiled primary implementation
New file:
- `src/candle/_cython/_future.pyx`

This is a direct Cython port of the current `src/candle/futures.py` logic. The first version intentionally keeps behavior unchanged and does not redesign the abstraction.

Implemented in the compiled module:
- `Future`
- `collect_all`

### 2. Converted `futures.py` into a fast-path loader + fallback
Updated file:
- `src/candle/futures.py`

`futures.py` now:
- imports `Future` / `collect_all` from `candle._cython._future` when available
- exposes `_FUTURE_CYTHON` so the active path is visible in tests/smoke checks
- falls back to the existing pure-Python implementation when the compiled module is missing
- narrows fallback to missing-module cases only, instead of swallowing unrelated import failures

This matches the pattern already used for the recent stream Cython migration.

### 3. Added build target
Updated file:
- `setup.py`

New extension:
- `candle._cython._future`

### 4. Added focused regression and compatibility tests
New file:
- `tests/cpu/test_futures.py`

Coverage includes:
- basic result propagation
- exception propagation
- `then()` chaining
- immediate callback execution after completion
- `collect_all()` ordering
- `collect_all()` exception propagation after all futures complete
- cross-thread blocking `wait()`
- compiled fast-path activation via `_FUTURE_CYTHON`

## Compatibility

This PR keeps existing callers unchanged.

In particular, `distributed.Work.get_future()` still does:
- `from ..futures import Future`
- constructs a `Future`
- returns `[]` from `wait()` on an empty `Work.result()`

That path was explicitly smoke-tested after the migration.

## Verification

### Build
- `python setup.py build_ext --inplace`
- verified `candle._cython._future` builds successfully

### Tests
- `python -m pytest tests/cpu/test_futures.py -v --tb=short`
- result: **8 passed**

### Smoke checks
Verified:
- `_FUTURE_CYTHON == True` after build
- `Future().set_result(1); wait() == 1`
- `distributed.Work.get_future()` still returns `Future` and `wait() == []`

## Files changed

- `setup.py`
- `src/candle/_cython/_future.pyx`
- `src/candle/futures.py`
- `tests/cpu/test_futures.py`
- `docs/plans/2026-03-19-future-cython-alignment.md`
