### PR TITLE
fix(ci): remove OpenI environment approval gate

### DIFF
--- a/.github/workflows/openi-910a-pr.yml
+++ b/.github/workflows/openi-910a-pr.yml
@@ -36,7 +36,6 @@ jobs:
   suite-start:
     name: Suite - Start
     runs-on: ubuntu-latest
-    environment: openi-npu
     timeout-minutes: 30
     env:
       OPENI_ARTIFACT_SUFFIX: suite
@@ -253,7 +252,6 @@ jobs:
     name: Dist 4-card - Start
     needs: suite-stop
     runs-on: ubuntu-latest
-    environment: openi-npu
     timeout-minutes: 30
     env:
       OPENI_ARTIFACT_SUFFIX: dist-4card


### PR DESCRIPTION
## Summary
- remove `environment: openi-npu` from the OpenI self-hosted PR workflow so it auto-starts without manual approval
- keep using repo-level `OPENI_*` secrets and variables, which are already configured upstream

## Test Plan
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/openi-910a-pr.yml').read())"`
- [ ] verify a fresh upstream smoke PR creates `OpenI 910A (PR)` immediately instead of `pending`
