### PR TITLE
fix(ci): use fork repo URL for prepare-remote in openi-910a-pr workflow

### DIFF
--- a/.github/workflows/openi-910a-pr.yml
+++ b/.github/workflows/openi-910a-pr.yml
@@ -43,7 +43,7 @@ jobs:
           OPENI_USER_PASSWORD: ${{ secrets.OPENI_USER_PASSWORD }}
         run: |
           python .github/scripts/openi_ci.py ensure-task \
-            --repo-url "${{ github.server_url }}/${{ github.repository }}.git" \
+            --repo-url "${{ github.event.pull_request.head.repo.clone_url }}" \
             --ref "${{ github.event.pull_request.head.sha }}" \
             --image-id "${{ secrets.OPENI_IMAGE_ID }}" \
             --image-name "${{ secrets.OPENI_IMAGE_NAME }}" \
@@ -63,7 +63,7 @@ jobs:
           OPENI_USER_PASSWORD: ${{ secrets.OPENI_USER_PASSWORD }}
         run: |
           python .github/scripts/openi_ci.py prepare-remote \
-            --repo-url "${{ github.server_url }}/${{ github.repository }}.git" \
+            --repo-url "${{ github.event.pull_request.head.repo.clone_url }}" \
             --ref "${{ github.event.pull_request.head.sha }}"
       - name: Upload task state
         uses: actions/upload-artifact@v4
@@ -96,7 +96,7 @@ jobs:
           OPENI_ARTIFACT_SUFFIX: suite
         run: |
           python .github/scripts/openi_ci.py prepare-remote \
-            --repo-url "${{ github.server_url }}/${{ github.repository }}.git" \
+            --repo-url "${{ github.event.pull_request.head.repo.clone_url }}" \
             --ref "${{ github.event.pull_request.head.sha }}"
       - name: Run 910A suite
         env:
@@ -141,7 +141,7 @@ jobs:
           OPENI_ARTIFACT_SUFFIX: dist-2card
         run: |
           python .github/scripts/openi_ci.py prepare-remote \
-            --repo-url "${{ github.server_url }}/${{ github.repository }}.git" \
+            --repo-url "${{ github.event.pull_request.head.repo.clone_url }}" \
             --ref "${{ github.event.pull_request.head.sha }}"
       - name: Run 2-card distributed tests
         env:
@@ -186,7 +186,7 @@ jobs:
           OPENI_ARTIFACT_SUFFIX: dist-4card
         run: |
           python .github/scripts/openi_ci.py prepare-remote \
-            --repo-url "${{ github.server_url }}/${{ github.repository }}.git" \
+            --repo-url "${{ github.event.pull_request.head.repo.clone_url }}" \
             --ref "${{ github.event.pull_request.head.sha }}"
       - name: Run 4-card HCCL tests
         env:


### PR DESCRIPTION
In `openi-910a-pr.yml`, `prepare-remote` was using the base repo URL (`candle-org/candle`) but the `--ref` is a commit SHA from the fork, which does not exist in the base repo.

Fix: use `github.event.pull_request.head.repo.clone_url` so the remote OpenI task clones from the fork and can checkout the PR head SHA.