### PR TITLE
perf(npu): add NPU direct-call fast-path in _fast_ops.pyx for hot binary ops

### DIFF
--- a/src/candle/_cython/_fast_ops.pyx
+++ b/src/candle/_cython/_fast_ops.pyx
@@ -32,6 +32,16 @@ cdef object _py_neg_fn = None
 cdef object _handle_tf = None
 cdef object _dispatch_fn = None
 
+# NPU fast-path: cached references for direct kernel calls
+cdef object _npu_add_fn = None
+cdef object _npu_mul_fn = None
+cdef object _npu_sub_fn = None
+cdef object _npu_div_fn = None
+cdef object _grad_mode_state = None
+cdef object _is_functionalize_fn = None
+cdef object _current_pipeline_fn = None
+cdef bint _npu_refs_loaded = False
+
 cdef inline void _ensure_originals():
     global _py_add_fn, _py_mul_fn, _py_matmul_fn, _py_sub_fn
     global _py_div_fn, _py_relu_fn, _py_neg_fn, _handle_tf, _dispatch_fn
@@ -53,6 +63,47 @@ cdef inline void _ensure_originals():
         _py_neg_fn = _py_neg
 
 
+cdef inline void _ensure_npu_refs():
+    """Load NPU op refs and guard state once."""
+    global _npu_add_fn, _npu_mul_fn, _npu_sub_fn, _npu_div_fn
+    global _grad_mode_state, _is_functionalize_fn, _current_pipeline_fn
+    global _npu_refs_loaded
+    if _npu_refs_loaded:
+        return
+    from candle._backends.npu.ops import add as _nadd, mul as _nmul
+    from candle._backends.npu.ops import sub as _nsub, div as _ndiv
+    from candle.autograd.grad_mode import _GRAD_MODE_STATE as _gms
+    from candle._dispatch.functionalize import is_functionalize_enabled as _ife
+    from candle._dispatch.pipeline import current_pipeline as _cp
+    _npu_add_fn = _nadd
+    _npu_mul_fn = _nmul
+    _npu_sub_fn = _nsub
+    _npu_div_fn = _ndiv
+    _grad_mode_state = _gms
+    _is_functionalize_fn = _ife
+    _current_pipeline_fn = _cp
+    _npu_refs_loaded = True
+
+
+cdef inline bint _npu_fast_ok(object a, object b):
+    """True if both are NPU tensors and we can call the NPU kernel directly."""
+    # b may be a scalar (float/int) — only proceed if it has a device attribute
+    cdef object b_dev = getattr(b, "device", None)
+    if b_dev is None:
+        return False
+    if a.device.type != "npu" or b_dev.type != "npu":
+        return False
+    # Grad: skip fast-path if grad enabled and any tensor requires grad
+    cdef bint grad_on = getattr(_grad_mode_state, "enabled", True)
+    if grad_on and (getattr(a, "requires_grad", False) or getattr(b, "requires_grad", False)):
+        return False
+    if _is_functionalize_fn():
+        return False
+    if _current_pipeline_fn() is not None:
+        return False
+    return True
+
+
 def add(a=None, b=None, *, alpha=1, out=None):
     """Fast add: skip __torch_function__ when both args are base Tensor."""
     _ensure_originals()
@@ -62,6 +113,11 @@ def add(a=None, b=None, *, alpha=1, out=None):
     if _is_base_tensor(a) and (_is_base_tensor(b) or not hasattr(b, "__torch_function__")):
         if alpha != 1:
             b = _dispatch_fn("mul", None, b, alpha)
+        else:
+            # NPU fast-path: bypass dispatcher entirely
+            _ensure_npu_refs()
+            if _npu_fast_ok(a, b):
+                return _npu_add_fn(a, b)
         return _dispatch_fn("add", None, a, b)
     r = _handle_tf(_py_add_fn, (a, b), {"alpha": alpha, "out": out})
     if r is not NotImplemented:
@@ -75,6 +131,10 @@ def mul(a, b):
     """Fast mul: skip __torch_function__ when both args are base Tensor."""
     _ensure_originals()
     if _is_base_tensor(a) and (_is_base_tensor(b) or not hasattr(b, "__torch_function__")):
+        # NPU fast-path: bypass dispatcher entirely
+        _ensure_npu_refs()
+        if _npu_fast_ok(a, b):
+            return _npu_mul_fn(a, b)
         return _dispatch_fn("mul", None, a, b)
     r = _handle_tf(_py_mul_fn, (a, b), {})
     if r is not NotImplemented:
@@ -99,6 +159,11 @@ def sub(a, b, *, alpha=1):
     if _is_base_tensor(a) and (_is_base_tensor(b) or not hasattr(b, "__torch_function__")):
         if alpha != 1:
             b = _dispatch_fn("mul", None, b, alpha)
+        else:
+            # NPU fast-path: bypass dispatcher entirely
+            _ensure_npu_refs()
+            if _npu_fast_ok(a, b):
+                return _npu_sub_fn(a, b)
         return _dispatch_fn("sub", None, a, b)
     r = _handle_tf(_py_sub_fn, (a, b), {"alpha": alpha})
     if r is not NotImplemented:
@@ -116,6 +181,10 @@ def div(a, b, *, rounding_mode=None):
             return _dispatch_fn("trunc_divide", None, a, b)
         if rounding_mode == "floor":
             return _dispatch_fn("floor_divide", None, a, b)
+        # NPU fast-path: bypass dispatcher entirely
+        _ensure_npu_refs()
+        if _npu_fast_ok(a, b):
+            return _npu_div_fn(a, b)
         return _dispatch_fn("true_divide", None, a, b)
     r = _handle_tf(_py_div_fn, (a, b), {"rounding_mode": rounding_mode})
     if r is not NotImplemented:


### PR DESCRIPTION
## Summary

For `add`/`mul`/`sub`/`div` with plain NPU Tensor args and no grad/functionalize/pipeline active, bypass the full Cython dispatcher entirely and call the ACLNN kernel directly from `_fast_ops.pyx`.

## Problem

Even with prior Cython dispatcher optimizations, the full dispatch path (keyset construction, schema validation, kernel lookup, kwargs preparation, context push/pop, version bumping) costs ~85 us per op. For steady-state inference this overhead is pure waste.

Previous profiling (after #164 + #165):
```
Stage                            Median (us)
─────────────────────────────────────────────
1_functional_add_total            236
2_dispatcher_core                 233     ← 85 us avoidable overhead
3b_cy_fast_binary_op              148
4_aclnn_add                        71
```

## Fix

In `_fast_ops.pyx` `add`/`mul`/`sub`/`div`, after the existing `type(a) is Tensor` check, add a C-level NPU fast-path before the `_dispatch_fn` call:

```cython
if _npu_fast_ok(a, b):
    return _npu_add_fn(a, b)  # bypasses full dispatcher
```

Guard conditions (checked at C level with cached module refs):
- `b.device` exists and both devices are `"npu"`
- grad disabled OR neither tensor requires grad
- functionalize not active
- no pipeline active
- `alpha == 1` for add/sub (otherwise falls through)

## Benchmark (910B3, 64×64 float32 add, 1000 iters)

| Build | Median | Delta |
|---|---|---|
| Baseline | 0.266 ms | — |
| #164 fast runtime/stream | 0.262 ms | −4 us |
| #165 event pool | 0.236 ms | −25 us |
| **This PR: NPU fast dispatch** | **0.164 ms** | **−72 us (−31%)** |

Total reduction vs baseline: **−38%**. Gap to torch_npu (0.060 ms): 2.7×.

## Tests

All 268 NPU tests pass.