### PR TITLE
debug(ci): print prepare-remote output on failure

### DIFF
--- a/.github/scripts/openi_ci.py
+++ b/.github/scripts/openi_ci.py
@@ -755,6 +755,7 @@ def _handle_prepare_remote(args: argparse.Namespace) -> int:
     )
     prepare_result = client.execute_shell(prepare_command, timeout=600)
     if prepare_result.get("exit_code", 0) != 0:
+        print(prepare_result.get("output", ""), flush=True)
         raise OpenITaskError(
             f"Remote prepare failed with exit code {prepare_result.get('exit_code', 1)}"
         )


### PR DESCRIPTION
Print remote script output when prepare-remote fails, to diagnose exit code 128 in suite jobs.