### PR TITLE
fix: restore no-arg Tensor.min and Tensor.max

### DIFF
--- a/src/candle/_tensor.py
+++ b/src/candle/_tensor.py
@@ -1893,6 +1893,9 @@ if getattr(_cython_mod, "_HAS_CYTHON_TENSOR_API", False):
     Tensor.record_stream = _cython_mod.tensor_record_stream
     Tensor.is_pinned = _cython_mod.tensor_is_pinned
 
+    _python_tensor_min = Tensor.min
+    _python_tensor_max = Tensor.max
+
     Tensor.__add__ = _cython_mod.tensor_add
     Tensor.__sub__ = _cython_mod.tensor_sub
     Tensor.__mul__ = _cython_mod.tensor_mul
@@ -2159,6 +2162,8 @@ if getattr(_cython_mod, "_HAS_CYTHON_TENSOR_API", False):
     Tensor.as_strided_copy = _cython_mod.tensor_as_strided_copy_method
     Tensor.as_strided_scatter = _cython_mod.tensor_as_strided_scatter_method
     Tensor.multinomial = _cython_mod.tensor_multinomial_method
+    Tensor.min = _python_tensor_min
+    Tensor.max = _python_tensor_max
     Tensor.ndim = property(_cython_mod.tensor_ndim_fget)
     Tensor.T = property(_cython_mod.tensor_T_fget)
     Tensor.is_floating_point = _cython_mod.tensor_is_floating_point

--- a/tests/cpu/test_ops_cpu.py
+++ b/tests/cpu/test_ops_cpu.py
@@ -307,6 +307,16 @@ def test_max_cpu():
     np.testing.assert_allclose(x.max(y).numpy(), expected)
 
 
+def test_tensor_min_no_arg():
+    x = torch.tensor([3.0, 1.0, 2.0])
+    assert float(x.min().item()) == 1.0
+
+
+def test_tensor_max_no_arg():
+    x = torch.tensor([3.0, 1.0, 2.0])
+    assert float(x.max().item()) == 3.0
+
+
 def test_amin_cpu():
     x = torch.tensor([[1.0, 2.0], [3.0, 0.5]])
     expected = np.amin(x.numpy(), axis=1)


### PR DESCRIPTION
## Summary

- preserve the existing Python no-arg `Tensor.min()` / `Tensor.max()` behavior when Cython tensor API bindings are enabled
- add regression tests for no-arg `x.min()` and `x.max()`

## Root cause

`src/candle/_tensor.py` already implements correct no-arg `Tensor.min/max` behavior, but the later Cython rebinding block replaces those methods with `tensor_min_method` / `tensor_max_method` from `src/candle/_cython/_tensor_api.pyx`, and those Cython methods require an `other` argument. As a result, `x.min()` and `x.max()` raise `TypeError` instead of dispatching to `amin/amax`.

## Test Plan

- [x] `pytest tests/cpu/test_ops_cpu.py -q -k "tensor_min_no_arg or tensor_max_no_arg"`
- [x] `pytest tests/cpu/ tests/contract/ -v --tb=short` → 2356 passed, 91 skipped
- [x] `pytest tests/mps/ -v --tb=short` → 363 passed
- [x] `pylint src/candle/_tensor.py --rcfile=.github/pylint.conf` → 10.00/10

Closes #314