### PR TITLE
build(cython): add macOS support for cross-platform extensions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,18 +28,13 @@ required_extensions = [
     ),
 ]
 
-linux_only_extensions = []
-if platform.system() == "Linux":
-    linux_only_extensions = [
-        Extension(
-            "candle._cython._aclnn_ffi",
-            ["src/candle/_cython/_aclnn_ffi.pyx"],
-            libraries=["dl"],
-        ),
-        Extension(
-            "candle._cython._npu_ops",
-            ["src/candle/_cython/_npu_ops.pyx"],
-        ),
+# ---------------------------------------------------------------------------
+# Cross-platform extensions (Linux + macOS)
+# ---------------------------------------------------------------------------
+_system = platform.system()
+cross_platform_extensions = []
+if _system in ("Linux", "Darwin"):
+    cross_platform_extensions = [
         Extension(
             "candle._cython._dispatch",
             ["src/candle/_cython/_dispatch.pyx"],
@@ -84,6 +79,23 @@ if platform.system() == "Linux":
             "candle.distributed._c10d_gloo",
             ["src/candle/distributed/_c10d_gloo.pyx"],
         ),
+    ]
+
+# ---------------------------------------------------------------------------
+# Linux-only extensions (NPU/CANN/HCCL — not available on macOS)
+# ---------------------------------------------------------------------------
+linux_only_extensions = []
+if _system == "Linux":
+    linux_only_extensions = [
+        Extension(
+            "candle._cython._aclnn_ffi",
+            ["src/candle/_cython/_aclnn_ffi.pyx"],
+            libraries=["dl"],
+        ),
+        Extension(
+            "candle._cython._npu_ops",
+            ["src/candle/_cython/_npu_ops.pyx"],
+        ),
         Extension(
             "candle.distributed._c10d_hccl",
             ["src/candle/distributed/_c10d_hccl.pyx"],
@@ -91,7 +103,7 @@ if platform.system() == "Linux":
     ]
 
 ext_modules = cythonize(
-    required_extensions + linux_only_extensions,
+    required_extensions + cross_platform_extensions + linux_only_extensions,
     compiler_directives={
         "language_level": "3",
         "boundscheck": False,


### PR DESCRIPTION
## Summary

Split Cython extensions into three groups based on platform support:

- **required** (all platforms): `_stream`, `_future`
- **cross_platform** (Linux + macOS): `_dispatch`, `_allocator`, `_storage`, `_tensor_impl`, `_dispatcher_core`, `_device`, `_dtype`, `_autograd_node`, `_fast_ops`, `_c10d`, `_c10d_gloo`
- **linux_only** (NPU/CANN/HCCL): `_aclnn_ffi`, `_npu_ops`, `_c10d_hccl`

Previously all non-required extensions were gated behind `platform.system() == "Linux"`, so macOS builds only got `_stream` and `_future`. Now all generic Cython extensions build on macOS as well.

## Testing

Built and verified all 13 extensions compile successfully on macOS Apple Silicon (arm64) with clang.