### PR TITLE
ci(ai-review): support custom API base URL

### DIFF
--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -64,12 +64,16 @@ jobs:
         id: review
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_BASE: ${{ secrets.ANTHROPIC_API_BASE }}
         run: |
           # Skip if no API key configured
           if [ -z "$ANTHROPIC_API_KEY" ]; then
             echo "⚠️ AI review skipped — \`ANTHROPIC_API_KEY\` not configured." > review_body.txt
             exit 0
           fi
+
+          # Custom base URL (default: official Anthropic API)
+          API_BASE="${ANTHROPIC_API_BASE:-https://api.anthropic.com}"
 
           SYSTEM_PROMPT=$(cat .github/scripts/ai-review-prompt.md)
           PR_META=$(cat pr_meta.json)
@@ -86,7 +90,7 @@ jobs:
 
           # Call Claude API
           RESPONSE=$(curl -s -w "\n%{http_code}" \
-            https://api.anthropic.com/v1/messages \
+            "${API_BASE}/v1/messages" \
             -H "content-type: application/json" \
             -H "x-api-key: $ANTHROPIC_API_KEY" \
             -H "anthropic-version: 2023-06-01" \


### PR DESCRIPTION
## Summary

Add `ANTHROPIC_API_BASE` secret support to the AI review workflow, allowing use of third-party or self-hosted API endpoints instead of the official Anthropic API.

## Configuration

Set two repository secrets:
- `ANTHROPIC_API_KEY` — your API key
- `ANTHROPIC_API_BASE` — custom endpoint URL (e.g. `https://your-proxy.example.com`), omit to use official `https://api.anthropic.com`

## Test plan

- [ ] Not run — CI-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)