### PR TITLE
fix: add torch._custom_ops compat shim

### DIFF
--- a/src/candle/_custom_ops.py
+++ b/src/candle/_custom_ops.py
@@ -1,0 +1,27 @@
+"""Minimal torch._custom_ops compatibility shim.
+
+Provides the small surface torchvision imports at module import time.
+This stub does not perform real custom-op registration.
+"""
+
+
+class _CustomOpContext:
+    def create_unbacked_symint(self):
+        return 0
+
+
+_CTX = _CustomOpContext()
+
+
+def get_ctx():
+    return _CTX
+
+
+def register(*_args, **_kwargs):
+    def decorator(fn):
+        return fn
+
+    return decorator
+
+
+__all__ = ["get_ctx", "register"]

--- a/tests/test_torch_compat.py
+++ b/tests/test_torch_compat.py
@@ -220,6 +220,17 @@ class TestImportHook:
         out, _, _ = _run(code, env_extra={"USE_CANDLE": "1"})
         assert "OK" in out
 
+    def test_import_torch_custom_ops(self):
+        """Regression: torchvision meta registrations import torch._custom_ops."""
+        code = textwrap.dedent("""\
+            import importlib
+            mod = importlib.import_module("torch._custom_ops")
+            assert mod is not None
+            print("OK")
+        """)
+        out, _, _ = _run(code, env_extra={"USE_CANDLE": "1"})
+        assert "OK" in out
+
     def test_torch_hub_set_dir_updates_get_dir_without_warning(self):
         code = textwrap.dedent("""\
             import tempfile


### PR DESCRIPTION
## Summary

- Add `src/candle/_custom_ops.py`: minimal shim for `torch._custom_ops` so torchvision meta registrations (`torchvision._meta_registrations`) can `import torch._custom_ops` without error under the Candle torch redirect
- Add regression test `TestImportHook.test_import_torch_custom_ops` in `tests/test_torch_compat.py`

## Reproducer

```python
import importlib
import torch
mod = importlib.import_module('torch._custom_ops')
assert mod is not None
```

## Test Plan

- [x] `tests/test_torch_compat.py -k custom_ops` → 1 passed
- [x] `pytest tests/cpu/ tests/contract/ -v --tb=short` → 2352 passed, 91 skipped
- [x] `pytest tests/mps/ -v --tb=short` → 363 passed
- [x] `pylint src/candle/_custom_ops.py --rcfile=.github/pylint.conf` → 10.00/10

Closes #316