### PR TITLE
feat(storage): align storage Python surface with torch/storage.py (B1)

### DIFF
--- a/docs/superpowers/plans/2026-04-14-whole-storage-b1-python-surface-alignment.md
+++ b/docs/superpowers/plans/2026-04-14-whole-storage-b1-python-surface-alignment.md
@@ -1,0 +1,642 @@
+# Whole Storage Batch B1 Python Surface Alignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Align Candle’s Python storage surface to `torch/storage.py` while keeping the whole-storage-mechanism architecture in view, removing private CPU storage implementation classes and bookkeeping helpers from `candle._storage` without breaking serialization, multiprocessing, or built-in CPU/CUDA/NPU storage entry points.
+
+**Architecture:** This is the first implementation batch derived from the whole-storage-mechanism v2 master spec. It focuses on the Python storage boundary only: `candle._storage` should look more like a public shell, while private CPU implementation classes and bookkeeping helpers move behind the runtime/helper boundary in `_cython/_storage.pyx`. The batch also preserves the built-in device-storage story by keeping CPU/CUDA/NPU public factories available and by keeping multiprocessing/serialization behavior working through internal imports rather than public-shell leakage.
+
+**Tech Stack:** Python, Cython, pytest, Candle Storage runtime
+
+---
+
+## File Structure / Responsibilities
+
+- `src/candle/_storage.py` — public Python storage shell; after B1 it should expose storage API and factories, not private CPU implementation classes or bookkeeping helpers
+- `src/candle/_cython/_storage.pyx` — private storage helper/runtime layer; receives the moved CPU untyped storage classes and bookkeeping helpers
+- `src/candle/serialization.py` — internal storage rebuild consumer; must stop importing private CPU storage classes from `candle._storage`
+- `src/candle/multiprocessing/reductions.py` — internal reduction/rebuild consumer; must stop importing private CPU storage classes from `candle._storage`
+- `src/candle/multiprocessing/__init__.py` — public multiprocessing surface; may continue to expose `cleanup_shared_files()` / `shared_files_count()` while importing them from the private helper layer
+- `tests/contract/test_storage_contract.py` — primary storage public-surface regression rail
+- `tests/contract/test_tensor_storage_owner_contract.py` — owner-boundary regression rail for storage-related Tensor behavior
+- `docs/superpowers/specs/2026-04-14-whole-storage-mechanism-realignment-master-design.md` — v2 master spec that defines the whole storage target
+
+---
+
+### Task 1: Add whole-storage B1 public-surface rails
+
+**Files:**
+- Modify: `tests/contract/test_storage_contract.py`
+- Modify: `tests/contract/test_tensor_storage_owner_contract.py`
+- Reference: `src/candle/_storage.py:1-220`
+- Reference: `src/candle/multiprocessing/__init__.py:1-55`
+
+- [ ] **Step 1: Add non-exposure and public-entry rails to the storage contract file**
+
+Append these tests to `tests/contract/test_storage_contract.py`:
+
+```python
+import candle._storage as candle_storage
+```
+
+```python
+def test_storage_module_does_not_expose_shared_file_bookkeeping_helpers():
+    helper_names = {
+        "_register_shared_file",
+        "_unregister_shared_file",
+        "_cleanup_shared_file",
+        "_close_fd_and_cleanup",
+        "cleanup_shared_files",
+        "shared_files_count",
+    }
+
+    exported = {name for name in helper_names if hasattr(candle_storage, name)}
+
+    assert exported == set()
+```
+
+```python
+def test_storage_module_still_exposes_public_storage_entry_points():
+    public_names = {
+        "TypedStorage",
+        "UntypedStorage",
+        "typed_storage_from_numpy",
+        "empty_cpu_typed_storage",
+        "meta_typed_storage_from_shape",
+        "npu_typed_storage_from_ptr",
+        "pinned_cpu_typed_storage_from_numpy",
+    }
+
+    exported = {name for name in public_names if hasattr(candle_storage, name)}
+
+    assert exported == public_names
+```
+
+```python
+def test_storage_module_does_not_expose_private_untyped_storage_classes():
+    assert not hasattr(candle_storage, "_PinnedCPUUntypedStorage")
+    assert not hasattr(candle_storage, "_CPUUntypedStorage")
+```
+
+```python
+def test_multiprocessing_storage_bookkeeping_surface_still_exists():
+    import candle.multiprocessing as candle_mp
+
+    assert callable(candle_mp.cleanup_shared_files)
+    assert callable(candle_mp.shared_files_count)
+```
+
+- [ ] **Step 2: Add the narrow pinned-factory availability rail**
+
+Append this test to `tests/contract/test_tensor_storage_owner_contract.py`:
+
+```python
+def test_public_pinned_storage_factory_still_exists():
+    import candle._storage as candle_storage
+
+    assert hasattr(candle_storage, "pinned_cpu_typed_storage_from_numpy")
+```
+
+- [ ] **Step 3: Run the new B1 rails to verify the baseline**
+
+Run:
+```bash
+source /opt/miniconda3/etc/profile.d/conda.sh && PYTHONPATH=/home/dndx/lvyufeng/candle/.worktrees/runtime-rebuild-a3/src \
+  conda run --no-capture-output -n candle python -m pytest \
+  tests/contract/test_storage_contract.py::test_storage_module_does_not_expose_shared_file_bookkeeping_helpers \
+  tests/contract/test_storage_contract.py::test_storage_module_still_exposes_public_storage_entry_points \
+  tests/contract/test_storage_contract.py::test_storage_module_does_not_expose_private_untyped_storage_classes \
+  tests/contract/test_storage_contract.py::test_multiprocessing_storage_bookkeeping_surface_still_exists \
+  tests/contract/test_tensor_storage_owner_contract.py::test_public_pinned_storage_factory_still_exists \
+  -v --tb=short
+```
+
+Expected:
+- the public-entry and multiprocessing-surface rails pass
+- the helper/class non-exposure rails fail before implementation
+
+- [ ] **Step 4: Commit the B1 failing rails**
+
+```bash
+git add tests/contract/test_storage_contract.py tests/contract/test_tensor_storage_owner_contract.py
+git commit -m "test(storage): add B1 whole-storage surface rails"
+```
+
+---
+
+### Task 2: Move CPU untyped implementation classes behind the helper layer
+
+**Files:**
+- Modify: `src/candle/_storage.py`
+- Modify: `src/candle/_cython/_storage.pyx`
+- Modify: `src/candle/serialization.py`
+- Modify: `src/candle/multiprocessing/reductions.py`
+- Test: `tests/contract/test_storage_contract.py`
+- Test: `tests/contract/test_tensor_storage_owner_contract.py`
+
+- [ ] **Step 1: Add the CPU untyped storage helper classes to `_cython/_storage.pyx`**
+
+At the top of `src/candle/_cython/_storage.pyx`, add the imports needed for the moved CPU helper classes:
+
+```python
+import ctypes
+import mmap
+import os
+import tempfile
+import threading
+import weakref
+
+import numpy as np
+```
+
+Then add these helper classes below the shared-file bookkeeping helpers section:
+
+```python
+class CyPinnedCPUUntypedStorage:
+    def __init__(self, array, ptr, filename=None, shared=False, device=None):
+        from candle._device import device as Device
+        from candle._backends.npu import runtime as npu_runtime
+
+        self.device = device or Device("cpu")
+        self._array = array
+        self._shared = shared
+        self._filename = filename
+        self._ptr = int(ptr)
+        self._finalizer = weakref.finalize(self, npu_runtime.free_host, self._ptr)
+
+    def nbytes(self):
+        return int(self._array.nbytes)
+
+    def data_ptr(self):
+        return int(self._array.ctypes.data)
+
+    def buffer(self):
+        return self._array
+
+    def resize_(self, new_nbytes):
+        raise NotImplementedError("pinned storage cannot resize")
+
+    def share_memory_(self):
+        self._shared = True
+        return self
+
+    def is_shared(self):
+        return self._shared
+
+    def is_pinned(self):
+        return True
+
+    @classmethod
+    def from_file(cls, filename, shared=False):
+        data = np.memmap(filename, mode="r+", dtype=np.uint8)
+        return cls(data, int(data.ctypes.data), filename=filename, shared=shared)
+
+    def filename(self):
+        return self._filename
+```
+
+```python
+class CyCPUUntypedStorage:
+    def __init__(
+        self,
+        array,
+        filename=None,
+        shared=False,
+        device=None,
+        mmap_obj=None,
+        fd=None,
+        tmp_file=None,
+        sharing_mechanism=None,
+        cleanup_finalizer=None,
+    ):
+        from candle._device import device as Device
+
+        self.device = device or Device("cpu")
+        self._array = array
+        self._shared = shared
+        self._filename = filename
+        self._mmap = mmap_obj
+        self._fd = fd
+        self._tmp_file = tmp_file
+        self._sharing_mechanism = sharing_mechanism
+        self._cleanup_finalizer = cleanup_finalizer
+
+    def nbytes(self):
+        return int(self._array.nbytes)
+
+    def data_ptr(self):
+        return int(self._array.ctypes.data)
+
+    def buffer(self):
+        return self._array
+
+    def resize_(self, new_nbytes):
+        if self._filename is not None or self._shared:
+            raise RuntimeError("Trying to resize storage that is not resizable")
+        new_array = np.empty(int(new_nbytes), dtype=np.uint8)
+        old_bytes = self._array.view(np.uint8)
+        copy_bytes = min(old_bytes.size, new_array.size)
+        new_array[:copy_bytes] = old_bytes[:copy_bytes]
+        self._array = new_array
+        return self
+
+    def share_memory_(self, strategy="file_descriptor"):
+        if self._shared:
+            return self
+
+        nbytes = int(self._array.nbytes)
+        if nbytes == 0:
+            self._shared = True
+            self._sharing_mechanism = strategy
+            return self
+
+        if strategy == "file_descriptor":
+            fd, filename = tempfile.mkstemp(prefix="candle_fd_", suffix=".bin")
+            try:
+                os.ftruncate(fd, nbytes)
+                mm = mmap.mmap(fd, nbytes)
+            except Exception:
+                os.close(fd)
+                raise
+
+            dst = np.frombuffer(mm, dtype=np.uint8, count=nbytes)
+            dst[:] = self._array.view(np.uint8).reshape(-1)
+
+            self._array = dst
+            self._mmap = mm
+            self._fd = fd
+            self._tmp_file = filename
+            self._filename = filename
+            self._shared = True
+            self._sharing_mechanism = "file_descriptor"
+
+            if self._cleanup_finalizer is not None:
+                self._cleanup_finalizer.detach()
+            self._cleanup_finalizer = weakref.finalize(
+                self,
+                cy_cleanup_shared_resource,
+                int(fd),
+                filename,
+            )
+            return self
+
+        if strategy == "file_system":
+            fd, filename = tempfile.mkstemp(prefix="candle_shm_", suffix=".bin")
+            try:
+                with open(fd, "wb", closefd=False) as f:
+                    f.truncate(nbytes)
+            finally:
+                os.close(fd)
+
+            mmap_arr = np.memmap(filename, mode="r+", dtype=np.uint8, shape=(nbytes,))
+            mmap_arr[:] = self._array.view(np.uint8).reshape(-1)
+
+            self._array = mmap_arr
+            self._filename = filename
+            self._shared = True
+            self._sharing_mechanism = "file_system"
+            cy_register_shared_file(filename)
+
+            if self._cleanup_finalizer is not None:
+                self._cleanup_finalizer.detach()
+            self._cleanup_finalizer = None
+            return self
+
+        raise ValueError(f"unsupported sharing strategy: {strategy}")
+
+    def is_shared(self):
+        return self._shared
+
+    def shared_memory_meta(self):
+        if self._sharing_mechanism == "file_descriptor":
+            return {
+                "mechanism": "file_descriptor",
+                "fd": int(self._fd),
+                "filename": self._filename,
+                "nbytes": int(self._array.nbytes),
+            }
+        if self._sharing_mechanism == "file_system":
+            return {
+                "mechanism": "file_system",
+                "filename": self._filename,
+                "nbytes": int(self._array.nbytes),
+            }
+        return None
+
+    def typed_view(self, dtype, size):
+        from candle._dtype import to_numpy_dtype
+        return np.frombuffer(self._array, dtype=to_numpy_dtype(dtype), count=int(size))
+
+    @classmethod
+    def from_shared_memory(cls, filename, nbytes):
+        data = np.memmap(filename, mode="r+", dtype=np.uint8, shape=(int(nbytes),))
+        cy_register_shared_file(filename)
+        return cls(data, filename=filename, shared=True, sharing_mechanism="file_system")
+
+    @classmethod
+    def from_shared_fd(cls, fd, nbytes, filename=None):
+        fd = int(fd)
+        mm = mmap.mmap(fd, int(nbytes))
+        arr = np.frombuffer(mm, dtype=np.uint8, count=int(nbytes))
+        storage = cls(
+            arr,
+            filename=filename,
+            shared=True,
+            mmap_obj=mm,
+            fd=fd,
+            tmp_file=filename,
+            sharing_mechanism="file_descriptor",
+        )
+        storage._cleanup_finalizer = weakref.finalize(
+            storage,
+            cy_cleanup_shared_resource,
+            fd,
+            filename,
+        )
+        return storage
+
+    @classmethod
+    def from_file(cls, filename, shared=False):
+        data = np.memmap(filename, mode="r+", dtype=np.uint8)
+        return cls(data, filename=filename, shared=shared)
+
+    def filename(self):
+        return self._filename
+```
+
+- [ ] **Step 2: Verify the new non-exposure rails fail before `_storage.py` is updated**
+
+Run:
+```bash
+source /opt/miniconda3/etc/profile.d/conda.sh && PYTHONPATH=/home/dndx/lvyufeng/candle/.worktrees/runtime-rebuild-a3/src \
+  conda run --no-capture-output -n candle python -m pytest \
+  tests/contract/test_storage_contract.py::test_storage_module_does_not_expose_private_untyped_storage_classes \
+  tests/contract/test_tensor_storage_owner_contract.py::test_public_pinned_storage_factory_still_exists \
+  -v --tb=short
+```
+
+Expected:
+- private-class non-exposure rail still FAILS before the `_storage.py` public-shell cleanup
+- pinned factory rail PASSES
+
+- [ ] **Step 3: Replace the private CPU class definitions in `_storage.py` with private Cython imports**
+
+In `src/candle/_storage.py`, add these imports near the top:
+
+```python
+from ._cython._storage import (  # pylint: disable=import-error,no-name-in-module
+    CyCPUUntypedStorage,
+    CyPinnedCPUUntypedStorage,
+    cy_cleanup_shared_files as _cy_cleanup_shared_files,
+    cy_cleanup_shared_resource as _cy_cleanup_shared_resource,
+    cy_register_shared_file as _cy_register_shared_file,
+)
+```
+
+Then remove the entire definitions of:
+
+```python
+class _PinnedCPUUntypedStorage(UntypedStorage):
+    ...
+
+class _CPUUntypedStorage(UntypedStorage):
+    ...
+```
+
+Replace all remaining private uses in `_storage.py` as follows:
+
+```python
+return CyCPUUntypedStorage(self.buffer()[index], filename=None, shared=self._shared, device=self.device)
+```
+
+```python
+return CyCPUUntypedStorage.from_file(filename, shared=shared)
+```
+
+```python
+untyped = CyPinnedCPUUntypedStorage(raw, host_ptr, device=device)
+```
+
+```python
+untyped = CyCPUUntypedStorage(arr.view(np.uint8), device=device)
+```
+
+- [ ] **Step 4: Update internal consumers to import the private CPU helper class from `_cython._storage`**
+
+In `src/candle/serialization.py`, replace:
+
+```python
+from ._storage import TypedStorage, _CPUUntypedStorage, typed_storage_from_numpy
+```
+
+with:
+
+```python
+from ._cython._storage import CyCPUUntypedStorage  # pylint: disable=import-error,no-name-in-module
+from ._storage import TypedStorage, typed_storage_from_numpy
+```
+
+And replace the call sites:
+
+```python
+_CPUUntypedStorage.from_shared_memory(...)
+_CPUUntypedStorage.from_shared_fd(...)
+```
+
+with:
+
+```python
+CyCPUUntypedStorage.from_shared_memory(...)
+CyCPUUntypedStorage.from_shared_fd(...)
+```
+
+In `src/candle/multiprocessing/reductions.py`, replace:
+
+```python
+from .._storage import _CPUUntypedStorage, TypedStorage
+```
+
+with:
+
+```python
+from .._cython._storage import CyCPUUntypedStorage  # pylint: disable=import-error,no-name-in-module
+from .._storage import TypedStorage
+```
+
+And replace these uses:
+
+```python
+return _CPUUntypedStorage.from_shared_memory(...)
+return _CPUUntypedStorage.from_shared_fd(...)
+if isinstance(untyped, _CPUUntypedStorage):
+reduction.register(_CPUUntypedStorage, _reduce_cpu_storage)
+```
+
+with:
+
+```python
+return CyCPUUntypedStorage.from_shared_memory(...)
+return CyCPUUntypedStorage.from_shared_fd(...)
+if isinstance(untyped, CyCPUUntypedStorage):
+reduction.register(CyCPUUntypedStorage, _reduce_cpu_storage)
+```
+
+- [ ] **Step 5: Rebuild extensions and run the focused B1 rails**
+
+Run:
+```bash
+cd /home/dndx/lvyufeng/candle/.worktrees/runtime-rebuild-a3 && \
+source /opt/miniconda3/etc/profile.d/conda.sh && \
+PYTHONPATH=/home/dndx/lvyufeng/candle/.worktrees/runtime-rebuild-a3/src \
+conda run --no-capture-output -n candle python setup.py build_ext --inplace
+```
+
+Then run:
+```bash
+source /opt/miniconda3/etc/profile.d/conda.sh && PYTHONPATH=/home/dndx/lvyufeng/candle/.worktrees/runtime-rebuild-a3/src \
+  conda run --no-capture-output -n candle python -m pytest \
+  tests/contract/test_storage_contract.py::test_storage_module_does_not_expose_private_untyped_storage_classes \
+  tests/contract/test_tensor_storage_owner_contract.py::test_public_pinned_storage_factory_still_exists \
+  -v --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run one internal-consumer smoke check**
+
+Run:
+```bash
+source /opt/miniconda3/etc/profile.d/conda.sh && PYTHONPATH=/home/dndx/lvyufeng/candle/.worktrees/runtime-rebuild-a3/src \
+  conda run --no-capture-output -n candle python - <<'PY'
+import candle.serialization
+import candle.multiprocessing.reductions
+print("ok")
+PY
+```
+
+Expected: prints `ok`.
+
+- [ ] **Step 7: Commit the CPU private-class downshift**
+
+```bash
+git add src/candle/_storage.py src/candle/_cython/_storage.pyx src/candle/serialization.py src/candle/multiprocessing/reductions.py tests/contract/test_storage_contract.py tests/contract/test_tensor_storage_owner_contract.py
+git commit -m "refactor(storage): move pinned host storage internals out of shell"
+```
+
+---
+
+### Task 3: Preserve multiprocessing bookkeeping API while keeping `_storage.py` clean
+
+**Files:**
+- Modify: `src/candle/multiprocessing/__init__.py`
+- Modify: `src/candle/_storage.py`
+- Modify: `src/candle/_cython/_storage.pyx`
+- Test: `tests/contract/test_storage_contract.py`
+
+- [ ] **Step 1: Add a focused multiprocessing API rail if missing**
+
+If not already present from Task 1, ensure `tests/contract/test_storage_contract.py` contains:
+
+```python
+def test_multiprocessing_storage_bookkeeping_surface_still_exists():
+    import candle.multiprocessing as candle_mp
+
+    assert callable(candle_mp.cleanup_shared_files)
+    assert callable(candle_mp.shared_files_count)
+```
+
+- [ ] **Step 2: Keep multiprocessing importing bookkeeping from the private helper layer**
+
+In `src/candle/multiprocessing/__init__.py`, ensure the import is:
+
+```python
+from .._cython._storage import (  # pylint: disable=import-error,no-name-in-module
+    cy_cleanup_shared_files as _cleanup_shared_files,
+    cy_shared_files_count as _shared_files_count,
+)
+```
+
+and **not** from `.._storage`.
+
+- [ ] **Step 3: Re-run the bookkeeping surface tests**
+
+Run:
+```bash
+source /opt/miniconda3/etc/profile.d/conda.sh && PYTHONPATH=/home/dndx/lvyufeng/candle/.worktrees/runtime-rebuild-a3/src \
+  conda run --no-capture-output -n candle python -m pytest \
+  tests/contract/test_storage_contract.py::test_storage_module_does_not_expose_shared_file_bookkeeping_helpers \
+  tests/contract/test_storage_contract.py::test_multiprocessing_storage_bookkeeping_surface_still_exists \
+  -v --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit the multiprocessing surface preservation if it required any additional change**
+
+```bash
+git add src/candle/multiprocessing/__init__.py src/candle/_storage.py src/candle/_cython/_storage.pyx tests/contract/test_storage_contract.py
+git commit -m "refactor(storage): preserve multiprocessing bookkeeping api"
+```
+
+If no code change was required in this task because Task 2 already landed the exact final form, skip this commit step.
+
+---
+
+### Task 4: Validate whole-storage B1 and preserve built-in storage surface
+
+**Files:**
+- Validate: `tests/contract/test_storage_contract.py`
+- Validate: `tests/contract/test_tensor_storage_owner_contract.py`
+- Validate: `src/candle/serialization.py`
+- Validate: `src/candle/multiprocessing/reductions.py`
+- Validate: `src/candle/multiprocessing/__init__.py`
+
+- [ ] **Step 1: Run the full whole-storage B1 validation rails**
+
+Run:
+```bash
+source /opt/miniconda3/etc/profile.d/conda.sh && PYTHONPATH=/home/dndx/lvyufeng/candle/.worktrees/runtime-rebuild-a3/src \
+  conda run --no-capture-output -n candle python -m pytest \
+  tests/contract/test_storage_contract.py \
+  tests/contract/test_tensor_storage_owner_contract.py \
+  -v --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run focused import smoke checks for the moved private CPU helpers**
+
+Run:
+```bash
+source /opt/miniconda3/etc/profile.d/conda.sh && PYTHONPATH=/home/dndx/lvyufeng/candle/.worktrees/runtime-rebuild-a3/src \
+  conda run --no-capture-output -n candle python - <<'PY'
+import candle.serialization
+import candle.multiprocessing
+import candle.multiprocessing.reductions
+print("storage-b1-ok")
+PY
+```
+
+Expected: prints `storage-b1-ok`.
+
+- [ ] **Step 3: Review the final diff against the whole-storage B1 goal**
+
+Manually verify the diff satisfies all of these checks:
+
+```text
+- src/candle/_storage.py is closer in role to torch/storage.py than before
+- candle._storage no longer exposes shared-file bookkeeping helpers
+- candle._storage no longer exposes _PinnedCPUUntypedStorage or _CPUUntypedStorage
+- public storage factories and entry points remain available, including pinned_cpu_typed_storage_from_numpy and npu_typed_storage_from_ptr
+- serialization and multiprocessing reductions no longer depend on importing private CPU storage classes from candle._storage
+- candle.multiprocessing still exposes cleanup_shared_files() and shared_files_count()
+- no dispatcher / autograd / backend scope creep was introduced
+- NPU remains part of the built-in storage surface story, not a plugin-only afterthought
+```
+
+- [ ] **Step 4: Commit the validated whole-storage B1 batch**
+
+```bash
+git add src/candle/_storage.py src/candle/_cython/_storage.pyx src/candle/serialization.py src/candle/multiprocessing/reductions.py src/candle/multiprocessing/__init__.py tests/contract/test_storage_contract.py tests/contract/test_tensor_storage_owner_contract.py
+git commit -m "refactor(storage): align python storage surface with torch"
+```

--- a/docs/superpowers/specs/2026-04-14-whole-storage-mechanism-realignment-master-design.md
+++ b/docs/superpowers/specs/2026-04-14-whole-storage-mechanism-realignment-master-design.md
@@ -1,0 +1,401 @@
+# Whole Storage Mechanism Realignment Master Design
+
+Date: 2026-04-14
+Status: Drafted after storage mechanism re-scope
+Parent spec: `docs/superpowers/specs/2026-04-13-candle-runtime-rebuild-design.md`
+Replaces narrower storage master direction: `docs/superpowers/specs/2026-04-14-storage-runtime-realignment-master-design.md`
+
+## 1. Master Spec Definition
+
+- **Subsystem:** S1 Tensor / Storage runtime core
+- **Primary focus:** whole Storage mechanism
+- **Spec type:** master spec, not a single implementation batch
+- **Purpose:** define Candle’s full Storage alignment target across Python surface, runtime owner model, sharing/serialization behavior, and built-in device storage specialization for CPU / CUDA / NPU
+
+This spec is intentionally broader than the earlier storage-surface-first direction. It exists because the user wants the **whole storage mechanism** aligned, not only `_storage.py` cleanup, and explicitly wants NPU storage included in the target architecture from the start.
+
+This document does **not** require implementation in one uninterrupted batch. It requires that the final target be written down in one coherent place before more storage work continues.
+
+## 2. Why This Spec Exists
+
+A1-A3 improved Tensor / Storage convergence, especially on the Tensor side:
+
+- A1 defined Tensor / Storage ownership boundaries
+- A2 moved important version-sensitive and view-sensitive Tensor runtime truth into `TensorImpl`
+- A3 moved `Tensor.data` runtime truth onto the Cython-backed runtime path
+
+But the next structural problem is larger than a single residual Tensor path.
+
+The project still lacks a fully specified answer to:
+
+- what Candle’s Storage Python surface should look like
+- what Candle’s real Storage owner model should be
+- how sharing / serialization / multiprocessing should attach to Storage ownership
+- how CPU / CUDA / NPU storage should fit into one built-in Candle storage architecture
+
+Without that, further work risks drifting into:
+
+- Python-shell-heavy storage logic
+- CPU-first designs that later treat CUDA/NPU as special exceptions
+- NPU designs that mimic torch_npu plugin layering instead of a built-in Candle storage model
+- Tensor follow-up work built on unstable storage boundaries
+
+This spec exists to stop that drift.
+
+## 3. Source Alignment Basis
+
+### 3.1 `torch/storage.py` — Python storage surface reference
+
+PyTorch’s `torch/storage.py` is the primary reference for Candle’s Python storage surface.
+
+It establishes the public Python-visible storage layer:
+
+- `_StorageBase`
+- `UntypedStorage`
+- `TypedStorage`
+- Python-visible repr / conversion / wrapper behavior
+- public methods such as `cpu()`, `cuda()`, `share_memory_()`, `to()`, `clone()`, and typed/untyped accessors
+
+The key lesson is not that Candle must copy every exact symbol or implementation detail. The key lesson is that the Python storage file has a **constrained public-shell role**.
+
+It is not the final owner of storage runtime truth.
+
+### 3.2 `c10/core/StorageImpl.h` — runtime owner model reference
+
+PyTorch’s actual storage owner model is defined at the `StorageImpl` layer.
+
+That layer directly owns or defines:
+
+- backing `DataPtr`
+- allocator attachment
+- device type / device placement
+- `nbytes`
+- resizable state
+- mutable pointer access rules
+- storage identity semantics
+
+The key architectural lesson is:
+
+> aligning to PyTorch storage requires more than matching `torch/storage.py`; it requires a runtime owner model that is structurally compatible with `StorageImpl`-style truth.
+
+### 3.3 PyTorch sharing / serialization / reductions paths
+
+PyTorch storage behavior is not fully captured by Python classes alone.
+
+Storage sharing, multiprocessing reductions, rebuild paths, and serialization all rely on storage identity and owner metadata. That means Candle’s storage target cannot be correct unless it also defines how Storage participates in:
+
+- `share_memory_`
+- multiprocessing reductions / rebuild
+- serialization / checkpoint rebuild
+- typed/untyped storage reconstruction
+
+### 3.4 torch_npu — runtime ownership direction only
+
+torch_npu is a secondary reference for **runtime ownership direction**, not for overall architecture.
+
+The important lesson from torch_npu is that NPU storage is still built on a storage-owner concept (`NPUStorageImpl : StorageImpl`) rather than being an unrelated external data wrapper.
+
+That means the right Candle conclusion is:
+
+- NPU storage must live inside Candle’s own storage architecture
+- torch_npu behavior and native ownership are useful references
+- torch_npu’s plugin-style position is **not** Candle’s target architecture
+
+### 3.5 Architectural rule for Candle
+
+Candle’s long-term rule is:
+
+- CPU / CUDA / NPU storage all belong to one Candle-owned storage mechanism
+- device-specific behavior may differ by backend/runtime implementation
+- but they must fit the same owner model and surface boundary story
+- NPU storage is a built-in device specialization, not a plugin-owned side channel
+
+## 4. Problem Statement
+
+The storage problem is not simply that `_storage.py` contains too much code. The problem has four coupled layers.
+
+### 4.1 Python-surface drift
+
+`src/candle/_storage.py` currently mixes together:
+
+- public storage API surface
+- lifecycle helpers
+- sharing bookkeeping
+- pinned host lifetime behavior
+- device-specific storage details
+- typed/untyped runtime glue
+
+That is broader than the role PyTorch gives `torch/storage.py`.
+
+### 4.2 Runtime-owner drift
+
+Candle does not yet have a fully clarified storage owner model equivalent in role to `StorageImpl`.
+
+That means there is not yet one stable fact source for:
+
+- pointer ownership
+- allocation lifetime
+- resizable behavior
+- device placement truth
+- storage identity semantics
+- typed/untyped backing linkage
+
+### 4.3 device-architecture drift
+
+Without a full mechanism spec, storage design can drift into a fragmented model:
+
+- CPU storage treated as the “real” storage path
+- CUDA storage treated as a special backend path
+- NPU storage treated as a plugin-like or add-on path
+
+That is specifically not the target architecture.
+
+### 4.4 Tensor-coupling drift
+
+Further Tensor convergence depends on Storage boundaries being stable.
+
+If Storage architecture remains underspecified, later Tensor shell reduction will keep inheriting unstable assumptions about ownership and rebuild semantics.
+
+## 5. Scope
+
+### 5.1 In scope
+
+This master spec defines the target architecture for the whole Storage mechanism, including:
+
+- Python storage public surface responsibilities
+- runtime storage owner model
+- typed/untyped storage role boundaries
+- pointer / lifetime / allocator / device-placement truth
+- storage sharing / multiprocessing / serialization participation
+- built-in device storage unification across CPU / CUDA / NPU
+- the dependency relationship between Storage convergence and later Tensor shell reduction
+- decomposition into later implementation batches
+
+### 5.2 Out of scope
+
+This master spec does not itself implement or redesign:
+
+- dispatcher/schema behavior
+- autograd graph/runtime
+- backend kernel implementations unrelated to storage architecture
+- the full later Tensor shell convergence work
+
+This document defines the whole storage target and the downstream handoff, but remains a Storage-first architecture spec.
+
+## 6. Target Architecture
+
+### 6.1 Python storage surface target
+
+`src/candle/_storage.py` should converge toward the role played by `torch/storage.py`.
+
+That means it may continue to provide:
+
+- public storage classes and user-facing entry points
+- Python-visible repr / convenience methods
+- public wrapper methods genuinely part of the storage API
+- thin wrappers around runtime-owned storage state
+
+It should stop being the place where long-term storage owner truth is established.
+
+### 6.2 Runtime storage owner target
+
+Candle needs a stable storage runtime owner layer that plays the same architectural role that `StorageImpl` plays in PyTorch.
+
+That owner layer should carry or define the actual truth for:
+
+- backing pointer ownership
+- allocation lifetime
+- allocator attachment
+- `nbytes`
+- resizable state
+- device placement
+- storage identity semantics
+- typed/untyped linkage truth
+- share / rebuild relevant owner metadata
+
+Python storage wrappers may expose that behavior, but should not remain the primary fact source for it.
+
+### 6.3 Typed / untyped storage target
+
+Candle should preserve a user-visible distinction between typed and untyped storage only where that distinction is meaningfully part of the PyTorch-compatible API.
+
+But the runtime truth for typed/untyped linkage should not rely on Python wrappers inventing or maintaining that ownership relationship.
+
+The target is:
+
+- Python wrappers expose the public distinction
+- runtime owners define the actual backing relationship
+
+### 6.4 Sharing / serialization target
+
+Storage sharing and storage serialization must be treated as first-class parts of the storage mechanism.
+
+That means Candle’s storage architecture must define how storage owner truth participates in:
+
+- `share_memory_`
+- shared-memory bookkeeping
+- multiprocessing reductions / rebuild
+- serialization / checkpoint rebuild
+- typed storage reconstruction from untyped backing
+
+These behaviors must be built on the same storage owner model, not on a separate ad hoc Python-only layer.
+
+### 6.5 Built-in device storage target
+
+Candle’s storage architecture should converge on one rule across device types:
+
+- CPU storage is a built-in storage specialization
+- CUDA storage is a built-in storage specialization
+- NPU storage is a built-in storage specialization
+
+This does **not** mean the implementations are identical.
+
+It means all three belong to the same storage mechanism and owner model.
+
+NPU is therefore not a plugin-owned storage architecture. It is a Candle-owned storage specialization that uses NPU-specific runtime behavior internally.
+
+## 7. Required Boundary Rules
+
+### 7.1 Rule: Python exposes, runtime owns
+
+Whenever storage behavior is runtime-sensitive, the default rule should be:
+
+> Python exposes the API; runtime/Cython owns the truth.
+
+### 7.2 Rule: no new owner truth in `_storage.py`
+
+Future storage work must not add new lifecycle-sensitive owner logic to `_storage.py` unless PyTorch clearly keeps equivalent logic at the Python storage layer.
+
+### 7.3 Rule: one storage architecture, many device specializations
+
+Candle must not evolve separate storage architectures for CPU / CUDA / NPU.
+
+It may evolve device-specialized implementations, but they must belong to one unified built-in storage mechanism.
+
+### 7.4 Rule: NPU is built-in, not plugin storage
+
+Future NPU storage work must not introduce or preserve a plugin-owned architectural split.
+
+Using torch_npu as a runtime behavior and ownership reference is allowed.
+
+Using torch_npu’s plugin position as Candle’s architecture target is not allowed.
+
+### 7.5 Rule: Tensor follows Storage
+
+Further Tensor shell reduction should be built on a stabilized storage architecture.
+
+Storage boundary work is therefore upstream of later Tensor residual batches.
+
+## 8. Decomposition Into Future Implementation Batches
+
+This master spec is intended to feed multiple implementation batches.
+
+### 8.1 Batch B1: Python storage surface alignment
+
+Purpose:
+
+- align `src/candle/_storage.py` more closely to `torch/storage.py`
+- reduce Python-shell lifecycle and bookkeeping exposure
+- preserve only the public Python storage surface that Candle should continue exposing
+
+### 8.2 Batch B2: storage owner core alignment
+
+Purpose:
+
+- define and migrate toward a clearer Candle storage owner model aligned in role to `StorageImpl`
+- stabilize pointer / lifetime / allocator / resizable / device truth
+- reduce Python-layer owner truth around typed/untyped backing
+
+### 8.3 Batch B3: sharing / serialization / reduction alignment
+
+Purpose:
+
+- unify storage sharing and rebuild behavior under the storage owner model
+- align multiprocessing reductions and serialization rebuild paths with the new owner truth
+- eliminate ad hoc Python-only storage lifecycle assumptions
+
+### 8.4 Batch B4: built-in device storage unification
+
+Purpose:
+
+- make the Candle-owned storage model explicitly uniform across CPU / CUDA / NPU
+- ensure NPU storage follows the same built-in storage architecture class as CUDA storage
+- push any remaining plugin-style drift out of the storage layer
+
+### 8.5 Tensor handoff batch
+
+Once the first storage batches land, later Tensor residual work can continue shrinking `_tensor.py` and related shell-level logic on top of the stabilized storage boundary.
+
+## 9. Relationship to Tensor Work
+
+This spec does not make Tensor the implementation target of the next batch.
+
+Instead, it establishes the ordering rule:
+
+1. define the whole storage target first
+2. land storage batches on top of that target
+3. continue Tensor shell convergence after Storage architecture stabilizes
+
+So the relationship is explicit:
+
+- Storage-first in architecture
+- Tensor-next in residual shell reduction
+
+## 10. Testing Strategy
+
+### 10.1 General principle
+
+Use tests to lock both:
+
+- the public Python storage surface
+- the owner-boundary rules that prevent runtime truth from drifting back into Python shell code
+- the cross-path correctness of sharing / serialization / rebuild behavior
+
+### 10.2 Primary rails
+
+The most relevant existing rails are:
+
+- `tests/contract/test_storage_contract.py`
+- `tests/contract/test_tensor_storage_owner_contract.py`
+- multiprocessing / serialization tests that exercise storage rebuild behavior
+
+### 10.3 Additional rails allowed
+
+Future storage batches may add focused contract tests only when current tests do not adequately capture:
+
+- Python public surface alignment
+- typed/untyped boundary behavior
+- owner-model invariants
+- serialization/rebuild invariants
+- device-storage specialization invariants
+
+### 10.4 NPU confidence rails
+
+NPU-related storage verification should remain architecture-focused:
+
+- validate built-in storage interface/owner expectations
+- validate rebuild/share behavior where relevant
+- avoid turning storage batches into broad backend-kernel campaigns
+
+## 11. Success Criteria for the Master Spec
+
+This whole-storage line of work is successful only when:
+
+1. Candle has an explicit storage target aligned to `torch/storage.py` at the Python surface level
+2. Candle has a runtime storage owner model aligned in role to `StorageImpl`
+3. storage sharing / serialization / multiprocessing behavior are built on that owner model
+4. Python storage shell code is no longer the long-term fact source for runtime-sensitive storage truth
+5. Candle has a clear built-in storage architecture spanning CPU / CUDA / NPU
+6. NPU storage is aligned as first-class Candle storage rather than plugin-owned storage
+7. later Tensor shell reduction can proceed on top of a stabilized Storage architecture
+
+## 12. Final Design Summary
+
+This v2 master spec defines Candle’s complete Storage mechanism target in one place.
+
+- `torch/storage.py` is the primary reference for the Python storage surface
+- `StorageImpl` is the primary reference for the runtime owner model
+- torch sharing / serialization paths are part of the storage architecture target, not side details
+- torch_npu is a secondary reference for runtime ownership direction only
+- Candle’s long-term rule is one built-in storage mechanism across CPU / CUDA / NPU
+- later Tensor shell reduction should follow that Storage stabilization

--- a/src/candle/_cython/_storage.pyx
+++ b/src/candle/_cython/_storage.pyx
@@ -8,7 +8,476 @@ runtime-owned device pointers and helpers that Python storage shells call into.
 NPU path is intentionally Cython-only — no Python fallback.
 """
 
+import ctypes
+import mmap
+import os
+import tempfile
+import threading
+import weakref
+
+import numpy as np
+
 from libc.stdint cimport int64_t
+
+
+# ---------------------------------------------------------------------------
+# Shared-file bookkeeping helpers for Python storage shell
+# ---------------------------------------------------------------------------
+
+_SHARED_FILE_REGISTRY = set()
+_SHARED_FILE_REGISTRY_LOCK = threading.Lock()
+
+
+def cy_register_shared_file(path):
+    if not path:
+        return
+    with _SHARED_FILE_REGISTRY_LOCK:
+        _SHARED_FILE_REGISTRY.add(path)
+
+
+def cy_unregister_shared_file(path):
+    if not path:
+        return
+    with _SHARED_FILE_REGISTRY_LOCK:
+        _SHARED_FILE_REGISTRY.discard(path)
+
+
+def cy_cleanup_shared_files():
+    with _SHARED_FILE_REGISTRY_LOCK:
+        paths = list(_SHARED_FILE_REGISTRY)
+    for path in paths:
+        cy_cleanup_shared_resource(None, path)
+
+
+def cy_cleanup_shared_resource(fd=None, path=None):
+    if fd is not None:
+        try:
+            os.close(int(fd))
+        except Exception:
+            pass
+    if not path:
+        return
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        pass
+    except Exception:
+        return
+    cy_unregister_shared_file(path)
+
+
+def cy_shared_files_count():
+    with _SHARED_FILE_REGISTRY_LOCK:
+        return len(_SHARED_FILE_REGISTRY)
+
+
+class CyPinnedCPUUntypedStorage:
+    def __init__(self, array, ptr, filename=None, shared=False, device=None):
+        from candle._device import device as Device
+        from candle._backends.npu import runtime as npu_runtime
+
+        if isinstance(device, str):
+            device = Device(device)
+        self.device = device or Device("cpu")
+        self._array = array
+        self._shared = shared
+        self._filename = filename
+        self._ptr = int(ptr)
+        self._finalizer = weakref.finalize(self, npu_runtime.free_host, self._ptr)
+
+    def __repr__(self):
+        values = [f" {item}" for item in self.buffer().tolist()]
+        body = "\n".join(values) if values else " "
+        return (
+            f"{body}\n"
+            f"[torch.storage.UntypedStorage(device={self.device.type}) of size {self.nbytes()}]"
+        )
+
+    def __len__(self):
+        return self.nbytes()
+
+    def __iter__(self):
+        return iter(self.buffer().tolist())
+
+    def __getitem__(self, index):
+        if isinstance(index, bool):
+            raise TypeError("can't index a torch.UntypedStorage with bool")
+        if isinstance(index, np.integer):
+            index = int(index)
+        elif isinstance(index, np.generic):
+            raise TypeError(
+                f"can't index a torch.UntypedStorage with numpy.{type(index).__name__}"
+            )
+        if isinstance(index, np.ndarray):
+            raise TypeError("can't index a torch.UntypedStorage with numpy.ndarray")
+        if isinstance(index, float):
+            raise TypeError("can't index a torch.UntypedStorage with float")
+        if isinstance(index, str):
+            raise TypeError("can't index a torch.UntypedStorage with str")
+        if isinstance(index, bytes):
+            raise TypeError("can't index a torch.UntypedStorage with bytes")
+        if isinstance(index, bytearray):
+            raise TypeError("can't index a torch.UntypedStorage with bytearray")
+        if isinstance(index, memoryview):
+            raise TypeError("can't index a torch.UntypedStorage with memoryview")
+        if isinstance(index, list):
+            raise TypeError("can't index a torch.UntypedStorage with list")
+        if isinstance(index, tuple):
+            raise TypeError("can't index a torch.UntypedStorage with tuple")
+        from candle._tensor import Tensor
+
+        if isinstance(index, Tensor):
+            raise TypeError("can't index a torch.UntypedStorage with Tensor")
+        if index is None:
+            raise TypeError("can't index a torch.UntypedStorage with NoneType")
+        if index is Ellipsis:
+            raise TypeError("can't index a torch.UntypedStorage with ellipsis")
+        if isinstance(index, slice):
+            return CyCPUUntypedStorage(
+                self.buffer()[index],
+                filename=None,
+                shared=self._shared,
+                device=self.device,
+            )
+        try:
+            return self.buffer()[index].item()
+        except IndexError as exc:
+            err_index = index
+            if isinstance(index, int) and index < 0:
+                err_index = index + self.nbytes()
+            raise IndexError(
+                f"index {err_index} out of range for storage of size {self.nbytes()}"
+            ) from exc
+
+    def __setitem__(self, index, value):
+        from candle._tensor import Tensor
+
+        if isinstance(index, np.integer):
+            index = int(index)
+        elif (
+            isinstance(
+                index,
+                (
+                    bool,
+                    list,
+                    tuple,
+                    np.generic,
+                    np.ndarray,
+                    Tensor,
+                    float,
+                    str,
+                    bytes,
+                    bytearray,
+                    memoryview,
+                ),
+            )
+            or index is None
+            or index is Ellipsis
+        ):
+            raise SystemError("error return without exception set")
+        try:
+            self.buffer()[index] = value
+        except IndexError as exc:
+            raise RuntimeError("out of bounds") from exc
+
+    def nbytes(self):
+        return int(self._array.nbytes)
+
+    def data_ptr(self):
+        return int(self._array.ctypes.data)
+
+    def buffer(self):
+        return self._array
+
+    def resize_(self, new_nbytes):
+        raise NotImplementedError("pinned storage cannot resize")
+
+    def share_memory_(self):
+        self._shared = True
+        return self
+
+    def is_shared(self):
+        return self._shared
+
+    def is_pinned(self):
+        return True
+
+    @classmethod
+    def from_file(cls, filename, shared=False):
+        data = np.memmap(filename, mode="r+", dtype=np.uint8)
+        return cls(data, int(data.ctypes.data), filename=filename, shared=shared)
+
+    def filename(self):
+        return self._filename
+
+
+class CyCPUUntypedStorage:
+    def __init__(
+        self,
+        array,
+        filename=None,
+        shared=False,
+        device=None,
+        mmap_obj=None,
+        fd=None,
+        tmp_file=None,
+        sharing_mechanism=None,
+        cleanup_finalizer=None,
+    ):
+        from candle._device import device as Device
+
+        if isinstance(device, str):
+            device = Device(device)
+        self.device = device or Device("cpu")
+        self._array = array
+        self._shared = shared
+        self._filename = filename
+        self._mmap = mmap_obj
+        self._fd = fd
+        self._tmp_file = tmp_file
+        self._sharing_mechanism = sharing_mechanism
+        self._cleanup_finalizer = cleanup_finalizer
+
+    def __repr__(self):
+        values = [f" {item}" for item in self.buffer().tolist()]
+        body = "\n".join(values) if values else " "
+        return (
+            f"{body}\n"
+            f"[torch.storage.UntypedStorage(device={self.device.type}) of size {self.nbytes()}]"
+        )
+
+    def __len__(self):
+        return self.nbytes()
+
+    def __iter__(self):
+        return iter(self.buffer().tolist())
+
+    def __getitem__(self, index):
+        if isinstance(index, bool):
+            raise TypeError("can't index a torch.UntypedStorage with bool")
+        if isinstance(index, np.integer):
+            index = int(index)
+        elif isinstance(index, np.generic):
+            raise TypeError(
+                f"can't index a torch.UntypedStorage with numpy.{type(index).__name__}"
+            )
+        if isinstance(index, np.ndarray):
+            raise TypeError("can't index a torch.UntypedStorage with numpy.ndarray")
+        if isinstance(index, float):
+            raise TypeError("can't index a torch.UntypedStorage with float")
+        if isinstance(index, str):
+            raise TypeError("can't index a torch.UntypedStorage with str")
+        if isinstance(index, bytes):
+            raise TypeError("can't index a torch.UntypedStorage with bytes")
+        if isinstance(index, bytearray):
+            raise TypeError("can't index a torch.UntypedStorage with bytearray")
+        if isinstance(index, memoryview):
+            raise TypeError("can't index a torch.UntypedStorage with memoryview")
+        if isinstance(index, list):
+            raise TypeError("can't index a torch.UntypedStorage with list")
+        if isinstance(index, tuple):
+            raise TypeError("can't index a torch.UntypedStorage with tuple")
+        from candle._tensor import Tensor
+
+        if isinstance(index, Tensor):
+            raise TypeError("can't index a torch.UntypedStorage with Tensor")
+        if index is None:
+            raise TypeError("can't index a torch.UntypedStorage with NoneType")
+        if index is Ellipsis:
+            raise TypeError("can't index a torch.UntypedStorage with ellipsis")
+        if isinstance(index, slice):
+            return CyCPUUntypedStorage(
+                self.buffer()[index],
+                filename=None,
+                shared=self._shared,
+                device=self.device,
+            )
+        try:
+            return self.buffer()[index].item()
+        except IndexError as exc:
+            err_index = index
+            if isinstance(index, int) and index < 0:
+                err_index = index + self.nbytes()
+            raise IndexError(
+                f"index {err_index} out of range for storage of size {self.nbytes()}"
+            ) from exc
+
+    def __setitem__(self, index, value):
+        from candle._tensor import Tensor
+
+        if isinstance(index, np.integer):
+            index = int(index)
+        elif (
+            isinstance(
+                index,
+                (
+                    bool,
+                    list,
+                    tuple,
+                    np.generic,
+                    np.ndarray,
+                    Tensor,
+                    float,
+                    str,
+                    bytes,
+                    bytearray,
+                    memoryview,
+                ),
+            )
+            or index is None
+            or index is Ellipsis
+        ):
+            raise SystemError("error return without exception set")
+        try:
+            self.buffer()[index] = value
+        except IndexError as exc:
+            raise RuntimeError("out of bounds") from exc
+
+    def nbytes(self):
+        return int(self._array.nbytes)
+
+    def data_ptr(self):
+        return int(self._array.ctypes.data)
+
+    def buffer(self):
+        return self._array
+
+    def resize_(self, new_nbytes):
+        if self._filename is not None or self._shared:
+            raise RuntimeError("Trying to resize storage that is not resizable")
+        new_array = np.empty(int(new_nbytes), dtype=np.uint8)
+        old_bytes = self._array.view(np.uint8)
+        copy_bytes = min(old_bytes.size, new_array.size)
+        new_array[:copy_bytes] = old_bytes[:copy_bytes]
+        self._array = new_array
+        return self
+
+    def share_memory_(self, strategy="file_descriptor"):
+        if self._shared:
+            return self
+
+        nbytes = int(self._array.nbytes)
+        if nbytes == 0:
+            self._shared = True
+            self._sharing_mechanism = strategy
+            return self
+
+        if strategy == "file_descriptor":
+            fd, filename = tempfile.mkstemp(prefix="candle_fd_", suffix=".bin")
+            try:
+                os.ftruncate(fd, nbytes)
+                mm = mmap.mmap(fd, nbytes)
+            except Exception:
+                os.close(fd)
+                raise
+
+            dst = np.frombuffer(mm, dtype=np.uint8, count=nbytes)
+            dst[:] = self._array.view(np.uint8).reshape(-1)
+
+            self._array = dst
+            self._mmap = mm
+            self._fd = fd
+            self._tmp_file = filename
+            self._filename = filename
+            self._shared = True
+            self._sharing_mechanism = "file_descriptor"
+
+            if self._cleanup_finalizer is not None:
+                self._cleanup_finalizer.detach()
+            self._cleanup_finalizer = weakref.finalize(
+                self,
+                cy_cleanup_shared_resource,
+                int(fd),
+                filename,
+            )
+            return self
+
+        if strategy == "file_system":
+            fd, filename = tempfile.mkstemp(prefix="candle_shm_", suffix=".bin")
+            try:
+                with open(fd, "wb", closefd=False) as f:
+                    f.truncate(nbytes)
+            finally:
+                os.close(fd)
+
+            mmap_arr = np.memmap(filename, mode="r+", dtype=np.uint8, shape=(nbytes,))
+            mmap_arr[:] = self._array.view(np.uint8).reshape(-1)
+
+            self._array = mmap_arr
+            self._filename = filename
+            self._shared = True
+            self._sharing_mechanism = "file_system"
+            cy_register_shared_file(filename)
+
+            if self._cleanup_finalizer is not None:
+                self._cleanup_finalizer.detach()
+            self._cleanup_finalizer = None
+            return self
+
+        raise ValueError(f"unsupported sharing strategy: {strategy}")
+
+    def is_shared(self):
+        return self._shared
+
+    def is_pinned(self):
+        return False
+
+    def shared_memory_meta(self):
+        if self._sharing_mechanism == "file_descriptor":
+            return {
+                "mechanism": "file_descriptor",
+                "fd": int(self._fd),
+                "filename": self._filename,
+                "nbytes": int(self._array.nbytes),
+            }
+        if self._sharing_mechanism == "file_system":
+            return {
+                "mechanism": "file_system",
+                "filename": self._filename,
+                "nbytes": int(self._array.nbytes),
+            }
+        return None
+
+    def typed_view(self, dtype, size):
+        from candle._dtype import to_numpy_dtype
+
+        return np.frombuffer(self._array, dtype=to_numpy_dtype(dtype), count=int(size))
+
+    @classmethod
+    def from_shared_memory(cls, filename, nbytes):
+        data = np.memmap(filename, mode="r+", dtype=np.uint8, shape=(int(nbytes),))
+        cy_register_shared_file(filename)
+        return cls(data, filename=filename, shared=True, sharing_mechanism="file_system")
+
+    @classmethod
+    def from_shared_fd(cls, fd, nbytes, filename=None):
+        fd = int(fd)
+        mm = mmap.mmap(fd, int(nbytes))
+        arr = np.frombuffer(mm, dtype=np.uint8, count=int(nbytes))
+        storage = cls(
+            arr,
+            filename=filename,
+            shared=True,
+            mmap_obj=mm,
+            fd=fd,
+            tmp_file=filename,
+            sharing_mechanism="file_descriptor",
+        )
+        storage._cleanup_finalizer = weakref.finalize(
+            storage,
+            cy_cleanup_shared_resource,
+            fd,
+            filename,
+        )
+        return storage
+
+    @classmethod
+    def from_file(cls, filename, shared=False):
+        data = np.memmap(filename, mode="r+", dtype=np.uint8)
+        return cls(data, filename=filename, shared=shared)
+
+    def filename(self):
+        return self._filename
 
 
 # ---------------------------------------------------------------------------

--- a/src/candle/_storage.py
+++ b/src/candle/_storage.py
@@ -1,72 +1,23 @@
+import abc
 import atexit
 import ctypes
-import os
-import threading
 import weakref
 import numpy as np
 
+from ._cython._storage import (  # pylint: disable=import-error,no-name-in-module
+    CyCPUUntypedStorage,
+    CyPinnedCPUUntypedStorage,
+    cy_cleanup_shared_files as _cy_cleanup_shared_files,
+)
 from ._device import _default_device, device as Device
 from ._dtype import float32, to_numpy_dtype
 ACL_MEMCPY_DEVICE_TO_DEVICE = 3
 
 
-_SHARED_FILE_REGISTRY = set()
-_SHARED_FILE_REGISTRY_LOCK = threading.Lock()
+atexit.register(_cy_cleanup_shared_files)
 
 
-def _register_shared_file(path):
-    if not path:
-        return
-    with _SHARED_FILE_REGISTRY_LOCK:
-        _SHARED_FILE_REGISTRY.add(path)
-
-
-def _unregister_shared_file(path):
-    if not path:
-        return
-    with _SHARED_FILE_REGISTRY_LOCK:
-        _SHARED_FILE_REGISTRY.discard(path)
-
-
-def _cleanup_shared_file(path):
-    if not path:
-        return False
-    try:
-        os.remove(path)
-        return True
-    except FileNotFoundError:
-        return True
-    except Exception:
-        return False
-
-
-def _close_fd_and_cleanup(fd, path=None):
-    if fd is not None:
-        try:
-            os.close(int(fd))
-        except Exception:
-            pass
-    if path and _cleanup_shared_file(path):
-        _unregister_shared_file(path)
-
-
-def cleanup_shared_files():
-    with _SHARED_FILE_REGISTRY_LOCK:
-        paths = list(_SHARED_FILE_REGISTRY)
-    for path in paths:
-        if _cleanup_shared_file(path):
-            _unregister_shared_file(path)
-
-
-def shared_files_count():
-    with _SHARED_FILE_REGISTRY_LOCK:
-        return len(_SHARED_FILE_REGISTRY)
-
-
-atexit.register(cleanup_shared_files)
-
-
-class UntypedStorage:
+class UntypedStorage(metaclass=abc.ABCMeta):
     """Public storage shell around runtime-owned backing memory.
 
     UntypedStorage is the user-facing storage shell exposed by Candle's Python API.
@@ -83,6 +34,7 @@ class UntypedStorage:
         if isinstance(device, str):
             device = Device(device)
         self.device = device
+        self._shared = False
 
     def __repr__(self):
         if self.device.type == "cpu":
@@ -136,7 +88,7 @@ class UntypedStorage:
             if index is Ellipsis:
                 raise TypeError("can't index a torch.UntypedStorage with ellipsis")
             if isinstance(index, slice):
-                return _CPUUntypedStorage(self.buffer()[index], filename=None, shared=self._shared, device=self.device)
+                return CyCPUUntypedStorage(self.buffer()[index], filename=None, shared=self._shared, device=self.device)
             try:
                 return self.buffer()[index].item()
             except IndexError as exc:
@@ -188,232 +140,11 @@ class UntypedStorage:
 
     @classmethod
     def from_file(cls, filename, shared=False):
-        return _CPUUntypedStorage.from_file(filename, shared=shared)
+        return CyCPUUntypedStorage.from_file(filename, shared=shared)
 
     def filename(self):
         return None
 
-
-
-class _PinnedCPUUntypedStorage(UntypedStorage):
-    def __init__(self, array, ptr, filename=None, shared=False, device=None):
-        super().__init__(device or Device("cpu"))
-        self._array = array
-        self._shared = shared
-        self._filename = filename
-        self._ptr = int(ptr)
-        from ._backends.npu import runtime as npu_runtime
-
-        self._finalizer = weakref.finalize(self, npu_runtime.free_host, self._ptr)
-
-    def nbytes(self):
-        return int(self._array.nbytes)
-
-    def data_ptr(self):
-        return int(self._array.ctypes.data)
-
-    def buffer(self):
-        return self._array
-
-    def resize_(self, new_nbytes):
-        raise NotImplementedError("pinned storage cannot resize")
-
-    def share_memory_(self):
-        self._shared = True
-        return self
-
-    def is_shared(self):
-        return self._shared
-
-    def is_pinned(self):
-        return True
-
-    @classmethod
-    def from_file(cls, filename, shared=False):
-        data = np.memmap(filename, mode="r+", dtype=np.uint8)
-        return cls(data, int(data.ctypes.data), filename=filename, shared=shared)
-
-    def filename(self):
-        return self._filename
-
-
-class _CPUUntypedStorage(UntypedStorage):
-    def __init__(
-        self,
-        array,
-        filename=None,
-        shared=False,
-        device=None,
-        mmap_obj=None,
-        fd=None,
-        tmp_file=None,
-        sharing_mechanism=None,
-        cleanup_finalizer=None,
-    ):
-        super().__init__(device or Device("cpu"))
-        self._array = array
-        self._shared = shared
-        self._filename = filename
-        self._mmap = mmap_obj
-        self._fd = fd
-        self._tmp_file = tmp_file
-        self._sharing_mechanism = sharing_mechanism
-        self._cleanup_finalizer = cleanup_finalizer
-
-    def nbytes(self):
-        return int(self._array.nbytes)
-
-    def data_ptr(self):
-        return int(self._array.ctypes.data)
-
-    def buffer(self):
-        return self._array
-
-    def resize_(self, new_nbytes):
-        if self._filename is not None or self._shared:
-            raise RuntimeError("Trying to resize storage that is not resizable")
-        new_array = np.empty(int(new_nbytes), dtype=np.uint8)
-        old_bytes = self._array.view(np.uint8)
-        copy_bytes = min(old_bytes.size, new_array.size)
-        new_array[:copy_bytes] = old_bytes[:copy_bytes]
-        self._array = new_array
-        return self
-
-    def share_memory_(self, strategy="file_descriptor"):
-        if self._shared:
-            return self
-
-        nbytes = int(self._array.nbytes)
-        if nbytes == 0:
-            self._shared = True
-            self._sharing_mechanism = strategy
-            return self
-
-        # A1 boundary note: this file remains the public storage API shell.
-        # Future runtime-sensitive storage ownership should move into Cython helpers
-        # instead of expanding Python-side owner state here.
-        if strategy == "file_descriptor":
-            import mmap
-            import os
-            import tempfile
-
-            fd, filename = tempfile.mkstemp(prefix="candle_fd_", suffix=".bin")
-            try:
-                os.ftruncate(fd, nbytes)
-                mm = mmap.mmap(fd, nbytes)
-            except Exception:
-                os.close(fd)
-                raise
-
-            dst = np.frombuffer(mm, dtype=np.uint8, count=nbytes)
-            dst[:] = self._array.view(np.uint8).reshape(-1)
-
-            self._array = dst
-            self._mmap = mm
-            self._fd = fd
-            self._tmp_file = filename
-            self._filename = filename
-            self._shared = True
-            self._sharing_mechanism = "file_descriptor"
-
-            if self._cleanup_finalizer is not None:
-                self._cleanup_finalizer.detach()
-            self._cleanup_finalizer = weakref.finalize(
-                self,
-                _close_fd_and_cleanup,
-                int(fd),
-                filename,
-            )
-            return self
-
-        if strategy == "file_system":
-            import tempfile
-
-            fd, filename = tempfile.mkstemp(prefix="candle_shm_", suffix=".bin")
-            try:
-                with open(fd, "wb", closefd=False) as f:
-                    f.truncate(nbytes)
-            finally:
-                import os
-
-                os.close(fd)
-
-            mmap_arr = np.memmap(filename, mode="r+", dtype=np.uint8, shape=(nbytes,))
-            mmap_arr[:] = self._array.view(np.uint8).reshape(-1)
-
-            self._array = mmap_arr
-            self._filename = filename
-            self._shared = True
-            self._sharing_mechanism = "file_system"
-            _register_shared_file(filename)
-
-            if self._cleanup_finalizer is not None:
-                self._cleanup_finalizer.detach()
-            # file_system lifetime is process-level; explicit cleanup occurs via cleanup_shared_files()
-            self._cleanup_finalizer = None
-            return self
-
-        raise ValueError(f"unsupported sharing strategy: {strategy}")
-
-    def is_shared(self):
-        return self._shared
-
-    def shared_memory_meta(self):
-        if self._sharing_mechanism == "file_descriptor":
-            return {
-                "mechanism": "file_descriptor",
-                "fd": int(self._fd),
-                "filename": self._filename,
-                "nbytes": int(self._array.nbytes),
-            }
-        if self._sharing_mechanism == "file_system":
-            return {
-                "mechanism": "file_system",
-                "filename": self._filename,
-                "nbytes": int(self._array.nbytes),
-            }
-        return None
-
-    def typed_view(self, dtype, size):
-        return np.frombuffer(self._array, dtype=to_numpy_dtype(dtype), count=int(size))
-
-    @classmethod
-    def from_shared_memory(cls, filename, nbytes):
-        data = np.memmap(filename, mode="r+", dtype=np.uint8, shape=(int(nbytes),))
-        _register_shared_file(filename)
-        return cls(data, filename=filename, shared=True, sharing_mechanism="file_system")
-
-    @classmethod
-    def from_shared_fd(cls, fd, nbytes, filename=None):
-        import mmap
-
-        fd = int(fd)
-        mm = mmap.mmap(fd, int(nbytes))
-        arr = np.frombuffer(mm, dtype=np.uint8, count=int(nbytes))
-        storage = cls(
-            arr,
-            filename=filename,
-            shared=True,
-            mmap_obj=mm,
-            fd=fd,
-            tmp_file=filename,
-            sharing_mechanism="file_descriptor",
-        )
-        storage._cleanup_finalizer = weakref.finalize(
-            storage,
-            _close_fd_and_cleanup,
-            fd,
-            filename,
-        )
-        return storage
-
-    @classmethod
-    def from_file(cls, filename, shared=False):
-        data = np.memmap(filename, mode="r+", dtype=np.uint8)
-        return cls(data, filename=filename, shared=shared)
-
-    def filename(self):
-        return self._filename
 
 
 _npu_allocator_mod = None  # cached after first NPU storage creation
@@ -531,6 +262,10 @@ class _MetaUntypedStorage(UntypedStorage):
     def resize_(self, new_nbytes):
         self._nbytes = int(new_nbytes)
         return self
+
+
+UntypedStorage.register(CyCPUUntypedStorage)
+UntypedStorage.register(CyPinnedCPUUntypedStorage)
 
 
 class TypedStorage:
@@ -886,7 +621,7 @@ class Storage(TypedStorage):
 
 def typed_storage_from_numpy(arr, dtype, device=None):
     arr = np.ascontiguousarray(arr, dtype=to_numpy_dtype(dtype))
-    untyped = _CPUUntypedStorage(arr.view(np.uint8), device=device)
+    untyped = CyCPUUntypedStorage(arr.view(np.uint8), device=device)
     return TypedStorage(untyped, dtype, arr.size, data=arr)
 
 
@@ -1019,6 +754,6 @@ def pinned_cpu_typed_storage_from_numpy(arr, dtype, device=None):
     buf = np.ctypeslib.as_array((ctypes.c_uint8 * size).from_address(int(host_ptr)))
     buf[:] = arr.view(np.uint8).reshape(-1)
     raw = np.frombuffer(buf, dtype=np.uint8)
-    untyped = _PinnedCPUUntypedStorage(raw, host_ptr, device=device)
+    untyped = CyPinnedCPUUntypedStorage(raw, host_ptr, device=device)
     data = np.frombuffer(raw, dtype=to_numpy_dtype(dtype), count=arr.size)
     return TypedStorage(untyped, dtype, arr.size, data=data)

--- a/src/candle/multiprocessing/__init__.py
+++ b/src/candle/multiprocessing/__init__.py
@@ -4,7 +4,10 @@ import multiprocessing
 import sys
 
 from .reductions import init_reductions
-from .._storage import cleanup_shared_files as _cleanup_shared_files, shared_files_count as _shared_files_count
+from .._cython._storage import (  # pylint: disable=import-error,no-name-in-module
+    cy_cleanup_shared_files as _cleanup_shared_files,
+    cy_shared_files_count as _shared_files_count,
+)
 
 
 __all__ = [

--- a/src/candle/multiprocessing/reductions.py
+++ b/src/candle/multiprocessing/reductions.py
@@ -1,8 +1,9 @@
 from multiprocessing import reduction
 
 from .. import multiprocessing as _mt_mp
+from .._cython._storage import CyCPUUntypedStorage  # pylint: disable=import-error,no-name-in-module
 from .._cython._tensor_impl import cy_make_tensor_from_storage  # pylint: disable=import-error,no-name-in-module
-from .._storage import _CPUUntypedStorage, TypedStorage
+from .._storage import TypedStorage
 from .._tensor import Tensor
 
 
@@ -17,7 +18,7 @@ _NON_LEAF_ERR_MSG = (
 def _rebuild_cpu_storage_from_meta(meta):
     mechanism = meta["mechanism"]
     if mechanism == "file_system":
-        return _CPUUntypedStorage.from_shared_memory(meta["filename"], meta["nbytes"])
+        return CyCPUUntypedStorage.from_shared_memory(meta["filename"], meta["nbytes"])
     if mechanism == "file_descriptor":
         fd = meta.get("fd")
         if fd is None:
@@ -25,7 +26,7 @@ def _rebuild_cpu_storage_from_meta(meta):
             if dup_fd is None:
                 raise RuntimeError("file_descriptor storage metadata missing fd/dup_fd")
             fd = dup_fd.detach()
-        return _CPUUntypedStorage.from_shared_fd(fd, meta["nbytes"], filename=meta.get("filename"))
+        return CyCPUUntypedStorage.from_shared_fd(fd, meta["nbytes"], filename=meta.get("filename"))
     raise RuntimeError(f"Unsupported CPU shared storage mechanism: {mechanism}")
 
 
@@ -49,7 +50,7 @@ def _rebuild_typed_storage(untyped, dtype, size):
 
 def _reduce_typed_storage(storage):
     untyped = storage.untyped_storage()
-    if isinstance(untyped, _CPUUntypedStorage):
+    if isinstance(untyped, CyCPUUntypedStorage):
         reduced = _reduce_cpu_storage(untyped)
         rebuild_untyped, args = reduced
         return (
@@ -94,7 +95,7 @@ def _rebuild_tensor_from_reduced_storage(rebuild_storage, storage_args, meta):
 
 
 def init_reductions():
-    reduction.register(_CPUUntypedStorage, _reduce_cpu_storage)
+    reduction.register(CyCPUUntypedStorage, _reduce_cpu_storage)
     reduction.register(TypedStorage, _reduce_typed_storage)
     reduction.register(Tensor, _reduce_tensor)
 

--- a/src/candle/serialization.py
+++ b/src/candle/serialization.py
@@ -29,7 +29,8 @@ from ._dtype import (
     uint8,
     to_numpy_dtype,
 )
-from ._storage import TypedStorage, _CPUUntypedStorage, typed_storage_from_numpy
+from ._cython._storage import CyCPUUntypedStorage  # pylint: disable=import-error,no-name-in-module
+from ._storage import TypedStorage, typed_storage_from_numpy
 from ._C import PyTorchFileReader, PyTorchFileWriter
 from ._stream import PyTorchStreamReader, PyTorchStreamWriter
 from ._tensor import Tensor as MindTensor
@@ -561,7 +562,7 @@ def _load_zip_checkpoint(
                 shape=(nbytes,),
             )
             arr = raw.view(np_dtype)
-            untyped = _CPUUntypedStorage(raw, device="cpu")
+            untyped = CyCPUUntypedStorage(raw, device="cpu")
             storage = TypedStorage(untyped, dtype=dtype, size=int(numel), data=arr)
         else:
             payload, _ = reader.getRecord(record_name)

--- a/tests/contract/test_storage_contract.py
+++ b/tests/contract/test_storage_contract.py
@@ -1,8 +1,57 @@
 import tempfile
 
 import candle as torch
+import candle._storage as candle_storage
 import torch as pt
 from .helpers import assert_torch_error
+
+
+
+def test_storage_module_does_not_expose_shared_file_bookkeeping_helpers():
+    helper_names = {
+        "_register_shared_file",
+        "_unregister_shared_file",
+        "_cleanup_shared_file",
+        "_close_fd_and_cleanup",
+        "cleanup_shared_files",
+        "shared_files_count",
+    }
+
+    exported = {name for name in helper_names if hasattr(candle_storage, name)}
+
+    assert exported == set()
+
+
+
+def test_storage_module_still_exposes_public_storage_entry_points():
+    public_names = {
+        "TypedStorage",
+        "UntypedStorage",
+        "typed_storage_from_numpy",
+        "empty_cpu_typed_storage",
+        "meta_typed_storage_from_shape",
+    }
+
+    exported = {name for name in public_names if hasattr(candle_storage, name)}
+
+    assert exported == public_names
+
+
+
+def test_storage_module_does_not_expose_private_untyped_storage_classes():
+    import candle._storage as storage_mod
+
+    assert not hasattr(storage_mod, "_PinnedCPUUntypedStorage")
+    assert not hasattr(storage_mod, "_CPUUntypedStorage")
+
+
+
+def test_multiprocessing_storage_bookkeeping_surface_still_exists():
+    import candle.multiprocessing as mt_mp
+
+    assert hasattr(mt_mp, "cleanup_shared_files")
+    assert hasattr(mt_mp, "shared_files_count")
+
 
 
 def test_storage_resize_file_backed_error():

--- a/tests/contract/test_tensor_storage_owner_contract.py
+++ b/tests/contract/test_tensor_storage_owner_contract.py
@@ -1,6 +1,7 @@
 import pytest
 
 import candle as torch
+import candle._storage as candle_storage
 
 
 def test_tensor_impl_declares_runtime_owned_fields():
@@ -85,6 +86,11 @@ def test_typed_storage_public_api_routes_through_untyped_runtime_owner():
 
     assert storage.data_ptr() == untyped.data_ptr()
     assert storage.device == untyped.device
+
+
+
+def test_pinned_cpu_storage_factory_still_exposed_as_public_entry_point():
+    assert hasattr(candle_storage, "pinned_cpu_typed_storage_from_numpy")
 
 
 

--- a/tests/cpu/test_serialization.py
+++ b/tests/cpu/test_serialization.py
@@ -293,6 +293,16 @@ def test_torch_load_with_map_location_torch_device_cpu(tmp_path):
     assert set(loaded.keys()) == {"weight", "bias"}
 
 
+def test_load_zip_mmap_cpu_storage_device_is_device_object(tmp_path):
+    path = tmp_path / "mmap_cpu_storage_device.pth"
+    torch.save({"x": torch.tensor([1.0, 2.0])}, path)
+
+    loaded = mt.load(path, mmap=True)
+
+    storage = loaded["x"].untyped_storage()
+    assert storage.device.type == "cpu"
+
+
 def _patch_checkpoint_location_tag(src_path, dst_path, old, new):
     assert len(old) == len(new)
     with zipfile.ZipFile(src_path, "r") as zin, zipfile.ZipFile(dst_path, "w", compression=zipfile.ZIP_STORED) as zout:


### PR DESCRIPTION
## Summary

- Move CPU storage helper classes (`_CPUUntypedStorage`, `_PinnedCPUUntypedStorage`) behind Cython boundary as `CyCPUUntypedStorage` / `CyPinnedCPUUntypedStorage` in `_cython/_storage.pyx`
- Hide shared-file bookkeeping helpers from the public `_storage` module surface while preserving `multiprocessing.cleanup_shared_files` / `shared_files_count` public API
- `UntypedStorage` uses `abc.ABCMeta` with virtual subclass registration so `isinstance(storage, UntypedStorage)` works with Cython helper classes
- Serialization and reductions rewired to use Cython storage classes
- Cython CPU storage constructors normalize string device to `Device` objects (fixes serialization regression)
- Contract tests enforce public/private surface boundaries

This is B1 of the whole-storage mechanism realignment. See `docs/superpowers/specs/2026-04-14-whole-storage-mechanism-realignment-master-design.md` for the full design.

## Test plan

- [x] Contract tests: `tests/contract/test_storage_contract.py` — 9 tests covering surface exposure boundaries
- [x] Contract tests: `tests/contract/test_tensor_storage_owner_contract.py` — 12 tests including pinned factory rail
- [x] CPU storage: `tests/cpu/test_storage.py::test_untyped_storage_slice_returns_storage_like_torch` — isinstance compatibility
- [x] Serialization: `tests/cpu/test_serialization.py` — including device normalization regression test
- [x] Full CPU + contract suite: 2895 passed, 7 skipped (5 pre-existing failures in declarative autograd)
- [x] Pylint: 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)