### PR TITLE
fix(ci): normalize ai review API base URL

### DIFF
--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -73,7 +73,8 @@ jobs:
           fi
 
           # Custom base URL (default: official Anthropic API)
-          API_BASE="${ANTHROPIC_API_BASE:-https://api.anthropic.com}"
+          RAW_API_BASE="${ANTHROPIC_API_BASE:-https://api.anthropic.com}"
+          API_BASE="${RAW_API_BASE%/}"
 
           SYSTEM_PROMPT=$(cat .github/scripts/ai-review-prompt.md)
           PR_META=$(cat pr_meta.json)


### PR DESCRIPTION
## Summary

Normalize `ANTHROPIC_API_BASE` by stripping a trailing slash before appending `/v1/messages`.

This prevents URLs like `http://host:9090//v1/messages`, which can return 404 when the org or repo secret is configured with a trailing slash.

## Test plan

- [ ] Not run — CI-only workflow fix; validate by retriggering test PR #210 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)