### PR TITLE
fix(npu): enable native 310B take_along_dim

### DIFF
--- a/src/candle/_backends/npu/ops_soc.py
+++ b/src/candle/_backends/npu/ops_soc.py
@@ -64,7 +64,6 @@ _FALLBACK_OPS = {
         "topk",         # aclnnTopk returns 561103
         "diag",         # aclnnDiag returns 561103
         "gather",       # aclnnGather returns 561103
-        "take_along_dim",  # aclnnGather returns 561103
         "layer_norm",   # aclnnLayerNorm returns 561103 for float32 (float16 works)
         "mish",         # aclnnMish returns 561103
         "batch_norm",   # aclnnBatchNorm returns 161002


### PR DESCRIPTION
Remove `take_along_dim` from the 310B fallback list.

## Scope
- Single-op change only
- Leaves `gather` unchanged because it still needs its own evaluation / PR

## Verification
- Based on latest upstream main: 548cea8
- Full local 310B + common NPU suites: **191 passed, 1 skipped**