### PR TITLE
fix(ci): use correct model ID in ai-review

### DIFF
--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -98,7 +98,7 @@ jobs:
               --arg system "$SYSTEM_PROMPT" \
               --arg user "$USER_MSG" \
               '{
-                model: "claude-sonnet-4-20250514",
+                model: "claude-sonnet-4-6",
                 max_tokens: 1024,
                 system: $system,
                 messages: [{role: "user", content: $user}]


### PR DESCRIPTION
## Summary

Fix model ID from `claude-sonnet-4-20250514` to `claude-sonnet-4-6` in the AI review workflow.

## Test plan

- [ ] Not run — CI-only, will validate via test PR #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)