### PR TITLE
fix 1D matmul backward handling

### DIFF
--- a/src/candle/_generated/_functions_cy.pyx
+++ b/src/candle/_generated/_functions_cy.pyx
@@ -119,8 +119,39 @@ def _div_tensor_other_backward_helper(grad, self_, other, *extra_and_keyset):
 
 
 def _matmul_backward_helper(grad, self_, other, grad_input_mask, keyset):
-    grad_self = _reduce_grad(_redispatch("matmul", keyset, grad, _redispatch("transpose", keyset, other, -1, -2)), self_.shape) if grad_input_mask[0] else None
-    grad_other = _reduce_grad(_redispatch("matmul", keyset, _redispatch("transpose", keyset, self_, -1, -2), grad), other.shape) if grad_input_mask[1] else None
+    grad_self = None
+    grad_other = None
+
+    if grad_input_mask[0]:
+        if len(other.shape) == 1:
+            if len(self_.shape) == 1:
+                grad_self_raw = _redispatch("mul", keyset, grad, other)
+            else:
+                grad_self_raw = _redispatch(
+                    "matmul",
+                    keyset,
+                    _redispatch("unsqueeze", keyset, grad, -1),
+                    _redispatch("unsqueeze", keyset, other, 0),
+                )
+        else:
+            grad_self_raw = _redispatch("matmul", keyset, grad, _redispatch("transpose", keyset, other, -1, -2))
+        grad_self = _reduce_grad(grad_self_raw, self_.shape)
+
+    if grad_input_mask[1]:
+        if len(self_.shape) == 1:
+            if len(other.shape) == 1:
+                grad_other_raw = _redispatch("mul", keyset, grad, self_)
+            else:
+                grad_other_raw = _redispatch(
+                    "matmul",
+                    keyset,
+                    _redispatch("unsqueeze", keyset, self_, -1),
+                    _redispatch("unsqueeze", keyset, grad, -2),
+                )
+        else:
+            grad_other_raw = _redispatch("matmul", keyset, _redispatch("transpose", keyset, self_, -1, -2), grad)
+        grad_other = _reduce_grad(grad_other_raw, other.shape)
+
     return grad_self, grad_other
 
 

--- a/src/candle/_generated/functions.py
+++ b/src/candle/_generated/functions.py
@@ -114,8 +114,39 @@ def _div_tensor_other_backward_helper(grad, self_, other, *extra_and_keyset):
 
 
 def _matmul_backward_helper(grad, self_, other, grad_input_mask, keyset):
-    grad_self = reduce_grad(redispatch("matmul", keyset, grad, redispatch("transpose", keyset, other, -1, -2)), self_.shape) if grad_input_mask[0] else None
-    grad_other = reduce_grad(redispatch("matmul", keyset, redispatch("transpose", keyset, self_, -1, -2), grad), other.shape) if grad_input_mask[1] else None
+    grad_self = None
+    grad_other = None
+
+    if grad_input_mask[0]:
+        if len(other.shape) == 1:
+            if len(self_.shape) == 1:
+                grad_self_raw = redispatch("mul", keyset, grad, other)
+            else:
+                grad_self_raw = redispatch(
+                    "matmul",
+                    keyset,
+                    redispatch("unsqueeze", keyset, grad, -1),
+                    redispatch("unsqueeze", keyset, other, 0),
+                )
+        else:
+            grad_self_raw = redispatch("matmul", keyset, grad, redispatch("transpose", keyset, other, -1, -2))
+        grad_self = reduce_grad(grad_self_raw, self_.shape)
+
+    if grad_input_mask[1]:
+        if len(self_.shape) == 1:
+            if len(other.shape) == 1:
+                grad_other_raw = redispatch("mul", keyset, grad, self_)
+            else:
+                grad_other_raw = redispatch(
+                    "matmul",
+                    keyset,
+                    redispatch("unsqueeze", keyset, self_, -1),
+                    redispatch("unsqueeze", keyset, grad, -2),
+                )
+        else:
+            grad_other_raw = redispatch("matmul", keyset, redispatch("transpose", keyset, self_, -1, -2), grad)
+        grad_other = reduce_grad(grad_other_raw, other.shape)
+
     return grad_self, grad_other
 
 
@@ -2375,8 +2406,8 @@ class MatmulBackward0(Node):
         from .._dispatch.dispatcher import current_dispatch_keyset
         keyset = _backward_dispatch_keyset(self._raw_keyset, self._active_keyset)
         _saved = self.saved_tensors()
-        other = _saved[self._saved_other_idx]
-        self_ = _saved[self._saved_self_idx]
+        other = _saved[self._saved_other_idx] if self._saved_other_idx is not None else None
+        self_ = _saved[self._saved_self_idx] if self._saved_self_idx is not None else None
         grad_input_mask = [True, True]
         with _grad_context(keyset):
             grad_self, grad_other = _matmul_backward_helper(grad, self_, other, grad_input_mask, keyset)

--- a/tests/contract/test_gen_functions_next_runtime_helpers.py
+++ b/tests/contract/test_gen_functions_next_runtime_helpers.py
@@ -1,5 +1,5 @@
 from tools.autograd.load_derivatives import load_derivatives
-from tools.autograd.gen_functions import _gen_one_node
+from tools.autograd.gen_functions import _HEADER, _gen_one_node
 
 
 def _node_src(func_name: str) -> str:
@@ -38,3 +38,10 @@ def test_cat_backward_uses_local_helper_without_undefined_tensor_list_name():
     assert '_cat_backward_helper(' in src
     assert 'to_args_sizes_symint' not in src
     assert 'to_args_scalartypes' not in src
+
+
+def test_generated_header_matmul_helper_has_vector_safe_paths():
+    assert 'len(other.shape) == 1' in _HEADER
+    assert 'len(self_.shape) == 1' in _HEADER
+    assert 'redispatch("unsqueeze", keyset, grad, -1)' in _HEADER
+    assert 'redispatch("unsqueeze", keyset, grad, -2)' in _HEADER

--- a/tests/cpu/test_autograd.py
+++ b/tests/cpu/test_autograd.py
@@ -1,3 +1,4 @@
+import numpy as np
 import candle as torch
 
 
@@ -74,3 +75,63 @@ def test_autograd_batched_matmul_backward_shape_safe():
 
     assert a.grad is not None
     assert b.grad is not None
+
+
+def test_autograd_matmul_vector_matrix_backward_shape_and_values():
+    x = torch.tensor([1.0, -2.0, 3.0])
+    w = torch.tensor(
+        [
+            [0.5, 1.0],
+            [-1.5, 2.0],
+            [3.0, -0.5],
+        ]
+    )
+    x.requires_grad = True
+    w.requires_grad = True
+
+    y = torch.matmul(x, w)
+    y.sum().backward()
+
+    assert x.grad is not None
+    assert w.grad is not None
+    np.testing.assert_allclose(x.grad.numpy(), np.array([1.5, 0.5, 2.5], dtype=np.float32))
+    np.testing.assert_allclose(
+        w.grad.numpy(),
+        np.array(
+            [
+                [1.0, 1.0],
+                [-2.0, -2.0],
+                [3.0, 3.0],
+            ],
+            dtype=np.float32,
+        ),
+    )
+
+
+def test_autograd_matmul_matrix_vector_backward_shape_and_values():
+    a = torch.tensor(
+        [
+            [1.0, 2.0, -1.0],
+            [0.0, -3.0, 4.0],
+        ]
+    )
+    x = torch.tensor([2.0, -1.0, 0.5])
+    a.requires_grad = True
+    x.requires_grad = True
+
+    y = torch.matmul(a, x)
+    y.sum().backward()
+
+    assert a.grad is not None
+    assert x.grad is not None
+    np.testing.assert_allclose(
+        a.grad.numpy(),
+        np.array(
+            [
+                [2.0, -1.0, 0.5],
+                [2.0, -1.0, 0.5],
+            ],
+            dtype=np.float32,
+        ),
+    )
+    np.testing.assert_allclose(x.grad.numpy(), np.array([1.0, -1.0, 3.0], dtype=np.float32))

--- a/tests/mps/test_autograd_mps.py
+++ b/tests/mps/test_autograd_mps.py
@@ -51,6 +51,70 @@ def test_matmul_backward_mps():
     assert b.grad is not None
 
 
+
+
+def test_matmul_vector_matrix_backward_mps():
+    x = torch.tensor([1.0, -2.0, 3.0], device="mps")
+    w = torch.tensor(
+        [
+            [0.5, 1.0],
+            [-1.5, 2.0],
+            [3.0, -0.5],
+        ],
+        device="mps",
+    )
+    x.requires_grad = True
+    w.requires_grad = True
+
+    y = torch.matmul(x, w)
+    y.sum().backward()
+
+    assert x.grad is not None
+    assert w.grad is not None
+    np.testing.assert_allclose(x.grad.cpu().numpy(), np.array([1.5, 0.5, 2.5], dtype=np.float32))
+    np.testing.assert_allclose(
+        w.grad.cpu().numpy(),
+        np.array(
+            [
+                [1.0, 1.0],
+                [-2.0, -2.0],
+                [3.0, 3.0],
+            ],
+            dtype=np.float32,
+        ),
+    )
+
+
+def test_matmul_matrix_vector_backward_mps():
+    a = torch.tensor(
+        [
+            [1.0, 2.0, -1.0],
+            [0.0, -3.0, 4.0],
+        ],
+        device="mps",
+    )
+    x = torch.tensor([2.0, -1.0, 0.5], device="mps")
+    a.requires_grad = True
+    x.requires_grad = True
+
+    y = torch.matmul(a, x)
+    y.sum().backward()
+
+    assert a.grad is not None
+    assert x.grad is not None
+    np.testing.assert_allclose(
+        a.grad.cpu().numpy(),
+        np.array(
+            [
+                [2.0, -1.0, 0.5],
+                [2.0, -1.0, 0.5],
+            ],
+            dtype=np.float32,
+        ),
+    )
+    np.testing.assert_allclose(x.grad.cpu().numpy(), np.array([1.0, -1.0, 3.0], dtype=np.float32))
+
+
 def test_linear_backward_mps():
     from candle import nn
     layer = nn.Linear(2, 3).to("mps")

--- a/tools/autograd/gen_functions.py
+++ b/tools/autograd/gen_functions.py
@@ -110,8 +110,39 @@ def _div_tensor_other_backward_helper(grad, self_, other, *extra_and_keyset):
 
 
 def _matmul_backward_helper(grad, self_, other, grad_input_mask, keyset):
-    grad_self = reduce_grad(redispatch("matmul", keyset, grad, redispatch("transpose", keyset, other, -1, -2)), self_.shape) if grad_input_mask[0] else None
-    grad_other = reduce_grad(redispatch("matmul", keyset, redispatch("transpose", keyset, self_, -1, -2), grad), other.shape) if grad_input_mask[1] else None
+    grad_self = None
+    grad_other = None
+
+    if grad_input_mask[0]:
+        if len(other.shape) == 1:
+            if len(self_.shape) == 1:
+                grad_self_raw = redispatch("mul", keyset, grad, other)
+            else:
+                grad_self_raw = redispatch(
+                    "matmul",
+                    keyset,
+                    redispatch("unsqueeze", keyset, grad, -1),
+                    redispatch("unsqueeze", keyset, other, 0),
+                )
+        else:
+            grad_self_raw = redispatch("matmul", keyset, grad, redispatch("transpose", keyset, other, -1, -2))
+        grad_self = reduce_grad(grad_self_raw, self_.shape)
+
+    if grad_input_mask[1]:
+        if len(self_.shape) == 1:
+            if len(other.shape) == 1:
+                grad_other_raw = redispatch("mul", keyset, grad, self_)
+            else:
+                grad_other_raw = redispatch(
+                    "matmul",
+                    keyset,
+                    redispatch("unsqueeze", keyset, self_, -1),
+                    redispatch("unsqueeze", keyset, grad, -2),
+                )
+        else:
+            grad_other_raw = redispatch("matmul", keyset, redispatch("transpose", keyset, self_, -1, -2), grad)
+        grad_other = reduce_grad(grad_other_raw, other.shape)
+
     return grad_self, grad_other
 
 


### PR DESCRIPTION
Closes #273

## Summary
- update generated matmul backward helpers to handle vector-matrix and matrix-vector cases correctly
- keep the Python and generated Cython helper sources aligned through the generator source-of-truth
- add focused CPU, MPS, and contract regressions covering the active runtime path for 1D matmul backward cases

## Test Plan
- [x] `PYTHONPATH=/tmp/candle311-verify-pkgs conda run -n candle311-tutorials python -m pylint src/candle/ --rcfile=.github/pylint.conf`
- [x] `PYTHONPATH=/tmp/candle311-verify-pkgs conda run -n candle311-tutorials python -m pytest tests/cpu/ tests/contract/ -v --tb=short`
- [x] `PYTHONPATH=/tmp/candle311-verify-pkgs conda run -n candle311-tutorials python -m pytest tests/mps/ -v --tb=short`
- [x] `conda run -n candle311-tutorials python -m pytest tests/cpu/test_autograd.py::test_autograd_matmul_vector_matrix_backward_shape_and_values tests/cpu/test_autograd.py::test_autograd_matmul_matrix_vector_backward_shape_and_values -v --tb=short`
- [x] `conda run -n candle311-tutorials python -m pytest tests/mps/test_autograd_mps.py::test_matmul_vector_matrix_backward_mps tests/mps/test_autograd_mps.py::test_matmul_matrix_vector_backward_mps -v --tb=short`
- [x] `PYTHONPATH=/tmp/candle311-verify-pkgs conda run -n candle311-tutorials python -m pytest tests/contract/test_gen_functions_next_runtime_helpers.py --noconftest -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)