### PR TITLE
docs(github): add issue and PR templates for human and AI contributors

### DIFF
--- a/.github/ISSUE_TEMPLATE/ai-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/ai-bug-report.yml
@@ -1,0 +1,75 @@
+name: "AI: Bug Report"
+description: Structured bug report generated or filed by an AI agent
+labels: ["bug"]
+title: "[AI Bug]: "
+body:
+  - type: dropdown
+    id: tool
+    attributes:
+      label: Agent tool
+      options:
+        - Claude Code
+        - Cursor
+        - GitHub Copilot
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: linked
+    attributes:
+      label: Related issue or roadmap item
+      placeholder: "#205"
+    validations:
+      required: false
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Structured summary
+      placeholder: Describe the bug in 2-5 sentences
+    validations:
+      required: true
+
+  - type: textarea
+    id: files
+    attributes:
+      label: Relevant files or subsystems
+      placeholder: |
+        - src/candle/...
+        - tests/...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Exact reproduction commands
+      render: shell
+      placeholder: |
+        python -m pytest ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed output
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: root_cause
+    attributes:
+      label: Likely root cause
+      description: Optional but encouraged.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/ai-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/ai-feature-request.yml
@@ -1,0 +1,61 @@
+name: "AI: Feature Request"
+description: Structured feature proposal generated or filed by an AI agent
+labels: ["enhancement"]
+title: "[AI Feature]: "
+body:
+  - type: dropdown
+    id: tool
+    attributes:
+      label: Agent tool
+      options:
+        - Claude Code
+        - Cursor
+        - GitHub Copilot
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: linked
+    attributes:
+      label: Linked roadmap issue
+      placeholder: "#204"
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      placeholder: Explain the problem this proposal solves
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed implementation direction
+      placeholder: Summarize the intended approach without pasting full code
+    validations:
+      required: true
+
+  - type: textarea
+    id: areas
+    attributes:
+      label: Affected files or subsystems
+      placeholder: |
+        - src/candle/...
+        - tests/...
+        - compat/...
+    validations:
+      required: true
+
+  - type: textarea
+    id: success
+    attributes:
+      label: Success criteria
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/ai-task.yml
+++ b/.github/ISSUE_TEMPLATE/ai-task.yml
@@ -1,0 +1,64 @@
+name: "AI: Task"
+description: Structured implementation task created by an AI agent
+title: "[AI Task]: "
+body:
+  - type: dropdown
+    id: tool
+    attributes:
+      label: Agent tool
+      options:
+        - Claude Code
+        - Cursor
+        - GitHub Copilot
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: parent
+    attributes:
+      label: Parent issue or roadmap item
+      placeholder: "#206"
+    validations:
+      required: true
+
+  - type: textarea
+    id: objective
+    attributes:
+      label: Task objective
+      placeholder: Describe the concrete deliverable
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope boundaries
+      placeholder: |
+        In scope:
+        - ...
+
+        Out of scope:
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: files
+    attributes:
+      label: Expected touched files
+      placeholder: |
+        - .github/...
+        - src/candle/...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,60 @@
+name: "Human: Bug Report"
+description: Report a reproducible bug in candle
+labels: ["bug"]
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug report. Please share the smallest reproducible case you can.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the incorrect behavior.
+      placeholder: candle returned X, but expected Y
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How can we reproduce it?
+      description: Include exact code, commands, or inputs.
+      placeholder: |
+        1. Run ...
+        2. Call ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      placeholder: Describe the correct or PyTorch-compatible behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Python version, backend/device, and candle commit if known.
+      placeholder: |
+        - OS:
+        - Python:
+        - Device/backend:
+        - candle commit:
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs, tracebacks, or screenshots
+      description: Paste any relevant output.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: General project issues
+    url: https://github.com/candle-org/candle/issues
+    about: If none of the templates fit, review existing issues before opening a new one.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,41 @@
+name: "Human: Feature Request"
+description: Propose a new feature or API improvement
+labels: ["enhancement"]
+title: "[Feature]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please focus on the user problem first and implementation details second.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      placeholder: I need candle to support ... because ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like to see?
+      placeholder: Describe the API, workflow, or behavior you want
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional. Share workarounds or other ideas you considered.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links to prior issues, benchmarks, docs, or model compatibility needs.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,33 @@
+name: "Human: Question"
+description: Ask a usage or project question
+labels: ["question"]
+title: "[Question]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please share enough context for someone else to answer without guessing.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: What is your question?
+      placeholder: I'm trying to understand ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Relevant context
+      description: Share the API, backend, model, or workflow involved.
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you already tried?
+      description: Optional. Mention docs, code, or experiments you checked first.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,49 @@
+name: "Human: Task (Sub-issue)"
+description: Break a roadmap item or larger issue into a concrete task
+title: "[Task]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for concrete work items that hang off a larger roadmap issue or parent task.
+
+  - type: input
+    id: parent
+    attributes:
+      label: Parent issue or roadmap item
+      description: Enter an issue number or full GitHub URL.
+      placeholder: "#204"
+    validations:
+      required: true
+
+  - type: textarea
+    id: objective
+    attributes:
+      label: Task objective
+      placeholder: Implement ... so that ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope boundaries
+      description: Describe what is in scope and what should explicitly stay out of scope.
+      placeholder: |
+        In scope:
+        - ...
+
+        Out of scope:
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE/ai.md
+++ b/.github/PULL_REQUEST_TEMPLATE/ai.md
@@ -1,0 +1,55 @@
+## Agent tool
+
+- Tool:
+- Model / environment (optional):
+
+## Linked issue(s)
+
+- Closes #
+- Related to #
+
+## Change summary
+
+-
+
+## Files changed / affected areas
+
+-
+
+## Validation evidence
+
+### Commands run
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n mindnlp python -m pytest ...
+pylint src/candle/ --rcfile=.github/pylint.conf
+```
+
+### Key output
+
+```text
+Paste the relevant passing output here.
+```
+
+## Test plan
+
+- [ ] CPU tests
+- [ ] MPS tests (if relevant)
+- [ ] NPU tests (if relevant)
+- [ ] Pylint
+- [ ] Not run (explain why)
+
+## Reviewer notes / remaining risks
+
+-
+
+## Checklist
+
+- [ ] I disclosed the agent tool used for this submission
+- [ ] I linked the relevant issue(s)
+- [ ] I included a concise change summary
+- [ ] I included validation evidence and commands run
+- [ ] I did not add unrelated changes
+- [ ] I did not bypass schema validation to make tests pass
+- [ ] I did not introduce CPU fallback for GPU/NPU behavior
+- [ ] I only updated docs/comments where needed

--- a/.github/PULL_REQUEST_TEMPLATE/human.md
+++ b/.github/PULL_REQUEST_TEMPLATE/human.md
@@ -1,0 +1,21 @@
+## Summary
+
+-
+
+## Linked issue
+
+- Closes #
+- Related to #
+
+## Test plan
+
+- [ ] Not run (explain why)
+- [ ] `source ~/miniconda3/etc/profile.d/conda.sh && conda run -n mindnlp python -m pytest ...`
+- [ ] `pylint src/candle/ --rcfile=.github/pylint.conf`
+
+## Checklist
+
+- [ ] I linked the relevant issue(s), if any
+- [ ] I ran relevant tests or explained why I did not
+- [ ] I updated docs/comments only where needed
+- [ ] This PR does not include unrelated changes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Summary
+
+-
+
+## Linked issue
+
+- Closes #
+- Related to #
+
+## Test plan
+
+- [ ] Not run (explain why)
+- [ ] `source ~/miniconda3/etc/profile.d/conda.sh && conda run -n mindnlp python -m pytest ...`
+- [ ] `pylint src/candle/ --rcfile=.github/pylint.conf`
+
+## Checklist
+
+- [ ] I linked the relevant issue(s), if any
+- [ ] I ran relevant tests or explained why I did not
+- [ ] I updated docs/comments only where needed
+- [ ] This PR does not include unrelated changes
+
+> If this PR is primarily AI-authored, switch to `.github/PULL_REQUEST_TEMPLATE/ai.md` so the submission includes tool disclosure, change summary, and validation evidence.

--- a/docs/superpowers/plans/2026-03-24-github-templates.md
+++ b/docs/superpowers/plans/2026-03-24-github-templates.md
@@ -1,0 +1,796 @@
+# GitHub Templates Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add GitHub-native issue and PR templates that distinguish human contributors from AI agents while keeping human submissions low-friction and AI submissions evidence-driven.
+
+**Architecture:** Create issue forms under `.github/ISSUE_TEMPLATE/` and separate PR templates under `.github/PULL_REQUEST_TEMPLATE/`. Human templates stay concise and contributor-friendly; AI templates require explicit tool provenance, linked issues, change summaries, and validation evidence.
+
+**Tech Stack:** GitHub issue forms (YAML), Markdown PR templates, git worktrees, gh CLI, Python stdlib for lightweight local validation
+
+---
+
+## File Map
+
+### New files
+- `.github/ISSUE_TEMPLATE/config.yml` — issue chooser behavior and blank-issue policy
+- `.github/ISSUE_TEMPLATE/bug-report.yml` — human bug report form
+- `.github/ISSUE_TEMPLATE/feature-request.yml` — human feature request form
+- `.github/ISSUE_TEMPLATE/task.yml` — human roadmap/sub-issue task form
+- `.github/ISSUE_TEMPLATE/question.yml` — human question form
+- `.github/ISSUE_TEMPLATE/ai-bug-report.yml` — AI bug report form
+- `.github/ISSUE_TEMPLATE/ai-feature-request.yml` — AI feature request form
+- `.github/ISSUE_TEMPLATE/ai-task.yml` — AI task form
+- `.github/PULL_REQUEST_TEMPLATE/human.md` — concise human PR template
+- `.github/PULL_REQUEST_TEMPLATE/ai.md` — structured AI PR template
+
+### Existing files to inspect during implementation
+- `CLAUDE.md` — repository constraints that AI PR checklist should reinforce
+- `.github/workflows/ci.yaml` — current CI jobs to reference in test-plan wording if needed
+- `docs/superpowers/specs/2026-03-24-github-templates-design.md` — approved design spec
+
+---
+
+## Chunk 1: Issue template infrastructure and human templates
+
+### Task 1: Create issue chooser config and core human forms
+
+**Files:**
+- Create: `.github/ISSUE_TEMPLATE/config.yml`
+- Create: `.github/ISSUE_TEMPLATE/bug-report.yml`
+- Create: `.github/ISSUE_TEMPLATE/feature-request.yml`
+- Test: `.github/ISSUE_TEMPLATE/config.yml`
+- Test: `.github/ISSUE_TEMPLATE/bug-report.yml`
+- Test: `.github/ISSUE_TEMPLATE/feature-request.yml`
+
+- [ ] **Step 1: Confirm the template directories do not already exist**
+
+Run:
+```bash
+ls .github/ISSUE_TEMPLATE .github/PULL_REQUEST_TEMPLATE
+```
+Expected: `No such file or directory` for both paths on a fresh checkout.
+
+- [ ] **Step 2: Create the template directories**
+
+Run:
+```bash
+mkdir -p .github/ISSUE_TEMPLATE .github/PULL_REQUEST_TEMPLATE
+```
+
+- [ ] **Step 3: Write `.github/ISSUE_TEMPLATE/config.yml`**
+
+```yml
+blank_issues_enabled: false
+```
+
+- [ ] **Step 4: Write `.github/ISSUE_TEMPLATE/bug-report.yml`**
+
+```yml
+name: Human: Bug Report
+description: Report a reproducible bug in candle
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug report. Please share the smallest reproducible case you can.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the incorrect behavior.
+      placeholder: candle returned X, but expected Y
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How can we reproduce it?
+      description: Include exact code, commands, or inputs.
+      placeholder: |
+        1. Run ...
+        2. Call ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      placeholder: Describe the correct or PyTorch-compatible behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Python version, backend/device, and candle commit if known.
+      placeholder: |
+        - OS:
+        - Python:
+        - Device/backend:
+        - candle commit:
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs, tracebacks, or screenshots
+      description: Paste any relevant output.
+      render: shell
+    validations:
+      required: false
+```
+
+- [ ] **Step 5: Write `.github/ISSUE_TEMPLATE/feature-request.yml`**
+
+```yml
+name: Human: Feature Request
+description: Propose a new feature or API improvement
+title: "[Feature]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please focus on the user problem first and implementation details second.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      placeholder: I need candle to support ... because ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like to see?
+      placeholder: Describe the API, workflow, or behavior you want
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional. Share workarounds or other ideas you considered.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links to prior issues, benchmarks, docs, or model compatibility needs.
+    validations:
+      required: false
+```
+
+- [ ] **Step 6: Run lightweight structural validation for the three files**
+
+Run:
+```bash
+python - <<'PY'
+from pathlib import Path
+paths = [
+    Path('.github/ISSUE_TEMPLATE/config.yml'),
+    Path('.github/ISSUE_TEMPLATE/bug-report.yml'),
+    Path('.github/ISSUE_TEMPLATE/feature-request.yml'),
+]
+for path in paths:
+    text = path.read_text()
+    assert text.strip(), f"{path} is empty"
+    if path.name == 'config.yml':
+        assert 'blank_issues_enabled:' in text
+    else:
+        assert text.startswith('name:'), f"{path} missing name header"
+        assert 'body:' in text, f"{path} missing body section"
+print('validated', len(paths), 'files')
+PY
+```
+Expected: `validated 3 files`
+
+- [ ] **Step 7: Commit the first issue template batch**
+
+```bash
+git add .github/ISSUE_TEMPLATE/config.yml .github/ISSUE_TEMPLATE/bug-report.yml .github/ISSUE_TEMPLATE/feature-request.yml
+git commit -m "docs(github): add human bug and feature templates"
+```
+
+### Task 2: Add human task and question forms
+
+**Files:**
+- Create: `.github/ISSUE_TEMPLATE/task.yml`
+- Create: `.github/ISSUE_TEMPLATE/question.yml`
+- Test: `.github/ISSUE_TEMPLATE/task.yml`
+- Test: `.github/ISSUE_TEMPLATE/question.yml`
+
+- [ ] **Step 1: Write `.github/ISSUE_TEMPLATE/task.yml`**
+
+```yml
+name: Human: Task (Sub-issue)
+description: Break a roadmap item or larger issue into a concrete task
+title: "[Task]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for concrete work items that hang off a larger roadmap issue or parent task.
+
+  - type: input
+    id: parent
+    attributes:
+      label: Parent issue or roadmap item
+      description: Enter an issue number or full GitHub URL.
+      placeholder: "#204"
+    validations:
+      required: true
+
+  - type: textarea
+    id: objective
+    attributes:
+      label: Task objective
+      placeholder: Implement ... so that ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope boundaries
+      description: Describe what is in scope and what should explicitly stay out of scope.
+      placeholder: |
+        In scope:
+        - ...
+
+        Out of scope:
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+```
+
+- [ ] **Step 2: Write `.github/ISSUE_TEMPLATE/question.yml`**
+
+```yml
+name: Human: Question
+description: Ask a usage or project question
+title: "[Question]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please share enough context for someone else to answer without guessing.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: What is your question?
+      placeholder: I'm trying to understand ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Relevant context
+      description: Share the API, backend, model, or workflow involved.
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you already tried?
+      description: Optional. Mention docs, code, or experiments you checked first.
+    validations:
+      required: false
+```
+
+- [ ] **Step 3: Run structural validation for the new human issue forms**
+
+Run:
+```bash
+python - <<'PY'
+from pathlib import Path
+paths = [
+    Path('.github/ISSUE_TEMPLATE/task.yml'),
+    Path('.github/ISSUE_TEMPLATE/question.yml'),
+]
+for path in paths:
+    text = path.read_text()
+    assert text.startswith('name:'), f"{path} missing name header"
+    assert 'body:' in text, f"{path} missing body section"
+    assert 'required: true' in text, f"{path} missing required fields"
+print('validated', len(paths), 'files')
+PY
+```
+Expected: `validated 2 files`
+
+- [ ] **Step 4: Commit the remaining human issue forms**
+
+```bash
+git add .github/ISSUE_TEMPLATE/task.yml .github/ISSUE_TEMPLATE/question.yml
+git commit -m "docs(github): add human task and question templates"
+```
+
+## Chunk 2: AI issue forms and PR templates
+
+### Task 3: Add AI issue forms with structured provenance and linkage
+
+**Files:**
+- Create: `.github/ISSUE_TEMPLATE/ai-bug-report.yml`
+- Create: `.github/ISSUE_TEMPLATE/ai-feature-request.yml`
+- Create: `.github/ISSUE_TEMPLATE/ai-task.yml`
+- Test: `.github/ISSUE_TEMPLATE/ai-bug-report.yml`
+- Test: `.github/ISSUE_TEMPLATE/ai-feature-request.yml`
+- Test: `.github/ISSUE_TEMPLATE/ai-task.yml`
+
+- [ ] **Step 1: Write `.github/ISSUE_TEMPLATE/ai-bug-report.yml`**
+
+```yml
+name: AI: Bug Report
+description: Structured bug report generated or filed by an AI agent
+title: "[AI Bug]: "
+body:
+  - type: dropdown
+    id: tool
+    attributes:
+      label: Agent tool
+      options:
+        - Claude Code
+        - Cursor
+        - GitHub Copilot
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: linked
+    attributes:
+      label: Related issue or roadmap item
+      placeholder: "#205"
+    validations:
+      required: false
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Structured summary
+      placeholder: Describe the bug in 2-5 sentences
+    validations:
+      required: true
+
+  - type: textarea
+    id: files
+    attributes:
+      label: Relevant files or subsystems
+      placeholder: |
+        - src/candle/...
+        - tests/...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Exact reproduction commands
+      render: shell
+      placeholder: |
+        python -m pytest ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed output
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: root_cause
+    attributes:
+      label: Likely root cause
+      description: Optional but encouraged.
+    validations:
+      required: false
+```
+
+- [ ] **Step 2: Write `.github/ISSUE_TEMPLATE/ai-feature-request.yml`**
+
+```yml
+name: AI: Feature Request
+description: Structured feature proposal generated or filed by an AI agent
+title: "[AI Feature]: "
+body:
+  - type: dropdown
+    id: tool
+    attributes:
+      label: Agent tool
+      options:
+        - Claude Code
+        - Cursor
+        - GitHub Copilot
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: linked
+    attributes:
+      label: Linked roadmap issue
+      placeholder: "#204"
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      placeholder: Explain the problem this proposal solves
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed implementation direction
+      placeholder: Summarize the intended approach without pasting full code
+    validations:
+      required: true
+
+  - type: textarea
+    id: areas
+    attributes:
+      label: Affected files or subsystems
+      placeholder: |
+        - src/candle/...
+        - tests/...
+        - compat/...
+    validations:
+      required: true
+
+  - type: textarea
+    id: success
+    attributes:
+      label: Success criteria
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+```
+
+- [ ] **Step 3: Write `.github/ISSUE_TEMPLATE/ai-task.yml`**
+
+```yml
+name: AI: Task
+description: Structured implementation task created by an AI agent
+title: "[AI Task]: "
+body:
+  - type: dropdown
+    id: tool
+    attributes:
+      label: Agent tool
+      options:
+        - Claude Code
+        - Cursor
+        - GitHub Copilot
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: parent
+    attributes:
+      label: Parent issue or roadmap item
+      placeholder: "#206"
+    validations:
+      required: true
+
+  - type: textarea
+    id: objective
+    attributes:
+      label: Task objective
+      placeholder: Describe the concrete deliverable
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope boundaries
+      placeholder: |
+        In scope:
+        - ...
+
+        Out of scope:
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: files
+    attributes:
+      label: Expected touched files
+      placeholder: |
+        - .github/...
+        - src/candle/...
+    validations:
+      required: false
+```
+
+- [ ] **Step 4: Validate the AI issue form files**
+
+Run:
+```bash
+python - <<'PY'
+from pathlib import Path
+paths = [
+    Path('.github/ISSUE_TEMPLATE/ai-bug-report.yml'),
+    Path('.github/ISSUE_TEMPLATE/ai-feature-request.yml'),
+    Path('.github/ISSUE_TEMPLATE/ai-task.yml'),
+]
+for path in paths:
+    text = path.read_text()
+    assert text.startswith('name:'), f"{path} missing name header"
+    assert 'Agent tool' in text, f"{path} missing agent disclosure"
+    assert 'body:' in text, f"{path} missing body section"
+print('validated', len(paths), 'files')
+PY
+```
+Expected: `validated 3 files`
+
+- [ ] **Step 5: Commit the AI issue forms**
+
+```bash
+git add .github/ISSUE_TEMPLATE/ai-bug-report.yml .github/ISSUE_TEMPLATE/ai-feature-request.yml .github/ISSUE_TEMPLATE/ai-task.yml
+git commit -m "docs(github): add AI issue templates"
+```
+
+### Task 4: Add separate human and AI PR templates
+
+**Files:**
+- Create: `.github/PULL_REQUEST_TEMPLATE/human.md`
+- Create: `.github/PULL_REQUEST_TEMPLATE/ai.md`
+- Test: `.github/PULL_REQUEST_TEMPLATE/human.md`
+- Test: `.github/PULL_REQUEST_TEMPLATE/ai.md`
+
+- [ ] **Step 1: Write `.github/PULL_REQUEST_TEMPLATE/human.md`**
+
+```md
+## Summary
+
+-
+
+## Linked issue
+
+- Closes #
+- Related to #
+
+## Test plan
+
+- [ ] Not run (explain why)
+- [ ] `source ~/miniconda3/etc/profile.d/conda.sh && conda run -n mindnlp python -m pytest ...`
+- [ ] `pylint src/candle/ --rcfile=.github/pylint.conf`
+
+## Checklist
+
+- [ ] I linked the relevant issue(s), if any
+- [ ] I ran relevant tests or explained why I did not
+- [ ] I updated docs/comments only where needed
+- [ ] This PR does not include unrelated changes
+```
+
+- [ ] **Step 2: Write `.github/PULL_REQUEST_TEMPLATE/ai.md`**
+
+```md
+## Agent tool
+
+- Tool:
+- Model / environment (optional):
+
+## Linked issue(s)
+
+- Closes #
+- Related to #
+
+## Change summary
+
+-
+
+## Files changed / affected areas
+
+-
+
+## Validation evidence
+
+### Commands run
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n mindnlp python -m pytest ...
+pylint src/candle/ --rcfile=.github/pylint.conf
+```
+
+### Key output
+
+```text
+Paste the relevant passing output here.
+```
+
+## Test plan
+
+- [ ] CPU tests
+- [ ] MPS tests (if relevant)
+- [ ] NPU tests (if relevant)
+- [ ] Pylint
+- [ ] Not run (explain why)
+
+## Reviewer notes / remaining risks
+
+-
+
+## Checklist
+
+- [ ] I disclosed the agent tool used for this submission
+- [ ] I linked the relevant issue(s)
+- [ ] I included a concise change summary
+- [ ] I included validation evidence and commands run
+- [ ] I did not add unrelated changes
+- [ ] I did not bypass schema validation to make tests pass
+- [ ] I did not introduce CPU fallback for GPU/NPU behavior
+- [ ] I only updated docs/comments where needed
+```
+
+- [ ] **Step 3: Validate the PR templates contain the required sections**
+
+Run:
+```bash
+python - <<'PY'
+from pathlib import Path
+required = {
+    Path('.github/PULL_REQUEST_TEMPLATE/human.md'): [
+        '## Summary',
+        '## Linked issue',
+        '## Test plan',
+        '## Checklist',
+    ],
+    Path('.github/PULL_REQUEST_TEMPLATE/ai.md'): [
+        '## Agent tool',
+        '## Linked issue(s)',
+        '## Change summary',
+        '## Validation evidence',
+        '## Checklist',
+    ],
+}
+for path, sections in required.items():
+    text = path.read_text()
+    for section in sections:
+        assert section in text, f"{path} missing {section}"
+print('validated', len(required), 'files')
+PY
+```
+Expected: `validated 2 files`
+
+- [ ] **Step 4: Commit the PR templates**
+
+```bash
+git add .github/PULL_REQUEST_TEMPLATE/human.md .github/PULL_REQUEST_TEMPLATE/ai.md
+git commit -m "docs(github): add human and AI PR templates"
+```
+
+## Chunk 3: Final validation and polish
+
+### Task 5: Validate the full template set and polish wording
+
+**Files:**
+- Modify: `.github/ISSUE_TEMPLATE/config.yml` (only if chooser wording needs a final tweak)
+- Modify: `.github/ISSUE_TEMPLATE/*.yml` (only if validation or review reveals wording problems)
+- Modify: `.github/PULL_REQUEST_TEMPLATE/*.md` (only if validation or review reveals wording problems)
+- Test: `.github/ISSUE_TEMPLATE/*.yml`
+- Test: `.github/PULL_REQUEST_TEMPLATE/*.md`
+
+- [ ] **Step 1: Verify only the expected template files were added under `.github/`**
+
+Run:
+```bash
+git status --short .github
+```
+Expected: only the new template files appear.
+
+- [ ] **Step 2: Run whitespace and formatting validation**
+
+Run:
+```bash
+git diff --check
+```
+Expected: no output.
+
+- [ ] **Step 3: Run a full structural validation pass across all templates**
+
+Run:
+```bash
+python - <<'PY'
+from pathlib import Path
+issue_files = sorted(Path('.github/ISSUE_TEMPLATE').glob('*.yml'))
+pr_files = sorted(Path('.github/PULL_REQUEST_TEMPLATE').glob('*.md'))
+assert len(issue_files) == 7, issue_files
+assert len(pr_files) == 2, pr_files
+for path in issue_files:
+    text = path.read_text()
+    assert text.strip(), f"{path} is empty"
+    if path.name == 'config.yml':
+        assert 'blank_issues_enabled:' in text
+    else:
+        assert 'name:' in text and 'body:' in text, f"{path} missing issue-form structure"
+for path in pr_files:
+    text = path.read_text()
+    assert '## Checklist' in text, f"{path} missing checklist"
+print('validated', len(issue_files), 'issue files and', len(pr_files), 'PR files')
+PY
+```
+Expected: `validated 7 issue files and 2 PR files`
+
+- [ ] **Step 4: Do a manual content pass focused on UX differences**
+
+Check manually:
+- human forms are clearly shorter than AI forms
+- AI forms require agent disclosure and linked issue context
+- AI PR template requires validation evidence
+- Task templates are suitable for roadmap decomposition
+
+- [ ] **Step 5: Make any final wording-only edits revealed by the validation pass**
+
+Apply only wording and required/optional-field tweaks. Do not add automation, CI, or extra template families.
+
+- [ ] **Step 6: Commit the final polish**
+
+```bash
+git add .github/ISSUE_TEMPLATE .github/PULL_REQUEST_TEMPLATE
+git commit -m "docs(github): polish contribution templates"
+```
+
+---
+
+## Notes for the implementing agent
+
+- Keep the scope limited to template files only.
+- Do not add GitHub Actions enforcement, bots, or auto-labeling.
+- Do not add `CONTRIBUTING.md` in this implementation.
+- Follow the approved design spec exactly unless a GitHub platform limitation forces a small compatibility adjustment; if that happens, document the reason in the PR description.
+- If GitHub PR-template selection behavior needs a fallback after manual validation, surface that as a follow-up issue instead of silently expanding scope.

--- a/docs/superpowers/specs/2026-03-24-github-templates-design.md
+++ b/docs/superpowers/specs/2026-03-24-github-templates-design.md
@@ -1,0 +1,418 @@
+# GitHub Issue and PR Templates Design Spec
+
+**Date:** 2026-03-24
+**Status:** Draft
+
+## Goal
+
+Add a first-class GitHub contribution intake system for candle with:
+
+1. structured **issue templates** for common contributor workflows
+2. differentiated **human** vs **AI agent** submission paths
+3. structured **PR templates** optimized for review quality and verification
+4. alignment with candle's existing engineering expectations (roadmap-driven work, conventional-commit style, verification evidence, and backend safety constraints)
+
+The design should improve issue triage quality and PR review quality without adding unnecessary process burden for human contributors.
+
+---
+
+## Background
+
+The repository currently has no issue templates and no PR templates under `.github/`. As a result:
+
+- issue quality depends entirely on contributor initiative
+- maintainers do not get consistent reproduction info, environment details, or acceptance criteria
+- AI-authored submissions are not explicitly distinguished from human-authored ones
+- review expectations such as linked issue, validation commands, and changed-file summary are not consistently requested
+
+At the same time, candle now has larger roadmap issues for Hugging Face ecosystem support, vLLM support, and Megatron compatibility. That makes it useful to add a **Task / sub-issue** template that can hang concrete implementation work off those umbrella roadmaps.
+
+---
+
+## Design Principles
+
+1. **Separate contributor experiences**
+   Human contributors should see short, friendly forms. AI agents should see more structured, machine-oriented forms with required evidence fields.
+
+2. **Use GitHub-native mechanisms**
+   Prefer GitHub issue forms (`.yml`) and built-in PR template selection rather than custom bots or CI parsing.
+
+3. **Minimize burden on humans**
+   Human templates should ask only for information that materially improves triage or review.
+
+4. **Require stronger structure from AI submissions**
+   AI-authored issues and PRs should explicitly disclose the agent/tool used, linked issue context, test evidence, and concise change summary.
+
+5. **Support roadmap decomposition**
+   Add a dedicated Task issue type so maintainers can turn large roadmap items into smaller tracked work units.
+
+6. **Keep the system simple to maintain**
+   Avoid dynamic automation or template logic that would require GitHub Apps, Actions, or external services.
+
+---
+
+## Approaches Considered
+
+### Approach A — Single shared template with a source field
+
+Use one issue template family and one PR template, with a dropdown for `Human` vs `AI Agent`.
+
+**Pros**
+- fewer files
+- easier to maintain
+- one canonical structure
+
+**Cons**
+- weaker separation between human and AI expectations
+- human contributors still see AI-oriented fields or instructions
+- harder to make AI templates significantly more structured
+
+### Approach B — Separate human and AI templates
+
+Create distinct issue templates for human contributors and AI contributors, plus separate PR templates for human and AI submissions.
+
+**Pros**
+- clear contributor-specific UX
+- human forms stay concise
+- AI forms can require structured fields without burdening humans
+- easier for maintainers to reason about submission quality expectations
+
+**Cons**
+- more files to maintain
+- some overlap in wording
+
+### Approach C — Shared human-facing templates plus automation-based AI labeling
+
+Keep one contributor-facing template set and rely on bot/CI logic or conventions to detect AI submissions.
+
+**Pros**
+- minimal template count
+- less visible complexity in the GitHub UI
+
+**Cons**
+- detection is unreliable
+- review quality still depends on submitter discipline
+- requires more automation later
+
+### Recommendation
+
+Use **Approach B: Separate human and AI templates**.
+
+This best matches the repository's needs: humans get a lighter-weight contribution path, while AI agents are held to a higher bar for structured context and verification evidence.
+
+---
+
+## Final Architecture
+
+### Directory layout
+
+```text
+.github/
+├── ISSUE_TEMPLATE/
+│   ├── config.yml
+│   ├── bug-report.yml
+│   ├── feature-request.yml
+│   ├── task.yml
+│   ├── question.yml
+│   ├── ai-bug-report.yml
+│   ├── ai-feature-request.yml
+│   └── ai-task.yml
+└── PULL_REQUEST_TEMPLATE/
+    ├── human.md
+    └── ai.md
+```
+
+### Why this structure
+
+- `ISSUE_TEMPLATE/config.yml` controls template chooser behavior and contributor guidance.
+- Human issue forms cover the four requested public contribution modes:
+  - Bug Report
+  - Feature Request
+  - Task (sub-issue)
+  - Question
+- AI issue forms focus on structured, high-signal reporting for the issue types most likely to be opened by agents:
+  - AI Bug Report
+  - AI Feature Request
+  - AI Task
+- PR templates are split into `human.md` and `ai.md` so reviewers can choose the right review contract for the submission source.
+
+---
+
+## Issue Template Design
+
+### Human issue templates
+
+#### 1. Bug Report
+
+**Purpose:** collect enough information to reproduce and triage a defect.
+
+**Fields**
+- summary / what happened
+- reproduction steps
+- expected behavior
+- environment
+- logs or screenshots (optional)
+
+**Tone:** natural language, low friction.
+
+#### 2. Feature Request
+
+**Purpose:** capture user value before implementation detail.
+
+**Fields**
+- problem or motivation
+- proposed solution
+- alternatives considered (optional)
+- additional context
+
+**Tone:** product/problem oriented.
+
+#### 3. Task (sub-issue)
+
+**Purpose:** break roadmap items or larger work into concrete, actionable tasks.
+
+**Fields**
+- parent issue / roadmap link
+- task description
+- scope boundaries
+- acceptance criteria
+
+**Tone:** actionable and maintainable.
+
+#### 4. Question
+
+**Purpose:** support usage questions without forcing them into bug/feature categories.
+
+**Fields**
+- question
+- context
+- what has already been tried
+
+**Tone:** conversational and lightweight.
+
+### AI issue templates
+
+AI issue templates should explicitly optimize for maintainability and reviewability.
+
+#### Common AI issue fields
+
+- **Agent tool declaration**
+  Example: Claude Code / Cursor / Copilot / other
+- **Linked issue or roadmap item**
+- **Structured summary**
+- **Relevant files or subsystems**
+- **Evidence** (commands, logs, reproduction details)
+
+#### AI Bug Report
+
+Adds:
+- exact reproduction commands
+- observed output / stack trace
+- expected result
+- likely root cause (optional but encouraged)
+
+#### AI Feature Request
+
+Adds:
+- motivation
+- proposed implementation direction
+- affected modules
+- linked roadmap issue
+
+#### AI Task
+
+Adds:
+- parent issue
+- task objective
+- implementation boundaries
+- acceptance criteria
+- expected touched files (optional)
+
+### Template chooser behavior
+
+`config.yml` should group templates clearly so contributors understand whether they are choosing a human or AI path. It should also include a discussions/support link if available in the future.
+
+---
+
+## PR Template Design
+
+### Human PR template
+
+The human PR template should optimize for concise reviewer context.
+
+**Sections**
+- Summary
+- Linked issue
+- Test plan
+- Checklist
+
+**Checklist items**
+- relevant tests were run
+- linked issue exists if applicable
+- docs updated if needed
+- no unrelated changes included
+
+This keeps the bar reasonable for human contributors while still improving review quality.
+
+### AI PR template
+
+The AI PR template should require stronger structure.
+
+**Required sections**
+- Agent tool declaration
+- Linked issue(s)
+- Change summary
+- Files changed / affected areas
+- Validation evidence
+- Test plan
+- Reviewer notes / remaining risks
+
+**Validation evidence should explicitly request**
+- command(s) run
+- key output
+- whether `pylint` was run
+- whether relevant `pytest` commands were run
+
+**AI checklist items**
+- linked issue(s) included
+- verification evidence included
+- no unrelated changes included
+- no schema validation bypass added
+- no CPU fallback introduced for GPU/NPU backends
+- comments/docs updated only where needed
+
+This aligns the PR template with candle's repository constraints and reduces the chance of low-context AI submissions.
+
+---
+
+## Human vs AI Optimization Strategy
+
+### Human optimization
+
+The human path should optimize for:
+- low friction
+- discoverability
+- clear wording
+- fewer mandatory fields
+
+Human contributors are more likely to provide nuance in freeform text, so the templates should not feel bureaucratic.
+
+### AI optimization
+
+The AI path should optimize for:
+- structured fields
+- explicit provenance
+- verification evidence
+- issue linkage
+- concise impact summary
+
+AI submissions often benefit from forcing key review context into explicit sections instead of assuming the PR description will be strong by default.
+
+---
+
+## Data Flow / Maintainer Workflow
+
+### Issue intake
+
+1. Contributor opens GitHub issue chooser.
+2. Contributor selects either a human template or AI template.
+3. Submitted issue arrives with consistent structure.
+4. Maintainers can triage more quickly because the issue type is obvious and the required information is normalized.
+
+### PR intake
+
+1. Contributor opens a PR.
+2. Contributor selects either the human or AI PR template.
+3. Reviewers immediately see either the concise human format or the evidence-heavy AI format.
+4. Review quality improves because linked issues, validation commands, and scope summary are consistently requested.
+
+---
+
+## Error Handling / Edge Cases
+
+1. **AI contributors using human templates**
+   This cannot be perfectly prevented with GitHub-native templates alone. The design accepts this limitation and optimizes for the happy path.
+
+2. **Human contributors using AI templates**
+   Harmless; they simply provide more detail.
+
+3. **AI-generated PRs without explicit AI disclosure**
+   Also cannot be perfectly prevented without automation. The design makes the expected path explicit but does not rely on enforcement.
+
+4. **Too many template files**
+   The selected set is intentionally small. Only three AI issue templates are added, not AI versions of every possible issue type.
+
+5. **Question issues opened as bug reports**
+   This is normal GitHub behavior. Adding a dedicated Question template reduces, but does not eliminate, misclassification.
+
+---
+
+## Testing Strategy
+
+Testing here is structural rather than code-heavy.
+
+### Manual validation
+
+- verify GitHub recognizes all issue form files under `.github/ISSUE_TEMPLATE/`
+- verify template chooser ordering and names are understandable
+- verify `config.yml` renders properly
+- verify PR template selection works with:
+  - default `pull_request_template.md` behavior avoided
+  - explicit `?template=human.md`
+  - explicit `?template=ai.md`
+- verify markdown rendering for checklists and fenced commands is clean
+
+### Content validation
+
+- ensure human forms are materially shorter than AI forms
+- ensure AI PR template explicitly requests:
+  - agent tool declaration
+  - linked issue(s)
+  - change summary
+  - verification evidence
+- ensure the Task issue template supports roadmap decomposition well
+
+---
+
+## Non-Goals
+
+This design does **not** include:
+
+- GitHub Actions enforcement of template completion
+- automatic labeling based on human vs AI detection
+- bots that reject incomplete issues or PRs
+- issue forms for every niche scenario
+- repository-wide CONTRIBUTING.md authoring
+
+These can be added later if the template system proves valuable.
+
+---
+
+## Rollout Plan
+
+### Phase 1
+
+Add the template files only:
+- issue forms
+- PR templates
+- chooser configuration
+
+### Phase 2
+
+Observe real usage and adjust:
+- required vs optional fields
+- wording
+- whether AI and human split is working in practice
+- whether labels or automation are worth adding later
+
+---
+
+## Success Criteria
+
+The design is successful if:
+
+1. maintainers receive more reproducible bug reports
+2. roadmap work is more easily decomposed into Task issues
+3. human contributors are not burdened by AI-oriented required fields
+4. AI PRs consistently include linked issues, verification evidence, and concise change summaries
+5. reviewers can understand PR intent faster without searching comments or commit history


### PR DESCRIPTION
## Summary
- add GitHub issue forms for human bug reports, feature requests, tasks, and questions
- add separate AI issue forms and AI PR template fields for tool disclosure, linked issues, and validation evidence
- add a default PR template plus design/implementation docs for the new template system

## Test Plan
- [x] Parse all issue template YAML files with PyYAML
- [x] Validate issue and PR template file structure with local Python checks
- [x] Run `git diff --check`
- [x] Run `pylint src/candle/ --rcfile=.github/pylint.conf`

## Notes
- Human templates are intentionally shorter and lower-friction.
- AI templates require structured provenance and review context.