### PR TITLE
docs: add LINUX DO friendly link to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,10 @@ pylint src/candle --rcfile=.github/pylint.conf
 
 We welcome contributions! Whether it's new ops, backend support, bug fixes, or docs — open an issue or submit a PR.
 
+## Friends
+
+- [LINUX DO](https://linux.do/)
+
 ## License
 
 [MIT](LICENSE)

--- a/README_zh.md
+++ b/README_zh.md
@@ -221,6 +221,10 @@ pylint src/candle --rcfile=.github/pylint.conf
 
 欢迎任何形式的贡献！无论是新算子、后端支持、bug 修复还是文档改进 — 提 issue 或者发 PR 都行。
 
+## 友情链接
+
+- [LINUX DO](https://linux.do/)
+
 ## 许可证
 
 [MIT](LICENSE)


### PR DESCRIPTION
## Summary
- Add a "Friends" / "友情链接" section to both `README.md` and `README_zh.md` with a link to [LINUX DO](https://linux.do/)

## Test plan
- [x] Verify links render correctly in both READMEs

🤖 Generated with [Claude Code](https://claude.com/claude-code)