### PR TITLE
fix: preserve scalar shape for full reductions

### DIFF
--- a/src/candle/_backends/cpu/ops.py
+++ b/src/candle/_backends/cpu/ops.py
@@ -339,7 +339,11 @@ def sum_(a, dim=None, keepdim=False, dtype=None):
             acc_dtype = np.int64
 
     out = arr.sum(axis=dim, keepdims=keepdim, dtype=acc_dtype)
-    out = np.ascontiguousarray(out.astype(to_numpy_dtype(out_dtype), copy=False))
+    if isinstance(out, np.generic):
+        out = np.array(out)
+    out = out.astype(to_numpy_dtype(out_dtype), copy=False)
+    if not (isinstance(out, np.ndarray) and out.ndim == 0):
+        out = np.ascontiguousarray(out)
     return _from_numpy(out, out_dtype, a.device)
 
 

--- a/tests/cpu/test_ops_cpu.py
+++ b/tests/cpu/test_ops_cpu.py
@@ -1213,3 +1213,16 @@ def test_sum_dtype_accumulates_in_target_dtype_matches_torch_cpu():
 
     assert str(out.dtype) == str(tout.dtype)
     assert out.item() == tout.item() == 240
+
+
+def test_sum_full_reduction_shape():
+    x = torch.tensor([1.0, 2.0, 3.0])
+    s = x.sum()
+    assert s.shape == ()
+    assert float(s.item()) == 6.0
+
+
+def test_scalar_inplace_sub():
+    a = torch.randn(())
+    g = torch.tensor([2.0]).sum()
+    a -= 1e-6 * g


### PR DESCRIPTION
## Summary

- preserve 0-d CPU tensor shape for full reductions by avoiding contiguity conversion on scalar `sum()` outputs
- add regression tests for scalar `sum()` shape and the in-place subtract path that previously failed with a broadcast error

## Root cause

`arr.sum(axis=None)` returns a NumPy scalar for full reductions. Wrapping it with `np.array(...)` keeps the correct `()` shape, but `np.ascontiguousarray(...)` reshapes that 0-d array to `(1,)`, which then produces a rank-1 Candle tensor instead of a scalar tensor.

## Test Plan

- [x] `pytest tests/cpu/test_ops_cpu.py -q -k "sum_full_reduction_shape or scalar_inplace_sub"`
- [x] `pytest tests/cpu/ tests/contract/ -v --tb=short` → 2354 passed, 91 skipped
- [x] `pytest tests/mps/ -v --tb=short` → 363 passed
- [x] `pylint src/candle/_backends/cpu/ops.py --rcfile=.github/pylint.conf` → 10.00/10

Closes #313