### PR TITLE
docs: replace blanket pylint gate with scope-based pre-PR validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,23 +29,38 @@ Treat this as a design guardrail, not a temporary check.
 
 ## Required Tests Before PR
 
-Every PR touching `src/candle/` must pass:
+**Determine validation scope based on what changed.** Do NOT blindly run pylint and the full test suite on every PR.
+
+### Change scope → validation matrix
+
+| Change scope | Pylint | CPU + contract tests | Local backend tests (MPS/NPU) |
+|---|---|---|---|
+| Only docs, markdown, scripts, CI yaml | Skip | Skip | Skip |
+| Only `tests/` (no `src/candle/` changes) | Skip | Run affected test files | Run if touching backend tests |
+| `src/candle/` code changes | **Required** | **Required** | **Required** if local hardware available |
+
+### When pylint is required
 
 ```bash
-pytest tests/contract/ -v --tb=short
+pylint src/candle/ --rcfile=.github/pylint.conf
 ```
 
-Recommended full gate:
+### When tests are required
+
+Every PR touching `src/candle/` must pass locally before pushing:
 
 ```bash
+# Always required
 pytest tests/cpu/ tests/contract/ -v --tb=short
-```
 
-On macOS with Apple Silicon, also run:
-
-```bash
+# Required on macOS with Apple Silicon
 pytest tests/mps/ -v --tb=short
+
+# Required on Ascend NPU hosts
+pytest tests/npu/ -v --tb=short
 ```
+
+**CI is a safety net, NOT a substitute for local testing.** Do NOT push untested code and rely on CI to catch failures. Run all locally available tests before opening a PR.
 
 ## PR Scope Rule
 
@@ -89,15 +104,11 @@ git rebase upstream/main
 
 Resolve any conflicts before proceeding.
 
-### 4. Pylint gate before PR
+### 4. Pre-PR validation gate
 
-Run pylint locally and confirm zero errors before pushing or creating a PR:
+Follow the validation matrix in [Required Tests Before PR](#required-tests-before-pr). Only run pylint and tests when the change scope requires it.
 
-```bash
-pylint src/candle/ --rcfile=.github/pylint.conf
-```
-
-Do NOT open a PR if pylint fails. Fix all issues first.
+Do NOT open a PR if pylint or tests fail. Fix all issues first.
 
 ### 5. Clean up after merge
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,17 +162,37 @@ git rebase upstream/main
 
 Resolve any conflicts before proceeding.
 
-#### 4. Pylint gate before PR
+#### 4. Pre-PR validation gate
 
-Run pylint locally and confirm zero errors before pushing or creating a PR:
+**Determine validation scope based on what changed.** Do NOT blindly run pylint and the full test suite on every PR — only run what the change actually requires.
+
+| Change scope | Pylint | CPU + contract tests | Local backend tests (MPS/NPU) |
+|---|---|---|---|
+| Only docs, markdown, scripts, CI yaml | Skip | Skip | Skip |
+| Only `tests/` (no `src/candle/` changes) | Skip | Run affected test files | Run if touching backend tests |
+| `src/candle/` code changes | **Required** | **Required** | **Required** if local hardware available |
+
+**When pylint is required:**
 
 ```bash
 pylint src/candle/ --rcfile=.github/pylint.conf
 ```
 
-Use `.github/pylint.conf` as the canonical pylint config path.
-
 Do NOT open a PR if pylint fails. Fix all issues first.
+
+**When tests are required:**
+
+```bash
+# CPU + contract tests (always required for src/candle/ changes)
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n mindnlp \
+  python -m pytest tests/cpu/ tests/contract/ -v --tb=short
+
+# MPS tests (required on macOS Apple Silicon when src/candle/ changes)
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n mindnlp \
+  python -m pytest tests/mps/ -v --tb=short
+```
+
+Do NOT open a PR if tests fail. Do NOT rely on CI as your test runner — CI is a safety net, not a substitute for local validation.
 
 #### 5. Clean up after merge
 
@@ -209,6 +229,14 @@ git checkout main && git pull upstream main && git push origin main
 ---
 
 ## Test Execution
+
+### When to run tests
+
+- **`src/candle/` changes**: Always run CPU + contract tests, plus local backend tests (MPS or NPU) if hardware is available.
+- **`tests/` only changes**: Run the affected test files.
+- **Docs, scripts, CI yaml only**: No tests needed.
+
+CI is a safety net, NOT a substitute for local testing. Do NOT push untested code and rely on CI to catch failures.
 
 ### Run Tests Locally
 


### PR DESCRIPTION
## Summary

- update `CLAUDE.md` and `AGENTS.md` to use a change-scope → validation matrix instead of a blanket pylint-before-PR rule
- clarify that docs / scripts / CI-only changes do not require local pylint or test runs
- require `src/candle/` changes to pass local CPU + contract tests and local backend tests (MPS/NPU) before opening a PR, and explicitly state that CI is a safety net rather than a substitute for local validation

## Test plan

- [x] No source code changes — documentation / workflow rule updates only
- [x] Verified final git diff matches requested policy changes
- [x] Skipped pylint and tests per updated rule because this PR only changes `CLAUDE.md` and `AGENTS.md`


🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>