### PR TITLE
fix(ci): install test dependencies in OpenI PR workflow

### DIFF
--- a/.github/workflows/openi-910a-pr.yml
+++ b/.github/workflows/openi-910a-pr.yml
@@ -174,6 +174,7 @@ jobs:
           conda install -y --override-channels -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/conda-forge -p "$ENV_DIR" ccache
           PY="$ENV_DIR/bin/python"
           PIP="$ENV_DIR/bin/pip"
+          $PIP install -i https://pypi.tuna.tsinghua.edu.cn/simple -r requirements/requirements-test.txt
           $PIP install -i https://pypi.tuna.tsinghua.edu.cn/simple Cython
           export CCACHE_DIR=/home/ma-user/work/.cache/ccache
           export CCACHE_MAXSIZE=10G
@@ -390,6 +391,7 @@ jobs:
           conda install -y --override-channels -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/conda-forge -p "$ENV_DIR" ccache
           PY="$ENV_DIR/bin/python"
           PIP="$ENV_DIR/bin/pip"
+          $PIP install -i https://pypi.tuna.tsinghua.edu.cn/simple -r requirements/requirements-test.txt
           $PIP install -i https://pypi.tuna.tsinghua.edu.cn/simple Cython
           export CCACHE_DIR=/home/ma-user/work/.cache/ccache
           export CCACHE_MAXSIZE=10G


### PR DESCRIPTION
## Summary
- align the self-hosted OpenI PR workflow with the old 910A flow by installing `requirements/requirements-test.txt` before build/test
- keep the existing `ccache` integration and Python 3.11 env handling
- ensure the OpenI runner has the same test dependency set before running pytest

## Test Plan
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/openi-910a-pr.yml').read())"`
- [ ] approve the `openi-npu` environment gate
- [ ] verify `Build candle` installs test dependencies on OpenI before pytest runs
