### PR TITLE
fix OpenI 4-card ccache and device visibility

### DIFF
--- a/.github/tests/test_openi_ci_self_hosted.py
+++ b/.github/tests/test_openi_ci_self_hosted.py
@@ -2,13 +2,21 @@ import argparse
 import importlib.util
 from pathlib import Path
 
+import yaml
 
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PR_WORKFLOW_PATH = REPO_ROOT / ".github/workflows/openi-910a-pr.yml"
 SPEC = importlib.util.spec_from_file_location(
     "openi_ci",
     str(Path(__file__).resolve().parents[1] / "scripts" / "openi_ci.py"),
 )
 openi_ci = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(openi_ci)
+
+
+def _load_pr_workflow():
+    return yaml.safe_load(PR_WORKFLOW_PATH.read_text(encoding="utf-8"))
 
 
 class DummySession:
@@ -27,6 +35,26 @@ def test_parser_does_not_expose_legacy_openi_commands():
     assert "run-910a-suite" not in commands
     assert "run-910a-dist" not in commands
     assert "fetch-artifacts" not in commands
+
+
+def test_pr_workflow_build_steps_add_env_bin_to_path_before_ccache():
+    workflow = _load_pr_workflow()
+    jobs = workflow["jobs"]
+
+    for job_name in ("suite-run", "dist4-run"):
+        build_step = next(step for step in jobs[job_name]["steps"] if step.get("name") == "Build candle")
+        run = build_step["run"]
+        assert 'export PATH="$ENV_DIR/bin:$PATH"' in run, f"{job_name} Build candle must export ENV_DIR/bin into PATH"
+
+
+def test_pr_workflow_dist4_steps_do_not_pin_visible_device_ids():
+    workflow = _load_pr_workflow()
+    steps = workflow["jobs"]["dist4-run"]["steps"]
+
+    for step_name in ("Run distributed tests", "Run 4-card HCCL tests"):
+        run = next(step["run"] for step in steps if step.get("name") == step_name)
+        assert "ASCEND_RT_VISIBLE_DEVICES" not in run, f"{step_name} should not hardcode ASCEND_RT_VISIBLE_DEVICES"
+        assert "ASCEND_VISIBLE_DEVICES" not in run, f"{step_name} should not hardcode ASCEND_VISIBLE_DEVICES"
 
 
 

--- a/.github/workflows/openi-910a-pr.yml
+++ b/.github/workflows/openi-910a-pr.yml
@@ -171,6 +171,7 @@ jobs:
             conda create -y --override-channels -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/conda-forge -p "$ENV_DIR" python=3.11
           fi
           conda install -y --override-channels -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/conda-forge -p "$ENV_DIR" ccache
+          export PATH="$ENV_DIR/bin:$PATH"
           PY="$ENV_DIR/bin/python"
           PIP="$ENV_DIR/bin/pip"
           $PIP install -i https://pypi.tuna.tsinghua.edu.cn/simple -r requirements/requirements-test.txt
@@ -387,6 +388,7 @@ jobs:
             conda create -y --override-channels -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/conda-forge -p "$ENV_DIR" python=3.11
           fi
           conda install -y --override-channels -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/conda-forge -p "$ENV_DIR" ccache
+          export PATH="$ENV_DIR/bin:$PATH"
           PY="$ENV_DIR/bin/python"
           PIP="$ENV_DIR/bin/pip"
           $PIP install -i https://pypi.tuna.tsinghua.edu.cn/simple -r requirements/requirements-test.txt
@@ -405,8 +407,6 @@ jobs:
           ENV_DIR=/home/ma-user/work/.conda/envs/candle-py311
           PY="$ENV_DIR/bin/python"
           export PATH="$ENV_DIR/bin:$PATH"
-          export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
-          export ASCEND_VISIBLE_DEVICES=0,1,2,3
           export PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
           $PY -m pytest tests/distributed/ -v --tb=short \
             -k 'not test_ddp' 2>&1 | tee dist.log
@@ -415,8 +415,6 @@ jobs:
           ENV_DIR=/home/ma-user/work/.conda/envs/candle-py311
           PY="$ENV_DIR/bin/python"
           export PATH="$ENV_DIR/bin:$PATH"
-          export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
-          export ASCEND_VISIBLE_DEVICES=0,1,2,3
           export PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
           $PY -m pytest \
             'tests/distributed/test_hccl_all_to_all_single_async_unequal_multicard.py::test_hccl_all_to_all_single_async_unequal_multicard[4-29724]' \


### PR DESCRIPTION
## Summary
- add regression tests for the OpenI PR workflow so build steps must expose the conda env bin directory before invoking `ccache`
- update OpenI build steps to export `PATH` with `$ENV_DIR/bin` so `ccache` resolves from the conda prefix
- stop hardcoding `ASCEND_VISIBLE_DEVICES` and `ASCEND_RT_VISIBLE_DEVICES` in the OpenI 4-card job so it uses the devices actually assigned by OpenI

## Test plan
- [x] `source ~/miniconda3/etc/profile.d/conda.sh && conda run -n mindnlp python -m pytest .github/tests/test_openi_ci_self_hosted.py -q --noconftest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)