### PR TITLE
fix(npu): enable native 310B sort

### DIFF
--- a/src/candle/_backends/npu/ops_soc.py
+++ b/src/candle/_backends/npu/ops_soc.py
@@ -60,7 +60,6 @@ _FALLBACK_OPS = {
         "isclose",      # aclnnIsClose returns 561103 on 310B
         "flip",         # aclnnFlip returns 561000
         "argsort",      # aclnnTopk (used by argsort) returns 561103
-        "sort",         # aclnnTopk returns 561103
         "topk",         # aclnnTopk returns 561103
         "diag",         # aclnnDiag returns 561103
         "gather",       # aclnnGather returns 561103


### PR DESCRIPTION
Remove `sort` from the 310B fallback list.

## Scope
- Single-op change only
- Leaves `argsort` and `topk` unchanged in their own PRs / fallback states

## Verification
- Based on latest upstream main: 548cea8
- Full local 310B + common NPU suites: **191 passed, 1 skipped**