### PR TITLE
ci: add AI PR reviewer (CodeRabbit + Claude Action)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: zh-CN
+tone_instructions: >
+  Review in English. Focus on correctness and PyTorch compatibility.
+  candle is a PyTorch-compatible ML framework (import candle as torch).
+  Flag any CPU fallback used in GPU/NPU backends, schema validation bypass,
+  or PyTorch API incompatibility.
+early_access: false
+enable_free_tier: true
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  high_level_summary_placeholder: "@coderabbitai summary"
+  auto_title_placeholder: "@coderabbitai"
+  review_status: true
+  path_instructions:
+    - path: "src/candle/_backends/npu/**"
+      instructions: >
+        NPU backend must use ACLNN kernels via ctypes. Never fall back to
+        numpy/CPU. Prefer single ACLNN large kernels over compositing
+        multiple small ops.
+    - path: "src/candle/_backends/mps/**"
+      instructions: >
+        MPS backend must stay on Metal GPU path. Never fall back to
+        numpy/CPU. Check _can_use_gpu() guard for float32/16, contiguous,
+        numel > 0, has metal_buffer.
+    - path: "src/candle/_backends/cuda/**"
+      instructions: >
+        CUDA backend must use CUDA kernels. Never fall back to numpy/CPU.
+    - path: "src/candle/_dispatch/**"
+      instructions: >
+        Schema validation is intentional — never bypass or weaken schemas
+        to make tests pass. Fix at the functional layer before dispatch.
+    - path: "src/candle/_tensor.py"
+      instructions: >
+        Tensor class must maintain PyTorch API compatibility.
+        Never import torch in source code.
+    - path: "tests/**"
+      instructions: >
+        Tests should validate against PyTorch reference output.
+        Do not modify tests to work around source bugs — fix the source.
+  auto_review:
+    enabled: true
+    ignore_title_keywords:
+      - "WIP"
+      - "DO NOT MERGE"
+    drafts: false
+chat:
+  auto_reply: true

--- a/.github/scripts/ai-review-prompt.md
+++ b/.github/scripts/ai-review-prompt.md
@@ -1,0 +1,43 @@
+You are reviewing a pull request for **candle**, a PyTorch-compatible ML framework (`import candle as torch`). Your review must be concise, actionable, and focused on project-specific invariants.
+
+## Project Invariants — Flag Violations
+
+1. **No CPU fallback on GPU/NPU**: MPS ops must stay on Metal, NPU ops must use ACLNN kernels, CUDA ops must use CUDA kernels. NumPy is ONLY for CPU backend.
+2. **No PyTorch import in source**: `src/candle/` must never `import torch`. PyTorch is test-only.
+3. **Schema validation is sacred**: Never bypass or weaken dispatch schema validation. Fix at functional layer.
+4. **PyTorch API compatibility**: Public API must match PyTorch signatures and behavior.
+5. **No application-specific hacks**: All changes must be generic PyTorch API implementations.
+
+## Review Structure
+
+Respond with EXACTLY this format (no extra sections):
+
+```
+## Candle AI Review
+
+### Scope
+- Files changed: {count} | Lines: +{added} / -{removed}
+- Areas: {comma-separated areas like: backend/npu, dispatch, nn, tests}
+
+### Findings
+
+{If no issues found: "No invariant violations detected."}
+
+{If issues found, list each as:}
+- **[CRITICAL/WARNING/INFO]** {file}:{line} — {description}
+
+### PR Completeness
+- Linked issue: {yes/no}
+- Test plan: {filled/empty/missing}
+- Template: {correct/wrong/missing}
+
+### Risk: {Low/Medium/High}
+
+{One sentence justification}
+```
+
+## Rules
+- Only flag real invariant violations, not style preferences
+- CodeRabbit handles general code quality — focus on candle-specific rules
+- Be direct. No praise, no filler.
+- If the diff is documentation-only or CI-only, just say "No source changes to review" under Findings and set Risk: Low

--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -1,0 +1,164 @@
+name: AI PR Review
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ai-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  candle-review:
+    runs-on: ubuntu-latest
+    # Skip draft PRs and PRs with WIP in title
+    if: >
+      !github.event.pull_request.draft &&
+      !contains(github.event.pull_request.title, 'WIP') &&
+      !contains(github.event.pull_request.title, 'DO NOT MERGE')
+    steps:
+      - name: Checkout base (safe — never checks out PR code)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          sparse-checkout: .github/scripts/ai-review-prompt.md
+
+      - name: Fetch PR diff
+        id: diff
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Get diff via API (safe for fork PRs)
+          gh api \
+            repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} \
+            -H "Accept: application/vnd.github.diff" \
+            > pr.diff
+
+          # Get PR metadata
+          gh api \
+            repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} \
+            --jq '{
+              title: .title,
+              body: (.body // "" | .[0:2000]),
+              changed_files: .changed_files,
+              additions: .additions,
+              deletions: .deletions
+            }' > pr_meta.json
+
+          # Get file list
+          gh api \
+            repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files \
+            --jq '.[].filename' > pr_files.txt
+
+          # Truncate diff to avoid token limits (keep first 8000 lines)
+          head -n 8000 pr.diff > pr_diff_truncated.txt
+          if [ "$(wc -l < pr.diff)" -gt 8000 ]; then
+            echo -e "\n\n... (diff truncated — $(wc -l < pr.diff) total lines)" >> pr_diff_truncated.txt
+          fi
+
+      - name: Run AI review
+        id: review
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          # Skip if no API key configured
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "review_body=⚠️ AI review skipped — \`ANTHROPIC_API_KEY\` not configured." >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          SYSTEM_PROMPT=$(cat .github/scripts/ai-review-prompt.md)
+          PR_META=$(cat pr_meta.json)
+          PR_FILES=$(cat pr_files.txt)
+          PR_DIFF=$(cat pr_diff_truncated.txt)
+
+          # Build the user message
+          USER_MSG=$(cat <<'ENDMSG'
+          PR metadata:
+          ENDMSG
+          )
+          USER_MSG="${USER_MSG}
+          ${PR_META}
+
+          Files changed:
+          ${PR_FILES}
+
+          Diff:
+          \`\`\`diff
+          ${PR_DIFF}
+          \`\`\`"
+
+          # Call Claude API
+          RESPONSE=$(curl -s -w "\n%{http_code}" \
+            https://api.anthropic.com/v1/messages \
+            -H "content-type: application/json" \
+            -H "x-api-key: $ANTHROPIC_API_KEY" \
+            -H "anthropic-version: 2023-06-01" \
+            -d "$(jq -n \
+              --arg system "$SYSTEM_PROMPT" \
+              --arg user "$USER_MSG" \
+              '{
+                model: "claude-sonnet-4-20250514",
+                max_tokens: 1024,
+                system: $system,
+                messages: [{role: "user", content: $user}]
+              }')")
+
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | sed '$d')
+
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "review_body=⚠️ AI review failed (HTTP $HTTP_CODE). PR is not blocked." >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Extract text content
+          REVIEW=$(echo "$BODY" | jq -r '.content[0].text // "AI review returned empty response."')
+
+          # Write to file to preserve newlines
+          echo "$REVIEW" > review_body.txt
+          echo "has_review=true" >> "$GITHUB_OUTPUT"
+
+      - name: Post or update comment
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          MARKER="<!-- candle-ai-review-marker -->"
+
+          if [ -f review_body.txt ]; then
+            REVIEW_BODY=$(cat review_body.txt)
+          elif [ -n "${{ steps.review.outputs.review_body }}" ]; then
+            REVIEW_BODY="${{ steps.review.outputs.review_body }}"
+          else
+            REVIEW_BODY="⚠️ AI review encountered an unexpected error. PR is not blocked."
+          fi
+
+          COMMENT_BODY="${REVIEW_BODY}
+
+          ${MARKER}"
+
+          # Find existing comment by marker
+          EXISTING_COMMENT_ID=$(gh api \
+            repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+            --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" \
+            2>/dev/null | head -1)
+
+          if [ -n "$EXISTING_COMMENT_ID" ]; then
+            # Update existing comment
+            gh api \
+              repos/${{ github.repository }}/issues/comments/$EXISTING_COMMENT_ID \
+              -X PATCH \
+              -f body="$COMMENT_BODY"
+            echo "Updated existing review comment #$EXISTING_COMMENT_ID"
+          else
+            # Create new comment
+            gh api \
+              repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+              -f body="$COMMENT_BODY"
+            echo "Created new review comment"
+          fi


### PR DESCRIPTION
## Summary

Add automated AI review for every PR — hybrid approach with two layers:

1. **CodeRabbit** (free third-party GitHub App): general code quality review via `.coderabbit.yaml` with Candle-specific path instructions
2. **Self-built Claude Action** (`ai-review.yaml`): posts one Candle-specific summary comment checking project invariants (no CPU fallback, no schema bypass, PyTorch compatibility, etc.)

Both are **non-blocking** — advisory comments only, never block merge.

## Security

- Uses `pull_request_target` for safe fork PR support
- Never checks out or executes PR code
- Reads diff via GitHub API only
- Claude API key stored as repository secret `ANTHROPIC_API_KEY`
- Graceful degradation if API key missing or API fails

## Files changed

- `.coderabbit.yaml` — CodeRabbit configuration with path-specific review instructions
- `.github/workflows/ai-review.yaml` — GitHub Action workflow for Claude-based review
- `.github/scripts/ai-review-prompt.md` — Candle-specific review prompt template

## Setup required after merge

1. Install [CodeRabbit](https://github.com/apps/coderabbit-ai) GitHub App on `candle-org/candle`
2. Add `ANTHROPIC_API_KEY` as a repository secret (for the Claude Action)

## Test plan

- [ ] Not run — no source code changes, CI/config only
- [x] YAML syntax validated
- [x] Workflow uses `pull_request_target` (not `pull_request`) for fork safety

🤖 Generated with [Claude Code](https://claude.com/claude-code)