### PR TITLE
fix torch.hub compatibility imports

### DIFF
--- a/src/candle/__init__.py
+++ b/src/candle/__init__.py
@@ -408,6 +408,8 @@ from . import linalg
 from . import fft
 from . import special
 from . import testing
+from . import hub
+from . import utils
 from ._random import (
     manual_seed, seed, initial_seed, get_rng_state, set_rng_state,
     Generator, default_generator,

--- a/src/candle/hub.py
+++ b/src/candle/hub.py
@@ -1,0 +1,169 @@
+"""candle.hub — compatibility stub for torch.hub.
+
+Exposes the subset of torch.hub used by third-party libraries such as
+torchvision::
+
+    from torch.hub import _get_torch_home
+    from torch.hub import load_state_dict_from_url
+
+All heavy operations (network download, checkpoint loading) are delegated to
+standard-library / PyTorch-free helpers; this module must not import torch at
+runtime.
+"""
+
+import errno
+import hashlib
+import os
+import re
+import tempfile
+import urllib.request
+import uuid
+import warnings
+from typing import Any
+from urllib.parse import urlparse
+
+ENV_TORCH_HOME = "TORCH_HOME"
+ENV_XDG_CACHE_HOME = "XDG_CACHE_HOME"
+DEFAULT_CACHE_DIR = "~/.cache"
+_HASH_REGEX = re.compile(r".*-([0-9a-f]{8,})\..*")
+_READ_DATA_CHUNK = 128 * 1024
+_hub_dir: str | None = None
+
+
+def _get_torch_home() -> str:
+    """Return the torch home directory."""
+    return os.path.expanduser(
+        os.getenv(
+            ENV_TORCH_HOME,
+            os.path.join(os.getenv(ENV_XDG_CACHE_HOME, DEFAULT_CACHE_DIR), "torch"),
+        )
+    )
+
+
+
+def get_dir() -> str:
+    """Return the hub cache directory."""
+    if _hub_dir is not None:
+        return _hub_dir
+    return os.path.join(_get_torch_home(), "hub")
+
+
+
+def set_dir(d: str | os.PathLike[str]) -> None:
+    """Set the hub cache directory used by load_state_dict_from_url."""
+    global _hub_dir
+    _hub_dir = os.path.expanduser(os.fspath(d))
+
+
+
+def _download_url_to_file(url: str, dst: str, hash_prefix: str | None = None) -> None:
+    """Download *url* to *dst* using a temporary .partial file."""
+    dst = os.path.expanduser(dst)
+    tmp_dst = None
+    handle = None
+
+    for _ in range(tempfile.TMP_MAX):
+        candidate = f"{dst}.{uuid.uuid4().hex}.partial"
+        try:
+            handle = open(candidate, "xb")
+            tmp_dst = candidate
+            break
+        except FileExistsError:
+            continue
+    else:
+        raise FileExistsError(errno.EEXIST, "No usable temporary file name found")
+
+    request = urllib.request.Request(url, headers={"User-Agent": "torch.hub"})
+    sha256 = hashlib.sha256() if hash_prefix is not None else None
+
+    try:
+        with urllib.request.urlopen(request) as response:  # noqa: S310
+            while True:
+                chunk = response.read(_READ_DATA_CHUNK)
+                if not chunk:
+                    break
+                handle.write(chunk)
+                if sha256 is not None:
+                    sha256.update(chunk)
+
+        handle.close()
+        handle = None
+
+        if sha256 is not None:
+            digest = sha256.hexdigest()
+            if not digest.startswith(hash_prefix):
+                raise RuntimeError(
+                    f'invalid hash value (expected "{hash_prefix}", got "{digest[:len(hash_prefix)]}")'
+                )
+
+        os.replace(tmp_dst, dst)
+        tmp_dst = None
+    finally:
+        if handle is not None:
+            handle.close()
+        if tmp_dst is not None and os.path.exists(tmp_dst):
+            os.remove(tmp_dst)
+
+
+
+def load_state_dict_from_url(
+    url: str,
+    model_dir: str | None = None,
+    map_location: Any = None,
+    progress: bool = True,
+    check_hash: bool = False,
+    file_name: str | None = None,
+    weights_only: bool = False,
+) -> "dict[str, Any]":
+    """Download and load a serialised state-dict from *url*."""
+    if os.getenv("TORCH_MODEL_ZOO"):
+        warnings.warn(
+            "TORCH_MODEL_ZOO is deprecated, please use env TORCH_HOME instead",
+            stacklevel=2,
+        )
+
+    if model_dir is None:
+        hub_dir = get_dir()
+        model_dir = os.path.join(hub_dir, "checkpoints")
+
+    os.makedirs(model_dir, exist_ok=True)
+
+    parts = urlparse(url)
+    filename = file_name or os.path.basename(parts.path)
+    cached_file = os.path.join(model_dir, filename)
+
+    hash_prefix = None
+    if check_hash:
+        match = _HASH_REGEX.search(filename)
+        hash_prefix = match.group(1) if match else None
+
+    if not os.path.exists(cached_file):
+        if progress:
+            warnings.warn(
+                "candle.hub: progress display not implemented; downloading silently.",
+                stacklevel=2,
+            )
+        _download_url_to_file(url, cached_file, hash_prefix=hash_prefix)
+
+    if check_hash and hash_prefix is not None:
+        sha256 = hashlib.sha256()
+        with open(cached_file, "rb") as handle:
+            for chunk in iter(lambda: handle.read(_READ_DATA_CHUNK), b""):
+                sha256.update(chunk)
+        digest = sha256.hexdigest()
+        if not digest.startswith(hash_prefix):
+            raise RuntimeError(
+                f'invalid hash value (expected "{hash_prefix}", got "{digest[:len(hash_prefix)]}")'
+            )
+
+    from candle import serialization
+
+    return serialization.load(cached_file, map_location=map_location, weights_only=weights_only)
+
+
+__all__ = [
+    "_get_torch_home",
+    "get_dir",
+    "set_dir",
+    "load_state_dict_from_url",
+]

--- a/src/candle/utils/__init__.py
+++ b/src/candle/utils/__init__.py
@@ -1,5 +1,6 @@
 from . import data
 from . import checkpoint
 from . import checkpoint_state
+from . import model_zoo
 
-__all__ = ["data", "checkpoint", "checkpoint_state"]
+__all__ = ["data", "checkpoint", "checkpoint_state", "model_zoo"]

--- a/src/candle/utils/model_zoo.py
+++ b/src/candle/utils/model_zoo.py
@@ -1,0 +1,13 @@
+"""candle.utils.model_zoo — compatibility stub for torch.utils.model_zoo.
+
+Some third-party libraries (for example older torchvision versions) import::
+
+    from torch.utils.model_zoo import load_url
+
+This module provides that symbol as an alias for
+:func:`candle.hub.load_state_dict_from_url`.
+"""
+
+from candle.hub import load_state_dict_from_url as load_url
+
+__all__ = ["load_url"]

--- a/tests/test_torch_compat.py
+++ b/tests/test_torch_compat.py
@@ -209,6 +209,91 @@ class TestImportHook:
         out, _, _ = _run(code, env_extra={"USE_CANDLE": "1"})
         assert "OK" in out
 
+    def test_from_torch_hub_imports_torchvision_symbols(self):
+        """Regression: torchvision imports these names from torch.hub."""
+        code = textwrap.dedent("""\
+            from torch.hub import _get_torch_home, load_state_dict_from_url
+            assert callable(_get_torch_home)
+            assert callable(load_state_dict_from_url)
+            print("OK")
+        """)
+        out, _, _ = _run(code, env_extra={"USE_CANDLE": "1"})
+        assert "OK" in out
+
+    def test_torch_hub_set_dir_updates_get_dir_without_warning(self):
+        code = textwrap.dedent("""\
+            import tempfile
+            import warnings
+            import torch.hub
+            target = tempfile.mkdtemp(prefix='candle-hub-dir-')
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter('always')
+                torch.hub.set_dir(target)
+            assert torch.hub.get_dir() == target
+            assert not caught, [str(w.message) for w in caught]
+            print('OK')
+        """)
+        out, _, _ = _run(code, env_extra={"USE_CANDLE": "1"})
+        assert "OK" in out
+
+    def test_torch_hub_load_state_dict_cleans_partial_file_on_failure(self):
+        code = textwrap.dedent("""\
+            import pathlib
+            import tempfile
+            import urllib.request
+            import torch.hub
+
+            class BrokenResponse:
+                def __init__(self):
+                    self.calls = 0
+
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, exc_type, exc, tb):
+                    return False
+
+                def read(self, _size=-1):
+                    self.calls += 1
+                    if self.calls == 1:
+                        return b'partial-download'
+                    raise RuntimeError('simulated download failure')
+
+            original_urlopen = urllib.request.urlopen
+            urllib.request.urlopen = lambda request: BrokenResponse()
+            model_dir = tempfile.mkdtemp(prefix='candle-hub-download-')
+            try:
+                try:
+                    torch.hub.load_state_dict_from_url(
+                        'https://example.com/state.pt',
+                        model_dir=model_dir,
+                        progress=False,
+                    )
+                except RuntimeError as exc:
+                    assert 'simulated download failure' in str(exc)
+                else:
+                    raise AssertionError('expected download failure')
+                partials = sorted(path.name for path in pathlib.Path(model_dir).glob('*.partial'))
+                cached = pathlib.Path(model_dir) / 'state.pt'
+                assert partials == [], partials
+                assert not cached.exists()
+                print('OK')
+            finally:
+                urllib.request.urlopen = original_urlopen
+        """)
+        out, _, _ = _run(code, env_extra={"USE_CANDLE": "1"})
+        assert "OK" in out
+
+    def test_from_torch_utils_model_zoo_imports_load_url(self):
+        """Older torchvision versions fall back to torch.utils.model_zoo."""
+        code = textwrap.dedent("""\
+            from torch.utils.model_zoo import load_url
+            assert callable(load_url)
+            print("OK")
+        """)
+        out, _, _ = _run(code, env_extra={"USE_CANDLE": "1"})
+        assert "OK" in out
+
     def test_torch_zeros(self):
         """Functional: actually create a tensor through the redirected import."""
         code = textwrap.dedent("""\


### PR DESCRIPTION
Closes #271

## Summary
- add a minimal `torch.hub` compatibility module for Candle's torch-compat import hook
- add `torch.utils.model_zoo.load_url` compatibility for older torchvision fallback paths
- add focused torch-compat regression tests for `torch.hub` and `torch.utils.model_zoo`

## Test Plan
- [x] `PYTHONPATH=/tmp/candle311-verify-pkgs conda run -n candle311-tutorials python -m pylint src/candle/hub.py src/candle/utils/model_zoo.py --rcfile=.github/pylint.conf`
- [x] `PYTHONPATH=/tmp/candle311-verify-pkgs conda run -n candle311-tutorials python -m pytest tests/cpu/ tests/contract/ -v --tb=short`
- [x] `PYTHONPATH=/tmp/candle311-verify-pkgs conda run -n candle311-tutorials python -m pytest tests/mps/ -v --tb=short`
- [x] `source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle311-tutorials python -m pytest tests/test_torch_compat.py -k \"hub or model_zoo\" -v --tb=short`

🤖 Generated with [Claude Code](https://claude.com/claude-code)