### PR TITLE
perf(npu): add fast runtime/stream accessors to skip activate() on op hot-path

### DIFF
--- a/src/candle/_backends/npu/runtime.py
+++ b/src/candle/_backends/npu/runtime.py
@@ -266,6 +266,19 @@ def get_runtime(device_id=0):
     return runtime
 
 
+def get_runtime_fast(device_id=0):
+    """Fast variant for the op hot-path.
+
+    Skips activate() (set_device / set_context ctypes round-trips) when the
+    runtime is already initialized.  Falls back to get_runtime() on first use
+    or when the runtime is not yet in the cache.
+    """
+    runtime = _RUNTIMES.get(device_id)
+    if runtime is None or not runtime.initialized:
+        return get_runtime(device_id)
+    return runtime
+
+
 def is_available(verbose=False):
     try:
         get_runtime(0)

--- a/src/candle/_backends/npu/state.py
+++ b/src/candle/_backends/npu/state.py
@@ -87,6 +87,21 @@ def current_stream(device_id=None):
     return stream
 
 
+def current_stream_fast(device_id=0):
+    """Fast variant for the op hot-path.
+
+    Skips _sync_default_streams_from_state() and the default_stream lock when
+    the stream for this device is already cached in TLS.  Falls back to the
+    full current_stream() path on first use or after set_current_stream().
+    """
+    tls_streams = getattr(_tls, "current_streams", None)
+    if tls_streams is not None:
+        stream = tls_streams.get(device_id)
+        if stream is not None:
+            return stream
+    return current_stream(device_id)
+
+
 def set_current_stream(stream):
     state = _state()
     state.current_streams[stream.device.index or 0] = stream

--- a/src/candle/_cython/_npu_ops.pyx
+++ b/src/candle/_cython/_npu_ops.pyx
@@ -116,8 +116,12 @@ cdef object _npu_state = None
 cdef object _npu_typed_storage_from_ptr = None
 cdef object _Tensor = None
 
+cdef object _get_runtime_fast = None
+cdef object _get_stream_fast = None
+
 cdef inline void _ensure_npu_imports():
     global _npu_runtime, _npu_state, _npu_typed_storage_from_ptr, _Tensor
+    global _get_runtime_fast, _get_stream_fast
     if _npu_runtime is not None:
         return
     from candle._backends.npu import runtime as rt
@@ -128,6 +132,8 @@ cdef inline void _ensure_npu_imports():
     _npu_state = st
     _npu_typed_storage_from_ptr = nfp
     _Tensor = T
+    _get_runtime_fast = rt.get_runtime_fast
+    _get_stream_fast = st.current_stream_fast
 
 
 def fast_binary_op(a, b, fn, str name):
@@ -150,10 +156,10 @@ def fast_binary_op(a, b, fn, str name):
     if a_dtype != b.dtype:
         raise ValueError(f"NPU {name} requires matching dtypes")
 
-    # 2. Get runtime + stream
+    # 2. Get runtime + stream (fast path: skip activate() and TLS lock)
     cdef int dev_idx = a_dev.index or 0
-    runtime = _npu_runtime.get_runtime(dev_idx)
-    stream = _npu_state.current_stream(dev_idx)
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
 
     # 3. Extract shapes into C arrays
     py_a_shape = a.shape


### PR DESCRIPTION
## Summary

Adds `get_runtime_fast()` and `current_stream_fast()` accessors that skip
expensive bookkeeping on the steady-state op hot-path.

### Problem

Every NPU op call goes through:
- `get_runtime()` → `runtime.activate()` → `set_device` + `set_context` via ctypes (2 round-trips)
- `current_stream()` → `_sync_default_streams_from_state()` + lock acquisition + dict lookups

Profiling a 64×64 float32 `torch.add` on 910B3 showed these contributed ~16 us
of avoidable overhead per op call.

### Fix

- `runtime.get_runtime_fast(device_id)`: returns the cached `_Runtime` directly
  when already initialized, skipping `activate()`. Falls back to `get_runtime()`
  on first use.
- `state.current_stream_fast(device_id)`: checks the TLS `current_streams` dict
  directly, skipping the lock and `_sync_default_streams_from_state()` when the
  stream is already cached. Falls back to `current_stream()` on first use.
- `_npu_ops.pyx` `fast_binary_op`: uses both fast accessors via cached module-level
  function references.

### Benchmark (910B3, 64×64 float32 add, 200 iters)

| Metric | Before | After | Delta |
|---|---|---|---|
| Dispatch overhead (total − aclnn) | 171 us | 155 us | −16 us (−9%) |
| End-to-end median | 0.266 ms | 0.262 ms | −4 us |

### Tests

All 268 NPU tests pass.