### PR TITLE
fix torch.accelerator compatibility

### DIFF
--- a/src/candle/__init__.py
+++ b/src/candle/__init__.py
@@ -392,6 +392,7 @@ from . import distributed
 from . import onnx
 from . import futures
 from . import amp
+from . import accelerator
 from . import compiler
 from . import _dynamo
 from . import quasirandom
@@ -689,6 +690,7 @@ __all__ = [
     "onnx",
     # amp
     "amp",
+    "accelerator",
     "is_autocast_enabled",
     "set_autocast_enabled",
     "get_autocast_dtype",

--- a/src/candle/accelerator.py
+++ b/src/candle/accelerator.py
@@ -1,0 +1,53 @@
+"""Minimal torch.accelerator compatibility helpers.
+
+This module provides the small compatibility surface needed by the current
+PyTorch beginner tutorials without depending on torch at runtime.
+"""
+
+from ._device import device as Device, get_default_device
+
+_ACCELERATOR_TYPES = ("npu", "cuda", "mps")
+
+
+def _availability_checks():
+    from . import npu, cuda, mps
+
+    return (
+        ("npu", npu.is_available),
+        ("cuda", cuda.is_available),
+        ("mps", mps.is_available),
+    )
+
+
+def _is_available(device_type):
+    for name, check in _availability_checks():
+        if name == device_type:
+            return bool(check())
+    return False
+
+
+def is_available() -> bool:
+    """Return True when any accelerator backend is available at runtime."""
+    return current_accelerator() is not None
+
+
+def current_accelerator(check_available: bool = False):
+    """Return the currently usable accelerator device, or None if unavailable.
+
+    Candle does not have PyTorch's compile-time accelerator selection concept, so
+    this compatibility shim resolves to a runtime-available accelerator only.
+    The optional ``check_available`` argument is accepted for API compatibility.
+    """
+    del check_available
+
+    default_device = get_default_device()
+    if default_device.type in _ACCELERATOR_TYPES and _is_available(default_device.type):
+        return Device(default_device.type, index=default_device.index)
+
+    for device_type, check in _availability_checks():
+        if check():
+            return Device(device_type)
+    return None
+
+
+__all__ = ["is_available", "current_accelerator"]

--- a/tests/test_torch_compat.py
+++ b/tests/test_torch_compat.py
@@ -221,6 +221,36 @@ class TestImportHook:
         out, _, _ = _run(code, env_extra={"USE_CANDLE": "1"})
         assert "OK" in out
 
+    def test_torch_accelerator_tutorial_snippet(self):
+        """Compatibility: tutorial device selection works through torch.accelerator."""
+        code = textwrap.dedent("""\
+            import torch
+
+            assert hasattr(torch, "accelerator")
+            assert hasattr(torch.accelerator, "is_available")
+            assert hasattr(torch.accelerator, "current_accelerator")
+
+            expected = any(
+                hasattr(torch, name) and hasattr(getattr(torch, name), "is_available")
+                and getattr(torch, name).is_available()
+                for name in ("npu", "cuda", "mps")
+            )
+            assert torch.accelerator.is_available() is expected
+
+            tensor = torch.ones(1)
+            if torch.accelerator.is_available():
+                accelerator = torch.accelerator.current_accelerator()
+                assert accelerator is not None
+                tensor = tensor.to(accelerator)
+                assert tensor.device.type == accelerator.type
+            else:
+                assert torch.accelerator.current_accelerator() is None
+
+            print("OK")
+        """)
+        out, _, _ = _run(code, env_extra={"USE_CANDLE": "1"})
+        assert "OK" in out
+
     def test_no_redirect_when_disabled(self):
         """When USE_CANDLE=0, ``import torch`` should NOT redirect."""
         code = textwrap.dedent("""\


### PR DESCRIPTION
Closes #272

## Summary
- add a minimal `torch.accelerator` compatibility surface in Candle
- export `accelerator` from the top-level `candle` package so `import torch; torch.accelerator...` works under the torch compatibility hook
- add a torch-compat regression test covering `is_available()` and `current_accelerator()` usage through the compatibility layer

## Test Plan
- [x] `PYTHONPATH=/tmp/candle311-verify-pkgs conda run -n candle311-tutorials python -m pylint src/candle/accelerator.py --rcfile=.github/pylint.conf`
- [x] `PYTHONPATH=/tmp/candle311-verify-pkgs conda run -n candle311-tutorials python -m pytest tests/cpu/ tests/contract/ -v --tb=short`
- [x] `PYTHONPATH=/tmp/candle311-verify-pkgs conda run -n candle311-tutorials python -m pytest tests/mps/ -v --tb=short`

🤖 Generated with [Claude Code](https://claude.com/claude-code)