### PR TITLE
build: add Cython build caching to 910A and 310B workflows

### DIFF
--- a/.github/workflows/npu-310b.yaml
+++ b/.github/workflows/npu-310b.yaml
@@ -37,6 +37,25 @@ jobs:
       JOB_CONDA_ENV: /tmp/candle-npu-ci-310b
     steps:
     - uses: actions/checkout@v4
+    # ── Cython build artifacts cache ──────────────────────────────
+    - name: Cache Cython build artifacts
+      id: cython-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          build/
+          src/candle/_cython/*.c
+          src/candle/_cython/*.so
+          src/candle/_generated/*.c
+          src/candle/_generated/*.so
+          src/candle/distributed/*.c
+          src/candle/distributed/*.so
+        key: cython-npu-310b-${{ hashFiles('src/**/*.pyx', 'setup.py', 'pyproject.toml') }}
+    - name: Freshen cached build artifacts
+      if: steps.cython-cache.outputs.cache-hit == 'true'
+      run: |
+        find src/ build/ \( -name '*.c' -o -name '*.o' -o -name '*.so' \) \
+          -exec touch {} + 2>/dev/null || true
     - name: Resolve Ascend env script
       shell: bash
       run: |
@@ -150,3 +169,4 @@ jobs:
           /usr/bin/sg "$ASCEND_REQUIRED_GROUP" -c "$cmd"
         }
         clean_env pytest tests/npu/common/ -v --tb=short
+

--- a/.github/workflows/npu.yaml
+++ b/.github/workflows/npu.yaml
@@ -37,6 +37,25 @@ jobs:
       JOB_CONDA_ENV: /tmp/candle-npu-ci-6-7
     steps:
     - uses: actions/checkout@v4
+    # ── Cython build artifacts cache ──────────────────────────────
+    - name: Cache Cython build artifacts
+      id: cython-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          build/
+          src/candle/_cython/*.c
+          src/candle/_cython/*.so
+          src/candle/_generated/*.c
+          src/candle/_generated/*.so
+          src/candle/distributed/*.c
+          src/candle/distributed/*.so
+        key: cython-npu-910a-${{ hashFiles('src/**/*.pyx', 'setup.py', 'pyproject.toml') }}
+    - name: Freshen cached build artifacts
+      if: steps.cython-cache.outputs.cache-hit == 'true'
+      run: |
+        find src/ build/ \( -name '*.c' -o -name '*.o' -o -name '*.so' \) \
+          -exec touch {} + 2>/dev/null || true
     - name: Prepare conda environment
       run: |
         "$CONDA_EXE" create -y -p "$JOB_CONDA_ENV" python=3.11 pip
@@ -142,6 +161,25 @@ jobs:
       JOB_CONDA_ENV: /tmp/candle-npu-ci-4-5
     steps:
     - uses: actions/checkout@v4
+    # ── Cython build artifacts cache ──────────────────────────────
+    - name: Cache Cython build artifacts
+      id: cython-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          build/
+          src/candle/_cython/*.c
+          src/candle/_cython/*.so
+          src/candle/_generated/*.c
+          src/candle/_generated/*.so
+          src/candle/distributed/*.c
+          src/candle/distributed/*.so
+        key: cython-npu-910a-${{ hashFiles('src/**/*.pyx', 'setup.py', 'pyproject.toml') }}
+    - name: Freshen cached build artifacts
+      if: steps.cython-cache.outputs.cache-hit == 'true'
+      run: |
+        find src/ build/ \( -name '*.c' -o -name '*.o' -o -name '*.so' \) \
+          -exec touch {} + 2>/dev/null || true
     - name: Prepare conda environment
       run: |
         "$CONDA_EXE" create -y -p "$JOB_CONDA_ENV" python=3.11 pip
@@ -277,6 +315,25 @@ jobs:
       JOB_CONDA_ENV: /tmp/candle-npu-ci-0-3
     steps:
     - uses: actions/checkout@v4
+    # ── Cython build artifacts cache ──────────────────────────────
+    - name: Cache Cython build artifacts
+      id: cython-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          build/
+          src/candle/_cython/*.c
+          src/candle/_cython/*.so
+          src/candle/_generated/*.c
+          src/candle/_generated/*.so
+          src/candle/distributed/*.c
+          src/candle/distributed/*.so
+        key: cython-npu-910a-${{ hashFiles('src/**/*.pyx', 'setup.py', 'pyproject.toml') }}
+    - name: Freshen cached build artifacts
+      if: steps.cython-cache.outputs.cache-hit == 'true'
+      run: |
+        find src/ build/ \( -name '*.c' -o -name '*.o' -o -name '*.so' \) \
+          -exec touch {} + 2>/dev/null || true
     - name: Prepare conda environment
       run: |
         "$CONDA_EXE" create -y -p "$JOB_CONDA_ENV" python=3.11 pip


### PR DESCRIPTION
## Summary
- Add Cython build artifact caching to `npu.yaml` (910A: test-npu, test-distributed-2card, test-distributed-4card)
- Add Cython build artifact caching to `npu-310b.yaml` (test-310b)
- Same pattern as ci.yaml: cache `.c`, `.so`, `build/` keyed on `.pyx` hashes, touch timestamps on hit to skip rebuild

## Test plan
- [ ] NPU 910A workflow runs successfully with cache steps
- [ ] NPU 310B workflow runs successfully with cache steps
- [ ] Second run on same branch shows cache hit and faster build


🤖 Generated with [Claude Code](https://claude.com/claude-code)