### PR TITLE
refactor tensor runtime truth into Cython

### DIFF
--- a/docs/superpowers/plans/2026-04-13-tensor-storage-batch-a1.md
+++ b/docs/superpowers/plans/2026-04-13-tensor-storage-batch-a1.md
@@ -1,0 +1,418 @@
+# Tensor / Storage Batch A1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Define and lightly enforce Tensor/Storage ownership boundaries so Python shell code stops expanding as a runtime owner before deeper semantic migration begins.
+
+**Architecture:** Keep this batch intentionally narrow. Do not redesign behavior across dispatcher, autograd, or NPU. Instead, make ownership boundaries explicit in Tensor/Storage code, add small guardrail tests that lock those boundaries in, and reduce a few obvious Python-owned runtime responsibilities only where the move is local and low-risk. The steady-state direction is Python shell + Cython runtime core.
+
+**Tech Stack:** Python, Cython, pytest, Candle Tensor/Storage runtime
+
+---
+
+## File Structure / Responsibilities
+
+- `src/candle/_tensor.py` — public Tensor shell; should expose methods and compatibility glue, but should not keep growing as a runtime owner
+- `src/candle/_cython/_tensor_impl.pxd` — Cython TensorImpl field declarations; this is the authoritative list of Tensor runtime-owned state
+- `src/candle/_cython/_tensor_impl.pyx` — Cython TensorImpl runtime behavior and cached metadata ownership
+- `src/candle/_storage.py` — Python storage shell and public storage API surface
+- `src/candle/_cython/_storage.pyx` — Cython storage fast/runtime helpers
+- `tests/contract/test_tensor_storage_owner_contract.py` — new focused contract tests for Tensor/Storage ownership boundaries in this batch
+- `tests/contract/test_tensor_alias_version_contract.py` — existing alias/version guardrails to keep from regressing while tightening boundaries
+- `docs/superpowers/specs/2026-04-13-tensor-storage-batch-a1-design.md` — approved scope boundary for this batch
+
+---
+
+### Task 1: Add contract tests that lock the A1 ownership boundary
+
+**Files:**
+- Create: `tests/contract/test_tensor_storage_owner_contract.py`
+- Test: `tests/contract/test_tensor_alias_version_contract.py`
+- Reference: `src/candle/_tensor.py`
+- Reference: `src/candle/_cython/_tensor_impl.pyx`
+
+- [ ] **Step 1: Write the failing ownership-boundary test file**
+
+```python
+import candle as torch
+
+
+def test_tensor_impl_declares_runtime_owned_fields():
+    x = torch.tensor([1.0, 2.0])
+    impl = x
+    for name in (
+        "_storage",
+        "_device_obj",
+        "_dtype_obj",
+        "_version_value",
+        "_base",
+        "_view_meta",
+        "_dispatch_keys",
+    ):
+        assert hasattr(impl, name), name
+
+
+def test_tensor_python_shell_still_exposes_public_storage_api():
+    x = torch.tensor([1.0, 2.0])
+    storage = x.storage()
+    untyped = x.untyped_storage()
+    assert storage is not None
+    assert untyped is not None
+
+
+def test_tensor_data_setter_still_routes_through_runtime_storage_swap():
+    x = torch.tensor([1.0, 2.0])
+    y = torch.tensor([3.0, 4.0])
+    before = x._version_counter.value
+    x.data = y
+    assert x.tolist() == [3.0, 4.0]
+    assert x._version_counter.value == before + 1
+
+
+def test_storage_public_surface_still_exposes_data_ptr_and_untyped_storage():
+    x = torch.tensor([1.0, 2.0])
+    storage = x.storage()
+    untyped = storage.untyped_storage()
+    assert isinstance(storage.data_ptr(), int)
+    assert isinstance(untyped.data_ptr(), int)
+```
+
+- [ ] **Step 2: Run the new contract file to establish the current baseline**
+
+Run:
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/contract/test_tensor_storage_owner_contract.py -v --tb=short
+```
+
+Expected: PASS or very small targeted failures. If it fails, the failures describe current boundary ambiguity that this batch will fix.
+
+- [ ] **Step 3: Re-run the existing alias/version contract as a no-regression baseline**
+
+Run:
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/contract/test_tensor_alias_version_contract.py -v --tb=short
+```
+
+Expected: PASS. If this fails before any edits, stop and record the pre-existing failure rather than broadening A1.
+
+- [ ] **Step 4: Commit the test-only boundary lock-in**
+
+```bash
+git add tests/contract/test_tensor_storage_owner_contract.py tests/contract/test_tensor_alias_version_contract.py
+git commit -m "test(contract): lock tensor storage ownership boundary"
+```
+
+---
+
+### Task 2: Make TensorImpl field ownership explicit in Cython declarations
+
+**Files:**
+- Modify: `src/candle/_cython/_tensor_impl.pxd`
+- Modify: `src/candle/_cython/_tensor_impl.pyx`
+- Test: `tests/contract/test_tensor_storage_owner_contract.py`
+
+- [ ] **Step 1: Tighten the TensorImpl field comments in the `.pxd` to mark runtime-owned state explicitly**
+
+Update the block comments in `src/candle/_cython/_tensor_impl.pxd` so the fields are grouped as runtime-owned categories, e.g.:
+
+```cython
+cdef class TensorImpl:
+    # -- runtime-owned tensor metadata --
+    cdef int64_t _c_shape[MAX_NDIM]
+    cdef int64_t _c_stride[MAX_NDIM]
+    cdef public int _ndim
+    cdef public int64_t _c_numel
+    cdef public int64_t _c_offset
+
+    # -- runtime-owned device/dtype caches --
+    cdef public int _device_type
+    cdef public int _device_index
+    cdef public object _device_obj
+    cdef public int _dtype_code
+    cdef public int _itemsize
+    cdef public object _dtype_obj
+
+    # -- runtime-owned storage and autograd attachment --
+    cdef public object _storage
+    cdef public int64_t _version_value
+    cdef public object _base
+    cdef public object _view_meta
+    cdef public unsigned int _dispatch_keys
+```
+
+- [ ] **Step 2: Mirror that ownership grouping in `_tensor_impl.pyx` top-level comments**
+
+Adjust the module/class comments near the top of `src/candle/_cython/_tensor_impl.pyx` so they explicitly say TensorImpl is the owner of tensor runtime metadata and cached runtime state, while Python `Tensor` is the public shell.
+
+Use wording like:
+
+```cython
+"""Cython TensorImpl — runtime owner for Tensor metadata.
+
+This module is the steady-state owner for tensor runtime fields such as
+shape/stride/offset, cached device/dtype state, dispatch-key-relevant state,
+version attachment, and base/view metadata attachment points. Public Python
+Tensor methods should forward into this runtime rather than grow new owner
+state in `_tensor.py`.
+"""
+```
+
+- [ ] **Step 3: Run the ownership contract test again**
+
+Run:
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/contract/test_tensor_storage_owner_contract.py -v --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit the explicit TensorImpl owner declaration**
+
+```bash
+git add src/candle/_cython/_tensor_impl.pxd src/candle/_cython/_tensor_impl.pyx tests/contract/test_tensor_storage_owner_contract.py
+git commit -m "refactor(tensor): declare TensorImpl runtime ownership boundary"
+```
+
+---
+
+### Task 3: Reduce duplicated Python Tensor owner helpers to thin adapters
+
+**Files:**
+- Modify: `src/candle/_tensor.py:180-231`
+- Modify: `src/candle/_cython/_tensor_impl.pyx:80-159`
+- Test: `tests/contract/test_tensor_storage_owner_contract.py`
+
+- [ ] **Step 1: Write a narrow adapter test for Tensor shell/device-dtype helpers**
+
+Append this test to `tests/contract/test_tensor_storage_owner_contract.py`:
+
+```python
+def test_tensor_shell_device_dtype_helpers_preserve_runtime_cache_values():
+    x = torch.tensor([1.0, 2.0])
+    before_device = x.device
+    before_dtype = x.dtype
+    x._set_device_from_storage(before_device)
+    x._set_dtype_from_storage(before_dtype)
+    assert x.device == before_device
+    assert x.dtype == before_dtype
+```
+
+- [ ] **Step 2: Run the single new test before changing code**
+
+Run:
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/contract/test_tensor_storage_owner_contract.py::test_tensor_shell_device_dtype_helpers_preserve_runtime_cache_values -v --tb=short
+```
+
+Expected: PASS. This protects behavior while we narrow the Python helpers.
+
+- [ ] **Step 3: Change `_tensor.py` helper methods into explicit thin adapters**
+
+In `src/candle/_tensor.py`, replace the current bodies of `_set_device_from_storage()` and `_set_dtype_from_storage()` with direct delegation to the Cython owner helpers:
+
+```python
+    def _set_device_from_storage(self, dev):
+        self._set_device_from_obj(dev)
+
+    def _set_dtype_from_storage(self, dtype):
+        self._set_dtype_from_obj(dtype)
+```
+
+Do not leave duplicated Python-side device/dtype recomputation logic in place.
+
+- [ ] **Step 4: Run the focused ownership test and the alias/version no-regression subset**
+
+Run:
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest \
+  tests/contract/test_tensor_storage_owner_contract.py::test_tensor_shell_device_dtype_helpers_preserve_runtime_cache_values \
+  tests/contract/test_tensor_alias_version_contract.py::test_detach_shares_version_counter_with_source \
+  -v --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the Python-shell thinning change**
+
+```bash
+git add src/candle/_tensor.py src/candle/_cython/_tensor_impl.pyx tests/contract/test_tensor_storage_owner_contract.py
+git commit -m "refactor(tensor): narrow Python shell device dtype helpers"
+```
+
+---
+
+### Task 4: Make storage shell/runtime ownership explicit without broad behavior change
+
+**Files:**
+- Modify: `src/candle/_storage.py`
+- Modify: `src/candle/_cython/_storage.pyx`
+- Test: `tests/contract/test_storage_contract.py`
+- Test: `tests/contract/test_tensor_storage_owner_contract.py`
+
+- [ ] **Step 1: Add a focused storage boundary test**
+
+Append this test to `tests/contract/test_tensor_storage_owner_contract.py`:
+
+```python
+def test_typed_storage_public_api_routes_through_untyped_runtime_owner():
+    x = torch.tensor([1.0, 2.0])
+    storage = x.storage()
+    untyped = storage.untyped_storage()
+    assert storage.data_ptr() == untyped.data_ptr()
+    assert storage.device == untyped.device
+```
+
+- [ ] **Step 2: Run the focused storage boundary test**
+
+Run:
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/contract/test_tensor_storage_owner_contract.py::test_typed_storage_public_api_routes_through_untyped_runtime_owner -v --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Clarify storage shell/runtime split in code comments, not behavior**
+
+In `src/candle/_storage.py`, add or update comments/docstrings so that:
+
+- `UntypedStorage` is explicitly described as the public storage shell
+- typed/untyped storage pointer ownership facts are described as runtime truths
+- Python storage API methods are described as wrappers around runtime-owned backing data
+
+In `src/candle/_cython/_storage.pyx`, update the module docstring to clarify it is the storage runtime/helper layer, not merely an optimization layer.
+
+Use wording like:
+
+```cython
+"""Cython storage helpers for runtime-owned storage operations.
+
+This module exists to keep storage-critical runtime behavior out of the Python
+API shell and to centralize low-level storage helpers that later phases can
+extend without growing new Python owners.
+"""
+```
+
+- [ ] **Step 4: Run the focused storage tests**
+
+Run:
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest \
+  tests/contract/test_storage_contract.py \
+  tests/contract/test_tensor_storage_owner_contract.py::test_typed_storage_public_api_routes_through_untyped_runtime_owner \
+  -v --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the storage ownership clarification**
+
+```bash
+git add src/candle/_storage.py src/candle/_cython/_storage.pyx tests/contract/test_storage_contract.py tests/contract/test_tensor_storage_owner_contract.py
+git commit -m "refactor(storage): document shell versus runtime ownership"
+```
+
+---
+
+### Task 5: Capture the A2 migration inventory directly in code-adjacent comments
+
+**Files:**
+- Modify: `src/candle/_tensor.py`
+- Modify: `src/candle/_storage.py`
+- Modify: `docs/superpowers/specs/2026-04-13-tensor-storage-batch-a1-design.md`
+
+- [ ] **Step 1: Add narrow A2 migration comments in `_tensor.py`**
+
+Near the remaining Python-owned runtime-sensitive methods in `src/candle/_tensor.py`, add concise comments like:
+
+```python
+    # A1 boundary note: this remains in the Python Tensor shell temporarily.
+    # A2 should migrate version/alias/view-sensitive runtime behavior into
+    # _cython/_tensor_impl.pyx rather than growing new shell ownership here.
+```
+
+Only add comments where they directly mark still-temporary ownership; do not annotate unrelated methods.
+
+- [ ] **Step 2: Add narrow A2 migration comments in `_storage.py`**
+
+For the storage shell sections that still expose low-level ownership-sensitive behavior, add comments like:
+
+```python
+# A1 boundary note: this file remains the public storage API shell.
+# Future runtime-sensitive storage ownership should move into Cython helpers
+# instead of expanding Python-side owner state here.
+```
+
+- [ ] **Step 3: Update the A1 spec file with the concrete A2 migration inventory**
+
+Append this subsection to `docs/superpowers/specs/2026-04-13-tensor-storage-batch-a1-design.md`:
+
+```markdown
+## 13. Concrete A2 Migration Inventory
+
+A2 should target the following runtime-sensitive responsibilities that remain temporary after A1:
+
+- version-sensitive Python Tensor shell behavior that still reaches into runtime-owned state
+- remaining alias/view boundary helpers that still live in `_tensor.py`
+- any storage-shell logic that still behaves like a low-level owner rather than a public API wrapper
+```
+
+- [ ] **Step 4: Run the smallest ownership boundary suite one final time**
+
+Run:
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest \
+  tests/contract/test_tensor_storage_owner_contract.py \
+  tests/contract/test_storage_contract.py \
+  tests/contract/test_tensor_alias_version_contract.py::test_detach_shares_version_counter_with_source \
+  -v --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the A2 handoff inventory**
+
+```bash
+git add src/candle/_tensor.py src/candle/_storage.py docs/superpowers/specs/2026-04-13-tensor-storage-batch-a1-design.md tests/contract/test_tensor_storage_owner_contract.py tests/contract/test_storage_contract.py
+git commit -m "docs(runtime): record tensor storage A2 migration inventory"
+```
+
+---
+
+## Self-review
+
+### Spec coverage
+
+- A1 requires explicit Tensor/Storage ownership boundaries: covered by Tasks 1-4
+- A1 requires no cross-subsystem edits: enforced by file scope in every task
+- A1 requires a migration inventory for A2: covered by Task 5
+- A1 requires narrow validation only: each task uses focused contract tests only
+
+### Placeholder scan
+
+- No TBD/TODO placeholders remain in tasks
+- Each task contains exact file paths and exact commands
+- Code-bearing steps include concrete code blocks
+
+### Type consistency
+
+- Tensor helper names match current code (`_set_device_from_storage`, `_set_dtype_from_storage`, `_set_device_from_obj`, `_set_dtype_from_obj`)
+- Test file name is introduced once and used consistently: `tests/contract/test_tensor_storage_owner_contract.py`
+- A2 references are consistent with the parent spec and batch design
+
+---
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-13-tensor-storage-batch-a1.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+**Which approach?**

--- a/docs/superpowers/plans/2026-04-14-tensor-storage-batch-a2.md
+++ b/docs/superpowers/plans/2026-04-14-tensor-storage-batch-a2.md
@@ -1,0 +1,537 @@
+# Tensor / Storage Batch A2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move version-sensitive and view-sensitive runtime truth out of the Python `Tensor` shell and into the Cython `TensorImpl`, while staying strictly inside the Tensor / Storage subsystem.
+
+**Architecture:** Implement A2 in two bounded phases. A2a converges version/detach/set_-related runtime truth into `src/candle/_cython/_tensor_impl.pyx`, reducing Python shell ownership for version-sensitive behavior. A2b then converges common view base/version attachment truth into the same Cython runtime center, while intentionally leaving some user-facing `_view_meta` payload assembly in the Python shell for now. The batch still does not touch dispatcher, autograd runtime, or backend code.
+
+**Tech Stack:** Python, Cython, pytest, Candle Tensor/Storage runtime
+
+---
+
+## File Structure / Responsibilities
+
+- `src/candle/_tensor.py` — public Tensor shell; should continue shrinking as a runtime owner for version/view-sensitive semantics
+- `src/candle/_cython/_tensor_impl.pxd` — authoritative declaration of Tensor runtime-owned fields and callable Cython interfaces
+- `src/candle/_cython/_tensor_impl.pyx` — runtime truth center for version, base/view linkage, and view-derived tensor creation
+- `tests/contract/test_tensor_alias_version_contract.py` — primary correctness rail for alias/version/view semantics in A2
+- `tests/contract/test_inplace_view_rules.py` — guardrail for view/inplace legality after view-truth migration
+- `tests/contract/test_tensor_storage_owner_contract.py` — ownership boundary guardrail added in A1, should remain green throughout A2
+- `tests/contract/test_storage_contract.py` — storage shell/runtime boundary regression guardrail
+- `docs/superpowers/specs/2026-04-14-tensor-storage-batch-a2-design.md` — approved A2 design and scope boundary
+
+---
+
+### Task 1: Add A2a-focused failing tests for detach/set_ runtime truth
+
+**Files:**
+- Modify: `tests/contract/test_tensor_alias_version_contract.py`
+- Reference: `src/candle/_tensor.py:562-572`
+- Reference: `src/candle/_tensor.py:652-661`
+- Reference: `src/candle/_cython/_tensor_impl.pyx:212-241,555-619`
+
+- [ ] **Step 1: Add focused A2a tests to the existing alias/version contract file**
+
+Append these tests to `tests/contract/test_tensor_alias_version_contract.py`:
+
+```python
+def test_detach_preserves_storage_shape_stride_offset_runtime_truth():
+    base = torch.tensor([[0.0, 1.0], [2.0, 3.0]], requires_grad=True)
+    view = base.view((4,))
+    detached = view.detach()
+
+    assert detached.storage().data_ptr() == view.storage().data_ptr()
+    assert detached.shape == view.shape
+    assert detached.stride == view.stride
+    assert detached.offset == view.offset
+    assert detached.requires_grad is False
+    assert detached.grad_fn is None
+
+
+def test_detach_of_view_preserves_base_version_sharing_truth():
+    base = torch.tensor([[0.0, 1.0], [2.0, 3.0]], requires_grad=True)
+    view = base.view((4,))
+    detached = view.detach()
+
+    before = detached._version_counter.value
+    base._version_counter.bump()
+    assert detached._version_counter.value == before + 1
+
+
+def test_set_preserves_device_dtype_runtime_truth():
+    x = torch.tensor([0.0, 1.0, 2.0, 3.0], dtype=torch.float32)
+    out = x.set_(x.storage(), 1, (2,), (1,))
+
+    assert out is x
+    assert x.device.type == "cpu"
+    assert x.dtype == torch.float32
+    assert x.tolist() == [1.0, 2.0]
+```
+
+- [ ] **Step 2: Run the three new tests to confirm the current baseline**
+
+Run:
+```bash
+source /opt/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest \
+  tests/contract/test_tensor_alias_version_contract.py::test_detach_preserves_storage_shape_stride_offset_runtime_truth \
+  tests/contract/test_tensor_alias_version_contract.py::test_detach_of_view_preserves_base_version_sharing_truth \
+  tests/contract/test_tensor_alias_version_contract.py::test_set_preserves_device_dtype_runtime_truth \
+  -v --tb=short
+```
+
+Expected: PASS or narrow A2a-relevant failures only.
+
+- [ ] **Step 3: Run the existing A2a primary rails as the no-regression baseline**
+
+Run:
+```bash
+source /opt/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest \
+  tests/contract/test_tensor_alias_version_contract.py::test_detach_shares_version_counter_with_source \
+  tests/contract/test_tensor_alias_version_contract.py::test_set_bumps_version_counter_once \
+  tests/contract/test_tensor_alias_version_contract.py::test_set_on_view_bumps_shared_version_counter_once \
+  tests/contract/test_tensor_alias_version_contract.py::test_setitem_bumps_version_counter \
+  tests/contract/test_tensor_alias_version_contract.py::test_dispatch_setitem_bumps_version_counter_exactly_once \
+  -v --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit the A2a-focused test additions**
+
+```bash
+git add tests/contract/test_tensor_alias_version_contract.py
+git commit -m "test(contract): add A2a tensor runtime truth rails"
+```
+
+---
+
+### Task 2: Move detach runtime truth into TensorImpl helper(s)
+
+**Files:**
+- Modify: `src/candle/_cython/_tensor_impl.pxd`
+- Modify: `src/candle/_cython/_tensor_impl.pyx`
+- Modify: `src/candle/_tensor.py:652-661`
+- Test: `tests/contract/test_tensor_alias_version_contract.py`
+
+- [ ] **Step 1: Add a dedicated Cython detach helper declaration**
+
+In `src/candle/_cython/_tensor_impl.pxd`, add a Cython API for detach-derived tensor construction:
+
+```cython
+cdef class TensorImpl:
+    cpdef object cy_detach(self)
+```
+
+- [ ] **Step 2: Run the current detach-focused tests before implementation**
+
+Run:
+```bash
+source /opt/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest \
+  tests/contract/test_tensor_alias_version_contract.py::test_detach_shares_version_counter_with_source \
+  tests/contract/test_tensor_alias_version_contract.py::test_detach_preserves_storage_shape_stride_offset_runtime_truth \
+  tests/contract/test_tensor_alias_version_contract.py::test_detach_of_view_preserves_base_version_sharing_truth \
+  -v --tb=short
+```
+
+Expected: PASS before the refactor.
+
+- [ ] **Step 3: Implement `cy_detach()` as the Cython fact source**
+
+In `src/candle/_cython/_tensor_impl.pyx`, add:
+
+```cython
+    cpdef object cy_detach(self):
+        cdef object tensor_type = type(self)
+        cdef TensorImpl out = <TensorImpl>tensor_type.__new__(tensor_type)
+        cy_init_tensor_fields(
+            out,
+            self._storage,
+            self._shape_tuple,
+            self._stride_tuple,
+            self._c_offset,
+            False,
+            None,
+            None,
+            None,
+            None,
+            self._pending,
+            False,
+            None,
+            self._version_value,
+            self._version_counter,
+        )
+        return out
+```
+
+Keep the helper narrow: same storage/shape/stride/offset/runtime cache truth, `requires_grad=False`, `grad=None`, `grad_fn=None`, shared version-counter truth via `_version_counter`.
+
+- [ ] **Step 4: Make Python `detach()` a thin shell over `cy_detach()`**
+
+In `src/candle/_tensor.py`, replace the current detach body with:
+
+```python
+    def detach(self):
+        return self.cy_detach()
+```
+
+Do not keep Python-side reconstruction logic in place.
+
+- [ ] **Step 5: Re-run the detach-focused tests**
+
+Run:
+```bash
+source /opt/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest \
+  tests/contract/test_tensor_alias_version_contract.py::test_detach_shares_version_counter_with_source \
+  tests/contract/test_tensor_alias_version_contract.py::test_detach_preserves_storage_shape_stride_offset_runtime_truth \
+  tests/contract/test_tensor_alias_version_contract.py::test_detach_of_view_preserves_base_version_sharing_truth \
+  -v --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the detach migration**
+
+```bash
+git add src/candle/_cython/_tensor_impl.pxd src/candle/_cython/_tensor_impl.pyx src/candle/_tensor.py tests/contract/test_tensor_alias_version_contract.py
+git commit -m "refactor(tensor): move detach runtime truth into TensorImpl"
+```
+
+---
+
+### Task 3: Move set_-related runtime truth into TensorImpl helper(s)
+
+**Files:**
+- Modify: `src/candle/_cython/_tensor_impl.pxd`
+- Modify: `src/candle/_cython/_tensor_impl.pyx`
+- Modify: `src/candle/_tensor.py:540-573`
+- Test: `tests/contract/test_tensor_alias_version_contract.py`
+
+- [ ] **Step 1: Add a dedicated Cython helper declaration for `set_` runtime mutation**
+
+In `src/candle/_cython/_tensor_impl.pxd`, add:
+
+```cython
+cdef class TensorImpl:
+    cpdef object cy_set_runtime_truth(
+        self,
+        object typed_storage,
+        tuple size,
+        object stride,
+        int64_t storage_offset,
+    )
+```
+
+- [ ] **Step 2: Run the set_-focused tests before implementation**
+
+Run:
+```bash
+source /opt/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest \
+  tests/contract/test_tensor_alias_version_contract.py::test_set_bumps_version_counter_once \
+  tests/contract/test_tensor_alias_version_contract.py::test_set_on_view_bumps_shared_version_counter_once \
+  tests/contract/test_tensor_alias_version_contract.py::test_set_preserves_device_dtype_runtime_truth \
+  -v --tb=short
+```
+
+Expected: PASS before the refactor.
+
+- [ ] **Step 3: Implement `cy_set_runtime_truth()` in Cython**
+
+In `src/candle/_cython/_tensor_impl.pyx`, add:
+
+```cython
+    cpdef object cy_set_runtime_truth(
+        self,
+        object typed_storage,
+        tuple size,
+        object stride,
+        int64_t storage_offset,
+    ):
+        cdef object device = getattr(typed_storage, "device", None)
+        cdef object dtype = getattr(typed_storage, "dtype", None)
+        self._storage = typed_storage
+        self._set_shape(size)
+        self._set_stride(stride)
+        self._c_offset = storage_offset
+        if device is not None:
+            self._set_device_from_obj(device)
+        if dtype is not None:
+            self._set_dtype_from_obj(dtype)
+        self._bump_version()
+        return self
+```
+
+Keep ownership-local logic here only. Do not move argument validation into Cython in this task.
+
+- [ ] **Step 4: Make Python `set_()` a thin shell once validation is done**
+
+In `src/candle/_tensor.py`, keep the current Python-side argument checks and bounds checks, but replace the post-validation runtime mutation block with:
+
+```python
+        self._check_inplace()
+        return self.cy_set_runtime_truth(
+            typed_storage,
+            size,
+            _StrideTuple(stride),
+            int(storage_offset),
+        )
+```
+
+Remove the old direct assignments to `_storage`, `shape`, `stride`, `offset`, `_set_device_from_storage`, `_set_dtype_from_storage`, and `_bump_version()` from the Python shell.
+
+- [ ] **Step 5: Re-run the set_-focused tests**
+
+Run:
+```bash
+source /opt/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest \
+  tests/contract/test_tensor_alias_version_contract.py::test_set_bumps_version_counter_once \
+  tests/contract/test_tensor_alias_version_contract.py::test_set_on_view_bumps_shared_version_counter_once \
+  tests/contract/test_tensor_alias_version_contract.py::test_set_preserves_device_dtype_runtime_truth \
+  -v --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the set_ runtime-truth migration**
+
+```bash
+git add src/candle/_cython/_tensor_impl.pxd src/candle/_cython/_tensor_impl.pyx src/candle/_tensor.py tests/contract/test_tensor_alias_version_contract.py
+git commit -m "refactor(tensor): move set_ runtime truth into TensorImpl"
+```
+
+---
+
+### Task 4: Add A2b-focused view metadata contract tests
+
+**Files:**
+- Modify: `tests/contract/test_tensor_alias_version_contract.py`
+- Modify: `tests/contract/test_inplace_view_rules.py`
+- Reference: `src/candle/_tensor.py:311-388,414-451`
+- Reference: `src/candle/_cython/_tensor_impl.pyx:468-549`
+
+- [ ] **Step 1: Add focused `_base` / `_view_meta` tests**
+
+Append these tests to `tests/contract/test_tensor_alias_version_contract.py`:
+
+```python
+def test_view_runtime_truth_sets_base_to_source_tensor():
+    base = torch.tensor([[0.0, 1.0], [2.0, 3.0]])
+    view = base.view((4,))
+    assert view._base is base
+
+
+def test_as_strided_runtime_truth_sets_base_to_source_tensor():
+    base = torch.tensor([[0.0, 1.0], [2.0, 3.0]])
+    view = base.as_strided((2, 2), (2, 1))
+    assert view._base is base
+
+
+def test_view_runtime_truth_records_view_meta():
+    base = torch.tensor([[0.0, 1.0], [2.0, 3.0]])
+    view = base.view((4,))
+    assert view._view_meta is not None
+    assert view._view_meta["op"] == "view"
+```
+
+- [ ] **Step 2: Run the new focused A2b tests**
+
+Run:
+```bash
+source /opt/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest \
+  tests/contract/test_tensor_alias_version_contract.py::test_view_runtime_truth_sets_base_to_source_tensor \
+  tests/contract/test_tensor_alias_version_contract.py::test_as_strided_runtime_truth_sets_base_to_source_tensor \
+  tests/contract/test_tensor_alias_version_contract.py::test_view_runtime_truth_records_view_meta \
+  -v --tb=short
+```
+
+Expected: PASS or narrow A2b-relevant failure only.
+
+- [ ] **Step 3: Run the existing A2b primary rails as baseline**
+
+Run:
+```bash
+source /opt/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest \
+  tests/contract/test_tensor_alias_version_contract.py::test_as_strided_view_shares_version_counter_with_source \
+  tests/contract/test_tensor_alias_version_contract.py::test_diagonal_view_shares_version_counter_with_source \
+  tests/contract/test_tensor_alias_version_contract.py::test_movedim_view_shares_version_counter_with_source \
+  tests/contract/test_tensor_alias_version_contract.py::test_moveaxis_view_shares_version_counter_with_source \
+  tests/contract/test_tensor_alias_version_contract.py::test_expand_view_shares_version_counter_with_source \
+  tests/contract/test_tensor_alias_version_contract.py::test_broadcast_to_view_shares_version_counter_with_source \
+  tests/contract/test_tensor_alias_version_contract.py::test_split_view_shares_version_counter_with_source \
+  tests/contract/test_tensor_alias_version_contract.py::test_chunk_view_shares_version_counter_with_source \
+  tests/contract/test_tensor_alias_version_contract.py::test_unary_inplace_preserves_view_aliasing \
+  tests/contract/test_inplace_view_rules.py \
+  -v --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit the A2b-focused test additions**
+
+```bash
+git add tests/contract/test_tensor_alias_version_contract.py tests/contract/test_inplace_view_rules.py
+git commit -m "test(contract): add A2b view runtime truth rails"
+```
+
+---
+
+### Task 5: Move common view truth into TensorImpl view constructors
+
+**Files:**
+- Modify: `src/candle/_cython/_tensor_impl.pyx`
+- Modify: `src/candle/_tensor.py:311-388,414-451`
+- Test: `tests/contract/test_tensor_alias_version_contract.py`
+- Test: `tests/contract/test_inplace_view_rules.py`
+
+- [ ] **Step 1: Add a Cython helper for common view attachment truth**
+
+In `src/candle/_cython/_tensor_impl.pyx`, add a small internal helper near the view constructors:
+
+```cython
+cdef inline void _attach_view_runtime_truth(TensorImpl base, TensorImpl view):
+    view._version_value = base._version_value
+    view._base = base._base if base._base is not None else base
+    view._vc_proxy = None
+    view._view_meta = None
+    view._pending = False
+    view._retain_grad = False
+    view._backward_hooks = None
+    view._output_nr = 0
+```
+```
+
+- [ ] **Step 2: Apply the helper inside `cy_view()` and `cy_as_strided()`**
+
+Replace the repeated block in both functions with:
+
+```cython
+        _attach_view_runtime_truth(self, v)
+```
+
+Retain the existing storage/device/dtype/dispatch/grad field propagation.
+
+- [ ] **Step 3: Keep Python view shells only for high-level metadata augmentation**
+
+In `src/candle/_tensor.py`, leave user-facing view/transpose shells in place, but ensure they no longer try to establish base/version truth that is already set by `cy_view()` / `cy_as_strided()` / `cy_transpose()`.
+
+The Python shell may still attach user-facing `_view_meta["op"]` detail where needed, but it should not overwrite the Cython-owned `_base` / version-sharing truth. Full `_view_meta` payload construction does not need to move into Cython in this task.
+
+- [ ] **Step 4: Run the new A2b tests and the primary rails**
+
+Run:
+```bash
+source /opt/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest \
+  tests/contract/test_tensor_alias_version_contract.py::test_view_runtime_truth_sets_base_to_source_tensor \
+  tests/contract/test_tensor_alias_version_contract.py::test_as_strided_runtime_truth_sets_base_to_source_tensor \
+  tests/contract/test_tensor_alias_version_contract.py::test_view_runtime_truth_records_view_meta \
+  tests/contract/test_tensor_alias_version_contract.py::test_as_strided_view_shares_version_counter_with_source \
+  tests/contract/test_tensor_alias_version_contract.py::test_unary_inplace_preserves_view_aliasing \
+  tests/contract/test_inplace_view_rules.py \
+  -v --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the view-truth migration**
+
+```bash
+git add src/candle/_cython/_tensor_impl.pyx src/candle/_tensor.py tests/contract/test_tensor_alias_version_contract.py tests/contract/test_inplace_view_rules.py
+git commit -m "refactor(tensor): centralize view runtime truth in TensorImpl"
+```
+
+---
+
+### Task 6: Run the full A2 boundary suite
+
+**Files:**
+- No code changes required unless failures are found.
+
+- [ ] **Step 1: Run the A2 total rails**
+
+Run:
+```bash
+source /opt/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest \
+  tests/contract/test_tensor_alias_version_contract.py \
+  tests/contract/test_inplace_view_rules.py \
+  tests/contract/test_tensor_storage_owner_contract.py \
+  tests/contract/test_storage_contract.py \
+  -v --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: If failures are found, fix only Tensor/Storage-local regressions**
+
+Allowed files for fixes:
+
+```text
+src/candle/_tensor.py
+src/candle/_cython/_tensor_impl.pyx
+src/candle/_cython/_tensor_impl.pxd
+src/candle/_storage.py
+src/candle/_cython/_storage.pyx
+tests/contract/test_tensor_alias_version_contract.py
+tests/contract/test_inplace_view_rules.py
+tests/contract/test_tensor_storage_owner_contract.py
+tests/contract/test_storage_contract.py
+```
+
+Do not fix A2 failures by changing dispatcher, autograd, or backend files.
+
+- [ ] **Step 3: Re-run the full A2 boundary suite after any fix**
+
+Run the same command again.
+Expected: PASS.
+
+- [ ] **Step 4: Commit the A2 verification gate if any follow-up fixes were needed**
+
+```bash
+git add src/candle/_tensor.py src/candle/_cython/_tensor_impl.pyx src/candle/_cython/_tensor_impl.pxd src/candle/_storage.py src/candle/_cython/_storage.pyx tests/contract/test_tensor_alias_version_contract.py tests/contract/test_inplace_view_rules.py tests/contract/test_tensor_storage_owner_contract.py tests/contract/test_storage_contract.py
+git commit -m "test(contract): verify tensor storage A2 boundary suite"
+```
+
+If no fixes were needed, skip this commit.
+
+---
+
+## Self-review
+
+### Spec coverage
+
+- A2 stays strictly inside Tensor/Storage: all tasks are confined to `_tensor.py`, `_tensor_impl.pyx/.pxd`, and contract tests
+- A2a covers version/detach/set_-related runtime truth: Tasks 1-3
+- A2b covers `_base` / `_view_meta` / view-family truth: Tasks 4-5
+- Existing contract rails remain the primary safety net: every task reuses `test_tensor_alias_version_contract.py` and `test_inplace_view_rules.py`
+- A2 total validation is explicit: Task 6
+
+### Placeholder scan
+
+- No TBD/TODO placeholders remain in tasks
+- Every test/implementation step contains exact code or exact commands
+- No task says "similar to above" or relies on undefined helper names outside the plan
+
+### Type consistency
+
+- New Cython methods are named consistently: `cy_detach`, `cy_set_runtime_truth`
+- New internal helper name is consistent: `_attach_view_runtime_truth`
+- Tests consistently refer to `_base`, `_view_meta`, `_version_counter`, `detach`, and `set_`
+
+---
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-14-tensor-storage-batch-a2.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-04-13-candle-runtime-rebuild-design.md
+++ b/docs/superpowers/specs/2026-04-13-candle-runtime-rebuild-design.md
@@ -1,0 +1,260 @@
+# Candle Runtime Rebuild Design
+
+Date: 2026-04-13
+Status: Drafted from source-driven analysis of PyTorch + torch_npu + current Candle
+
+## 1. Background and Goal
+
+Candle has reached the point where local fixes are no longer enough. The current implementation mixes Python shell logic, Python runtime ownership, Cython acceleration fragments, and backend-specific execution paths in ways that make long-term parity with `torch + torch_npu` increasingly fragile.
+
+The goal of this design is **not** to copy PyTorch code. The goal is to realign Candle's long-term architecture to the same **mechanism boundaries** as `torch + torch_npu` while preserving Candle's Python package surface and implementing its runtime core in **Cython + backend-native kernels/bindings**.
+
+Target outcome:
+
+- Python remains the public API and semantic shell
+- Cython becomes the steady-state runtime owner for hot-path mechanisms that PyTorch implements in C++
+- backend execution substrates remain backend-specific, but integrate under a unified owner model
+- Candle's runtime is rebuilt in bounded phases rather than via one-shot repo-wide rewrite
+
+## 2. Analysis Baseline
+
+This design is based on direct source inspection of:
+
+- PyTorch runtime core (`c10/core`, `aten/src/ATen/core`, `torch/csrc/autograd`, `torch/utils/_python_dispatch.py`, `torch/overrides.py`, `torch/_subclasses/fake_tensor.py`)
+- torch_npu runtime and extension layers (`torch_npu/csrc`, `torch_npu/npu`, `third_party/op-plugin/op_plugin/utils`)
+- current Candle implementation (`src/candle/_tensor.py`, `src/candle/_dispatch/dispatcher.py`, `src/candle/_backends/npu/aclnn.py`, `src/candle/_cython/_aclnn_ffi.pyx`)
+
+The design therefore uses **source-driven ownership alignment**, not guesses or API-only comparison.
+
+## 3. Mechanism Map
+
+### 3.1 Object runtime layer
+
+PyTorch centers tensor runtime ownership in `TensorImpl`, `StorageImpl`, dispatch key state, and autograd attachment points. `StorageImpl` owns the underlying backing buffer and allocator relationships; `TensorImpl` owns tensor identity, metadata, and dispatch state; autograd metadata is attached as runtime state, not as Python-owned side tables.
+
+For Candle, the corresponding long-term runtime owner must be Cython.
+
+### 3.2 Device runtime layer
+
+PyTorch/torch_npu place allocator, stream/event, and lifetime bookkeeping in native runtime layers. Python wraps these concepts but does not own them. torch_npu follows this pattern: Python `Stream`/`Event` are wrappers around `_C` base classes; allocator and memory bookkeeping live in native code.
+
+For Candle, device runtime bookkeeping must move to Cython/backend-native owners.
+
+### 3.3 Dispatcher/operator layer
+
+PyTorch uses schema, dispatch keys, runtime operator tables, boxed/unboxed boundaries, and redispatch as a first-class execution model. Schema alias/mutation/out semantics are runtime facts, not loose conventions. Candle already has dispatcher and keyset concepts, but too much runtime logic still lives in Python.
+
+For Candle, the dispatcher shell may remain Python, but the runtime core must move to Cython.
+
+### 3.4 Autograd layer
+
+PyTorch autograd is a runtime graph system: `AutogradMeta`, `Node`, `Edge(input_nr)`, `SavedVariable`, `output_nr`, `mark_dirty`, version checks, and forward-AD metadata all exist as core runtime mechanisms. They are not optional extensions.
+
+For Candle, autograd correctness-critical state must converge into Cython runtime ownership.
+
+### 3.5 Override / fake / functionalization layer
+
+PyTorch distinguishes API-level override (`__torch_function__`) from dispatcher-level override (`__torch_dispatch__`), and treats fake/meta/functionalization as legitimate architecture layers rather than test-only helpers. Candle does not need to fully implement these immediately, but the rebuilt runtime must preserve room for them.
+
+### 3.6 torch_npu extension layer
+
+torch_npu does not leave NPU execution ownership in Python. Python provides shell/configuration/context surfaces, while native code owns bindings, allocator, stream/event, command execution, and op-plugin substrate. This is the direct reference for Candle's NPU target state.
+
+## 4. Current Candle Architectural Drift
+
+### 4.1 Tensor/Storage drift
+
+Candle already has a Cython `TensorImpl`, but `_tensor.py` still owns too much runtime-critical logic, including metadata propagation and some mutation-sensitive behavior. This leaves object ownership split across Python and Cython.
+
+### 4.2 Autograd drift
+
+Candle has substantial autograd code in Cython, but key correctness mechanisms remain fragmented across tensor helpers, dispatcher behavior, and autograd runtime components. This makes version/view/output-slot semantics harder to reason about and evolve.
+
+### 4.3 Dispatcher drift
+
+Candle has keyset and pending-op concepts, but the dispatcher still performs too much runtime work in Python. This diverges from the role the dispatcher plays in PyTorch.
+
+### 4.4 NPU drift
+
+`src/candle/_backends/npu/aclnn.py` is still a Python execution owner. `_aclnn_ffi.pyx` accelerates primitives, but the owner structure remains Python-centered. This is the clearest mismatch with torch_npu.
+
+### 4.5 Automation drift risk
+
+Without strong automation constraints, Claude Code will tend to:
+
+- expand scope across multiple subsystems in one batch
+- preserve temporary bridges too long
+- reintroduce Python owners because they are easier to patch
+- mix architectural cleanup with feature work
+
+This design therefore includes a governance model, not just an implementation model.
+
+## 5. Target Architecture
+
+## 5.1 Python shell responsibilities
+
+Python may continue to own:
+
+- public API entrypoints
+- Tensor method surface
+- functional API shell
+- user-facing argument normalization
+- high-level context managers and flags
+- strategy selection where appropriate
+- high-level glue for override/fake/meta layers
+
+Python must **not** own steady-state runtime lifecycle for tensor metadata, storage ownership, autograd graph state, dispatcher hot path, or NPU execution infrastructure.
+
+### 5.2 Cython runtime core responsibilities
+
+Cython becomes the steady-state owner for:
+
+- tensor identity and metadata runtime
+- storage ownership core and typed storage mechanics
+- version / alias / view relationships
+- dispatch key state and dispatcher hot path machinery
+- autograd metadata, edge/node/output-slot storage, and backward runtime spine
+- backend bridge entrypoints
+- device-lifetime bookkeeping needed on hot paths
+- NPU execution ownership backbone
+
+### 5.3 Backend/native substrate responsibilities
+
+Backend-specific layers continue to own:
+
+- CPU kernels
+- MPS/CUDA/NPU runtime APIs
+- hardware allocator/event/stream specifics
+- NPU op_api/aclnn actual execution primitives
+
+But these backend layers integrate under Cython-owned runtime boundaries, not Python-owned ones.
+
+## 6. Ownership Decision Matrix
+
+### Must converge to Cython ownership
+
+- Tensor identity / shape / stride / offset / dtype / device runtime state
+- Storage / typed storage core ownership
+- version counters, alias/view runtime relationships
+- autograd metadata attachment and graph metadata
+- saved tensor version/output-slot metadata
+- dispatcher hot path, keyset synthesis, redispatch core
+- NPU bindings / init-finish owner
+- NPU descriptor / workspace / executor / queue / PTA owner
+- device-lifetime bookkeeping such as record-stream-style mechanisms
+
+### May remain in Python shell form
+
+- top-level API entrypoints
+- Tensor method wrappers
+- user-facing functional shells
+- user-facing context managers and flags
+- high-level override/fake/meta orchestration
+- testing and diagnostics glue
+
+### Forbidden long-term structures
+
+- Python execution owner for NPU (`aclnn.py`-style long-term center)
+- Python-only dispatcher hot path as steady-state design
+- Python-owned runtime alias/version/view core
+- long-lived dual owner layers after migration is complete
+- new `*_bridge.py` files that become permanent owner layers
+
+## 7. Subsystem Breakdown
+
+### S1. Tensor / Storage runtime core
+
+Foundational object model: tensor identity, storage ownership, version, alias, view metadata, device/dtype metadata.
+
+### S2. Autograd runtime core
+
+Autograd metadata, graph model, saved tensors, output slots, version checks, forward-AD core.
+
+### S3. Dispatcher / operator system
+
+Schema semantics, keyset routing, redispatch, operator core, functional shell boundary.
+
+### S4. NPU execution backbone
+
+Bindings, descriptors, workspace, executor, queue, PTA, custom kernel and fallback integration.
+
+### S5. Advanced extension layers
+
+Override, fake/meta, functionalization, compile/export-friendly boundaries.
+
+## 8. Dependency Order
+
+The required rebuild order is:
+
+1. S1 Tensor/Storage
+2. S2 Autograd
+3. S3 Dispatcher/operator
+4. S4 NPU backbone
+5. S5 Advanced layers
+
+This order is mandatory because:
+
+- autograd depends on tensor/storage runtime truth
+- dispatcher correctness depends on tensor/runtime semantics and partially on autograd semantics
+- NPU execution backbone consumes dispatcher and tensor/runtime boundaries
+- advanced layers depend on all earlier runtime boundaries being coherent
+
+## 9. Rebuild Program
+
+### Phase 0
+Source-driven mechanism mapping and architecture decisions.
+
+### Phase 1
+Tensor/Storage runtime convergence.
+
+### Phase 2
+Autograd runtime convergence.
+
+### Phase 3
+Dispatcher/operator convergence.
+
+### Phase 4
+NPU execution backbone rebuild and deletion of Python execution ownership.
+
+### Phase 5
+Advanced extension compatibility and future-proofing.
+
+Each phase must be executed in bounded batches, with a single primary subsystem per batch.
+
+## 10. Claude Code Governance Model
+
+Long-term automated development must be constrained by executable guardrails, not only prose instructions.
+
+### Required governance principles
+
+- default to planning, not direct unrestricted implementation
+- each batch must declare subsystem, allowed files, forbidden files, validations, and exit criteria
+- edits must be blocked outside the current batch whitelist
+- Python execution owner expansion must be blocked
+- scope expansion across multiple runtime subsystems in one batch must be blocked
+- pre-compact and stop hooks must preserve structured state handoff
+
+### Required configuration direction
+
+A project-level `.claude/settings.json` should eventually enforce:
+
+- planning-first permission mode
+- destructive Bash restrictions
+- edit-time whitelist enforcement per approved batch
+- post-edit architecture drift checks
+- bounded validation per batch
+- compaction/stop state capture
+
+## 11. Immediate First Step
+
+The first implementation batch must be **Tensor/Storage A1**, which defines runtime ownership boundaries without attempting broad behavioral migration. This is the minimum safe starting point for the rebuild program.
+
+## 12. Success Criteria
+
+This design is successful only when:
+
+1. Python is reduced to shell-level responsibilities for runtime-critical systems
+2. Cython becomes the steady-state runtime owner for the core mechanisms listed above
+3. each subsystem is rebuilt in dependency order without long-lived dual ownership
+4. the NPU execution substrate is no longer Python-owned
+5. Claude Code can execute bounded batches under enforced automation constraints without architectural drift

--- a/docs/superpowers/specs/2026-04-13-tensor-storage-batch-a1-design.md
+++ b/docs/superpowers/specs/2026-04-13-tensor-storage-batch-a1-design.md
@@ -1,0 +1,177 @@
+# Tensor / Storage Batch A1 Design
+
+Date: 2026-04-13
+Status: First bounded implementation batch under the Candle runtime rebuild program
+Parent spec: `docs/superpowers/specs/2026-04-13-candle-runtime-rebuild-design.md`
+
+## 1. Batch Definition
+
+- **Subsystem:** S1 Tensor / Storage runtime core
+- **Batch:** A1
+- **Purpose:** define and enforce long-term ownership boundaries for Tensor/Storage runtime state before attempting larger semantic or behavioral migration
+
+This batch is intentionally narrow. It is a boundary-definition batch, not a broad correctness or performance batch.
+
+## 2. Why This Batch Comes First
+
+Everything else in Candle depends on tensor/storage runtime truth:
+
+- autograd depends on version/view/alias truth
+- dispatcher depends on tensor metadata and mutation semantics
+- NPU execution depends on storage/device/runtime boundaries
+
+If these boundaries remain fuzzy, later phases will either drift architecturally or require repeated rework.
+
+## 3. Current Problem Statement
+
+Current Candle already uses a Cython tensor core, but ownership is still split:
+
+- `src/candle/_tensor.py` still contains runtime-critical owner logic
+- tensor/storage metadata propagation is not fully shell-vs-core separated
+- version / alias / view runtime responsibilities are not yet fully centralized
+- storage ownership boundaries are not explicit enough for later dispatcher/autograd/NPU convergence
+
+The problem in this batch is **not** "Tensor is totally wrong." The problem is that the long-term ownership boundary is not yet explicit or enforced.
+
+## 4. Batch Goal
+
+At the end of A1, the project must have a clear and enforced answer to all of the following:
+
+1. What state belongs to the Cython tensor core?
+2. What state belongs to the storage core?
+3. What responsibilities remain in Python `Tensor` shell code?
+4. Which currently Python-owned responsibilities are scheduled for migration in A2+?
+5. What new Python-side runtime owner logic is now forbidden?
+
+## 5. Allowed Files
+
+Only the following implementation files may be modified in A1:
+
+- `src/candle/_tensor.py`
+- `src/candle/_cython/_tensor_impl.pyx`
+- `src/candle/_storage.py`
+- `src/candle/_cython/_storage.pyx`
+
+Allowed supporting files:
+
+- targeted contract tests relevant to tensor/storage ownership boundaries
+- design/plan documents for this batch
+
+## 6. Forbidden Files
+
+A1 must not modify any of the following runtime subsystems:
+
+- `src/candle/_dispatch/**`
+- `src/candle/autograd/**`
+- `src/candle/_backends/npu/**`
+- `src/candle/_functional.py`
+- backend runtime implementations outside storage/tensor core
+
+Exception: read-only inspection is allowed during implementation, but not edits.
+
+## 7. Long-Term Ownership Boundary for Tensor / Storage
+
+### 7.1 Cython Tensor core must own
+
+- tensor identity state
+- shape / stride / offset runtime state
+- device / dtype cached runtime state
+- dispatch-key-relevant cached runtime state
+- version-counter attachment point
+- base/view relationship attachment point
+- autograd-metadata attachment point
+
+### 7.2 Storage core must own
+
+- underlying data pointer ownership
+- typed storage identity
+- pointer-lifetime-related core data
+- storage-backed dtype/device ownership facts
+
+### 7.3 Python Tensor shell may own
+
+- public method surface
+- argument normalization for user-facing APIs
+- high-level wrapper behavior that does not become a runtime owner
+- compatibility glue that forwards immediately into Cython/runtime layers
+
+### 7.4 Python Tensor shell must not grow to own
+
+- new version/alias/view core state
+- new persistent runtime device/dtype/storage ownership state
+- new execution or lifecycle ownership
+- new bridge-layer runtime caches intended to become permanent
+
+## 8. Expected A1 Deliverables
+
+A1 should produce:
+
+1. an explicit field/responsibility split between `_tensor.py` and `_tensor_impl.pyx`
+2. an explicit field/responsibility split between `_storage.py` and `_storage.pyx`
+3. removal or reduction of obvious Python runtime owner responsibilities where safe and tightly scoped
+4. a migration inventory for A2 showing which Python-owned pieces are still intentionally temporary
+5. targeted tests or assertions that make boundary drift harder
+
+## 9. Non-Goals
+
+A1 does **not** attempt to:
+
+- redesign autograd graph/runtime
+- redesign dispatcher or schema behavior
+- touch NPU execution ownership
+- chase performance improvements
+- resolve every existing tensor correctness issue
+- add advanced override/fake/meta compatibility
+
+If a proposed edit primarily serves one of these goals, it belongs to a later batch and must be deferred.
+
+## 10. Validation
+
+Validation for A1 is intentionally narrow.
+
+### Structural validation
+
+Confirm that:
+
+- no new Python runtime owner has been introduced
+- modified logic moved toward Cython/storage ownership rather than away from it
+- file responsibilities are clearer after the batch than before
+
+### Behavioral validation
+
+Run only the smallest relevant tests for:
+
+- tensor construction / storage attachment
+- version/view boundary checks if touched
+- any targeted contract tests created or updated for ownership boundaries
+
+No broad autograd, dispatcher, or backend validation should be introduced here unless directly required by touched tensor/storage behavior.
+
+## 11. Exit Criteria
+
+A1 is complete only when:
+
+1. the Tensor/Storage owner boundary is documented and reflected in code structure
+2. no forbidden subsystem files were modified
+3. Python shell responsibilities are no broader than before
+4. the next migration batch (A2) has a precise list of remaining runtime-owned responsibilities to move
+5. the batch can hand off cleanly without ambiguity about what belongs where
+
+## 12. A2 Preview
+
+A2 will build on A1 by converging the most correctness-critical runtime semantics in this subsystem:
+
+- version counter behavior
+- alias semantics
+- base/view metadata truth
+- detach-related ownership correctness
+
+A1 should make that batch easier, narrower, and less ambiguous — not partially absorb it.
+
+## 13. Concrete A2 Migration Inventory
+
+A2 should target the following runtime-sensitive responsibilities that remain temporary after A1:
+
+- version-sensitive Python Tensor shell behavior that still reaches into runtime-owned state
+- remaining alias/view boundary helpers that still live in `_tensor.py`
+- any storage-shell logic that still behaves like a low-level owner rather than a public API wrapper

--- a/docs/superpowers/specs/2026-04-14-tensor-storage-batch-a2-design.md
+++ b/docs/superpowers/specs/2026-04-14-tensor-storage-batch-a2-design.md
@@ -1,0 +1,281 @@
+# Tensor / Storage Batch A2 Design
+
+Date: 2026-04-14
+Status: Drafted after A1 completion
+Parent spec: `docs/superpowers/specs/2026-04-13-candle-runtime-rebuild-design.md`
+Previous batch: `docs/superpowers/specs/2026-04-13-tensor-storage-batch-a1-design.md`
+
+## 1. Batch Definition
+
+- **Subsystem:** S1 Tensor / Storage runtime core
+- **Batch:** A2
+- **Purpose:** move version-sensitive and view-sensitive runtime truth out of the Python `Tensor` shell and into the Cython `TensorImpl`, while staying strictly inside the Tensor / Storage subsystem
+
+A2 is the first Tensor/Storage batch that performs real correctness-convergence work rather than only declaring boundaries. It is still intentionally narrow: it does not redesign dispatcher, autograd runtime, backend behavior, or NPU execution.
+
+## 2. Why A2 Exists
+
+A1 established the long-term ownership boundary for Tensor/Storage and prevented new Python-side owner growth. However, several runtime-sensitive behaviors still remain temporarily in the Python shell:
+
+- version-sensitive behavior in `detach`, `set_`, and related Tensor-side mutation paths
+- view-sensitive behavior tied to `_base` and `_view_meta`
+- Tensor shell logic that still acts as a partial fact source for version/view truth rather than merely forwarding to Cython
+
+A2 exists to begin the actual owner migration that A1 prepared for.
+
+## 3. Problem Statement
+
+The problem A2 addresses is not “Tensor APIs are missing.” The problem is that version/view correctness still relies too heavily on Python-shell logic.
+
+That creates three risks:
+
+1. **Correctness risk** — version truth and view truth can drift apart across Python and Cython paths
+2. **Architecture drift risk** — future fixes will keep landing in `_tensor.py` because it is the easiest place to patch
+3. **Phase coupling risk** — later autograd and dispatcher work will inherit unstable Tensor/Storage truth
+
+A2 therefore treats version/view-sensitive runtime state as a **fact-source problem**, not merely a method-location problem.
+
+## 4. Scope
+
+### 4.1 In scope
+
+A2 covers two tightly related sub-batches:
+
+- **A2a:** version-sensitive runtime truth
+- **A2b:** view-sensitive runtime truth
+
+Together, they cover:
+
+- `_version_counter`
+- `detach`
+- `set_`
+- Tensor-side mutation-sensitive runtime truth that directly affects version correctness
+- `_base`
+- `_view_meta`
+- view-family helper truth to the extent needed to make `_base` / `_view_meta` more Cython-centered
+
+### 4.2 Out of scope
+
+A2 must not redesign or substantially modify:
+
+- dispatcher or schema behavior
+- autograd graph/runtime
+- backend-specific kernels or execution logic
+- NPU execution ownership
+- fake/meta/functionalization compatibility layers
+- performance-driven optimizations unrelated to owner convergence
+
+## 5. Allowed Files
+
+A2 should primarily modify only:
+
+- `src/candle/_tensor.py`
+- `src/candle/_cython/_tensor_impl.pyx`
+- `src/candle/_cython/_tensor_impl.pxd`
+
+Only if strictly necessary for Tensor/Storage-local correctness or support:
+
+- `src/candle/_storage.py`
+- `src/candle/_cython/_storage.pyx`
+- narrowly targeted contract tests under `tests/contract/`
+
+## 6. Forbidden Files
+
+A2 must not modify:
+
+- `src/candle/_dispatch/**`
+- `src/candle/autograd/**`
+- `src/candle/_backends/**`
+- `src/candle/_functional.py`
+- backend runtime code outside Tensor/Storage-local support
+
+If A2 appears to require one of those changes, that is evidence of scope leak and must be deferred or split into a later batch.
+
+## 7. Design Overview
+
+A2 is a **correctness-convergence** batch, not a feature batch. The guiding rule is:
+
+> Tensor/version/view truth should live where runtime metadata already lives: in `TensorImpl`, not in the Python shell.
+
+The Python `Tensor` class should continue to expose public APIs and user-facing argument handling, but it should stop being the place where version-sensitive and view-sensitive runtime facts are established.
+
+## 8. A2a — Version-Sensitive Runtime Truth
+
+### 8.1 Goal
+
+Move the core truth for version-sensitive Tensor behavior closer to `TensorImpl`, especially for:
+
+- `detach`
+- `_version_counter`
+- `set_`
+- Tensor-side mutation-sensitive metadata updates that directly affect version correctness
+
+### 8.2 Python shell responsibilities after A2a
+
+Python `Tensor` may still:
+
+- expose `detach()` and `set_()` as public methods
+- normalize user-facing arguments
+- provide user-facing error formatting
+
+Python `Tensor` should no longer be the primary owner of version-sensitive runtime truth.
+
+### 8.3 Cython responsibilities after A2a
+
+`_cython/_tensor_impl.pyx` should more clearly own:
+
+- version-counter truth
+- detach-derived runtime truth
+- version-sensitive metadata mutation paths used by Tensor-side operations
+
+### 8.4 A2a intended effect
+
+A2a does not need to move every related method wholesale into Cython. It needs to move the **fact source** and the most runtime-sensitive semantics into Cython so that Python becomes a thin shell over the same truth.
+
+## 9. A2b — View-Sensitive Runtime Truth
+
+### 9.1 Goal
+
+Move the core truth for view-sensitive Tensor behavior closer to `TensorImpl`, especially for:
+
+- `_base`
+- common view base/version attachment truth
+- view-family helper truth where Python still manually assembles derived runtime facts
+- the boundary between Cython-owned view runtime truth and Python-owned user-facing `_view_meta` augmentation
+
+### 9.2 Python shell responsibilities after A2b
+
+Python `Tensor` may still:
+
+- expose `view`, `as_strided`, `transpose`, and related APIs
+- normalize shape/dim arguments
+- raise user-facing errors
+- attach user-facing `_view_meta["op"]` detail and similar shell-level metadata augmentation
+
+Python `Tensor` should no longer be the main fact source for `_base` and version-sharing truth on common view paths, but `_view_meta` assembly may still remain partially in the Python shell for now.
+
+### 9.3 Cython responsibilities after A2b
+
+`_cython/_tensor_impl.pyx` should more clearly own:
+
+- base-view linkage truth
+- common view base/version attachment truth
+- attachment of view-derived objects to the same version-sharing/runtime truth model
+
+This batch does not require all `_view_meta` construction to move into Cython. Some user-facing `_view_meta` payload assembly may remain in the Python shell after A2.
+
+### 9.4 A2b intended effect
+
+A2b is not a full view-system rewrite. It is a controlled move toward a single runtime truth center for view-derived tensors.
+
+## 10. A2a / A2b Dependency Relationship
+
+A2a should land before A2b.
+
+Reason:
+
+- view truth must be compatible with version truth
+- once version-sensitive runtime ownership is more Cython-centered, view metadata can attach to a more stable base
+- doing A2b first would increase the chance of duplicating temporary logic
+
+So A2 is designed as one spec, but it should be implemented in two bounded phases:
+
+1. **A2a first**
+2. **A2b second**
+3. **A2 total validation last**
+
+## 11. Test Strategy
+
+### 11.1 General principle
+
+Use existing contract tests as the primary correctness rails. Add new tests only when a real gap exists.
+
+### 11.2 A2a primary rails
+
+Use existing tests in `tests/contract/test_tensor_alias_version_contract.py`:
+
+- `test_detach_shares_version_counter_with_source`
+- `test_set_bumps_version_counter_once`
+- `test_set_on_view_bumps_shared_version_counter_once`
+- `test_setitem_bumps_version_counter`
+- `test_dispatch_setitem_bumps_version_counter_exactly_once`
+
+Only add focused tests if the current suite cannot distinguish the intended owner migration from a regression.
+
+### 11.3 A2b primary rails
+
+Use existing tests in `tests/contract/test_tensor_alias_version_contract.py`:
+
+- `test_as_strided_view_shares_version_counter_with_source`
+- `test_diagonal_view_shares_version_counter_with_source`
+- `test_movedim_view_shares_version_counter_with_source`
+- `test_moveaxis_view_shares_version_counter_with_source`
+- `test_expand_view_shares_version_counter_with_source`
+- `test_broadcast_to_view_shares_version_counter_with_source`
+- `test_split_view_shares_version_counter_with_source`
+- `test_chunk_view_shares_version_counter_with_source`
+- `test_unary_inplace_preserves_view_aliasing`
+
+Only add focused `_base` / `_view_meta` tests if the current suite is too indirect for a concrete migration step.
+
+### 11.4 A2 total rails
+
+Before closing A2, run at minimum:
+
+- `tests/contract/test_tensor_alias_version_contract.py`
+- `tests/contract/test_inplace_view_rules.py`
+- `tests/contract/test_tensor_storage_owner_contract.py`
+- `tests/contract/test_storage_contract.py`
+
+## 12. Success Criteria
+
+### 12.1 A2a success
+
+A2a is complete only when:
+
+1. `detach` no longer relies primarily on Python-shell runtime truth
+2. `set_` is more clearly anchored to Cython-owned runtime truth
+3. version-sensitive Tensor truth is more centralized in `TensorImpl`
+4. the A2a primary rails pass
+5. no dispatcher/autograd/backend scope creep was introduced
+
+### 12.2 A2b success
+
+A2b is complete only when:
+
+1. `_base` and `_view_meta` truth are more centralized in `TensorImpl`
+2. view-derived tensors still satisfy the existing version-sharing contracts
+3. Python-shell view-sensitive owner logic is reduced further
+4. the A2b primary rails pass
+5. no dispatcher/autograd/backend scope creep was introduced
+
+### 12.3 A2 total success
+
+A2 is complete only when:
+
+1. A2a and A2b both land cleanly
+2. the A2 total rails pass
+3. Python `Tensor` shell owns less version/view-sensitive runtime truth than it did after A1
+4. `_cython/_tensor_impl.pyx` is a more explicit truth center for version/view runtime state
+5. A2 remains strictly inside the Tensor/Storage subsystem
+
+## 13. Relationship to Later Work
+
+A2 does **not** finish Tensor/Storage work. It prepares later work by making Tensor runtime truth more stable.
+
+In particular:
+
+- later autograd batches should inherit more reliable version/view semantics
+- later dispatcher batches should consume a more stable Tensor runtime model
+- later backend/NPU batches should not have to guess where Tensor runtime truth lives
+
+A2 is therefore a local correctness-convergence batch with system-wide downstream value.
+
+## 14. Final Design Summary
+
+A2 is a strict Tensor/Storage-only batch that covers both version-sensitive and view-sensitive runtime truth in one design, but implements them in two bounded stages.
+
+- **A2a** converges version/detach/set_-related runtime truth toward Cython `TensorImpl`
+- **A2b** converges `_base` / `_view_meta` / view-family runtime truth toward Cython `TensorImpl`
+- existing alias/version contract tests serve as the main safety rails
+- success is measured by owner convergence and correctness stability, not by feature count or performance

--- a/src/candle/_cython/_storage.pyx
+++ b/src/candle/_cython/_storage.pyx
@@ -1,8 +1,9 @@
 # cython: language_level=3, boundscheck=False, wraparound=False
-"""Cython fast-path for NPU storage creation.
+"""Cython storage runtime/helper layer.
 
-Replaces np.dtype(to_numpy_dtype(dtype)).itemsize with a C switch,
-and constructs the NPU storage wrappers directly in Cython.
+This module is part of Candle's storage runtime boundary, not just an
+optimization layer. It centralizes storage-backed object construction for
+runtime-owned device pointers and helpers that Python storage shells call into.
 
 NPU path is intentionally Cython-only — no Python fallback.
 """

--- a/src/candle/_cython/_tensor_impl.pxd
+++ b/src/candle/_cython/_tensor_impl.pxd
@@ -3,27 +3,26 @@ from libc.stdint cimport int64_t
 DEF MAX_NDIM = 64
 
 cdef class TensorImpl:
-    # -- shape / stride (C arrays + cached Python tuples) --
+    # -- runtime-owned tensor metadata --
     cdef int64_t _c_shape[MAX_NDIM]
     cdef int64_t _c_stride[MAX_NDIM]
     cdef public int _ndim
     cdef public int64_t _c_numel
     cdef public int64_t _c_offset
+    cdef public tuple _shape_tuple
+    cdef public object _stride_tuple
 
-    # -- device (int enum + cached object) --
+    # -- runtime-owned device / dtype caches --
     cdef public int _device_type
     cdef public int _device_index
     cdef public object _device_obj
-
-    # -- dtype (int code + cached object) --
     cdef public int _dtype_code
     cdef public int _itemsize
     cdef public object _dtype_obj
+    cdef public unsigned int _dispatch_keys
 
-    # -- storage --
+    # -- runtime-owned storage / autograd attachment --
     cdef public object _storage
-
-    # -- autograd --
     cdef public bint requires_grad
     cdef public object grad
     cdef public object grad_fn
@@ -34,18 +33,10 @@ cdef class TensorImpl:
     cdef public bint _retain_grad
     cdef public int _output_nr
     cdef public object _backward_hooks
-
-    cdef public tuple _shape_tuple
-    cdef public object _stride_tuple
+    cdef public object _vc_proxy
 
     # -- allow dynamic attrs (__dict__) --
     cdef dict __dict__
-
-    # -- cached version counter proxy --
-    cdef public object _vc_proxy
-
-    # -- precomputed dispatch key bits --
-    cdef public unsigned int _dispatch_keys
 
     # -- inline methods --
     cdef inline void _set_shape(self, tuple shape)
@@ -53,11 +44,20 @@ cdef class TensorImpl:
     cdef inline void _set_device_from_obj(self, object dev)
     cdef inline void _recompute_dispatch_keys(self)
     cdef inline void _set_dtype_from_obj(self, object dtype)
+    cdef inline void _attach_view_runtime_truth(self, TensorImpl view)
 
     # -- view operations --
+    cpdef object cy_detach(self)
     cpdef object cy_view(self, tuple new_shape)
     cpdef object cy_as_strided(self, tuple size, tuple stride, int64_t storage_offset)
     cpdef object cy_transpose(self, int dim0, int dim1)
+    cpdef object cy_set_runtime_truth(
+        self,
+        object typed_storage,
+        tuple size,
+        object stride,
+        int64_t storage_offset,
+    )
 
 
 cdef class _VersionCounterProxy:

--- a/src/candle/_cython/_tensor_impl.pyx
+++ b/src/candle/_cython/_tensor_impl.pyx
@@ -1,8 +1,9 @@
 # cython: language_level=3, boundscheck=False, wraparound=False
-"""Cython TensorImpl — C-level storage for Tensor metadata.
+"""Cython TensorImpl — runtime-owned tensor metadata and cached runtime state.
 
-Mirrors PyTorch's TensorImpl: shape/stride/device/dtype/autograd fields
-are stored as C-typed attributes for zero-overhead access from Cython code.
+TensorImpl is the internal owner for tensor shape/stride/device/dtype/autograd
+state and other cached runtime fields used by the dispatcher and lifecycle code.
+Python Tensor remains the public shell that exposes the user-facing API.
 VersionCounter is inlined as a C int64.
 """
 
@@ -51,7 +52,11 @@ cdef inline object _coerce_stride_tuple(object stride):
 
 
 cdef class TensorImpl:
-    """C-level base for Tensor. All hot fields are cdef-typed."""
+    """Internal runtime owner for tensor metadata and cached state.
+
+    Python Tensor is the public shell; TensorImpl holds the runtime-owned fields
+    that back that shell and keep hot-path metadata in Cython-managed storage.
+    """
     # Field and method declarations in _tensor_impl.pxd
 
     # ---------------------------------------------------------------
@@ -460,6 +465,38 @@ cdef class TensorImpl:
     # View operations — share storage, only update layout
     # ---------------------------------------------------------------
 
+    cpdef object cy_detach(self):
+        cdef object tensor_type = type(self)
+        cdef TensorImpl out = <TensorImpl>tensor_type.__new__(tensor_type)
+        cy_init_tensor_fields(
+            out,
+            self._storage,
+            self._shape_tuple,
+            self._stride_tuple,
+            self._c_offset,
+            False,
+            None,
+            None,
+            None,
+            None,
+            self._pending,
+            False,
+            None,
+            self._version_value,
+            self._version_counter,
+        )
+        return out
+
+    cdef inline void _attach_view_runtime_truth(self, TensorImpl view):
+        view._version_value = self._version_value
+        view._base = self._base if self._base is not None else self
+        view._vc_proxy = None
+        view._view_meta = None
+        view._pending = False
+        view._retain_grad = False
+        view._backward_hooks = None
+        view._output_nr = 0
+
     cpdef object cy_view(self, tuple new_shape):
         cdef int64_t new_numel = 1
         cdef int i
@@ -490,14 +527,7 @@ cdef class TensorImpl:
         v.requires_grad = self.requires_grad
         v.grad = None
         v.grad_fn = self.grad_fn
-        v._version_value = self._version_value
-        v._base = self._base if self._base is not None else self
-        v._vc_proxy = None
-        v._view_meta = None
-        v._pending = False
-        v._retain_grad = False
-        v._backward_hooks = None
-        v._output_nr = 0
+        self._attach_view_runtime_truth(v)
         return v
 
     cpdef object cy_as_strided(self, tuple size, tuple stride, int64_t storage_offset):
@@ -517,14 +547,7 @@ cdef class TensorImpl:
         v.requires_grad = self.requires_grad
         v.grad = None
         v.grad_fn = self.grad_fn
-        v._version_value = self._version_value
-        v._base = self._base if self._base is not None else self
-        v._vc_proxy = None
-        v._view_meta = None
-        v._pending = False
-        v._retain_grad = False
-        v._backward_hooks = None
-        v._output_nr = 0
+        self._attach_view_runtime_truth(v)
         return v
 
     cpdef object cy_transpose(self, int dim0, int dim1):
@@ -542,6 +565,27 @@ cdef class TensorImpl:
         new_shape[dim0], new_shape[dim1] = new_shape[dim1], new_shape[dim0]
         new_stride[dim0], new_stride[dim1] = new_stride[dim1], new_stride[dim0]
         return self.cy_as_strided(tuple(new_shape), tuple(new_stride), self._c_offset)
+
+    cpdef object cy_set_runtime_truth(
+        self,
+        object typed_storage,
+        tuple size,
+        object stride,
+        int64_t storage_offset,
+    ):
+        cdef object device = getattr(typed_storage, "device", None)
+        cdef object dtype = getattr(typed_storage, "dtype", None)
+        self._storage = typed_storage
+        self._set_shape(size)
+        self._set_stride(stride)
+        self._c_offset = storage_offset
+        if device is not None:
+            self._set_device_from_obj(device)
+        if dtype is not None:
+            self._set_dtype_from_obj(dtype)
+        self._bump_version()
+        return self
+
 
 # -------------------------------------------------------------------
 # Module-level tensor factory functions

--- a/src/candle/_storage.py
+++ b/src/candle/_storage.py
@@ -67,6 +67,18 @@ atexit.register(cleanup_shared_files)
 
 
 class UntypedStorage:
+    """Public storage shell around runtime-owned backing memory.
+
+    UntypedStorage is the user-facing storage shell exposed by Candle's Python API.
+    The underlying pointer, allocation lifetime, and device placement are runtime
+    truths supplied by backend/runtime storage objects; Python methods here wrap
+    that runtime-owned backing data rather than owning it independently.
+    """
+
+    # A1 boundary note: this file remains the public storage API shell.
+    # Future runtime-sensitive storage ownership should move into Cython helpers
+    # instead of expanding Python-side owner state here.
+
     def __init__(self, device):
         if isinstance(device, str):
             device = Device(device)
@@ -277,6 +289,9 @@ class _CPUUntypedStorage(UntypedStorage):
             self._sharing_mechanism = strategy
             return self
 
+        # A1 boundary note: this file remains the public storage API shell.
+        # Future runtime-sensitive storage ownership should move into Cython helpers
+        # instead of expanding Python-side owner state here.
         if strategy == "file_descriptor":
             import mmap
             import os
@@ -519,6 +534,14 @@ class _MetaUntypedStorage(UntypedStorage):
 
 
 class TypedStorage:
+    """Public typed storage wrapper over an untyped runtime owner.
+
+    Runtime pointer ownership lives in the referenced untyped storage object.
+    TypedStorage adds dtype/size interpretation for the public Python API while
+    methods like data_ptr(), device, is_shared(), and is_pinned() delegate to the
+    runtime-owned untyped backing storage.
+    """
+
     def __init__(self, untyped, dtype=None, size=0, data=None):
         self._untyped = untyped
         self.dtype = dtype or float32
@@ -735,9 +758,11 @@ class TypedStorage:
         return int(self._size * itemsize)
 
     def data_ptr(self):
+        """Return the runtime-owned pointer exposed through the typed shell."""
         return self._untyped.data_ptr()
 
     def untyped_storage(self):
+        """Return the runtime owner backing this typed public storage view."""
         return self._untyped
 
     def is_shared(self):

--- a/src/candle/_tensor.py
+++ b/src/candle/_tensor.py
@@ -178,57 +178,10 @@ class Tensor(_TensorBase):
     _DK_AUTOGRAD_META     = 1 << 10
 
     def _set_device_from_storage(self, dev):
-        """Cache device from storage into TensorImpl fields and recompute dispatch keys."""
-        self._device_obj = dev
-        dt = getattr(dev, "type", str(dev))
-        devt = Tensor._DEVICE_MAP.get(dt, -1)
-        self._device_type = devt
-        idx = getattr(dev, "index", None)
-        self._device_index = idx if idx is not None else -1
-        # Mirror _recompute_dispatch_keys from _tensor_impl.pyx
-        if devt == 0:
-            dk = Tensor._DK_CPU
-        elif devt == 1:
-            dk = Tensor._DK_NPU
-        elif devt == 2:
-            dk = Tensor._DK_CUDA
-        elif devt == 3:
-            dk = Tensor._DK_MPS
-        elif devt == 4:
-            dk = Tensor._DK_META
-        else:
-            dk = Tensor._DK_CPU
-        if self.requires_grad:
-            dk |= Tensor._DK_ADINPLACEORVIEW | Tensor._DK_AUTOGRAD
-            if devt == 0:
-                dk |= Tensor._DK_AUTOGRAD_CPU
-            elif devt == 1:
-                dk |= Tensor._DK_AUTOGRAD_NPU
-            elif devt == 2:
-                dk |= Tensor._DK_AUTOGRAD_CUDA
-            elif devt == 3:
-                dk |= Tensor._DK_AUTOGRAD_MPS
-            elif devt == 4:
-                dk |= Tensor._DK_AUTOGRAD_META
-        self._dispatch_keys = dk
+        self._set_device_from_obj(dev)
 
     def _set_dtype_from_storage(self, dtype):
-        """Cache dtype from storage into TensorImpl fields."""
-        self._dtype_obj = dtype
-        self._itemsize = getattr(dtype, "itemsize", 4)
-        name = getattr(dtype, "name", "")
-        self._dtype_code = {
-            "float32": 0,
-            "float16": 1,
-            "float64": 2,
-            "bfloat16": 3,
-            "int32": 4,
-            "int64": 5,
-            "int16": 6,
-            "int8": 7,
-            "uint8": 8,
-            "bool": 9,
-        }.get(name, -1)
+        self._set_dtype_from_obj(dtype)
 
     def __delattr__(self, name):
         if name == "grad":
@@ -252,6 +205,9 @@ class Tensor(_TensorBase):
             raise RuntimeError(f"shape mismatch: expected {self.shape}, got {new_data.shape}")
         if new_data.dtype != self.dtype:
             raise RuntimeError(f"dtype mismatch: expected {self.dtype}, got {new_data.dtype}")
+        # A2 follow-up note: version-sensitive shell behavior still remains here.
+        # Later Tensor/Storage work should keep shrinking Python-side mutation truth
+        # rather than growing new owner state in `_tensor.py`.
         # Replace storage
         self._storage = new_data._storage
         self.stride = new_data.stride
@@ -604,14 +560,12 @@ class Tensor(_TensorBase):
                 raise RuntimeError("set_() view exceeds storage bounds")
 
         self._check_inplace()
-        self._storage = typed_storage
-        self.shape = size
-        self.stride = _StrideTuple(stride)
-        self.offset = int(storage_offset)
-        self._set_device_from_storage(device)
-        self._set_dtype_from_storage(dtype)
-        self._bump_version()
-        return self
+        return self.cy_set_runtime_truth(
+            typed_storage,
+            size,
+            _StrideTuple(stride),
+            int(storage_offset),
+        )
 
     def as_strided(self, size, stride, storage_offset=None):
         """Create a view of the tensor with given size, stride, and storage_offset."""
@@ -691,12 +645,7 @@ class Tensor(_TensorBase):
         return self
 
     def detach(self):
-        out = cy_make_tensor_from_storage(self._storage, self.shape, self.stride, self.offset, False)
-        out.grad_fn = None
-        out.grad = None
-        out._pending = self._pending
-        out._version_counter = self._version_counter
-        return out
+        return self.cy_detach()
 
     def detach_(self):
         self.requires_grad = False

--- a/tests/contract/test_tensor_alias_version_contract.py
+++ b/tests/contract/test_tensor_alias_version_contract.py
@@ -31,6 +31,25 @@ def test_as_strided_view_shares_version_counter_with_source():
     assert base._version_counter.value == before_base + 1
 
 
+def test_view_runtime_truth_sets_base_to_source_tensor():
+    base = torch.tensor([[0.0, 1.0], [2.0, 3.0]])
+    view = base.view((4,))
+    assert view._base is base
+
+
+def test_as_strided_runtime_truth_sets_base_to_source_tensor():
+    base = torch.tensor([[0.0, 1.0], [2.0, 3.0]])
+    view = base.as_strided((2, 2), (2, 1))
+    assert view._base is base
+
+
+def test_view_runtime_truth_records_view_meta():
+    base = torch.tensor([[0.0, 1.0], [2.0, 3.0]])
+    view = base.view((4,))
+    assert view._view_meta is not None
+    assert view._view_meta["op"] == "view"
+
+
 def test_unary_inplace_preserves_view_aliasing():
     x = torch.tensor([[-1.0, 2.0], [-3.0, 4.0]])
     v = x.view((4,))
@@ -243,3 +262,33 @@ def test_set_on_view_bumps_shared_version_counter_once():
     assert v._version_counter.value == before_view + 1
     assert v.tolist() == [0.0, 1.0]
     assert v._base is x
+
+
+def test_detach_preserves_storage_shape_stride_offset_runtime_truth():
+    base = torch.tensor([[0.0, 1.0], [2.0, 3.0]], requires_grad=True)
+    view = base.view((4,))
+    detached = view.detach()
+    assert detached.storage().data_ptr() == view.storage().data_ptr()
+    assert detached.shape == view.shape
+    assert detached.stride == view.stride
+    assert detached.offset == view.offset
+    assert detached.requires_grad is False
+    assert detached.grad_fn is None
+
+
+def test_detach_of_view_preserves_base_version_sharing_truth():
+    base = torch.tensor([[0.0, 1.0], [2.0, 3.0]], requires_grad=True)
+    view = base.view((4,))
+    detached = view.detach()
+    before = detached._version_counter.value
+    base._version_counter.bump()
+    assert detached._version_counter.value == before + 1
+
+
+def test_set_preserves_device_dtype_runtime_truth():
+    x = torch.tensor([0.0, 1.0, 2.0, 3.0], dtype=torch.float32)
+    out = x.set_(x.storage(), 1, (2,), (1,))
+    assert out is x
+    assert x.device.type == "cpu"
+    assert x.dtype == torch.float32
+    assert x.tolist() == [1.0, 2.0]

--- a/tests/contract/test_tensor_storage_owner_contract.py
+++ b/tests/contract/test_tensor_storage_owner_contract.py
@@ -1,0 +1,50 @@
+import candle as torch
+
+
+def test_tensor_impl_declares_runtime_owned_fields():
+    x = torch.tensor([1.0, 2.0])
+
+    assert hasattr(x, "_storage")
+    assert hasattr(x, "_device_obj")
+    assert hasattr(x, "_dtype_obj")
+    assert hasattr(x, "_version_value")
+    assert hasattr(x, "_base")
+    assert hasattr(x, "_view_meta")
+    assert hasattr(x, "_dispatch_keys")
+
+
+def test_tensor_python_shell_still_exposes_public_storage_api():
+    x = torch.tensor([1.0, 2.0])
+
+    assert x.storage() is not None
+    assert x.untyped_storage() is not None
+
+
+def test_tensor_data_setter_still_routes_through_runtime_storage_swap():
+    x = torch.tensor([1.0, 2.0])
+    y = torch.tensor([3.0, 4.0])
+
+    before = x._version_counter.value
+    x.data = y
+
+    assert x.tolist() == [3.0, 4.0]
+    assert x._version_counter.value == before + 1
+
+
+def test_tensor_shell_device_dtype_helpers_preserve_runtime_cache_values():
+    x = torch.tensor([1.0, 2.0])
+    before_device = x.device
+    before_dtype = x.dtype
+    x._set_device_from_storage(before_device)
+    x._set_dtype_from_storage(before_dtype)
+    assert x.device == before_device
+    assert x.dtype == before_dtype
+
+
+def test_typed_storage_public_api_routes_through_untyped_runtime_owner():
+    x = torch.tensor([1.0, 2.0])
+    storage = x.storage()
+    untyped = storage.untyped_storage()
+
+    assert storage.data_ptr() == untyped.data_ptr()
+    assert storage.device == untyped.device


### PR DESCRIPTION
## Summary
- move detach, set_, and common view base/version attachment truth from the Python Tensor shell into Cython TensorImpl helpers
- add Tensor/Storage contract coverage for ownership, alias/version, and view runtime truth
- include the runtime rebuild design and A1/A2 batch specs/plans that guided this bounded Tensor/Storage convergence work

## Test Plan
- [x] source /opt/miniconda3/etc/profile.d/conda.sh && conda run -n candle python -m pytest tests/contract/test_tensor_alias_version_contract.py tests/contract/test_inplace_view_rules.py tests/contract/test_tensor_storage_owner_contract.py tests/contract/test_storage_contract.py -v --tb=short

🤖 Generated with [Claude Code](https://claude.com/claude-code)