### PR TITLE
ci: smoke test merged upstream OpenI workflow

### DIFF
--- a/.github/scripts/trigger_openi_upstream.txt
+++ b/.github/scripts/trigger_openi_upstream.txt
@@ -1,0 +1,1 @@
+# upstream retest 1774806252


### PR DESCRIPTION
## Summary
- touch `.github/scripts/trigger_openi_upstream.txt` to force the merged upstream OpenI workflow to run from current `candle-org/candle` `main`

## Test Plan
- [ ] approve the `openi-npu` environment gate
- [ ] verify the new `OpenI 910A (PR)` self-hosted workflow is the one that executes
- [ ] verify suite + dist4 rounds start and runner registration still works on upstream
