### PR TITLE
feat(cpu): Cython fast-path kernels for element-wise and activation ops

### DIFF
--- a/docs/superpowers/plans/2026-03-20-cython-cpu-ops.md
+++ b/docs/superpowers/plans/2026-03-20-cython-cpu-ops.md
@@ -1,0 +1,486 @@
+# Cython CPU Ops Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace NumPy ufunc calls in `_backends/cpu/ops.py` with Cython kernels that operate directly on raw C memory, eliminating NumPy from the arithmetic hot path.
+
+**Architecture:** Storage is numpy-backed (`_CPUUntypedStorage._array`). `t._numpy_view()` returns a zero-copy strided numpy array. Cython kernels receive C-contiguous typed `float[::1]` / `double[::1]` memoryviews (caller flattens+contiguous), compute in C loops with `libc.math` intrinsics, and write into a pre-allocated numpy output buffer. NumPy is retained only for memory allocation (`np.empty`) and buffer wrapping — never for arithmetic. A `_cpu_kernels_fallback.py` with `None` stubs keeps everything importable when the `.so` is absent.
+
+**Tech Stack:** Cython 3.x, libc.math (expf/logf/erff/…), cblas (sgemm/dgemm), Python 3.11, Linux aarch64 + macOS arm64
+
+---
+
+## Chunk 1: Skeleton — new pyx file, fallback, build wiring
+
+### Task 1: Create `_cpu_kernels_fallback.py`
+
+**Files:**
+- Create: `src/candle/_cython/_cpu_kernels_fallback.py`
+
+- [ ] **Step 1: Write the file**
+
+```python
+"""Pure-Python fallback for _cpu_kernels.pyx.
+
+All symbols are None; ops.py falls back to numpy when Cython .so is absent.
+"""
+# element-wise binary (float32)
+add_f32 = None
+sub_f32 = None
+mul_f32 = None
+div_f32 = None
+# element-wise binary (float64)
+add_f64 = None
+sub_f64 = None
+mul_f64 = None
+div_f64 = None
+# scalar binary (float32)
+add_scalar_f32 = None
+sub_scalar_f32 = None
+mul_scalar_f32 = None
+div_scalar_f32 = None
+# scalar binary (float64)
+add_scalar_f64 = None
+sub_scalar_f64 = None
+mul_scalar_f64 = None
+div_scalar_f64 = None
+# unary float32
+neg_f32 = None
+abs_f32 = None
+relu_f32 = None
+gelu_f32 = None
+sigmoid_f32 = None
+exp_f32 = None
+log_f32 = None
+sqrt_f32 = None
+rsqrt_f32 = None
+sin_f32 = None
+cos_f32 = None
+tan_f32 = None
+tanh_f32 = None
+sinh_f32 = None
+cosh_f32 = None
+asinh_f32 = None
+acosh_f32 = None
+atanh_f32 = None
+erf_f32 = None
+erfc_f32 = None
+exp2_f32 = None
+log2_f32 = None
+log10_f32 = None
+pow_f32 = None
+square_f32 = None
+# unary float64
+neg_f64 = None
+abs_f64 = None
+relu_f64 = None
+gelu_f64 = None
+sigmoid_f64 = None
+exp_f64 = None
+log_f64 = None
+sqrt_f64 = None
+rsqrt_f64 = None
+sin_f64 = None
+cos_f64 = None
+tan_f64 = None
+tanh_f64 = None
+sinh_f64 = None
+cosh_f64 = None
+asinh_f64 = None
+acosh_f64 = None
+atanh_f64 = None
+erf_f64 = None
+erfc_f64 = None
+exp2_f64 = None
+log2_f64 = None
+log10_f64 = None
+pow_f64 = None
+square_f64 = None
+# matmul
+matmul_f32 = None
+matmul_f64 = None
+```
+
+- [ ] **Step 2: Verify importable**
+
+```bash
+cd .worktrees/cython-cpu-ops
+source /opt/miniconda3/etc/profile.d/conda.sh && conda run -n candle python -c "from candle._cython._cpu_kernels_fallback import add_f32; print('ok')"
+```
+Expected: `ok`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/candle/_cython/_cpu_kernels_fallback.py
+git commit -m "feat(cython-cpu): add _cpu_kernels_fallback skeleton"
+```
+
+---
+
+### Task 2: Create `_cpu_kernels.pyx` with element-wise binary + unary kernels
+
+**Files:**
+- Create: `src/candle/_cython/_cpu_kernels.pyx`
+
+- [ ] **Step 1: Write `_cpu_kernels.pyx`**
+
+The file must:
+- Use `# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True`
+- Use `cimport cython` and `from libc.math cimport ...`
+- Fused types `floating` = `float | double` (Cython fused type)
+- All kernels take flat C-contiguous 1-D typed memoryviews `floating[::1]`
+- All kernels return `void` (write into pre-allocated `out`)
+
+```cython
+# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
+"""Cython CPU kernels — pure C loops, no NumPy arithmetic."""
+
+cimport cython
+from libc.math cimport (
+    expf, logf, sqrtf, sinf, cosf, tanf, tanhf,
+    sinhf, coshf, asinhf, acoshf, atanhf, erff, erfcf,
+    exp2f, log2f, log10f, powf, fabsf,
+    exp, log, sqrt, sin, cos, tan, tanh,
+    sinh, cosh, asinh, acosh, atanh, erf, erfc,
+    exp2, log2, log10, pow, fabs,
+)
+
+# Fused type covering float32 and float64
+ctypedef fused floating:
+    float
+    double
+
+
+# ---------------------------------------------------------------------------
+# Element-wise binary: float32
+# ---------------------------------------------------------------------------
+
+def add_f32(float[::1] a, float[::1] b, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] + b[i]
+
+def sub_f32(float[::1] a, float[::1] b, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] - b[i]
+
+def mul_f32(float[::1] a, float[::1] b, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] * b[i]
+
+def div_f32(float[::1] a, float[::1] b, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] / b[i]
+
+# ---------------------------------------------------------------------------
+# Element-wise binary: float64
+# ---------------------------------------------------------------------------
+
+def add_f64(double[::1] a, double[::1] b, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] + b[i]
+
+def sub_f64(double[::1] a, double[::1] b, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] - b[i]
+
+def mul_f64(double[::1] a, double[::1] b, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] * b[i]
+
+def div_f64(double[::1] a, double[::1] b, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] / b[i]
+
+# ---------------------------------------------------------------------------
+# Scalar binary: float32  (a is tensor, b is Python scalar)
+# ---------------------------------------------------------------------------
+
+def add_scalar_f32(float[::1] a, float b, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] + b
+
+def sub_scalar_f32(float[::1] a, float b, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] - b
+
+def mul_scalar_f32(float[::1] a, float b, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] * b
+
+def div_scalar_f32(float[::1] a, float b, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] / b
+
+# ---------------------------------------------------------------------------
+# Scalar binary: float64
+# ---------------------------------------------------------------------------
+
+def add_scalar_f64(double[::1] a, double b, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] + b
+
+def sub_scalar_f64(double[::1] a, double b, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] - b
+
+def mul_scalar_f64(double[::1] a, double b, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] * b
+
+def div_scalar_f64(double[::1] a, double b, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] / b
+
+# ---------------------------------------------------------------------------
+# Unary: float32
+# ---------------------------------------------------------------------------
+
+def neg_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = -a[i]
+
+def abs_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = fabsf(a[i])
+
+def relu_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] if a[i] > 0.0 else 0.0
+
+def gelu_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    cdef float x
+    cdef float M_SQRT1_2 = 0.7071067811865476
+    for i in range(n):
+        x = a[i]
+        out[i] = 0.5 * x * (1.0 + erff(x * M_SQRT1_2))
+
+def sigmoid_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = 1.0 / (1.0 + expf(-a[i]))
+
+def exp_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = expf(a[i])
+
+def log_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = logf(a[i])
+
+def sqrt_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = sqrtf(a[i])
+
+def rsqrt_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = 1.0 / sqrtf(a[i])
+
+def sin_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = sinf(a[i])
+
+def cos_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = cosf(a[i])
+
+def tan_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = tanf(a[i])
+
+def tanh_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = tanhf(a[i])
+
+def sinh_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = sinhf(a[i])
+
+def cosh_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = coshf(a[i])
+
+def asinh_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = asinhf(a[i])
+
+def acosh_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = acoshf(a[i])
+
+def atanh_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = atanhf(a[i])
+
+def erf_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = erff(a[i])
+
+def erfc_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = erfcf(a[i])
+
+def exp2_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = exp2f(a[i])
+
+def log2_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = log2f(a[i])
+
+def log10_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = log10f(a[i])
+
+def pow_f32(float[::1] a, float b, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = powf(a[i], b)
+
+def square_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] * a[i]
+
+# ---------------------------------------------------------------------------
+# Unary: float64
+# ---------------------------------------------------------------------------
+
+def neg_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = -a[i]
+
+def abs_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = fabs(a[i])
+
+def relu_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] if a[i] > 0.0 else 0.0
+
+def gelu_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    cdef double x
+    cdef double M_SQRT1_2 = 0.7071067811865476
+    for i in range(n):
+        x = a[i]
+        out[i] = 0.5 * x * (1.0 + erf(x * M_SQRT1_2))
+
+def sigmoid_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = 1.0 / (1.0 + exp(-a[i]))
+
+def exp_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = exp(a[i])
+
+def log_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = log(a[i])
+
+def sqrt_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = sqrt(a[i])
+
+def rsqrt_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = 1.0 / sqrt(a[i])
+
+def sin_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = sin(a[i])
+
+def cos_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = cos(a[i])
+
+def tan_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = tan(a[i])
+
+def tanh_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = tanh(a[i])
+
+def sinh_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = sinh(a[i])
+
+def cosh_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = cosh(a[i])
+
+def asinh_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = asinh(a[i])
+
+def acosh_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = acosh(a[i])
+
+def atanh_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = atanh(a[i])
+
+def erf_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = erf(a[i])
+
+def erfc_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,11 @@ if _system in ("Linux", "Darwin"):
             ["src/candle/_cython/_fast_ops.pyx"],
         ),
         Extension(
+            "candle._cython._cpu_kernels",
+            ["src/candle/_cython/_cpu_kernels.pyx"],
+            extra_compile_args=["-O3", "-ffast-math"],
+        ),
+        Extension(
             "candle.distributed._c10d",
             ["src/candle/distributed/_c10d.pyx"],
         ),

--- a/src/candle/_backends/cpu/ops.py
+++ b/src/candle/_backends/cpu/ops.py
@@ -1,6 +1,11 @@
 import math
 import numpy as np
 
+try:
+    from ..._cython import _cpu_kernels as _ck
+except ImportError:
+    from ..._cython import _cpu_kernels_fallback as _ck  # type: ignore[no-redef]
+
 from ..._dtype import bool as bool_dtype
 from ..._dtype import bfloat16 as bfloat16_dtype
 from ..._dtype import complex64 as complex64_dtype
@@ -120,15 +125,87 @@ def _binary_out_dtype(a, b, *, for_div=False):
     return _promote_binary_dtype(dtype_a, dtype_b)
 
 
+def _cython_unary(kernel_f32, kernel_f64, arr, out_np_dtype):
+    """Apply a Cython unary kernel to a numpy array, returning a numpy result.
+
+    Falls back to returning None if the array dtype is not float32/float64 or
+    if the Cython extension is not available (kernel is None).
+    """
+    if kernel_f32 is None:
+        return None
+    if arr.dtype == np.float32 and kernel_f32 is not None:
+        flat = np.ascontiguousarray(arr).ravel()
+        out = np.empty(flat.shape[0], dtype=np.float32)
+        kernel_f32(flat, out)
+        return out.reshape(arr.shape).astype(out_np_dtype, copy=False)
+    if arr.dtype == np.float64 and kernel_f64 is not None:
+        flat = np.ascontiguousarray(arr).ravel()
+        out = np.empty(flat.shape[0], dtype=np.float64)
+        kernel_f64(flat, out)
+        return out.reshape(arr.shape).astype(out_np_dtype, copy=False)
+    return None
+
+
+def _cython_binary(kernel_f32, kernel_f64, a_arr, b_arr, out_np_dtype):
+    """Apply a Cython element-wise binary kernel.
+
+    Only used when both arrays have the same shape (no broadcast needed) and
+    are float32 or float64.  Returns None otherwise so callers fall back to
+    numpy.
+    """
+    if kernel_f32 is None or a_arr.shape != b_arr.shape:
+        return None
+    if a_arr.dtype == np.float32 and b_arr.dtype == np.float32:
+        a_flat = np.ascontiguousarray(a_arr).ravel()
+        b_flat = np.ascontiguousarray(b_arr).ravel()
+        out = np.empty(a_flat.shape[0], dtype=np.float32)
+        kernel_f32(a_flat, b_flat, out)
+        return out.reshape(a_arr.shape).astype(out_np_dtype, copy=False)
+    if a_arr.dtype == np.float64 and b_arr.dtype == np.float64:
+        a_flat = np.ascontiguousarray(a_arr).ravel()
+        b_flat = np.ascontiguousarray(b_arr).ravel()
+        out = np.empty(a_flat.shape[0], dtype=np.float64)
+        kernel_f64(a_flat, b_flat, out)
+        return out.reshape(a_arr.shape).astype(out_np_dtype, copy=False)
+    return None
+
+
+def _cython_scalar_binary(kernel_f32, kernel_f64, a_arr, scalar, out_np_dtype):
+    """Apply a Cython tensor-scalar binary kernel.
+
+    Returns None if Cython unavailable or dtype not float32/float64.
+    """
+    if kernel_f32 is None:
+        return None
+    if a_arr.dtype == np.float32:
+        flat = np.ascontiguousarray(a_arr).ravel()
+        out = np.empty(flat.shape[0], dtype=np.float32)
+        kernel_f32(flat, float(scalar), out)
+        return out.reshape(a_arr.shape).astype(out_np_dtype, copy=False)
+    if a_arr.dtype == np.float64:
+        flat = np.ascontiguousarray(a_arr).ravel()
+        out = np.empty(flat.shape[0], dtype=np.float64)
+        kernel_f64(flat, float(scalar), out)
+        return out.reshape(a_arr.shape).astype(out_np_dtype, copy=False)
+    return None
+
+
 def add(a, b):
     a_np = _to_numpy(a)
     b_np = _to_numpy(b) if isinstance(b, Tensor) else b
     out_dtype = _binary_out_dtype(a, b)
+    out_np_dtype = to_numpy_dtype(out_dtype)
+    if isinstance(b, Tensor):
+        result = _cython_binary(_ck.add_f32, _ck.add_f64, a_np, b_np, out_np_dtype)
+    else:
+        result = _cython_scalar_binary(_ck.add_scalar_f32, _ck.add_scalar_f64, a_np, b_np, out_np_dtype)
+    if result is not None:
+        return _from_numpy(result, out_dtype, a.device)
     try:
         out = np.add(a_np, b_np)
     except ValueError as exc:
         raise RuntimeError(str(exc)) from exc
-    out = out.astype(to_numpy_dtype(out_dtype), copy=False)
+    out = out.astype(out_np_dtype, copy=False)
     return _from_numpy(out, out_dtype, a.device)
 
 
@@ -136,7 +213,14 @@ def mul(a, b):
     a_np = _to_numpy(a)
     b_np = _to_numpy(b) if isinstance(b, Tensor) else b
     out_dtype = _binary_out_dtype(a, b)
-    out = np.multiply(a_np, b_np).astype(to_numpy_dtype(out_dtype), copy=False)
+    out_np_dtype = to_numpy_dtype(out_dtype)
+    if isinstance(b, Tensor):
+        result = _cython_binary(_ck.mul_f32, _ck.mul_f64, a_np, b_np, out_np_dtype)
+    else:
+        result = _cython_scalar_binary(_ck.mul_scalar_f32, _ck.mul_scalar_f64, a_np, b_np, out_np_dtype)
+    if result is not None:
+        return _from_numpy(result, out_dtype, a.device)
+    out = np.multiply(a_np, b_np).astype(out_np_dtype, copy=False)
     return _from_numpy(out, out_dtype, a.device)
 
 
@@ -144,8 +228,15 @@ def div(a, b):
     a_np = _to_numpy(a)
     b_np = _to_numpy(b) if isinstance(b, Tensor) else b
     out_dtype = _binary_out_dtype(a, b, for_div=True)
+    out_np_dtype = to_numpy_dtype(out_dtype)
+    if isinstance(b, Tensor):
+        result = _cython_binary(_ck.div_f32, _ck.div_f64, a_np, b_np, out_np_dtype)
+    else:
+        result = _cython_scalar_binary(_ck.div_scalar_f32, _ck.div_scalar_f64, a_np, b_np, out_np_dtype)
+    if result is not None:
+        return _from_numpy(result, out_dtype, a.device)
     with np.errstate(divide="ignore", invalid="ignore"):
-        out = np.true_divide(a_np, b_np).astype(to_numpy_dtype(out_dtype), copy=False)
+        out = np.true_divide(a_np, b_np).astype(out_np_dtype, copy=False)
     return _from_numpy(out, out_dtype, a.device)
 
 
@@ -166,11 +257,18 @@ def bmm(a, b):
 
 
 def relu(a):
-    return _from_numpy(np.maximum(_to_numpy(a), 0), a.dtype, a.device)
+    arr = _to_numpy(a)
+    result = _cython_unary(_ck.relu_f32, _ck.relu_f64, arr, to_numpy_dtype(a.dtype))
+    if result is not None:
+        return _from_numpy(result, a.dtype, a.device)
+    return _from_numpy(np.maximum(arr, 0), a.dtype, a.device)
 
 
 def gelu(a):
     arr = _to_numpy(a)
+    result = _cython_unary(_ck.gelu_f32, _ck.gelu_f64, arr, to_numpy_dtype(a.dtype))
+    if result is not None:
+        return _from_numpy(result, a.dtype, a.device)
     out = 0.5 * arr * (1.0 + np.vectorize(math.erf)(arr / math.sqrt(2.0)))
     return _from_numpy(np.ascontiguousarray(out), a.dtype, a.device)
 
@@ -1038,43 +1136,82 @@ def contiguous(a):
 
 
 def abs(a):
-    return _from_numpy(np.abs(_to_numpy(a)), a.dtype, a.device)
+    arr = _to_numpy(a)
+    result = _cython_unary(_ck.abs_f32, _ck.abs_f64, arr, to_numpy_dtype(a.dtype))
+    if result is not None:
+        return _from_numpy(result, a.dtype, a.device)
+    return _from_numpy(np.abs(arr), a.dtype, a.device)
 
 
 def neg(a):
-    return _from_numpy(np.negative(_to_numpy(a)), a.dtype, a.device)
+    arr = _to_numpy(a)
+    result = _cython_unary(_ck.neg_f32, _ck.neg_f64, arr, to_numpy_dtype(a.dtype))
+    if result is not None:
+        return _from_numpy(result, a.dtype, a.device)
+    return _from_numpy(np.negative(arr), a.dtype, a.device)
 
 
 def exp(a):
-    return _from_numpy(np.exp(_to_numpy(a)), a.dtype, a.device)
+    arr = _to_numpy(a)
+    result = _cython_unary(_ck.exp_f32, _ck.exp_f64, arr, to_numpy_dtype(a.dtype))
+    if result is not None:
+        return _from_numpy(result, a.dtype, a.device)
+    return _from_numpy(np.exp(arr), a.dtype, a.device)
 
 
 def log(a):
-    return _from_numpy(np.log(_to_numpy(a)), a.dtype, a.device)
+    arr = _to_numpy(a)
+    result = _cython_unary(_ck.log_f32, _ck.log_f64, arr, to_numpy_dtype(a.dtype))
+    if result is not None:
+        return _from_numpy(result, a.dtype, a.device)
+    return _from_numpy(np.log(arr), a.dtype, a.device)
 
 
 def sqrt(a):
-    return _from_numpy(np.sqrt(_to_numpy(a)), a.dtype, a.device)
+    arr = _to_numpy(a)
+    result = _cython_unary(_ck.sqrt_f32, _ck.sqrt_f64, arr, to_numpy_dtype(a.dtype))
+    if result is not None:
+        return _from_numpy(result, a.dtype, a.device)
+    return _from_numpy(np.sqrt(arr), a.dtype, a.device)
 
 
 def sin(a):
-    return _from_numpy(np.sin(_to_numpy(a)), a.dtype, a.device)
+    arr = _to_numpy(a)
+    result = _cython_unary(_ck.sin_f32, _ck.sin_f64, arr, to_numpy_dtype(a.dtype))
+    if result is not None:
+        return _from_numpy(result, a.dtype, a.device)
+    return _from_numpy(np.sin(arr), a.dtype, a.device)
 
 
 def cos(a):
-    return _from_numpy(np.cos(_to_numpy(a)), a.dtype, a.device)
+    arr = _to_numpy(a)
+    result = _cython_unary(_ck.cos_f32, _ck.cos_f64, arr, to_numpy_dtype(a.dtype))
+    if result is not None:
+        return _from_numpy(result, a.dtype, a.device)
+    return _from_numpy(np.cos(arr), a.dtype, a.device)
 
 
 def tan(a):
-    return _from_numpy(np.tan(_to_numpy(a)), a.dtype, a.device)
+    arr = _to_numpy(a)
+    result = _cython_unary(_ck.tan_f32, _ck.tan_f64, arr, to_numpy_dtype(a.dtype))
+    if result is not None:
+        return _from_numpy(result, a.dtype, a.device)
+    return _from_numpy(np.tan(arr), a.dtype, a.device)
 
 
 def tanh(a):
-    return _from_numpy(np.tanh(_to_numpy(a)), a.dtype, a.device)
+    arr = _to_numpy(a)
+    result = _cython_unary(_ck.tanh_f32, _ck.tanh_f64, arr, to_numpy_dtype(a.dtype))
+    if result is not None:
+        return _from_numpy(result, a.dtype, a.device)
+    return _from_numpy(np.tanh(arr), a.dtype, a.device)
 
 
 def sigmoid(a):
     arr = _to_numpy(a)
+    result = _cython_unary(_ck.sigmoid_f32, _ck.sigmoid_f64, arr, to_numpy_dtype(a.dtype))
+    if result is not None:
+        return _from_numpy(result, a.dtype, a.device)
     out = 1.0 / (1.0 + np.exp(-arr))
     return _from_numpy(out, a.dtype, a.device)
 
@@ -1116,19 +1253,34 @@ def pow(a, b):
 
 
 def log2(a):
-    return _from_numpy(np.log2(_to_numpy(a)), a.dtype, a.device)
+    arr = _to_numpy(a)
+    result = _cython_unary(_ck.log2_f32, _ck.log2_f64, arr, to_numpy_dtype(a.dtype))
+    if result is not None:
+        return _from_numpy(result, a.dtype, a.device)
+    return _from_numpy(np.log2(arr), a.dtype, a.device)
 
 
 def log10(a):
-    return _from_numpy(np.log10(_to_numpy(a)), a.dtype, a.device)
+    arr = _to_numpy(a)
+    result = _cython_unary(_ck.log10_f32, _ck.log10_f64, arr, to_numpy_dtype(a.dtype))
+    if result is not None:
+        return _from_numpy(result, a.dtype, a.device)
+    return _from_numpy(np.log10(arr), a.dtype, a.device)
 
 
 def exp2(a):
-    return _from_numpy(np.exp2(_to_numpy(a)), a.dtype, a.device)
+    arr = _to_numpy(a)
+    result = _cython_unary(_ck.exp2_f32, _ck.exp2_f64, arr, to_numpy_dtype(a.dtype))
+    if result is not None:
+        return _from_numpy(result, a.dtype, a.device)
+    return _from_numpy(np.exp2(arr), a.dtype, a.device)
 
 
 def rsqrt(a):
     arr = _to_numpy(a)
+    result = _cython_unary(_ck.rsqrt_f32, _ck.rsqrt_f64, arr, to_numpy_dtype(a.dtype))
+    if result is not None:
+        return _from_numpy(result, a.dtype, a.device)
     out = 1.0 / np.sqrt(arr)
     return _from_numpy(out, a.dtype, a.device)
 
@@ -1139,6 +1291,9 @@ def sign(a):
 
 def square(a):
     arr = _to_numpy(a)
+    result = _cython_unary(_ck.square_f32, _ck.square_f64, arr, to_numpy_dtype(a.dtype))
+    if result is not None:
+        return _from_numpy(result, a.dtype, a.device)
     out = np.square(arr)
     return _from_numpy(np.ascontiguousarray(out), a.dtype, a.device)
 
@@ -1164,33 +1319,59 @@ def isfinite(a):
 
 
 def sinh(a):
-    return _from_numpy(np.sinh(_to_numpy(a)), a.dtype, a.device)
+    arr = _to_numpy(a)
+    result = _cython_unary(_ck.sinh_f32, _ck.sinh_f64, arr, to_numpy_dtype(a.dtype))
+    if result is not None:
+        return _from_numpy(result, a.dtype, a.device)
+    return _from_numpy(np.sinh(arr), a.dtype, a.device)
 
 
 def cosh(a):
-    return _from_numpy(np.cosh(_to_numpy(a)), a.dtype, a.device)
+    arr = _to_numpy(a)
+    result = _cython_unary(_ck.cosh_f32, _ck.cosh_f64, arr, to_numpy_dtype(a.dtype))
+    if result is not None:
+        return _from_numpy(result, a.dtype, a.device)
+    return _from_numpy(np.cosh(arr), a.dtype, a.device)
 
 
 def asinh(a):
-    return _from_numpy(np.arcsinh(_to_numpy(a)), a.dtype, a.device)
+    arr = _to_numpy(a)
+    result = _cython_unary(_ck.asinh_f32, _ck.asinh_f64, arr, to_numpy_dtype(a.dtype))
+    if result is not None:
+        return _from_numpy(result, a.dtype, a.device)
+    return _from_numpy(np.arcsinh(arr), a.dtype, a.device)
 
 
 def acosh(a):
-    return _from_numpy(np.arccosh(_to_numpy(a)), a.dtype, a.device)
+    arr = _to_numpy(a)
+    result = _cython_unary(_ck.acosh_f32, _ck.acosh_f64, arr, to_numpy_dtype(a.dtype))
+    if result is not None:
+        return _from_numpy(result, a.dtype, a.device)
+    return _from_numpy(np.arccosh(arr), a.dtype, a.device)
 
 
 def atanh(a):
-    return _from_numpy(np.arctanh(_to_numpy(a)), a.dtype, a.device)
+    arr = _to_numpy(a)
+    result = _cython_unary(_ck.atanh_f32, _ck.atanh_f64, arr, to_numpy_dtype(a.dtype))
+    if result is not None:
+        return _from_numpy(result, a.dtype, a.device)
+    return _from_numpy(np.arctanh(arr), a.dtype, a.device)
 
 
 def erf(a):
     arr = _to_numpy(a)
+    result = _cython_unary(_ck.erf_f32, _ck.erf_f64, arr, to_numpy_dtype(a.dtype))
+    if result is not None:
+        return _from_numpy(result, a.dtype, a.device)
     out = np.vectorize(math.erf)(arr)
     return _from_numpy(out, a.dtype, a.device)
 
 
 def erfc(a):
     arr = _to_numpy(a)
+    result = _cython_unary(_ck.erfc_f32, _ck.erfc_f64, arr, to_numpy_dtype(a.dtype))
+    if result is not None:
+        return _from_numpy(result, a.dtype, a.device)
     out = np.vectorize(math.erfc)(arr)
     return _from_numpy(out, a.dtype, a.device)
 
@@ -2407,7 +2588,15 @@ def adaptive_avg_pool2d(input, output_size):
 def sub(a, b):
     a_np = _to_numpy(a)
     b_np = _to_numpy(b) if isinstance(b, Tensor) else b
-    return _from_numpy(a_np - b_np, a.dtype, a.device)
+    out_dtype = _binary_out_dtype(a, b)
+    out_np_dtype = to_numpy_dtype(out_dtype)
+    if isinstance(b, Tensor):
+        result = _cython_binary(_ck.sub_f32, _ck.sub_f64, a_np, b_np, out_np_dtype)
+    else:
+        result = _cython_scalar_binary(_ck.sub_scalar_f32, _ck.sub_scalar_f64, a_np, b_np, out_np_dtype)
+    if result is not None:
+        return _from_numpy(result, out_dtype, a.device)
+    return _from_numpy(a_np - b_np, out_dtype, a.device)
 
 
 def log1p(a):

--- a/src/candle/_cython/_cpu_kernels.pyx
+++ b/src/candle/_cython/_cpu_kernels.pyx
@@ -1,0 +1,449 @@
+# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
+"""Cython CPU kernels — pure C loops, no NumPy arithmetic.
+
+All kernels operate on flat C-contiguous 1-D typed memoryviews.
+Callers are responsible for ensuring contiguity (np.ascontiguousarray +
+np.ravel) before passing buffers in.
+"""
+
+cimport cython
+from libc.math cimport (
+    expf, logf, sqrtf, sinf, cosf, tanf, tanhf,
+    sinhf, coshf, asinhf, acoshf, atanhf, erff, erfcf,
+    exp2f, log2f, log10f, powf, fabsf,
+    exp, log, sqrt, sin, cos, tan, tanh,
+    sinh, cosh, asinh, acosh, atanh, erf, erfc,
+    exp2, log2, log10, pow, fabs,
+)
+
+
+# ---------------------------------------------------------------------------
+# Element-wise binary: float32
+# ---------------------------------------------------------------------------
+
+def add_f32(float[::1] a, float[::1] b, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] + b[i]
+
+
+def sub_f32(float[::1] a, float[::1] b, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] - b[i]
+
+
+def mul_f32(float[::1] a, float[::1] b, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] * b[i]
+
+
+def div_f32(float[::1] a, float[::1] b, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] / b[i]
+
+
+# ---------------------------------------------------------------------------
+# Element-wise binary: float64
+# ---------------------------------------------------------------------------
+
+def add_f64(double[::1] a, double[::1] b, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] + b[i]
+
+
+def sub_f64(double[::1] a, double[::1] b, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] - b[i]
+
+
+def mul_f64(double[::1] a, double[::1] b, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] * b[i]
+
+
+def div_f64(double[::1] a, double[::1] b, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] / b[i]
+
+
+# ---------------------------------------------------------------------------
+# Scalar binary: float32  (tensor op scalar)
+# ---------------------------------------------------------------------------
+
+def add_scalar_f32(float[::1] a, float b, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] + b
+
+
+def sub_scalar_f32(float[::1] a, float b, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] - b
+
+
+def mul_scalar_f32(float[::1] a, float b, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] * b
+
+
+def div_scalar_f32(float[::1] a, float b, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] / b
+
+
+# ---------------------------------------------------------------------------
+# Scalar binary: float64
+# ---------------------------------------------------------------------------
+
+def add_scalar_f64(double[::1] a, double b, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] + b
+
+
+def sub_scalar_f64(double[::1] a, double b, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] - b
+
+
+def mul_scalar_f64(double[::1] a, double b, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] * b
+
+
+def div_scalar_f64(double[::1] a, double b, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] / b
+
+
+# ---------------------------------------------------------------------------
+# Unary: float32
+# ---------------------------------------------------------------------------
+
+def neg_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = -a[i]
+
+
+def abs_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = fabsf(a[i])
+
+
+def relu_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] if a[i] > 0.0 else 0.0
+
+
+def gelu_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    cdef float x
+    cdef float inv_sqrt2 = 0.7071067811865476
+    for i in range(n):
+        x = a[i]
+        out[i] = 0.5 * x * (1.0 + erff(x * inv_sqrt2))
+
+
+def sigmoid_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = 1.0 / (1.0 + expf(-a[i]))
+
+
+def exp_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = expf(a[i])
+
+
+def log_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = logf(a[i])
+
+
+def sqrt_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = sqrtf(a[i])
+
+
+def rsqrt_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = 1.0 / sqrtf(a[i])
+
+
+def sin_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = sinf(a[i])
+
+
+def cos_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = cosf(a[i])
+
+
+def tan_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = tanf(a[i])
+
+
+def tanh_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = tanhf(a[i])
+
+
+def sinh_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = sinhf(a[i])
+
+
+def cosh_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = coshf(a[i])
+
+
+def asinh_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = asinhf(a[i])
+
+
+def acosh_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = acoshf(a[i])
+
+
+def atanh_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = atanhf(a[i])
+
+
+def erf_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = erff(a[i])
+
+
+def erfc_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = erfcf(a[i])
+
+
+def exp2_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = exp2f(a[i])
+
+
+def log2_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = log2f(a[i])
+
+
+def log10_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = log10f(a[i])
+
+
+def pow_f32(float[::1] a, float b, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = powf(a[i], b)
+
+
+def square_f32(float[::1] a, float[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] * a[i]
+
+
+# ---------------------------------------------------------------------------
+# Unary: float64
+# ---------------------------------------------------------------------------
+
+def neg_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = -a[i]
+
+
+def abs_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = fabs(a[i])
+
+
+def relu_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] if a[i] > 0.0 else 0.0
+
+
+def gelu_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    cdef double x
+    cdef double inv_sqrt2 = 0.7071067811865476
+    for i in range(n):
+        x = a[i]
+        out[i] = 0.5 * x * (1.0 + erf(x * inv_sqrt2))
+
+
+def sigmoid_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = 1.0 / (1.0 + exp(-a[i]))
+
+
+def exp_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = exp(a[i])
+
+
+def log_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = log(a[i])
+
+
+def sqrt_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = sqrt(a[i])
+
+
+def rsqrt_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = 1.0 / sqrt(a[i])
+
+
+def sin_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = sin(a[i])
+
+
+def cos_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = cos(a[i])
+
+
+def tan_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = tan(a[i])
+
+
+def tanh_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = tanh(a[i])
+
+
+def sinh_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = sinh(a[i])
+
+
+def cosh_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = cosh(a[i])
+
+
+def asinh_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = asinh(a[i])
+
+
+def acosh_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = acosh(a[i])
+
+
+def atanh_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = atanh(a[i])
+
+
+def erf_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = erf(a[i])
+
+
+def erfc_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = erfc(a[i])
+
+
+def exp2_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = exp2(a[i])
+
+
+def log2_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = log2(a[i])
+
+
+def log10_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = log10(a[i])
+
+
+def pow_f64(double[::1] a, double b, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = pow(a[i], b)
+
+
+def square_f64(double[::1] a, double[::1] out):
+    cdef Py_ssize_t i, n = a.shape[0]
+    for i in range(n):
+        out[i] = a[i] * a[i]
+
+
+# matmul_f32 / matmul_f64 intentionally omitted:
+# numpy matmul already dispatches to OpenBLAS sgemm/dgemm internally.
+# cblas.h is not installed in this environment.
+# ops.py keeps matmul on the numpy @ path.

--- a/src/candle/_cython/_cpu_kernels_fallback.py
+++ b/src/candle/_cython/_cpu_kernels_fallback.py
@@ -1,0 +1,79 @@
+"""Pure-Python fallback for _cpu_kernels.pyx.
+
+All symbols are None; ops.py falls back to numpy when the Cython .so is absent.
+"""
+# element-wise binary float32
+add_f32 = None
+sub_f32 = None
+mul_f32 = None
+div_f32 = None
+# element-wise binary float64
+add_f64 = None
+sub_f64 = None
+mul_f64 = None
+div_f64 = None
+# scalar binary float32
+add_scalar_f32 = None
+sub_scalar_f32 = None
+mul_scalar_f32 = None
+div_scalar_f32 = None
+# scalar binary float64
+add_scalar_f64 = None
+sub_scalar_f64 = None
+mul_scalar_f64 = None
+div_scalar_f64 = None
+# unary float32
+neg_f32 = None
+abs_f32 = None
+relu_f32 = None
+gelu_f32 = None
+sigmoid_f32 = None
+exp_f32 = None
+log_f32 = None
+sqrt_f32 = None
+rsqrt_f32 = None
+sin_f32 = None
+cos_f32 = None
+tan_f32 = None
+tanh_f32 = None
+sinh_f32 = None
+cosh_f32 = None
+asinh_f32 = None
+acosh_f32 = None
+atanh_f32 = None
+erf_f32 = None
+erfc_f32 = None
+exp2_f32 = None
+log2_f32 = None
+log10_f32 = None
+pow_f32 = None
+square_f32 = None
+# unary float64
+neg_f64 = None
+abs_f64 = None
+relu_f64 = None
+gelu_f64 = None
+sigmoid_f64 = None
+exp_f64 = None
+log_f64 = None
+sqrt_f64 = None
+rsqrt_f64 = None
+sin_f64 = None
+cos_f64 = None
+tan_f64 = None
+tanh_f64 = None
+sinh_f64 = None
+cosh_f64 = None
+asinh_f64 = None
+acosh_f64 = None
+atanh_f64 = None
+erf_f64 = None
+erfc_f64 = None
+exp2_f64 = None
+log2_f64 = None
+log10_f64 = None
+pow_f64 = None
+square_f64 = None
+# matmul
+matmul_f32 = None
+matmul_f64 = None


### PR DESCRIPTION
## Summary

Replace NumPy ufunc calls in the CPU backend with Cython C-loop kernels that call `libc.math` intrinsics directly. This eliminates Python/C boundary overhead for element-wise operations on float32/float64 tensors.

### Motivation

NumPy ufuncs incur per-call overhead from type checking, iterator setup, and GIL management — even for simple element-wise ops on contiguous buffers. For small-to-medium tensors common in model inference (e.g., activations, normalization), this overhead dominates actual compute time. By dropping to typed C `for` loops via Cython memoryviews, we skip the entire NumPy dispatch machinery.

### What's included

**Binary ops** (tensor-tensor and tensor-scalar variants, f32 + f64):
- `add`, `sub`, `mul`, `div`

**Unary ops** (f32 + f64, 25 per dtype):
- Activation: `relu`, `gelu`, `sigmoid`
- Exponential/log: `exp`, `log`, `exp2`, `log2`, `log10`
- Power: `pow`, `square`, `sqrt`, `rsqrt`
- Trigonometric: `sin`, `cos`, `tan`, `tanh`, `sinh`, `cosh`
- Inverse hyperbolic: `asinh`, `acosh`, `atanh`
- Error function: `erf`, `erfc`
- Other: `neg`, `abs`

### Design

- **Zero-copy hot path**: `np.ascontiguousarray().ravel()` gives a flat C buffer → Cython typed memoryview `float[::1]` → pure C loop with `libc.math` (e.g., `expf`, `erff`, `sqrtf`)
- **Graceful fallback**: If the `.so` is not compiled, `_cpu_kernels_fallback.py` provides `None` stubs; `ops.py` checks `if result is not None` and falls back to the existing NumPy path
- **Non-float dtypes** (int, bool, bfloat16, complex) and **broadcast cases** (shape mismatch) automatically use the NumPy path — no behavior change
- **matmul excluded**: NumPy's `@` already dispatches to OpenBLAS `sgemm`/`dgemm`, so a Cython wrapper would add no value

### Files changed

| File | Description |
|------|-------------|
| `src/candle/_cython/_cpu_kernels.pyx` | New: 449-line Cython module with all kernel implementations |
| `src/candle/_cython/_cpu_kernels_fallback.py` | New: Pure-Python `None`-stub module for import fallback |
| `src/candle/_backends/cpu/ops.py` | Modified: Added `_cython_unary`/`_cython_binary`/`_cython_scalar_binary` dispatch helpers; wired all covered ops through them |
| `setup.py` | Modified: Added `_cpu_kernels` Cython extension with `-O3 -ffast-math` |

## Test plan

- [x] All 1830 existing CPU + contract tests pass (`pytest tests/cpu/ tests/contract/ -v`)
- [x] Pylint clean (10/10)
- [ ] CI validation (CPU + MPS pipelines)