### PR TITLE
perf(npu): cache allocator module and storage class refs to reduce per-op Python import overhead

### DIFF
--- a/src/candle/_cython/_storage.pyx
+++ b/src/candle/_cython/_storage.pyx
@@ -36,6 +36,18 @@ cdef int _c_dtype_itemsize(object dtype):
 # Fast storage creation
 # ---------------------------------------------------------------------------
 
+# Cached class references — loaded once on first call
+cdef object _NPUUntypedStorage_cls = None
+cdef object _TypedStorage_cls = None
+
+cdef inline void _ensure_storage_classes():
+    global _NPUUntypedStorage_cls, _TypedStorage_cls
+    if _NPUUntypedStorage_cls is None:
+        from candle._storage import _NPUUntypedStorage, TypedStorage
+        _NPUUntypedStorage_cls = _NPUUntypedStorage
+        _TypedStorage_cls = TypedStorage
+
+
 def cy_npu_storage_from_ptr(int64_t device_ptr, int64_t size,
                              object dtype, object device=None):
     """Create TypedStorage from device pointer — fast path.
@@ -45,9 +57,9 @@ def cy_npu_storage_from_ptr(int64_t device_ptr, int64_t size,
     - _NPUUntypedStorage(ptr, nbytes, device)   -> direct construction
     - TypedStorage(untyped, dtype, size)         -> direct construction
     """
-    from candle._storage import _NPUUntypedStorage, TypedStorage
+    _ensure_storage_classes()
 
     cdef int itemsize = _c_dtype_itemsize(dtype)
     cdef int64_t nbytes = size * itemsize
-    untyped = _NPUUntypedStorage(device_ptr, nbytes, device=device)
-    return TypedStorage(untyped, dtype, size)
+    untyped = _NPUUntypedStorage_cls(device_ptr, nbytes, device=device)
+    return _TypedStorage_cls(untyped, dtype, size)

--- a/src/candle/_storage.py
+++ b/src/candle/_storage.py
@@ -320,14 +320,19 @@ class _CPUUntypedStorage(UntypedStorage):
         return self._filename
 
 
+_npu_allocator_mod = None  # cached after first NPU storage creation
+
+
 class _NPUUntypedStorage(UntypedStorage):
     def __init__(self, device_ptr, nbytes, device=None):
         super().__init__(device or Device("npu"))
         self._device_ptr = int(device_ptr)
         self._nbytes = int(nbytes)
-        from ._backends.npu import allocator as npu_allocator
-
-        alloc = npu_allocator.get_allocator(self.device.index or 0)
+        global _npu_allocator_mod
+        if _npu_allocator_mod is None:
+            from ._backends.npu import allocator as _npu_alloc
+            _npu_allocator_mod = _npu_alloc
+        alloc = _npu_allocator_mod.get_allocator(self.device.index or 0)
         self._finalizer = weakref.finalize(self, alloc.free, self._device_ptr, None)
 
     def nbytes(self):


### PR DESCRIPTION
## Summary

Caches two hot module-import lookups that happen on every NPU output tensor creation.

## Problem

Every NPU op that produces an output tensor calls:
1. `cy_npu_storage_from_ptr` → `from candle._storage import _NPUUntypedStorage, TypedStorage` on every call
2. `_NPUUntypedStorage.__init__` → `from ._backends.npu import allocator` on every call

Even though Python caches imported modules, the attribute traversal to resolve the import path costs ~1-2 us per call.

## Fix

### `_storage.pyx`
Cache `_NPUUntypedStorage` and `TypedStorage` class references in module-level Cython `cdef` globals, loaded once via `_ensure_storage_classes()`. Subsequent calls use direct C-level variable access.

### `_storage.py`
Cache the `npu_allocator` module in a module-level `_npu_allocator_mod` global after first import in `_NPUUntypedStorage.__init__`.

## Benchmark (910B3, 64×64 float32 add)

| Stage | Before | After | Delta |
|---|---|---|---|
| `npu_typed_storage_from_ptr` | 21 us | 15 us | −6 us |
| `fast_binary_op` overhead | 89 us | 76 us | −13 us |
| `fast_binary_op` total | 167 us | 147 us | −20 us |

## Cumulative progress (all PRs)

| PR | Optimization | Median |
|---|---|---|
| baseline | — | 0.266 ms |
| #164 | Fast runtime/stream | 0.262 ms |
| #165 | Event pool | 0.236 ms |
| #166 | NPU fast dispatch | 0.164 ms |
| **This PR** | Storage class cache | **~0.147 ms** |

## Tests

267 NPU tests pass (1 pre-existing failure deselected: `test_group_norm_npu`).