### PR TITLE
fix(ci): enrich OpenI task matching with task detail spec id

### DIFF
--- a/.github/scripts/openi_ci.py
+++ b/.github/scripts/openi_ci.py
@@ -464,7 +464,23 @@ def _find_matching_task_in_my_list(session: requests.Session, args: argparse.Nam
                 tasks.append(item)
     elif isinstance(data, list):
         tasks = data
-    candidates = [task for task in tasks if _task_matches_request(task, args)]
+
+    candidates = []
+    for task in tasks:
+        enriched_task = task
+        if getattr(args, "spec_id", None) is not None and task.get("spec_id") is None and task.get("id") is not None:
+            try:
+                detail = _api_call(session, "get", f"/api/v1/ai_task?id={task['id']}").get("data", {})
+                detailed_task = detail.get("task") if isinstance(detail, dict) else None
+                if isinstance(detailed_task, dict):
+                    spec = detailed_task.get("spec") or {}
+                    if spec.get("id") is not None:
+                        enriched_task = dict(task)
+                        enriched_task["spec_id"] = str(spec["id"])
+            except Exception:  # pylint: disable=broad-except
+                pass
+        if _task_matches_request(enriched_task, args):
+            candidates.append(enriched_task)
     if not candidates:
         return None
     candidates.sort(key=lambda task: (int(task.get("start_time") or 0), int(task.get("id") or 0)), reverse=True)

--- a/.github/tests/test_openi_ci_self_hosted.py
+++ b/.github/tests/test_openi_ci_self_hosted.py
@@ -29,7 +29,39 @@ def test_parser_does_not_expose_legacy_openi_commands():
     assert "fetch-artifacts" not in commands
 
 
-def test_runner_api_token_prefers_openi_runner_token(monkeypatch):
+
+
+def test_find_matching_task_in_my_list_uses_task_detail_spec_id_when_my_list_lacks_spec(monkeypatch):
+    session = DummySession()
+
+    tasks_payload = {
+        "data": {
+            "tasks": [
+                {"task": {"id": 11, "cluster": "C2Net", "compute_source": "NPU", "image_id": "img", "image_name": "image", "start_time": 200}},
+                {"task": {"id": 22, "cluster": "C2Net", "compute_source": "NPU", "image_id": "img", "image_name": "image", "start_time": 100}},
+            ]
+        }
+    }
+
+    details = {
+        "/api/v1/ai_task?id=11": {"data": {"task": {"spec": {"id": 328}}}},
+        "/api/v1/ai_task?id=22": {"data": {"task": {"spec": {"id": 340}}}},
+    }
+
+    def fake_api_call(_session, method, path, **_kwargs):
+        assert method == "get"
+        if path == "/api/v1/ai_task/my_list":
+            return tasks_payload
+        return details[path]
+
+    monkeypatch.setattr(openi_ci, "_api_call", fake_api_call)
+
+    args = argparse.Namespace(spec_id="340", cluster="C2Net", compute_source="NPU", image_id="img", image_name="image")
+    task = openi_ci._find_matching_task_in_my_list(session, args)
+
+    assert task is not None
+    assert task["id"] == 22
+
     monkeypatch.setenv("OPENI_RUNNER_TOKEN", "runner-token")
     monkeypatch.setenv("GITHUB_TOKEN", "github-token")
 


### PR DESCRIPTION
## Summary
- when `my_list` lacks `spec_id`, enrich candidate tasks with `/api/v1/ai_task?id=...` detail data and match on `task.spec.id`
- prevent suite/dist task drift from selecting the wrong replacement task after OpenI restarts and task IDs change
- add regression coverage for the spec-enrichment path

## Test Plan
- [x] `python -m pytest .github/tests/test_openi_ci_self_hosted.py -q`
