### PR TITLE
fix: support out= in top-level torch.mul

### DIFF
--- a/src/candle/_functional.py
+++ b/src/candle/_functional.py
@@ -96,7 +96,12 @@ def _py_mul(*args, **kwargs):
     r = _handle_torch_function(_py_mul, args, kwargs)
     if r is not NotImplemented:
         return r
-    return dispatch("mul", None, *args, **kwargs)
+    out = kwargs.pop("out", None)
+    result = dispatch("mul", None, *args, **kwargs)
+    if out is not None:
+        out.copy_(result)
+        return out
+    return result
 
 
 def _py_matmul(*args, **kwargs):
@@ -213,7 +218,7 @@ def _py_matmul_wrapper(*args, **kwargs):
 add = _add_impl
 transpose = _transpose_impl
 reshape = _reshape_impl
-mul = _mul_impl
+mul = _py_mul
 matmul = _matmul_impl
 
 

--- a/tests/cpu/test_functional_contract.py
+++ b/tests/cpu/test_functional_contract.py
@@ -147,6 +147,14 @@ class TestMulWrapper:
         # d(a*b)/da = b
         _allclose(a.grad, [4.0, 5.0])
 
+    def test_mul_out_writes_into_provided_tensor(self):
+        a = torch.ones(4, 4)
+        b = torch.ones(4, 4)
+        out = torch.zeros(4, 4)
+        result = torch.mul(a, b, out=out)
+        assert result is out
+        assert float(out.sum().item()) == 16.0
+
 
 # ===========================================================================
 # 3. matmul wrapper


### PR DESCRIPTION
## Summary

- keep top-level `torch.mul` on the Python functional wrapper so `out=` is accepted
- copy the computed result into the user-provided output tensor and return that tensor
- add a regression test for `torch.mul(..., out=...)`

## Root cause

`src/candle/_functional.py` already had a Python `_py_mul(*args, **kwargs)` entry point that could naturally accept keyword arguments, but the top-level exported `mul` name was rebound to the Cython implementation from `src/candle/_cython/_functional_ops.pyx`. That Cython `mul(a, b)` signature rejects `out=` and raises `TypeError` before dispatch.

## Test Plan

- [x] `pytest tests/cpu/test_functional_contract.py -q -k "mul_out_writes_into_provided_tensor"`
- [x] `pytest tests/cpu/ tests/contract/ -v --tb=short` → 2355 passed, 91 skipped
- [x] `pytest tests/mps/ -v --tb=short` → 363 passed
- [x] `pylint src/candle/_functional.py --rcfile=.github/pylint.conf` → 10.00/10

Closes #315