### PR TITLE
ci: retrigger OpenI 4-card validation

### DIFF
--- a/.github/scripts/trigger_openi_upstream_ccache.txt
+++ b/.github/scripts/trigger_openi_upstream_ccache.txt
@@ -1,1 +1,2 @@
 # single smoke rerun 1774847023
+# retrigger after merge a71ef005 for 4-card OpenI validation


### PR DESCRIPTION
## Summary
- retrigger the upstream OpenI PR workflow after merging the ccache and visible-device fixes
- validate the real 4-card OpenI path on a fresh PR run

## Test Plan
- [ ] Confirm `OpenI 910A (PR)` starts on this PR
- [ ] Confirm the 4-card stage reaches `Dist 4-card - Run`
- [ ] Inspect whether `ccache` resolves and 4-card tests no longer skip for pinned device IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)