### PR TITLE
perf(ci): add ccache to OpenI builds

### DIFF
--- a/.github/workflows/openi-910a-pr.yml
+++ b/.github/workflows/openi-910a-pr.yml
@@ -149,6 +149,7 @@ jobs:
             /home/ma-user/work/.conda/envs/candle-py311
             /home/ma-user/work/.conda/pkgs
             /home/ma-user/.cache/pip
+            /home/ma-user/work/.cache/ccache
           key: openi-conda-${{ runner.os }}-py311-${{ hashFiles('requirements/**', 'pyproject.toml', 'setup.py') }}
           restore-keys: |
             openi-conda-${{ runner.os }}-py311-
@@ -170,11 +171,19 @@ jobs:
             mkdir -p /home/ma-user/work/.conda/envs
             conda create -y --override-channels -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/conda-forge -p "$ENV_DIR" python=3.11
           fi
+          conda install -y --override-channels -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/conda-forge -p "$ENV_DIR" ccache
           PY="$ENV_DIR/bin/python"
           PIP="$ENV_DIR/bin/pip"
           $PIP install -i https://pypi.tuna.tsinghua.edu.cn/simple Cython
+          export CCACHE_DIR=/home/ma-user/work/.cache/ccache
+          export CCACHE_MAXSIZE=10G
+          mkdir -p "$CCACHE_DIR"
+          export CC='ccache gcc'
+          export CXX='ccache g++'
+          ccache --show-stats || true
           $PY setup.py build_ext --inplace
           $PIP install -i https://pypi.tuna.tsinghua.edu.cn/simple -e . --no-build-isolation
+          ccache --show-stats || true
       - name: Run suite tests
         run: |
           ENV_DIR=/home/ma-user/work/.conda/envs/candle-py311
@@ -356,6 +365,7 @@ jobs:
             /home/ma-user/work/.conda/envs/candle-py311
             /home/ma-user/work/.conda/pkgs
             /home/ma-user/.cache/pip
+            /home/ma-user/work/.cache/ccache
           key: openi-conda-${{ runner.os }}-py311-${{ hashFiles('requirements/**', 'pyproject.toml', 'setup.py') }}
           restore-keys: |
             openi-conda-${{ runner.os }}-py311-
@@ -377,11 +387,19 @@ jobs:
             mkdir -p /home/ma-user/work/.conda/envs
             conda create -y --override-channels -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/conda-forge -p "$ENV_DIR" python=3.11
           fi
+          conda install -y --override-channels -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/conda-forge -p "$ENV_DIR" ccache
           PY="$ENV_DIR/bin/python"
           PIP="$ENV_DIR/bin/pip"
           $PIP install -i https://pypi.tuna.tsinghua.edu.cn/simple Cython
+          export CCACHE_DIR=/home/ma-user/work/.cache/ccache
+          export CCACHE_MAXSIZE=10G
+          mkdir -p "$CCACHE_DIR"
+          export CC='ccache gcc'
+          export CXX='ccache g++'
+          ccache --show-stats || true
           $PY setup.py build_ext --inplace
           $PIP install -i https://pypi.tuna.tsinghua.edu.cn/simple -e . --no-build-isolation
+          ccache --show-stats || true
       - name: Run distributed tests
         run: |
           ENV_DIR=/home/ma-user/work/.conda/envs/candle-py311


### PR DESCRIPTION
## Summary
- add `ccache` to the OpenI self-hosted runner build steps using the persistent OpenI work volume
- cache the `candle-py311` conda env, conda package cache, pip cache, build directory, generated C/C++ files, and `ccache` directory to speed repeated runs
- print `ccache --show-stats` before and after builds so cache hit/miss behavior is visible in CI logs

## Test Plan
- [x] `python -m pytest .github/tests/test_openi_ci_self_hosted.py -q`
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/openi-910a-pr.yml').read())"`
- [ ] run the upstream OpenI workflow again and confirm `ccache` is installed into `candle-py311`
- [ ] confirm `ccache --show-stats` reports cache activity across repeated runs
