### PR TITLE
refactor tensor data runtime truth

### DIFF
--- a/docs/superpowers/plans/2026-04-14-tensor-storage-batch-a3.md
+++ b/docs/superpowers/plans/2026-04-14-tensor-storage-batch-a3.md
@@ -1,0 +1,323 @@
+# Tensor / Storage Batch A3 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move `Tensor.data` shallow metadata-copy runtime truth out of the Python `Tensor` shell and into the Cython `TensorImpl`, aligning Candle more closely with PyTorch's `TensorImpl::shallow_copy_from()` ownership model while staying strictly inside the Tensor / Storage subsystem.
+
+**Architecture:** Keep `Tensor.data` as a Python property for public API validation and user-facing errors, but introduce one narrow Cython helper that becomes the single fact source for storage / shape / stride / offset / device / dtype refresh and version-sensitive mutation on the `data` path. The batch is PyTorch-led, references torch_npu only as a runtime-ownership direction check, and preserves Candle’s long-term direction that NPU storage is built-in framework-owned device storage like CUDA rather than a plugin-style layer.
+
+**Tech Stack:** Python, Cython, pytest, Candle Tensor/Storage runtime
+
+---
+
+## File Structure / Responsibilities
+
+- `src/candle/_tensor.py` — public Tensor shell; after A3 it should only validate `Tensor.data` arguments and forward the actual runtime mutation to Cython
+- `src/candle/_cython/_tensor_impl.pxd` — authoritative declaration of Tensor runtime-owned fields and callable Cython interfaces; declare the new A3 helper here
+- `src/candle/_cython/_tensor_impl.pyx` — runtime truth center for tensor metadata mutation; implement the new `Tensor.data` shallow-copy helper here
+- `tests/contract/test_tensor_storage_owner_contract.py` — ownership-boundary rails for proving `Tensor.data` now routes through a runtime-owned helper rather than Python field writes
+- `tests/contract/test_tensor_alias_version_contract.py` — alias/version rails for proving version behavior and metadata-copy behavior stay stable after the migration
+- `tests/contract/test_inplace_view_rules.py` — regression guardrail for view / inplace legality after the ownership move
+- `tests/contract/test_storage_contract.py` — storage-shell regression guardrail
+- `tests/npu/test_npu_fast_storage.py` — optional targeted NPU confidence rail if the current contract changes touch device-storage refresh behavior on NPU; do not expand A3 scope beyond a narrow smoke verification
+- `docs/superpowers/specs/2026-04-14-tensor-storage-batch-a3-design.md` — approved A3 design and scope boundary
+
+---
+
+### Task 1: Add A3-focused failing tests for `Tensor.data` runtime truth
+
+**Files:**
+- Modify: `tests/contract/test_tensor_storage_owner_contract.py`
+- Modify: `tests/contract/test_tensor_alias_version_contract.py`
+- Reference: `src/candle/_tensor.py:199-215`
+- Reference: `src/candle/_cython/_tensor_impl.pyx:569-587`
+
+- [ ] **Step 1: Add focused `Tensor.data` ownership tests to the storage-owner contract file**
+
+Append these tests to `tests/contract/test_tensor_storage_owner_contract.py`:
+
+```python
+def test_tensor_data_setter_preserves_source_storage_stride_and_offset_truth():
+    x = torch.tensor([1.0, 2.0])
+    z = torch.tensor([9.0, 3.0, 4.0])
+    y = z[1:]
+
+    x.data = y
+
+    assert x.storage().data_ptr() == y.storage().data_ptr()
+    assert x.stride == y.stride
+    assert x.offset == y.offset
+    assert x.tolist() == [3.0, 4.0]
+
+
+def test_tensor_data_setter_preserves_runtime_device_dtype_caches():
+    x = torch.tensor([1.0, 2.0], dtype=torch.float32)
+    y = torch.tensor([3.0, 4.0], dtype=torch.float32)
+
+    x.data = y
+
+    assert x.device.type == y.device.type
+    assert x.dtype == y.dtype
+```
+
+- [ ] **Step 2: Add focused version rail for the `Tensor.data` path**
+
+Append this test to `tests/contract/test_tensor_alias_version_contract.py` near the other version-sensitive mutation tests:
+
+```python
+def test_data_setter_bumps_version_counter_once():
+    x = torch.tensor([1.0, 2.0])
+    y = torch.tensor([3.0, 4.0])
+    before = x._version_counter.value
+
+    x.data = y
+
+    assert x._version_counter.value == before + 1
+    assert x.tolist() == [3.0, 4.0]
+```
+
+- [ ] **Step 3: Run the new `Tensor.data` tests to verify the current baseline**
+
+Run:
+```bash
+source /opt/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest \
+  tests/contract/test_tensor_storage_owner_contract.py::test_tensor_data_setter_preserves_source_storage_stride_and_offset_truth \
+  tests/contract/test_tensor_storage_owner_contract.py::test_tensor_data_setter_preserves_runtime_device_dtype_caches \
+  tests/contract/test_tensor_alias_version_contract.py::test_data_setter_bumps_version_counter_once \
+  -v --tb=short
+```
+
+Expected: PASS or a narrow A3-relevant failure only.
+
+- [ ] **Step 4: Run existing `Tensor.data` ownership baseline tests**
+
+Run:
+```bash
+source /opt/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest \
+  tests/contract/test_tensor_storage_owner_contract.py::test_tensor_data_setter_still_routes_through_runtime_storage_swap \
+  tests/contract/test_tensor_alias_version_contract.py::test_set_bumps_version_counter_once \
+  tests/contract/test_tensor_alias_version_contract.py::test_set_preserves_device_dtype_runtime_truth \
+  -v --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the A3 test additions**
+
+```bash
+git add tests/contract/test_tensor_storage_owner_contract.py tests/contract/test_tensor_alias_version_contract.py
+git commit -m "test(contract): add A3 tensor data runtime truth rails"
+```
+
+---
+
+### Task 2: Add a dedicated Cython helper for `Tensor.data` shallow metadata-copy truth
+
+**Files:**
+- Modify: `src/candle/_cython/_tensor_impl.pxd`
+- Modify: `src/candle/_cython/_tensor_impl.pyx`
+- Test: `tests/contract/test_tensor_storage_owner_contract.py`
+- Test: `tests/contract/test_tensor_alias_version_contract.py`
+
+- [ ] **Step 1: Declare the A3 helper in `_tensor_impl.pxd`**
+
+Add this declaration to `src/candle/_cython/_tensor_impl.pxd` near the existing `cy_detach` / `cy_set_runtime_truth` declarations:
+
+```cython
+    cpdef object cy_set_data_runtime_truth_from(self, object other)
+```
+
+- [ ] **Step 2: Run the focused `Tensor.data` tests before implementation**
+
+Run:
+```bash
+source /opt/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest \
+  tests/contract/test_tensor_storage_owner_contract.py::test_tensor_data_setter_still_routes_through_runtime_storage_swap \
+  tests/contract/test_tensor_storage_owner_contract.py::test_tensor_data_setter_preserves_source_storage_stride_and_offset_truth \
+  tests/contract/test_tensor_storage_owner_contract.py::test_tensor_data_setter_preserves_runtime_device_dtype_caches \
+  tests/contract/test_tensor_alias_version_contract.py::test_data_setter_bumps_version_counter_once \
+  -v --tb=short
+```
+
+Expected: PASS before the refactor.
+
+- [ ] **Step 3: Implement the A3 helper in `_tensor_impl.pyx`**
+
+Add this method to `src/candle/_cython/_tensor_impl.pyx` next to `cy_set_runtime_truth`:
+
+```cython
+    cpdef object cy_set_data_runtime_truth_from(self, object other):
+        cdef TensorImpl src = <TensorImpl>other
+        self._storage = src._storage
+        self._set_shape(src._shape_tuple)
+        self._set_stride(src._stride_tuple)
+        self._c_offset = src._c_offset
+        self._device_type = src._device_type
+        self._device_index = src._device_index
+        self._device_obj = src._device_obj
+        self._dtype_code = src._dtype_code
+        self._itemsize = src._itemsize
+        self._dtype_obj = src._dtype_obj
+        self._recompute_dispatch_keys()
+        self._bump_version()
+        return self
+```
+
+This helper is intentionally narrow:
+- it shallow-copies storage / shape / stride / offset truth from the source tensor
+- it refreshes runtime device / dtype cache fields from the source runtime owner
+- it keeps the version bump rule in one Cython-owned place
+- it does **not** redesign autograd behavior or view metadata behavior
+
+- [ ] **Step 4: Re-run the focused `Tensor.data` tests after adding the helper**
+
+Run:
+```bash
+source /opt/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest \
+  tests/contract/test_tensor_storage_owner_contract.py::test_tensor_data_setter_still_routes_through_runtime_storage_swap \
+  tests/contract/test_tensor_storage_owner_contract.py::test_tensor_data_setter_preserves_source_storage_stride_and_offset_truth \
+  tests/contract/test_tensor_storage_owner_contract.py::test_tensor_data_setter_preserves_runtime_device_dtype_caches \
+  tests/contract/test_tensor_alias_version_contract.py::test_data_setter_bumps_version_counter_once \
+  -v --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the Cython helper addition**
+
+```bash
+git add src/candle/_cython/_tensor_impl.pxd src/candle/_cython/_tensor_impl.pyx tests/contract/test_tensor_storage_owner_contract.py tests/contract/test_tensor_alias_version_contract.py
+git commit -m "refactor(tensor): add A3 data runtime truth helper"
+```
+
+---
+
+### Task 3: Make Python `Tensor.data` a thin shell over the Cython helper
+
+**Files:**
+- Modify: `src/candle/_tensor.py:199-215`
+- Modify: `tests/contract/test_tensor_storage_owner_contract.py`
+- Modify: `tests/contract/test_tensor_alias_version_contract.py`
+
+- [ ] **Step 1: Replace Python-side field mutation in the `data` setter**
+
+In `src/candle/_tensor.py`, replace the body after validation with this forwarding call:
+
+```python
+    @data.setter
+    def data(self, new_data):
+        """Replace the tensor's data with new_data (in-place)."""
+        if not isinstance(new_data, Tensor):
+            raise TypeError(f"data must be a Tensor, got {type(new_data).__name__}")
+        if new_data.shape != self.shape:
+            raise RuntimeError(f"shape mismatch: expected {self.shape}, got {new_data.shape}")
+        if new_data.dtype != self.dtype:
+            raise RuntimeError(f"dtype mismatch: expected {self.dtype}, got {new_data.dtype}")
+        self.cy_set_data_runtime_truth_from(new_data)
+```
+
+Do **not** keep direct Python-side assignments to `_storage`, `stride`, `offset`, or `_bump_version()`.
+
+- [ ] **Step 2: Add one regression test that the public validation still stays in Python**
+
+Append this test to `tests/contract/test_tensor_storage_owner_contract.py`:
+
+```python
+def test_tensor_data_setter_rejects_non_tensor_input_before_runtime_mutation():
+    x = torch.tensor([1.0, 2.0])
+
+    with pytest.raises(TypeError, match=r"data must be a Tensor"):
+        x.data = [3.0, 4.0]
+```
+
+Also add the import at the top of that file if needed:
+
+```python
+import pytest
+```
+
+- [ ] **Step 3: Run the `Tensor.data` contract tests after the Python-shell slimming**
+
+Run:
+```bash
+source /opt/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest \
+  tests/contract/test_tensor_storage_owner_contract.py \
+  tests/contract/test_tensor_alias_version_contract.py -k "data_setter or set_preserves_device_dtype_runtime_truth" \
+  -v --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit the Python-shell forwarding change**
+
+```bash
+git add src/candle/_tensor.py tests/contract/test_tensor_storage_owner_contract.py tests/contract/test_tensor_alias_version_contract.py
+git commit -m "refactor(tensor): route data setter through TensorImpl"
+```
+
+---
+
+### Task 4: Run A3 validation rails and a narrow NPU confidence check
+
+**Files:**
+- Validate: `tests/contract/test_tensor_storage_owner_contract.py`
+- Validate: `tests/contract/test_tensor_alias_version_contract.py`
+- Validate: `tests/contract/test_inplace_view_rules.py`
+- Validate: `tests/contract/test_storage_contract.py`
+- Optional validate: `tests/npu/test_npu_fast_storage.py`
+
+- [ ] **Step 1: Run the full A3 contract rails**
+
+Run:
+```bash
+source /opt/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest \
+  tests/contract/test_tensor_storage_owner_contract.py \
+  tests/contract/test_tensor_alias_version_contract.py \
+  tests/contract/test_inplace_view_rules.py \
+  tests/contract/test_storage_contract.py \
+  -v --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run a narrow NPU storage confidence check if NPU hardware is available**
+
+Run:
+```bash
+source /opt/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest \
+  tests/npu/test_npu_fast_storage.py::test_typed_storage_interface \
+  tests/npu/test_npu_fast_storage.py::test_storage_data_ptr_nonzero \
+  -v --tb=short
+```
+
+Expected:
+- PASS on an NPU-capable machine
+- SKIP only if NPU is unavailable
+
+This step is only a confidence rail. Do **not** widen A3 into backend redesign work if these tests expose unrelated NPU issues.
+
+- [ ] **Step 3: Review the final diff against the A3 spec before committing**
+
+Manually verify the diff satisfies all of these checks:
+
+```text
+- src/candle/_tensor.py no longer directly assigns _storage / stride / offset or calls _bump_version() in the data setter
+- src/candle/_cython/_tensor_impl.pyx owns the single data-path runtime mutation helper
+- version bump behavior for Tensor.data is single-sourced in Cython
+- no dispatcher / autograd / backend files were modified
+- NPU direction remains framework-owned built-in storage by architecture, without introducing any torch_npu-style plugin layer
+```
+
+- [ ] **Step 4: Commit the validated A3 batch**
+
+```bash
+git add src/candle/_tensor.py src/candle/_cython/_tensor_impl.pxd src/candle/_cython/_tensor_impl.pyx tests/contract/test_tensor_storage_owner_contract.py tests/contract/test_tensor_alias_version_contract.py
+git commit -m "refactor(tensor): move data runtime truth into TensorImpl"
+```

--- a/docs/superpowers/specs/2026-04-14-tensor-storage-batch-a3-design.md
+++ b/docs/superpowers/specs/2026-04-14-tensor-storage-batch-a3-design.md
@@ -1,0 +1,279 @@
+# Tensor / Storage Batch A3 Design
+
+Date: 2026-04-14
+Status: Drafted after A2 completion
+Parent spec: `docs/superpowers/specs/2026-04-13-candle-runtime-rebuild-design.md`
+Previous batch: `docs/superpowers/specs/2026-04-14-tensor-storage-batch-a2-design.md`
+
+## 1. Batch Definition
+
+- **Subsystem:** S1 Tensor / Storage runtime core
+- **Batch:** A3
+- **Purpose:** move `Tensor.data` shallow metadata-copy truth out of the Python `Tensor` shell and into the Cython `TensorImpl`, aligning Candle more closely with PyTorch's `TensorImpl::shallow_copy_from()` model while staying strictly inside the Tensor / Storage subsystem
+
+A3 is a narrow residual S1 batch. It does not introduce new Tensor features. It tightens runtime ownership so that `Tensor.data` stops being a Python-side fact source for storage/shape/stride/offset mutation.
+
+## 2. Why A3 Exists
+
+A2 moved important version-sensitive and common view-sensitive runtime truth into `TensorImpl`. However, one important Tensor mutation path still remains owned by the Python shell:
+
+- `src/candle/_tensor.py:199-215` still performs direct `data`-setter runtime mutation in Python by assigning `_storage`, `stride`, `offset`, and bumping version state from the shell
+
+That leaves Candle in a partially converged state:
+
+- `detach()` is already Cython-centered
+- common view attachment is already more Cython-centered
+- but `Tensor.data = other` still mutates runtime truth from Python
+
+A3 exists to eliminate that remaining mismatch.
+
+## 3. Source Alignment Basis
+
+A3 is explicitly anchored to **PyTorch source structure**, while also using **torch_npu as a reference for NPU runtime ownership direction**.
+
+### 3.1 PyTorch alignment point
+
+PyTorch documents Tensor metadata shallow-copy ownership in `c10/core/TensorImpl.h:2029-2066`.
+
+That note establishes two distinct runtime patterns:
+
+1. `detach()` uses `shallow_copy_and_detach()`
+2. `set_data(tensor)` uses `shallow_copy_from()`
+
+The key architectural point is not only which public API exists. The key point is **where runtime truth lives**:
+
+- storage pointer
+- sizes
+- strides
+- storage offset
+- related metadata-copy behavior
+
+all belong to `TensorImpl`-level shallow-copy machinery, not to a Python shell wrapper.
+
+### 3.2 torch_npu reference point
+
+torch_npu is relevant to A3 as a **runtime ownership reference**, but **not** as a plugin architecture template for Candle.
+
+The important lesson from torch_npu is that NPU runtime-sensitive truth is kept in native-facing runtime owners rather than in long-term Python wrapper state. However, Candle should **not** mirror torch_npu's external plugin-style layering as the long-term architecture target.
+
+For Candle, the intended structural direction is:
+
+- NPU remains a first-class built-in Candle device
+- NPU storage should converge toward the same kind of framework-owned device-storage role that CUDA has in Candle
+- NPU Tensor / Storage runtime truth should live inside Candle's own Tensor / Storage runtime model, not in a torch_npu-style add-on ownership layer
+
+A3 itself does not finish that NPU-storage convergence. But it must remain consistent with that direction by continuing to centralize Tensor / Storage runtime truth inside Candle-owned runtime objects.
+
+## 4. Problem Statement
+
+The problem A3 addresses is not that Candle lacks a `data` setter. The problem is that Candle still lets the Python shell act as a runtime truth source for shallow metadata replacement.
+
+That creates three risks:
+
+1. **Owner drift risk** — future fixes to `data`-related semantics will keep landing in `_tensor.py`
+2. **Correctness drift risk** — metadata-copy truth can diverge from the Cython-centered runtime model established by A2
+3. **Phase-coupling risk** — later autograd work will inherit an unstable split where some Tensor metadata mutation paths are runtime-owned and others are shell-owned
+
+A3 therefore treats `Tensor.data` as a **runtime-owner convergence problem**, not as a surface API problem.
+
+## 5. Scope
+
+### 5.1 In scope
+
+A3 covers:
+
+- `Tensor.data` setter runtime truth
+- shallow metadata-copy behavior for:
+  - storage
+  - size/shape
+  - stride
+  - storage offset
+  - device cache refresh
+  - dtype cache refresh
+- version-sensitive behavior directly tied to this metadata-copy path, to the extent needed to keep existing Tensor / Storage contract behavior stable
+- narrow contract tests proving the new ownership boundary
+
+### 5.2 Out of scope
+
+A3 must not redesign or substantially modify:
+
+- autograd graph/runtime
+- dispatcher/schema behavior
+- backend-specific execution code
+- view-family redesign
+- `_view_meta` architecture beyond what is strictly needed for `data`-setter correctness
+- Python-side public API shape of `Tensor.data`
+- full PyTorch `set_data` autograd parity across all edge cases
+
+A3 is intentionally about **fact-source migration first**, not full semantic completion of all future autograd-sensitive cases.
+
+## 6. Allowed Files
+
+A3 should primarily modify only:
+
+- `src/candle/_tensor.py`
+- `src/candle/_cython/_tensor_impl.pyx`
+- `src/candle/_cython/_tensor_impl.pxd`
+- narrowly targeted contract tests under `tests/contract/`
+
+Only if strictly necessary for Tensor / Storage-local support:
+
+- `src/candle/_storage.py`
+- `src/candle/_cython/_storage.pyx`
+
+## 7. Forbidden Files
+
+A3 must not modify:
+
+- `src/candle/_dispatch/**`
+- `src/candle/autograd/**`
+- `src/candle/_backends/**`
+- `src/candle/_functional.py`
+
+If A3 appears to require those changes, that is evidence of scope leak and should be deferred to a later batch.
+
+## 8. Design Overview
+
+A3 follows the same owner-convergence rule as A2:
+
+> Tensor runtime metadata truth should live in `TensorImpl`, not in the Python `Tensor` shell.
+
+After A3:
+
+- Python `Tensor.data` remains the public API entry point
+- Python still performs user-facing validation and error reporting
+- Cython `TensorImpl` becomes the fact source for the actual shallow metadata-copy mutation
+
+This mirrors the PyTorch split between public Variable/Tensor surface and `TensorImpl` shallow-copy ownership.
+
+## 9. Runtime Ownership After A3
+
+### 9.1 Python shell responsibilities after A3
+
+Python `Tensor` may still:
+
+- expose the public `data` property and setter
+- validate that the replacement object is a `Tensor`
+- validate user-visible compatibility constraints (shape, dtype, or other currently supported public checks)
+- raise user-facing errors
+
+Python `Tensor` should no longer directly mutate runtime truth for the `data` setter by assigning storage/stride/offset/version fields itself.
+
+### 9.2 Cython responsibilities after A3
+
+`src/candle/_cython/_tensor_impl.pyx` should more clearly own:
+
+- shallow metadata-copy from one tensor runtime object to another
+- storage replacement for the `data` setter path
+- size/stride/storage-offset refresh for that path
+- device/dtype runtime cache refresh tied to that path
+- version-sensitive runtime mutation tied to the same path
+
+### 9.3 Intended Cython helper shape
+
+A3 should introduce one narrow helper in `TensorImpl`, with a name such as:
+
+- `cy_set_data_runtime_truth_from(self, other)`
+
+or
+
+- `cy_shallow_copy_runtime_truth_from(self, other)`
+
+The exact helper name is less important than the ownership rule: the helper should be the single fact source for the runtime mutation.
+
+## 10. Alignment Semantics
+
+### 10.1 PyTorch-aligned conceptual mapping
+
+After A3, Candle's ownership story should read cleanly against PyTorch:
+
+- `detach()` ↔ `shallow_copy_and_detach()`-style runtime truth
+- `data` setter ↔ `shallow_copy_from()`-style runtime truth
+
+A3 does **not** claim full PyTorch implementation parity. It claims the correct **mechanical ownership direction**.
+
+### 10.2 What A3 does not attempt yet
+
+PyTorch's broader `set_data` behavior interacts with autograd-specific constraints and metadata-change policy. A3 does not pull all of that into scope.
+
+Instead, A3 makes one controlled move:
+
+- the Tensor / Storage runtime metadata-copy path stops being shell-owned
+- later autograd batches can refine higher-level semantics on top of a more correct runtime owner boundary
+
+## 11. Version Behavior Rule
+
+A3 must preserve Candle's currently intended contract behavior for the `data` setter unless an existing contract test proves that behavior is already wrong.
+
+In practice, this means:
+
+- no double version bumps
+- no silent loss of version updates
+- no new Python/Cython split where both layers partially own the bump rule
+
+The version-sensitive rule for this path should be expressed in one Cython-centered helper.
+
+## 12. Test Strategy
+
+### 12.1 General principle
+
+Use existing contract tests as the primary rails. Add only focused tests that make the A3 ownership migration observable.
+
+### 12.2 Primary rails
+
+Use existing tests in:
+
+- `tests/contract/test_tensor_storage_owner_contract.py`
+- `tests/contract/test_tensor_alias_version_contract.py`
+
+### 12.3 Required focused coverage
+
+A3 should ensure there is explicit coverage for:
+
+1. `Tensor.data` routing through runtime-owned shallow metadata-copy truth
+2. storage pointer after `data` replacement matching the source tensor
+3. shape / stride / offset after `data` replacement matching the source tensor where the public contract permits it
+4. device / dtype runtime cache remaining correct after the replacement
+5. version behavior remaining single-sourced and stable
+
+If those checks are not already present, add narrow contract tests for them.
+
+### 12.4 A3 validation rails
+
+Before closing A3, run at minimum:
+
+- `tests/contract/test_tensor_storage_owner_contract.py`
+- `tests/contract/test_tensor_alias_version_contract.py`
+- `tests/contract/test_inplace_view_rules.py`
+- `tests/contract/test_storage_contract.py`
+
+## 13. Success Criteria
+
+A3 is complete only when:
+
+1. `src/candle/_tensor.py` no longer directly performs `data`-setter runtime truth mutation by assigning storage/stride/offset/version fields itself
+2. `TensorImpl` is the single fact source for shallow metadata-copy truth on the `data` path
+3. Candle's runtime ownership story maps more cleanly to PyTorch's `shallow_copy_from()` model
+4. A3 validation rails pass
+5. no dispatcher/autograd/backend scope creep is introduced
+
+## 14. Relationship to Later Work
+
+A3 does not finish S1. It prepares later work by removing one more shell-owned metadata mutation path.
+
+In particular:
+
+- later autograd batches can refine `set_data`-adjacent semantics on top of a more stable runtime owner
+- later Tensor residual batches can continue shrinking shell-owned truth only where real runtime ownership still leaks upward
+- later storage-focused S1 work should keep pushing NPU storage toward the same built-in Candle device-storage model used for CUDA, rather than toward a torch_npu-style plugin ownership split
+- later backend/NPU work can rely on a cleaner Tensor / Storage metadata owner boundary
+
+## 15. Final Design Summary
+
+A3 is a narrow Tensor / Storage residual batch that aligns Candle more directly to PyTorch's TensorImpl shallow-copy model.
+
+- it targets `Tensor.data` as the next owner-convergence step
+- it moves shallow metadata-copy runtime truth into Cython `TensorImpl`
+- it keeps Python as the public shell for validation and errors only
+- it uses existing contract tests plus a few focused rails to prove the migration
+- it stays strictly inside S1 Tensor / Storage scope

--- a/src/candle/_cython/_tensor_api.pyx
+++ b/src/candle/_cython/_tensor_api.pyx
@@ -324,10 +324,7 @@ def tensor_set_data(self, new_data):
         raise RuntimeError(f"shape mismatch: expected {self.shape}, got {new_data.shape}")
     if new_data.dtype != self.dtype:
         raise RuntimeError(f"dtype mismatch: expected {self.dtype}, got {new_data.dtype}")
-    self._storage = new_data._storage
-    self.stride = new_data.stride
-    self.offset = new_data.offset
-    self._bump_version()
+    self.cy_set_data_runtime_truth_from(new_data)
 
 
 def tensor_fw_get(self, level):

--- a/src/candle/_cython/_tensor_impl.pxd
+++ b/src/candle/_cython/_tensor_impl.pxd
@@ -58,6 +58,8 @@ cdef class TensorImpl:
         object stride,
         int64_t storage_offset,
     )
+    # Internal helper: callers must already pass a validated Tensor/TensorImpl.
+    # This is not a public validation boundary.
     cpdef object cy_set_data_runtime_truth_from(self, object other)
 
 

--- a/src/candle/_cython/_tensor_impl.pxd
+++ b/src/candle/_cython/_tensor_impl.pxd
@@ -58,6 +58,7 @@ cdef class TensorImpl:
         object stride,
         int64_t storage_offset,
     )
+    cpdef object cy_set_data_runtime_truth_from(self, object other)
 
 
 cdef class _VersionCounterProxy:

--- a/src/candle/_cython/_tensor_impl.pyx
+++ b/src/candle/_cython/_tensor_impl.pyx
@@ -587,11 +587,16 @@ cdef class TensorImpl:
         return self
 
     cpdef object cy_set_data_runtime_truth_from(self, object other):
+        # Internal fast path: callers already validated other as Tensor/TensorImpl.
+        # Keep this helper as a trusted copy boundary rather than re-validating here.
         cdef TensorImpl src = <TensorImpl>other
         self._storage = src._storage
         self._set_shape(src._shape_tuple)
         self._set_stride(src._stride_tuple)
         self._c_offset = src._c_offset
+        # Copy cached runtime metadata directly so set_data_ preserves the source
+        # tensor's already-resolved device/dtype truth without re-deriving it from
+        # Python objects or re-running the broader cy_set_runtime_truth path.
         self._device_type = src._device_type
         self._device_index = src._device_index
         self._device_obj = src._device_obj

--- a/src/candle/_cython/_tensor_impl.pyx
+++ b/src/candle/_cython/_tensor_impl.pyx
@@ -586,6 +586,22 @@ cdef class TensorImpl:
         self._bump_version()
         return self
 
+    cpdef object cy_set_data_runtime_truth_from(self, object other):
+        cdef TensorImpl src = <TensorImpl>other
+        self._storage = src._storage
+        self._set_shape(src._shape_tuple)
+        self._set_stride(src._stride_tuple)
+        self._c_offset = src._c_offset
+        self._device_type = src._device_type
+        self._device_index = src._device_index
+        self._device_obj = src._device_obj
+        self._dtype_code = src._dtype_code
+        self._itemsize = src._itemsize
+        self._dtype_obj = src._dtype_obj
+        self._recompute_dispatch_keys()
+        self._bump_version()
+        return self
+
 
 # -------------------------------------------------------------------
 # Module-level tensor factory functions

--- a/src/candle/_tensor.py
+++ b/src/candle/_tensor.py
@@ -205,14 +205,7 @@ class Tensor(_TensorBase):
             raise RuntimeError(f"shape mismatch: expected {self.shape}, got {new_data.shape}")
         if new_data.dtype != self.dtype:
             raise RuntimeError(f"dtype mismatch: expected {self.dtype}, got {new_data.dtype}")
-        # A2 follow-up note: version-sensitive shell behavior still remains here.
-        # Later Tensor/Storage work should keep shrinking Python-side mutation truth
-        # rather than growing new owner state in `_tensor.py`.
-        # Replace storage
-        self._storage = new_data._storage
-        self.stride = new_data.stride
-        self.offset = new_data.offset
-        self._bump_version()
+        self.cy_set_data_runtime_truth_from(new_data)
 
     @classmethod
     def __torch_function__(cls, func, types, args=(), kwargs=None):

--- a/tests/contract/test_tensor_alias_version_contract.py
+++ b/tests/contract/test_tensor_alias_version_contract.py
@@ -207,6 +207,14 @@ def test_chunk_view_shares_version_counter_with_source():
     view._version_counter.bump()
     assert base._version_counter.value == before_base + 1
 
+# Guards the Python __setitem__ entry point; the direct dispatch path is covered
+# by test_dispatch_setitem_bumps_version_counter_exactly_once below.
+def test_setitem_bumps_version_counter():
+    x = torch.tensor([1.0, 2.0, 3.0])
+    before = x._version_counter.value
+    x[0] = torch.tensor(9.0)
+    assert x._version_counter.value == before + 1
+
 
 def test_data_setter_bumps_version_counter_once():
     x = torch.tensor([1.0, 2.0])

--- a/tests/contract/test_tensor_alias_version_contract.py
+++ b/tests/contract/test_tensor_alias_version_contract.py
@@ -218,12 +218,12 @@ def test_setitem_bumps_version_counter():
 
 def test_data_setter_bumps_version_counter_once():
     x = torch.tensor([1.0, 2.0])
-    y = torch.tensor([3.0, 4.0])
     before = x._version_counter.value
 
-    x.data = y
+    x.data = torch.tensor([3.0, 4.0])
 
     assert x._version_counter.value == before + 1
+    assert x.tolist() == [3.0, 4.0]
 
 
 def test_dispatch_setitem_bumps_version_counter_exactly_once():

--- a/tests/contract/test_tensor_alias_version_contract.py
+++ b/tests/contract/test_tensor_alias_version_contract.py
@@ -208,12 +208,13 @@ def test_chunk_view_shares_version_counter_with_source():
     assert base._version_counter.value == before_base + 1
 
 
-# Guards the Python __setitem__ entry point; the direct dispatch path is covered
-# by test_dispatch_setitem_bumps_version_counter_exactly_once below.
-def test_setitem_bumps_version_counter():
-    x = torch.tensor([1.0, 2.0, 3.0])
+def test_data_setter_bumps_version_counter_once():
+    x = torch.tensor([1.0, 2.0])
+    y = torch.tensor([3.0, 4.0])
     before = x._version_counter.value
-    x[0] = torch.tensor(9.0)
+
+    x.data = y
+
     assert x._version_counter.value == before + 1
 
 

--- a/tests/contract/test_tensor_storage_owner_contract.py
+++ b/tests/contract/test_tensor_storage_owner_contract.py
@@ -31,6 +31,33 @@ def test_tensor_data_setter_still_routes_through_runtime_storage_swap():
     assert x._version_counter.value == before + 1
 
 
+def test_tensor_data_setter_preserves_source_storage_stride_and_offset_truth():
+    x = torch.tensor([1.0, 2.0])
+    z = torch.tensor([9.0, 3.0, 4.0])
+    y = z[1:]
+
+    x.data = y
+
+    assert x.storage().data_ptr() == y.storage().data_ptr()
+    assert x.stride == y.stride
+    assert x.offset == y.offset
+    assert x.tolist() == [3.0, 4.0]
+
+
+def test_tensor_data_setter_preserves_runtime_device_dtype_caches():
+    x = torch.tensor([1.0, 2.0], dtype=torch.float32)
+    y = torch.tensor([3.0, 4.0], dtype=torch.float32)
+
+    before_device = x.device
+    before_dtype = x.dtype
+    x.data = y
+
+    assert x.device == before_device
+    assert x.dtype == before_dtype
+    assert x.device.type == "cpu"
+    assert x.dtype == torch.float32
+
+
 def test_tensor_shell_device_dtype_helpers_preserve_runtime_cache_values():
     x = torch.tensor([1.0, 2.0])
     before_device = x.device

--- a/tests/contract/test_tensor_storage_owner_contract.py
+++ b/tests/contract/test_tensor_storage_owner_contract.py
@@ -48,14 +48,12 @@ def test_tensor_data_setter_preserves_runtime_device_dtype_caches():
     x = torch.tensor([1.0, 2.0], dtype=torch.float32)
     y = torch.tensor([3.0, 4.0], dtype=torch.float32)
 
-    before_device = x.device
-    before_dtype = x.dtype
     x.data = y
 
-    assert x.device == before_device
-    assert x.dtype == before_dtype
-    assert x.device.type == "cpu"
-    assert x.dtype == torch.float32
+    assert x.device == y.device
+    assert x.dtype == y.dtype
+    assert x.device.type == y.device.type == "cpu"
+    assert x.dtype == y.dtype == torch.float32
 
 
 def test_tensor_shell_device_dtype_helpers_preserve_runtime_cache_values():

--- a/tests/contract/test_tensor_storage_owner_contract.py
+++ b/tests/contract/test_tensor_storage_owner_contract.py
@@ -90,6 +90,10 @@ def test_typed_storage_public_api_routes_through_untyped_runtime_owner():
 
 def test_tensor_data_setter_rejects_non_tensor_input_before_runtime_mutation():
     x = torch.tensor([1.0, 2.0])
+    before = x._version_counter.value
 
     with pytest.raises(TypeError, match=r"data must be a Tensor"):
         x.data = [3.0, 4.0]
+
+    assert x.tolist() == [1.0, 2.0]
+    assert x._version_counter.value == before

--- a/tests/contract/test_tensor_storage_owner_contract.py
+++ b/tests/contract/test_tensor_storage_owner_contract.py
@@ -1,3 +1,5 @@
+import pytest
+
 import candle as torch
 
 
@@ -76,7 +78,6 @@ def test_tensor_shell_device_dtype_helpers_preserve_runtime_cache_values():
     assert x.device == before_device
     assert x.dtype == before_dtype
 
-
 def test_typed_storage_public_api_routes_through_untyped_runtime_owner():
     x = torch.tensor([1.0, 2.0])
     storage = x.storage()
@@ -84,3 +85,11 @@ def test_typed_storage_public_api_routes_through_untyped_runtime_owner():
 
     assert storage.data_ptr() == untyped.data_ptr()
     assert storage.device == untyped.device
+
+
+
+def test_tensor_data_setter_rejects_non_tensor_input_before_runtime_mutation():
+    x = torch.tensor([1.0, 2.0])
+
+    with pytest.raises(TypeError, match=r"data must be a Tensor"):
+        x.data = [3.0, 4.0]

--- a/tests/contract/test_tensor_storage_owner_contract.py
+++ b/tests/contract/test_tensor_storage_owner_contract.py
@@ -48,12 +48,23 @@ def test_tensor_data_setter_preserves_runtime_device_dtype_caches():
     x = torch.tensor([1.0, 2.0], dtype=torch.float32)
     y = torch.tensor([3.0, 4.0], dtype=torch.float32)
 
+    x._set_device_from_storage(torch.device("meta"))
+    x._set_dtype_from_storage(torch.float64)
+
+    assert x._device_type != y._device_type
+    assert x._dtype_code != y._dtype_code
+    assert x._itemsize != y._itemsize
+    assert x._dtype_obj != y._dtype_obj
+    assert x._dispatch_keys != y._dispatch_keys
+
     x.data = y
 
-    assert x.device == y.device
-    assert x.dtype == y.dtype
-    assert x.device.type == y.device.type == "cpu"
-    assert x.dtype == y.dtype == torch.float32
+    assert x._device_type == y._device_type
+    assert x._device_index == y._device_index
+    assert x._dtype_code == y._dtype_code
+    assert x._itemsize == y._itemsize
+    assert x._dtype_obj == y._dtype_obj
+    assert x._dispatch_keys == y._dispatch_keys
 
 
 def test_tensor_shell_device_dtype_helpers_preserve_runtime_cache_values():


### PR DESCRIPTION
## Summary
- route the live `Tensor.data` setter path through `TensorImpl` so storage/shape/stride/offset and device/dtype cache truth are single-sourced in Cython
- add focused contract rails for `Tensor.data` storage aliasing, cache refresh, version bump, and rejection-before-mutation behavior
- include the A3 design and implementation plan docs for the source-aligned Tensor/Storage follow-up batch

## Test plan
- [x] `source /opt/miniconda3/etc/profile.d/conda.sh && PYTHONPATH=/home/dndx/lvyufeng/candle/.worktrees/runtime-rebuild-a3/src conda run --no-capture-output -n candle python -m pytest tests/contract/test_tensor_storage_owner_contract.py tests/contract/test_tensor_alias_version_contract.py tests/contract/test_inplace_view_rules.py tests/contract/test_storage_contract.py -v --tb=short`
- [x] `source /opt/miniconda3/etc/profile.d/conda.sh && source /usr/local/Ascend/cann-8.5.0/set_env.sh && PYTHONPATH=/home/dndx/lvyufeng/candle/.worktrees/runtime-rebuild-a3/src conda run --no-capture-output -n candle python -m pytest tests/npu/test_npu_fast_storage.py::test_typed_storage_interface tests/npu/test_npu_fast_storage.py::test_storage_data_ptr_nonzero -v --tb=short`

🤖 Generated with [Claude Code](https://claude.com/claude-code)