### PR TITLE
fix(ci): fetch pull request refs on remote for PR checkout

### DIFF
--- a/.github/scripts/openi_ci.py
+++ b/.github/scripts/openi_ci.py
@@ -309,6 +309,7 @@ rm -rf {remote_repo}
 git -c http.proxy= -c https.proxy= clone {repo_url} {remote_repo}
 cd {remote_repo}
 git -c http.proxy= -c https.proxy= fetch --all --tags
+git -c http.proxy= -c https.proxy= fetch origin '+refs/pull/*/head:refs/remotes/origin/pr/*' 2>/dev/null || true
 git checkout {ref}
 env | sort > remote_env.txt
 npu-smi info > npu-smi.txt 2>&1 || true

--- a/.github/tests/test_openi_ci_helpers.py
+++ b/.github/tests/test_openi_ci_helpers.py
@@ -325,8 +325,9 @@ def test_ensure_task_creates_when_no_prior_task_state(openi_ci_module, tmp_path,
     monkeypatch.setattr(openi_ci_module, "ARTIFACT_ROOT", tmp_path / ".artifacts" / "openi-910a")
     monkeypatch.setattr(openi_ci_module, "_load_session_config", lambda: {"cookie": "c", "csrf": "x", "source": "env"})
 
+    # my_list returns empty → falls through to create
     fake_session = _FakeSession([
-        {"code": 0, "data": {"id": 111, "status": "WAITING"}},
+        {"code": 0, "data": {"tasks": []}},  # my_list: no existing tasks
     ])
     monkeypatch.setattr(openi_ci_module, "_make_requests_session", lambda session_cfg: fake_session)
 
@@ -354,7 +355,8 @@ def test_ensure_task_creates_when_no_prior_task_state(openi_ci_module, tmp_path,
     assert saved["status"] == "WAITING"
     assert saved["repo_url"] == "https://github.com/candle-org/candle.git"
     assert saved["ref"] == "main"
-    assert fake_session.calls == []
+    assert len(fake_session.calls) == 1  # only my_list was called
+    assert "my_list" in fake_session.calls[0][1]
 
 
 

--- a/.github/workflows/openi-910a-pr.yml
+++ b/.github/workflows/openi-910a-pr.yml
@@ -43,7 +43,7 @@ jobs:
           OPENI_USER_PASSWORD: ${{ secrets.OPENI_USER_PASSWORD }}
         run: |
           python .github/scripts/openi_ci.py ensure-task \
-            --repo-url "${{ github.event.pull_request.head.repo.clone_url }}" \
+            --repo-url "${{ github.server_url }}/${{ github.repository }}.git" \
             --ref "${{ github.event.pull_request.head.sha }}" \
             --image-id "${{ secrets.OPENI_IMAGE_ID }}" \
             --image-name "${{ secrets.OPENI_IMAGE_NAME }}" \
@@ -63,7 +63,7 @@ jobs:
           OPENI_USER_PASSWORD: ${{ secrets.OPENI_USER_PASSWORD }}
         run: |
           python .github/scripts/openi_ci.py prepare-remote \
-            --repo-url "${{ github.event.pull_request.head.repo.clone_url }}" \
+            --repo-url "${{ github.server_url }}/${{ github.repository }}.git" \
             --ref "${{ github.event.pull_request.head.sha }}"
       - name: Upload task state
         uses: actions/upload-artifact@v4
@@ -96,7 +96,7 @@ jobs:
           OPENI_ARTIFACT_SUFFIX: suite
         run: |
           python .github/scripts/openi_ci.py prepare-remote \
-            --repo-url "${{ github.event.pull_request.head.repo.clone_url }}" \
+            --repo-url "${{ github.server_url }}/${{ github.repository }}.git" \
             --ref "${{ github.event.pull_request.head.sha }}"
       - name: Run 910A suite
         env:
@@ -141,7 +141,7 @@ jobs:
           OPENI_ARTIFACT_SUFFIX: dist-2card
         run: |
           python .github/scripts/openi_ci.py prepare-remote \
-            --repo-url "${{ github.event.pull_request.head.repo.clone_url }}" \
+            --repo-url "${{ github.server_url }}/${{ github.repository }}.git" \
             --ref "${{ github.event.pull_request.head.sha }}"
       - name: Run 2-card distributed tests
         env:
@@ -186,7 +186,7 @@ jobs:
           OPENI_ARTIFACT_SUFFIX: dist-4card
         run: |
           python .github/scripts/openi_ci.py prepare-remote \
-            --repo-url "${{ github.event.pull_request.head.repo.clone_url }}" \
+            --repo-url "${{ github.server_url }}/${{ github.repository }}.git" \
             --ref "${{ github.event.pull_request.head.sha }}"
       - name: Run 4-card HCCL tests
         env:


### PR DESCRIPTION
The remote OpenI task clones from the base repo but needs to checkout the PR head SHA. `git fetch --all --tags` does not fetch `refs/pull/*/head`.

Fix: explicitly fetch `+refs/pull/*/head:refs/remotes/origin/pr/*` (with `2>/dev/null || true` to not fail on repos that disallow it).

Also reverts the fork repo URL change from #295 back to base repo URL since the OpenI network can access `candle-org/candle` but cannot access GitHub in general reliably.

Updates test for `ensure-task` to reflect that `my_list` is now always queried when no local task state exists.