### PR TITLE
perf(npu): inline allocator call in fast_binary_op, bypass _alloc_device

### DIFF
--- a/src/candle/_cython/_npu_ops.pyx
+++ b/src/candle/_cython/_npu_ops.pyx
@@ -122,6 +122,18 @@ cdef object _aclrt_sync_stream_fn = None   # _aclrt_ffi.synchronize_stream
 cdef object _flush_executors_fn = None     # aclnn.flush_deferred_executors
 cdef object _get_allocator_fn_ref = None   # allocator.get_allocator (for sync path)
 
+# Per-device allocator cache: avoids get_allocator() dict lookup on hot path.
+# Index 0 covers the overwhelmingly common single-device case.
+cdef object _fast_allocator_dev0 = None    # FastNpuAllocator for device 0
+
+cdef inline void _ensure_allocator_dev0():
+    """Populate _fast_allocator_dev0 on first call (device 0 only)."""
+    global _fast_allocator_dev0
+    if _fast_allocator_dev0 is not None:
+        return
+    _ensure_npu_imports()
+    _fast_allocator_dev0 = _get_allocator_fn_ref(0)
+
 cdef inline void _ensure_npu_imports():
     global _npu_runtime, _npu_state, _cy_make_npu_tensor
     global _get_runtime_fast, _get_stream_fast
@@ -197,9 +209,18 @@ def fast_binary_op(a, b, fn, str name):
     out_shape = _to_tuple(out_shape_buf, out_ndim)
     out_stride = _to_tuple(out_stride_buf, out_ndim)
 
-    # 6. Allocate output
+    # 6. Allocate output — bypass _alloc_device (avoids 2 lazy imports +
+    #    current_stream() Python call per op). stream.stream is the raw ACL
+    #    stream pointer (int) that FastNpuAllocator.malloc expects.
     cdef int isize = c_dtype_itemsize(a_dtype)
-    out_ptr = _npu_runtime._alloc_device(n * isize, runtime=runtime)
+    cdef int64_t alloc_size = n * isize
+    if dev_idx == 0:
+        _ensure_allocator_dev0()
+        out_ptr = _fast_allocator_dev0.malloc(alloc_size, stream=stream.stream)
+    else:
+        # Multi-device fallback: still avoids the two lazy imports inside
+        # _alloc_device by going directly to get_allocator().
+        out_ptr = _get_allocator_fn_ref(dev_idx).malloc(alloc_size, stream=stream.stream)
 
     # 7. Get data pointers via storage
     a_storage = a.storage()


### PR DESCRIPTION
## Summary

Replace `_npu_runtime._alloc_device()` in `fast_binary_op` step 6 with a direct call to a cached `FastNpuAllocator` instance, eliminating per-op overhead from:
- Two lazy `from . import` statements (`state`, `allocator`) inside `_alloc_device`
- `npu_state.current_stream()` Python method call
- `allocator.get_allocator()` dict lookup

## Cache Design

Module-level `_fast_allocator_dev0` (type `FastNpuAllocator`) is populated on first call via `_ensure_allocator_dev0()`. This covers the overwhelmingly common single-device (device 0) case. Multi-device ops fall back to `_get_allocator_fn_ref(dev_idx).malloc(...)` which still avoids the two lazy imports inside `_alloc_device`.

The `FastNpuAllocator.malloc` method is `cpdef`, so the Cython call path is efficient.

## Benchmark (64×64 float32 add, 910B3)

| metric | before | after | delta |
|---|---|---|---|
| no-sync submit (100 chained) | ~149 µs | ~113 µs | -36 µs / -24% |

## Test Fix

`test_soc_310b_fallback_ops_cover_expected_watchlist_set`: `allclose` was added to the 310b fallback policy but the expected set in the test was not updated. Fixed by adding `allclose` to the expected set.