### PR TITLE
perf(npu): reuse PTA cached add executors

### DIFF
--- a/src/candle/_cython/_aclnn_ffi.pyx
+++ b/src/candle/_cython/_aclnn_ffi.pyx
@@ -43,6 +43,18 @@ ctypedef int32_t (*aclDestroyTensorList_t)(void*) noexcept nogil
 ctypedef int32_t (*aclnnExec_t)(void*, uint64_t, void*, void*) noexcept nogil
 
 # ---------------------------------------------------------------------------
+# PTA executor cache function pointer typedefs (from libnnopbase.so)
+# These mirror torch_npu's op_api_common.h typedefs exactly.
+# ---------------------------------------------------------------------------
+
+ctypedef void (*InitPTACacheThreadLocal_t)() noexcept nogil
+ctypedef void (*UnInitPTACacheThreadLocal_t)() noexcept nogil
+ctypedef void (*SetPTACacheHashKey_t)(uint8_t*, size_t) noexcept nogil
+ctypedef void* (*PTAFindExecCache_t)(uint8_t*, size_t, uint64_t*) noexcept nogil
+ctypedef int (*CanUsePTACache_t)(const char*) noexcept nogil
+ctypedef void (*AddTensorAddrToCachedList_t)(void*) noexcept nogil
+
+# ---------------------------------------------------------------------------
 # Module-level cached function pointers
 # ---------------------------------------------------------------------------
 
@@ -61,6 +73,18 @@ cdef aclDestroyTensorList_t _fn_destroy_tensor_list = NULL
 cdef bint _initialized = 0
 
 DEF MAX_NDIM = 16
+
+# ---------------------------------------------------------------------------
+# PTA executor cache function pointers (resolved from libnnopbase.so)
+# ---------------------------------------------------------------------------
+
+cdef InitPTACacheThreadLocal_t   _fn_init_pta_cache    = NULL
+cdef UnInitPTACacheThreadLocal_t _fn_uninit_pta_cache  = NULL
+cdef SetPTACacheHashKey_t        _fn_set_pta_hash_key  = NULL
+cdef PTAFindExecCache_t          _fn_pta_find_cache    = NULL
+cdef CanUsePTACache_t            _fn_can_use_pta_cache = NULL
+cdef AddTensorAddrToCachedList_t _fn_add_tensor_addr   = NULL
+cdef bint _pta_cache_available = 0
 
 # Stored dlopen handles (as uintptr_t) for op symbol resolution
 _lib_handles = []
@@ -277,9 +301,217 @@ def init(list lib_paths):
 
     _initialized = 1
 
+    # Try to resolve PTA executor cache symbols from libnnopbase.so.
+    # These are optional — cache is simply disabled if symbols are missing.
+    _init_pta_cache_symbols(handles, lib_paths)
+
 
 def is_initialized():
     return _initialized != 0
+
+
+def is_pta_cache_available():
+    return _pta_cache_available != 0
+
+
+cdef void _init_pta_cache_symbols(list handles, list lib_paths):
+    global _fn_init_pta_cache, _fn_uninit_pta_cache
+    global _fn_set_pta_hash_key, _fn_pta_find_cache
+    global _fn_can_use_pta_cache, _fn_add_tensor_addr
+    global _pta_cache_available
+
+    cdef void* nnopbase_handle = NULL
+    cdef void* sym
+    cdef int idx
+    cdef object p
+
+    for idx, p in enumerate(lib_paths):
+        if isinstance(p, bytes):
+            p = p.decode("utf-8")
+        if "libnnopbase.so" in p:
+            nnopbase_handle = <void*><uintptr_t>handles[idx]
+            break
+
+    if nnopbase_handle == NULL:
+        return
+
+    dlerror()
+    sym = dlsym(nnopbase_handle, b"InitPTACacheThreadLocal")
+    if sym == NULL:
+        return
+    _fn_init_pta_cache = <InitPTACacheThreadLocal_t>sym
+
+    sym = dlsym(nnopbase_handle, b"UnInitPTACacheThreadLocal")
+    if sym == NULL:
+        return
+    _fn_uninit_pta_cache = <UnInitPTACacheThreadLocal_t>sym
+
+    sym = dlsym(nnopbase_handle, b"SetPTACacheHashKey")
+    if sym == NULL:
+        return
+    _fn_set_pta_hash_key = <SetPTACacheHashKey_t>sym
+
+    sym = dlsym(nnopbase_handle, b"PTAFindExecCache")
+    if sym == NULL:
+        return
+    _fn_pta_find_cache = <PTAFindExecCache_t>sym
+
+    sym = dlsym(nnopbase_handle, b"CanUsePTACache")
+    if sym == NULL:
+        return
+    _fn_can_use_pta_cache = <CanUsePTACache_t>sym
+
+    sym = dlsym(nnopbase_handle, b"AddTensorAddrToCachedList")
+    if sym == NULL:
+        return
+    _fn_add_tensor_addr = <AddTensorAddrToCachedList_t>sym
+
+    _pta_cache_available = 1
+
+
+DEF PTA_HASH_BUF_SIZE = 8192
+DEF PTA_HASH_BUF_MAX_SIZE = 9216
+
+
+cdef inline void _pta_buf_append(
+    uint8_t* buf, int* offset,
+    const void* data, size_t nbytes) noexcept nogil:
+    cdef size_t i
+    cdef const uint8_t* src
+    cdef int cur = offset[0]
+    if cur + <int>nbytes > PTA_HASH_BUF_SIZE:
+        offset[0] = PTA_HASH_BUF_MAX_SIZE
+        return
+    src = <const uint8_t*>data
+    for i in range(nbytes):
+        buf[cur + i] = src[i]
+    offset[0] = cur + <int>nbytes
+
+
+cdef inline void _pta_buf_append_cstr(
+    uint8_t* buf, int* offset,
+    const char* s) noexcept nogil:
+    cdef size_t n = 0
+    while s[n] != 0:
+        n += 1
+    _pta_buf_append(buf, offset, s, n)
+    _pta_buf_append(buf, offset, &n, sizeof(size_t))
+
+
+cdef inline int64_t _pta_numel(const int64_t* shape, int ndim) noexcept nogil:
+    cdef int i
+    cdef int64_t n = 1
+    for i in range(ndim):
+        n *= shape[i]
+    return n
+
+
+cdef inline void _pta_buf_append_tensor(
+    uint8_t* buf, int* offset,
+    const int64_t* shape, const int64_t* stride, int ndim,
+    int32_t dtype_code, int64_t storage_offset,
+    void* data_ptr) noexcept nogil:
+    cdef char sep = ','
+    cdef int64_t storage_dim
+
+    _pta_buf_append(buf, offset, shape, ndim * sizeof(int64_t))
+    _pta_buf_append(buf, offset, &dtype_code, sizeof(int32_t))
+    _pta_buf_append(buf, offset, &sep, 1)
+    _pta_buf_append(buf, offset, stride, ndim * sizeof(int64_t))
+    _pta_buf_append(buf, offset, &storage_offset, sizeof(int64_t))
+    storage_dim = _pta_numel(shape, ndim)
+    _pta_buf_append(buf, offset, &storage_dim, sizeof(int64_t))
+    _fn_add_tensor_addr(data_ptr)
+
+
+cdef inline void _pta_buf_append_scalar(
+    uint8_t* buf, int* offset,
+    const void* scalar_data, int scalar_nbytes, int32_t scalar_dtype_code) noexcept nogil:
+    _pta_buf_append(buf, offset, scalar_data, scalar_nbytes)
+    _pta_buf_append(buf, offset, &scalar_dtype_code, sizeof(int32_t))
+
+
+def pta_begin_add_cache_lookup(
+        self_shape, self_stride,
+        other_shape, other_stride,
+        out_shape, out_stride,
+        int32_t dtype_code,
+        uintptr_t self_ptr, uintptr_t other_ptr, uintptr_t out_ptr,
+        bytes alpha_scalar_bytes, int32_t alpha_dtype_code,
+        uintptr_t stream):
+    """Begin torch_npu-style PTA cache context for aclnnAdd.
+
+    Returns (pta_active: bool, workspace_size: int, executor_ptr: int).
+    If executor_ptr is nonzero, the cache lookup hit and caller can execute directly.
+    If executor_ptr is zero, the cache lookup missed, but PTA context remains active
+    and caller must keep it alive through GetWorkspaceSize/Execute, then call
+    pta_end_cache_lookup().
+    """
+    if not _pta_cache_available:
+        return None
+
+    cdef int can_use
+    with nogil:
+        can_use = _fn_can_use_pta_cache(b"aclnnAdd")
+    if not can_use:
+        return None
+
+    cdef int self_ndim = len(self_shape)
+    cdef int other_ndim = len(other_shape)
+    cdef int out_ndim = len(out_shape)
+    cdef int i
+    cdef int64_t[MAX_NDIM] s_shape, s_stride
+    cdef int64_t[MAX_NDIM] o_shape, o_stride
+    cdef int64_t[MAX_NDIM] r_shape, r_stride
+    cdef uint8_t[PTA_HASH_BUF_MAX_SIZE] hash_buf
+    cdef int hash_offset = 0
+    cdef bint deterministic_status = 0
+    cdef uint64_t ws_size = 0
+    cdef void* executor = NULL
+    cdef const uint8_t* alpha_data = <const uint8_t*>alpha_scalar_bytes
+    cdef int alpha_nbytes = len(alpha_scalar_bytes)
+
+    for i in range(self_ndim):
+        s_shape[i] = self_shape[i]
+        s_stride[i] = self_stride[i]
+    for i in range(other_ndim):
+        o_shape[i] = other_shape[i]
+        o_stride[i] = other_stride[i]
+    for i in range(out_ndim):
+        r_shape[i] = out_shape[i]
+        r_stride[i] = out_stride[i]
+
+    with nogil:
+        _fn_init_pta_cache()
+
+        # Match torch_npu hit_cache_v2 order exactly:
+        # deterministic_status, op_name, args..., stream
+        _pta_buf_append(hash_buf, &hash_offset, &deterministic_status, sizeof(bint))
+        _pta_buf_append_cstr(hash_buf, &hash_offset, b"aclnnAdd")
+        _pta_buf_append_tensor(hash_buf, &hash_offset, s_shape, s_stride, self_ndim, dtype_code, 0, <void*>self_ptr)
+        _pta_buf_append_tensor(hash_buf, &hash_offset, o_shape, o_stride, other_ndim, dtype_code, 0, <void*>other_ptr)
+        _pta_buf_append_scalar(hash_buf, &hash_offset, alpha_data, alpha_nbytes, alpha_dtype_code)
+        _pta_buf_append_tensor(hash_buf, &hash_offset, r_shape, r_stride, out_ndim, dtype_code, 0, <void*>out_ptr)
+        _pta_buf_append(hash_buf, &hash_offset, &stream, sizeof(uintptr_t))
+
+        if hash_offset == PTA_HASH_BUF_MAX_SIZE:
+            _fn_set_pta_hash_key(NULL, 0)
+        else:
+            _fn_set_pta_hash_key(&hash_buf[0], <size_t>hash_offset)
+
+        executor = _fn_pta_find_cache(&hash_buf[0], <size_t>hash_offset, &ws_size)
+
+    return (True, ws_size, <uintptr_t>executor)
+
+
+def pta_end_cache_lookup():
+    """End an active PTA cache context started by pta_begin_add_cache_lookup()."""
+    if not _pta_cache_available:
+        return
+    with nogil:
+        _fn_uninit_pta_cache()
+
+
 
 # ---------------------------------------------------------------------------
 # Tensor creation / destruction

--- a/src/candle/_cython/_npu_ops.pyx
+++ b/src/candle/_cython/_npu_ops.pyx
@@ -257,11 +257,15 @@ cdef object _defer_executor_fn = None    # aclnn._defer_executor
 cdef object _acl_rt_malloc_fn = None     # acl.rt.malloc
 cdef object _acl_rt_free_fn = None       # acl.rt.free (for workspace)
 cdef dict _alpha_one_handles = {}        # dtype_code -> alpha=1 scalar handle (int)
+cdef dict _alpha_one_bytes_cache = {}    # dtype_code -> (bytes, alpha_dtype_code) for PTA hash
+cdef object _pta_cache_begin_fn = None   # _aclnn_ffi.pta_begin_add_cache_lookup
+cdef object _pta_cache_end_fn = None     # _aclnn_ffi.pta_end_cache_lookup
 
 
 cdef inline void _ensure_ffi_add() except *:
     global _ffi_ref, _add_getws_ptr, _add_exec_ptr
     global _defer_executor_fn, _acl_rt_malloc_fn, _acl_rt_free_fn
+    global _pta_cache_begin_fn, _pta_cache_end_fn
     if _ffi_ref is not None:
         return
     from candle._cython import _aclnn_ffi as _f  # pylint: disable=import-error,no-name-in-module
@@ -272,6 +276,9 @@ cdef inline void _ensure_ffi_add() except *:
     _acl = _eacl()
     _acl_rt_malloc_fn = _acl.rt.malloc
     _acl_rt_free_fn = _acl.rt.free
+    if _f.is_pta_cache_available():
+        _pta_cache_begin_fn = _f.pta_begin_add_cache_lookup
+        _pta_cache_end_fn = _f.pta_end_cache_lookup
 
 
 cdef uintptr_t _get_alpha_one(int dtype_code) except? 0:
@@ -280,7 +287,6 @@ cdef uintptr_t _get_alpha_one(int dtype_code) except? 0:
     cdef object existing = _alpha_one_handles.get(dtype_code)
     if existing is not None:
         return <uintptr_t>existing
-    # Build alpha=1 scalar bytes matching aclnn._scalar_bytes(1, dtype)
     import struct
     if dtype_code == 0:    # float32
         scalar_bytes = struct.pack('<f', 1.0)
@@ -307,6 +313,41 @@ cdef uintptr_t _get_alpha_one(int dtype_code) except? 0:
     cdef uintptr_t handle = <uintptr_t>_ffi_ref.create_scalar(scalar_bytes, dtype_code)
     _alpha_one_handles[dtype_code] = handle
     return handle
+
+
+cdef object _get_alpha_one_bytes(int dtype_code):
+    """Return cached (scalar_bytes, scalar_dtype_code) for alpha=1."""
+    global _alpha_one_bytes_cache
+    cdef object existing = _alpha_one_bytes_cache.get(dtype_code)
+    if existing is not None:
+        return existing
+    import struct
+    if dtype_code == 0:    # float32
+        scalar_bytes = struct.pack('<f', 1.0)
+    elif dtype_code == 1:  # float16
+        scalar_bytes = b'\x00\x3c'
+    elif dtype_code == 27: # bfloat16
+        scalar_bytes = b'\x80\x3f'
+    elif dtype_code == 3:  # int32
+        scalar_bytes = struct.pack('<i', 1)
+    elif dtype_code == 9:  # int64
+        scalar_bytes = struct.pack('<q', 1)
+    elif dtype_code == 11: # float64
+        scalar_bytes = struct.pack('<d', 1.0)
+    elif dtype_code == 2:  # int8
+        scalar_bytes = b'\x01'
+    elif dtype_code == 4:  # uint8
+        scalar_bytes = b'\x01'
+    elif dtype_code == 6:  # int16
+        scalar_bytes = b'\x01\x00'
+    elif dtype_code == 12: # bool
+        scalar_bytes = b'\x01'
+    else:
+        scalar_bytes = struct.pack('<f', 1.0)
+        dtype_code = 0
+    existing = (scalar_bytes, dtype_code)
+    _alpha_one_bytes_cache[dtype_code] = existing
+    return existing
 
 
 def fast_add(a, b):
@@ -400,45 +441,91 @@ def fast_add(a, b):
     else:
         dtype_code = 0  # fallback to float32
 
-    cdef uintptr_t alpha_handle = _get_alpha_one(dtype_code)
-
     # 8. Get data pointers — direct C attribute access (no Python method calls)
     cdef uintptr_t a_ptr, b_ptr, o_ptr
     a_ptr = a._storage._untyped._device_ptr
     b_ptr = b._storage._untyped._device_ptr
     o_ptr = out_ptr
 
-    # 9. Call binary_op_with_alpha directly (skips all aclnn.add wrapper overhead)
-    ws_size, executor = _ffi_ref.binary_op_with_alpha(
-        _add_getws_ptr, _add_exec_ptr,
-        py_a_shape, a.stride,
-        py_b_shape, b.stride,
-        out_shape, out_stride,
-        dtype_code, 2,  # ACL_FORMAT_ND = 2
-        a_ptr, b_ptr, o_ptr,
-        alpha_handle,
-        int(stream.stream))
+    cdef uintptr_t stream_raw = int(stream.stream)
+    cdef bint pta_active = False
+    cdef uintptr_t alpha_handle
 
-    # 10. Handle workspace (rare: ws_size > 0 means execute not yet called)
-    if ws_size:
-        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
-        if ret != 0:
-            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
-        try:
-            ret = _ffi_ref.execute(
-                _add_exec_ptr, int(workspace_ptr), ws_size,
-                executor, int(stream.stream))
+    # 9. Try PTA executor cache (torch_npu-aligned hit_cache_v2 path)
+    if _pta_cache_begin_fn is not None:
+        alpha_bytes_pair = _get_alpha_one_bytes(dtype_code)
+        state = _pta_cache_begin_fn(
+            py_a_shape, a.stride,
+            py_b_shape, b.stride,
+            out_shape, out_stride,
+            dtype_code,
+            a_ptr, b_ptr, o_ptr,
+            alpha_bytes_pair[0], alpha_bytes_pair[1],
+            stream_raw)
+        if state is not None:
+            pta_active = bool(state[0])
+            ws_size = state[1]
+            executor = state[2]
+            if executor:
+                try:
+                    if ws_size:
+                        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+                        if ret != 0:
+                            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+                        try:
+                            ret = _ffi_ref.execute(
+                                _add_exec_ptr, int(workspace_ptr), ws_size,
+                                executor, stream_raw)
+                            if ret != 0:
+                                raise RuntimeError(f"aclnnAdd execute failed: {ret}")
+                        finally:
+                            runtime.defer_raw_free(workspace_ptr)
+                    else:
+                        ret = _ffi_ref.execute(_add_exec_ptr, 0, 0, executor, stream_raw)
+                        if ret != 0:
+                            raise RuntimeError(f"aclnnAdd execute failed: {ret}")
+                    return _cy_make_npu_tensor(out_ptr, n, a_dtype, a_dev, out_shape, out_stride)
+                finally:
+                    if pta_active:
+                        _pta_cache_end_fn()
+                        pta_active = False
+
+    try:
+        # 10. Cache miss: full GetWorkspaceSize + Execute path
+        alpha_handle = _get_alpha_one(dtype_code)
+        ws_size, executor = _ffi_ref.binary_op_with_alpha(
+            _add_getws_ptr, _add_exec_ptr,
+            py_a_shape, a.stride,
+            py_b_shape, b.stride,
+            out_shape, out_stride,
+            dtype_code, 2,  # ACL_FORMAT_ND = 2
+            a_ptr, b_ptr, o_ptr,
+            alpha_handle,
+            stream_raw)
+
+        # 11. Handle workspace (rare: ws_size > 0 means execute not yet called)
+        if ws_size:
+            workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
             if ret != 0:
-                raise RuntimeError(f"aclnnAdd execute failed: {ret}")
-        finally:
-            runtime.defer_raw_free(workspace_ptr)
+                raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+            try:
+                ret = _ffi_ref.execute(
+                    _add_exec_ptr, int(workspace_ptr), ws_size,
+                    executor, stream_raw)
+                if ret != 0:
+                    raise RuntimeError(f"aclnnAdd execute failed: {ret}")
+            finally:
+                runtime.defer_raw_free(workspace_ptr)
 
-    # 11. Defer executor cleanup — pass raw int handle directly
-    #     (skips ctypes.c_void_p wrapping; _defer_executor extracts int via
-    #     _executor_handle which handles both c_void_p and plain int)
-    _defer_executor_fn(executor)
+        # 12. Defer executor cleanup — pass raw int handle directly
+        #     (skips ctypes.c_void_p wrapping; _defer_executor extracts int via
+        #     _executor_handle which handles both c_void_p and plain int)
+        _defer_executor_fn(executor)
+    finally:
+        if pta_active:
+            _pta_cache_end_fn()
 
-    # 12. Wrap output — construct Tensor entirely in Cython (same as fast_binary_op)
+    # 13. Wrap output — construct Tensor entirely in Cython (same as fast_binary_op)
     return _cy_make_npu_tensor(out_ptr, n, a_dtype, a_dev, out_shape, out_stride)
 
 

--- a/tests/npu/cython/test_fast_add_hot_path.py
+++ b/tests/npu/cython/test_fast_add_hot_path.py
@@ -51,3 +51,34 @@ def test_fast_add_skips_ctypes_void_p_wrapper(npu_device, monkeypatch):
     _ = torch.add(a, b)
 
     assert calls["count"] == 0
+
+
+def test_fast_add_reuses_cached_executor_for_same_signature(npu_device, monkeypatch):
+    """fast_add should miss once, then hit the PTA executor cache for the same signature."""
+    import pytest
+    import candle as torch
+    import candle._cython._aclnn_ffi as ffi_mod  # pylint: disable=import-error,no-name-in-module
+
+    if not ffi_mod.is_pta_cache_available():
+        pytest.skip("PTA executor cache not available on this CANN build")
+
+    a = torch.randn(7, 5, 3, device=npu_device)
+    b = torch.randn(7, 5, 3, device=npu_device)
+    torch.npu.synchronize()
+
+    calls = {"count": 0}
+    original_binary_op_with_alpha = ffi_mod.binary_op_with_alpha
+
+    def wrapped_binary_op_with_alpha(*args, **kwargs):
+        calls["count"] += 1
+        return original_binary_op_with_alpha(*args, **kwargs)
+
+    monkeypatch.setattr(ffi_mod, "binary_op_with_alpha", wrapped_binary_op_with_alpha)
+
+    _ = torch.add(a, b)
+    torch.npu.synchronize()
+    assert calls["count"] == 1
+
+    _ = torch.add(a, b)
+    torch.npu.synchronize()
+    assert calls["count"] == 1

--- a/tests/npu/cython/test_tensor_desc_cache.py
+++ b/tests/npu/cython/test_tensor_desc_cache.py
@@ -50,7 +50,9 @@ def test_add_uses_cache(npu_device):
     a = torch.randn(4, 4, device=npu_device)
     b = torch.randn(4, 4, device=npu_device)
     torch.npu.synchronize()
-    for _ in range(5):
-        c = torch.add(a, b)
+    _ = torch.add(a, b)
     torch.npu.synchronize()
-    assert cache.size() == 2, f"Expected 2 cached (a,b), got {cache.size()}"
+    # Two valid outcomes:
+    # - 2 entries: add went through GetWorkspaceSize and reused the tensor-desc cache
+    # - 0 entries: a pre-warmed PTA executor cache hit bypassed descriptor creation entirely
+    assert cache.size() in (0, 2), f"Expected 0 or 2 cached entries, got {cache.size()}"


### PR DESCRIPTION
## Summary
- keep the PTA cache context alive across aclnnAdd workspace lookup so repeated identical NPU add calls can reuse cached executors
- add PTA executor-cache symbol resolution and per-call hash-buffer construction in the Cython ACLNN FFI layer
- strengthen NPU hot-path tests for executor-cache reuse and relax descriptor-cache integration coverage for valid PTA-hit behavior

## Test Plan
- [x] `source /opt/miniconda3/etc/profile.d/conda.sh && source /usr/local/Ascend/cann-8.5.0/set_env.sh && conda run -n candle python -m pytest /home/dndx/lvyufeng/candle/.worktrees/perf-pta-cache/tests/npu/cython/test_fast_add_hot_path.py /home/dndx/lvyufeng/candle/.worktrees/perf-pta-cache/tests/npu/cython/test_tensor_desc_cache.py -v --tb=short`
- [x] `source /opt/miniconda3/etc/profile.d/conda.sh && source /usr/local/Ascend/cann-8.5.0/set_env.sh && conda run -n candle python -m pytest /home/dndx/lvyufeng/candle/.worktrees/perf-pta-cache/tests/npu/ -v --tb=short`
- [x] `source /opt/miniconda3/etc/profile.d/conda.sh && source /usr/local/Ascend/cann-8.5.0/set_env.sh && conda run -n candle pylint /home/dndx/lvyufeng/candle/.worktrees/perf-pta-cache/src/candle/ --rcfile=/home/dndx/lvyufeng/candle/.worktrees/perf-pta-cache/.github/pylint.conf`
- [x] `source /opt/miniconda3/etc/profile.d/conda.sh && source /usr/local/Ascend/cann-8.5.0/set_env.sh && conda run -n candle python /home/dndx/lvyufeng/candle/.worktrees/perf-pta-cache/bench_torch_npu.py`
- [x] `source /opt/miniconda3/etc/profile.d/conda.sh && source /usr/local/Ascend/cann-8.5.0/set_env.sh && conda run -n mindie python /home/dndx/lvyufeng/candle/.worktrees/perf-pta-cache/bench_torch_npu.py`

## Benchmarks
Measured on the 910B3 test machine for `torch.add((64,64), float32)`:

| implementation | with sync median | no-sync median |
| --- | ---: | ---: |
| torch_npu | 64.9us | 18.6us |
| candle (this PR) | 116.0us | 53.2us |
| candle (before PTA cache) | 147us | 149us |

Compared with the pre-PTA-cache candle baseline, this PR improves:
- with-sync latency by about **21%** (`147us -> 116.0us`)
- no-sync hot-path latency by about **64%** (`149us -> 53.2us`)

Current gap vs `torch_npu` after this PR:
- with-sync: about **1.79x** slower (`116.0us / 64.9us`)
- no-sync: about **2.86x** slower (`53.2us / 18.6us`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)