### PR TITLE
ci: incremental AI review + skip unrelated CI jobs

### DIFF
--- a/.github/scripts/ai-review-incremental-prompt.md
+++ b/.github/scripts/ai-review-incremental-prompt.md
@@ -1,0 +1,55 @@
+You are performing an **incremental review** of a pull request for **candle**, a PyTorch-compatible ML framework (`import candle as torch`). New commits have been pushed since the last review. Focus on what changed.
+
+## Project Invariants — Flag Violations
+
+1. **No CPU fallback on GPU/NPU**: MPS ops must stay on Metal, NPU ops must use ACLNN kernels, CUDA ops must use CUDA kernels. NumPy is ONLY for CPU backend.
+2. **No PyTorch import in source**: `src/candle/` must never `import torch`. PyTorch is test-only.
+3. **Schema validation is sacred**: Never bypass or weaken dispatch schema validation. Fix at functional layer.
+4. **PyTorch API compatibility**: Public API must match PyTorch signatures and behavior.
+5. **No application-specific hacks**: All changes must be generic PyTorch API implementations.
+
+## Your Task
+
+You are given:
+1. **Previous review** — the last AI review comment on this PR
+2. **Incremental diff** — only the new commits since that review
+3. **Full PR diff** — the complete PR diff for context
+
+Focus your review on the **incremental diff**. Compare against the previous review to determine:
+- Which previously flagged issues have been **addressed/fixed**?
+- Which previously flagged issues are **still open**?
+- Are there any **new issues** introduced by the new commits?
+
+## Review Structure
+
+Respond with EXACTLY this format (no extra sections):
+
+```
+## Candle AI Review (Update)
+
+### Changes Since Last Review
+- {1-2 sentence summary of what the new commits do}
+
+### Previously Flagged Issues
+- {For each issue from the previous review:}
+  - **[FIXED]** / **[STILL OPEN]** — {brief description}
+
+{If no previous issues: "No issues were flagged in the previous review."}
+
+### New Findings
+
+{If no new issues: "No new invariant violations detected."}
+
+{If new issues found, list each as:}
+- **[CRITICAL/WARNING/INFO]** {file}:{line} — {description}
+
+### Risk: {Low/Medium/High}
+
+{One sentence justification}
+```
+
+## Rules
+- Only flag real invariant violations, not style preferences
+- Be direct. No praise, no filler.
+- If the incremental diff is documentation-only or CI-only, just say "No source changes to review" under New Findings and set Risk: Low
+- When a previously flagged issue is fixed, acknowledge it clearly

--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -25,22 +25,32 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.sha }}
-          sparse-checkout: .github/scripts/ai-review-prompt.md
+          sparse-checkout: |
+            .github/scripts/ai-review-prompt.md
+            .github/scripts/ai-review-incremental-prompt.md
 
       - name: Fetch PR diff
         id: diff
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Get diff via API (safe for fork PRs)
+          EVENT_ACTION="${{ github.event.action }}"
+          echo "event_action=$EVENT_ACTION" >> "$GITHUB_OUTPUT"
+
+          PR_NUM="${{ github.event.pull_request.number }}"
+          REPO="${{ github.repository }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          echo "head_sha=${HEAD_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+          # Get full PR diff via API (safe for fork PRs)
           gh api \
-            repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} \
+            "repos/$REPO/pulls/$PR_NUM" \
             -H "Accept: application/vnd.github.diff" \
             > pr.diff
 
           # Get PR metadata
           gh api \
-            repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} \
+            "repos/$REPO/pulls/$PR_NUM" \
             --jq '{
               title: .title,
               body: (.body // "" | .[0:2000]),
@@ -51,13 +61,49 @@ jobs:
 
           # Get file list
           gh api \
-            repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files \
+            "repos/$REPO/pulls/$PR_NUM/files" \
             --jq '.[].filename' > pr_files.txt
 
           # Truncate diff to avoid token limits (keep first 8000 lines)
           head -n 8000 pr.diff > pr_diff_truncated.txt
           if [ "$(wc -l < pr.diff)" -gt 8000 ]; then
             echo -e "\n\n... (diff truncated — $(wc -l < pr.diff) total lines)" >> pr_diff_truncated.txt
+          fi
+
+          # For synchronize events: fetch incremental diff and previous review
+          if [ "$EVENT_ACTION" = "synchronize" ]; then
+            BEFORE="${{ github.event.before }}"
+            AFTER="${{ github.event.after }}"
+
+            # Get incremental diff between the old and new head commits
+            if gh api \
+              "repos/$REPO/compare/${BEFORE}...${AFTER}" \
+              -H "Accept: application/vnd.github.diff" \
+              > incremental.diff 2>/dev/null; then
+
+              head -n 4000 incremental.diff > incremental_truncated.txt
+              if [ "$(wc -l < incremental.diff)" -gt 4000 ]; then
+                echo -e "\n\n... (incremental diff truncated — $(wc -l < incremental.diff) total lines)" >> incremental_truncated.txt
+              fi
+              echo "has_incremental=true" >> "$GITHUB_OUTPUT"
+            else
+              # Force push or compare failed — fall back to full review
+              echo "has_incremental=false" >> "$GITHUB_OUTPUT"
+            fi
+
+            # Fetch previous review comment for context
+            MARKER="<!-- candle-ai-review-marker -->"
+            gh api \
+              "repos/$REPO/issues/$PR_NUM/comments" --paginate \
+              --jq ".[] | select(.body | contains(\"$MARKER\")) | .body" \
+              2>/dev/null | tail -1 > previous_review.txt
+
+            # If previous review is empty, mark no incremental
+            if [ ! -s previous_review.txt ]; then
+              echo "has_incremental=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "has_incremental=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run AI review
@@ -76,17 +122,40 @@ jobs:
           RAW_API_BASE="${ANTHROPIC_API_BASE:-https://api.anthropic.com}"
           API_BASE="${RAW_API_BASE%/}"
 
-          # Build the user message via jq --rawfile to avoid ARG_MAX limits
-          jq -n \
-            --rawfile meta pr_meta.json \
-            --rawfile files pr_files.txt \
-            --rawfile diff pr_diff_truncated.txt \
-            '"PR metadata:\n" + $meta + "\n\nFiles changed:\n" + $files + "\n\nDiff:\n```diff\n" + $diff + "\n```"' \
-            -r > user_msg.txt
+          EVENT_ACTION="${{ steps.diff.outputs.event_action }}"
+          HAS_INCREMENTAL="${{ steps.diff.outputs.has_incremental }}"
+
+          if [ "$HAS_INCREMENTAL" = "true" ]; then
+            # --- Incremental review ---
+            PROMPT_FILE=".github/scripts/ai-review-incremental-prompt.md"
+            if [ ! -f "$PROMPT_FILE" ]; then
+              # Fallback if incremental prompt not yet checked in
+              PROMPT_FILE=".github/scripts/ai-review-prompt.md"
+            fi
+
+            jq -n \
+              --rawfile meta pr_meta.json \
+              --rawfile files pr_files.txt \
+              --rawfile prev previous_review.txt \
+              --rawfile incr incremental_truncated.txt \
+              --rawfile full pr_diff_truncated.txt \
+              '"PR metadata:\n" + $meta + "\n\nFiles changed:\n" + $files + "\n\n## Previous review:\n" + $prev + "\n\n## Incremental diff (new commits):\n```diff\n" + $incr + "\n```\n\n## Full PR diff (for context):\n```diff\n" + $full + "\n```"' \
+              -r > user_msg.txt
+          else
+            # --- Full review (opened / reopened / fallback) ---
+            PROMPT_FILE=".github/scripts/ai-review-prompt.md"
+
+            jq -n \
+              --rawfile meta pr_meta.json \
+              --rawfile files pr_files.txt \
+              --rawfile diff pr_diff_truncated.txt \
+              '"PR metadata:\n" + $meta + "\n\nFiles changed:\n" + $files + "\n\nDiff:\n```diff\n" + $diff + "\n```"' \
+              -r > user_msg.txt
+          fi
 
           # Build API request body from files to avoid ARG_MAX limits
           jq -n \
-            --rawfile system .github/scripts/ai-review-prompt.md \
+            --rawfile system "$PROMPT_FILE" \
             --rawfile user user_msg.txt \
             '{
               model: "claude-sonnet-4-6",
@@ -121,6 +190,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           MARKER="<!-- candle-ai-review-marker -->"
+          HEAD_SHA="${{ steps.diff.outputs.head_sha }}"
+          EVENT_ACTION="${{ steps.diff.outputs.event_action }}"
 
           if [ -f review_body.txt ]; then
             REVIEW_BODY=$(cat review_body.txt)
@@ -128,27 +199,42 @@ jobs:
             REVIEW_BODY="⚠️ AI review encountered an unexpected error. PR is not blocked."
           fi
 
+          # Add metadata footer
+          if [ "$EVENT_ACTION" = "synchronize" ]; then
+            REVIEW_TYPE="Incremental review"
+          else
+            REVIEW_TYPE="Full review"
+          fi
+          TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M UTC")
+          FOOTER="---
+          *${REVIEW_TYPE} at commit ${HEAD_SHA} (${TIMESTAMP})*"
+
           COMMENT_BODY="${REVIEW_BODY}
+
+          ${FOOTER}
 
           ${MARKER}"
 
+          PR_NUM="${{ github.event.pull_request.number }}"
+          REPO="${{ github.repository }}"
+
           # Find existing comment by marker
           EXISTING_COMMENT_ID=$(gh api \
-            repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+            "repos/$REPO/issues/$PR_NUM/comments" --paginate \
             --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" \
             2>/dev/null | head -1)
 
           if [ -n "$EXISTING_COMMENT_ID" ]; then
             # Update existing comment
             gh api \
-              repos/${{ github.repository }}/issues/comments/$EXISTING_COMMENT_ID \
+              "repos/$REPO/issues/comments/$EXISTING_COMMENT_ID" \
               -X PATCH \
               -f body="$COMMENT_BODY"
-            echo "Updated existing review comment #$EXISTING_COMMENT_ID"
+            echo "Updated existing review comment #$EXISTING_COMMENT_ID ($REVIEW_TYPE)"
           else
             # Create new comment
             gh api \
-              repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+              "repos/$REPO/issues/$PR_NUM/comments" \
               -f body="$COMMENT_BODY"
-            echo "Created new review comment"
+            echo "Created new review comment ($REVIEW_TYPE)"
           fi


### PR DESCRIPTION
## Summary
Two CI optimizations in one PR:

### 1. Incremental AI review on PR updates
- On `synchronize` events (new commits pushed), the AI reviewer now performs an **incremental review** instead of repeating the same full review
- Fetches the incremental diff between old/new HEAD via GitHub compare API
- Passes the previous review comment as context so the AI can report: which issues were fixed, which are still open, and any new findings
- Adds commit SHA + timestamp footer to review comments for visibility
- Falls back to full review if compare API fails (e.g. force push)

### 2. Skip unrelated CI jobs based on changed files
- Add `detect-changes` job using `dorny/paths-filter` to determine which areas changed
- Source/build/CI config changes → full CI (pylint + all test suites)
- Test-only changes → only the affected test suite, no pylint
- `conftest.py` changes → all test suites, no pylint
- Docs/examples/assets/benchmarks/tools → CI not triggered at all
- Switch from `paths:` (whitelist) to `paths-ignore:` (blacklist) so new code dirs are auto-covered

### Job trigger matrix

| Changed files | pylint | CPU | MPS | NPU | dist |
|:---|:---:|:---:|:---:|:---:|:---:|
| `src/candle/**` / build config / CI config | Y | Y | Y | Y | Y |
| `tests/cpu/**` or `tests/contract/**` | - | Y | - | - | - |
| `tests/mps/**` | - | - | Y | - | - |
| `tests/npu/**` | - | - | - | Y | Y |
| `tests/distributed/**` | - | - | - | Y | Y |
| `tests/conftest.py` | - | Y | Y | Y | Y |
| docs/examples/assets/benchmarks/tools | no CI | | | | |

## Files changed
- `.github/workflows/ai-review.yaml` — incremental review logic + event detection
- `.github/scripts/ai-review-incremental-prompt.md` — new prompt for incremental reviews
- `.github/workflows/ci.yaml` — `detect-changes` job + conditional `if` on all test jobs

## Test plan
- [ ] Open a test PR with source changes → full CI runs
- [ ] Push test-only changes → only relevant test suite runs, no pylint
- [ ] Push doc-only changes → CI not triggered
- [ ] Verify AI review posts incremental review on subsequent pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)