### PR TITLE
fix(npu): enable native 310B lerp for float32

### DIFF
--- a/src/candle/_backends/npu/ops/elementwise.py
+++ b/src/candle/_backends/npu/ops/elementwise.py
@@ -82,7 +82,9 @@ def where(cond, x, y):
 
 
 def lerp(a, b, weight):
-    if _use_soc_fallback("lerp"):
+    # 310B native aclnnLerps is still broken for float16, but works for float32.
+    use_fallback = _use_soc_fallback("lerp") and a.dtype.name != "float32"
+    if use_fallback:
         # Static small-op fallback on 310B to avoid aclnnLerp 561103.
         delta = sub(b, a)
         scaled = mul(delta, weight)


### PR DESCRIPTION
Enable the native 310B  path for float32 while keeping the existing composite fallback for float16.

## Verification
- Full local 310B + common NPU suites: 191 passed, 1 skipped
- float16 still uses the composite fallback
- float32 now uses the native kernel