### PR TITLE
feat(tensor): deep-align Python surface with torch, move runtime to Cython _C

### DIFF
--- a/docs/superpowers/plans/2026-04-27-tensor-print-alignment.md
+++ b/docs/superpowers/plans/2026-04-27-tensor-print-alignment.md
@@ -1,0 +1,616 @@
+# Tensor Print Alignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rewrite Candle’s tensor printing stack so `src/candle/_tensor_str.py` becomes the primary torch-style implementation and dense/main-path repr behavior closely matches local torch.
+
+**Architecture:** Port the main structure of `torch/_tensor_str.py` into `src/candle/_tensor_str.py`, adapt torch runtime hooks to Candle equivalents, and shrink `src/candle/_printing.py` into a compatibility wrapper. Keep unsupported special branches on explicit local fallbacks so the batch stays bounded to printing.
+
+**Tech Stack:** Python, Candle tensor API, pytest, local torch reference implementation
+
+---
+
+## File map
+
+- **Modify:** `src/candle/_tensor_str.py`
+  - Becomes the canonical owner of tensor print options and formatting.
+  - Hosts `PRINT_OPTS`, `set_printoptions`, `get_printoptions`, `printoptions`, `_Formatter`, `_scalar_str`, `_vector_str`, `_tensor_str_with_formatter`, `_tensor_str`, and `_str`.
+
+- **Modify:** `src/candle/_printing.py`
+  - Reduced to a compatibility wrapper that delegates into `_tensor_str.py`.
+  - Must not own independent print-option state after the rewrite.
+
+- **Modify:** `tests/cpu/test_tensor_print.py`
+  - Expanded to compare Candle output directly against local torch output for dense/main-path behavior and printoption state.
+
+- **Possibly modify:** `src/candle/__init__.py`
+  - Only if export wiring needs adjustment after the `_tensor_str.py` rewrite.
+
+---
+
+### Task 1: Port print-option ownership into `_tensor_str.py`
+
+**Files:**
+- Modify: `src/candle/_tensor_str.py`
+- Modify: `src/candle/_printing.py`
+- Test: `tests/cpu/test_tensor_print.py`
+
+- [ ] **Step 1: Write the failing printoptions ownership tests**
+
+```python
+import candle as torch
+from candle import _tensor_str
+
+
+def test_printoptions_state_lives_in_tensor_str_module():
+    prev = torch.get_printoptions()
+    try:
+        torch.set_printoptions(precision=2, linewidth=70)
+        opts = torch.get_printoptions()
+        assert opts["precision"] == 2
+        assert opts["linewidth"] == 70
+        assert _tensor_str.get_printoptions()["precision"] == 2
+        assert _tensor_str.get_printoptions()["linewidth"] == 70
+    finally:
+        torch.set_printoptions(**prev)
+
+
+def test_printoptions_context_restores_state():
+    prev = torch.get_printoptions()
+    with torch.printoptions(precision=2, sci_mode=True):
+        inside = torch.get_printoptions()
+        assert inside["precision"] == 2
+        assert inside["sci_mode"] is True
+    assert torch.get_printoptions() == prev
+```
+
+- [ ] **Step 2: Run the targeted tests to verify the gap**
+
+Run:
+
+```bash
+conda run -n candle311 python -m pytest tests/cpu/test_tensor_print.py -q --tb=short -k "printoptions_state_lives_in_tensor_str_module or printoptions_context_restores_state"
+```
+
+Expected: at least one FAIL because `_tensor_str.py` is still only a thin wrapper and does not own the torch-style printing stack.
+
+- [ ] **Step 3: Replace `_tensor_str.py` with torch-style print-option scaffolding**
+
+Use `torch/_tensor_str.py` as the source structure. The resulting Candle file should define the option state in `_tensor_str.py` itself and keep `_str()` in the same module.
+
+```python
+# src/candle/_tensor_str.py
+# mypy: allow-untyped-defs
+import contextlib
+import dataclasses
+import math
+from typing import Any
+
+import candle as torch
+from candle import inf
+
+
+@dataclasses.dataclass
+class __PrinterOptions:
+    precision: int = 4
+    threshold: float = 1000
+    edgeitems: int = 3
+    linewidth: int = 80
+    sci_mode: bool | None = None
+
+
+PRINT_OPTS = __PrinterOptions()
+
+
+def set_printoptions(
+    precision=None,
+    threshold=None,
+    edgeitems=None,
+    linewidth=None,
+    profile=None,
+    sci_mode=None,
+):
+    if profile is not None:
+        if profile == "default":
+            PRINT_OPTS.precision = 4
+            PRINT_OPTS.threshold = 1000
+            PRINT_OPTS.edgeitems = 3
+            PRINT_OPTS.linewidth = 80
+        elif profile == "short":
+            PRINT_OPTS.precision = 2
+            PRINT_OPTS.threshold = 1000
+            PRINT_OPTS.edgeitems = 2
+            PRINT_OPTS.linewidth = 80
+        elif profile == "full":
+            PRINT_OPTS.precision = 4
+            PRINT_OPTS.threshold = inf
+            PRINT_OPTS.edgeitems = 3
+            PRINT_OPTS.linewidth = 80
+    if precision is not None:
+        PRINT_OPTS.precision = precision
+    if threshold is not None:
+        PRINT_OPTS.threshold = threshold
+    if edgeitems is not None:
+        PRINT_OPTS.edgeitems = edgeitems
+    if linewidth is not None:
+        PRINT_OPTS.linewidth = linewidth
+    PRINT_OPTS.sci_mode = sci_mode
+
+
+def get_printoptions() -> dict[str, Any]:
+    return dataclasses.asdict(PRINT_OPTS)
+
+
+@contextlib.contextmanager
+
+def printoptions(**kwargs):
+    old_kwargs = get_printoptions()
+    set_printoptions(**kwargs)
+    try:
+        yield
+    finally:
+        set_printoptions(**old_kwargs)
+```
+
+- [ ] **Step 4: Reduce `_printing.py` to a pure compatibility wrapper**
+
+`_printing.py` should stop owning separate state and instead delegate to `_tensor_str.py`.
+
+```python
+# src/candle/_printing.py
+from ._tensor_str import get_printoptions, printoptions, set_printoptions, _str
+
+
+def format_tensor(tensor, tensor_contents=None):
+    return _str(tensor, tensor_contents=tensor_contents)
+```
+
+- [ ] **Step 5: Run the targeted tests again**
+
+Run:
+
+```bash
+conda run -n candle311 python -m pytest tests/cpu/test_tensor_print.py -q --tb=short -k "printoptions_state_lives_in_tensor_str_module or printoptions_context_restores_state"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/candle/_tensor_str.py src/candle/_printing.py tests/cpu/test_tensor_print.py
+git commit -m "refactor(print): move print option ownership into _tensor_str"
+```
+
+---
+
+### Task 2: Port the dense/main-path formatter from torch
+
+**Files:**
+- Modify: `src/candle/_tensor_str.py`
+- Test: `tests/cpu/test_tensor_print.py`
+
+- [ ] **Step 1: Write failing dense-format comparison tests**
+
+```python
+import candle as candle_torch
+import torch as ref_torch
+
+
+def test_dense_vector_repr_matches_local_torch():
+    c = candle_torch.tensor([1.23456, 2.0, -3.5], dtype=candle_torch.float32)
+    r = ref_torch.tensor([1.23456, 2.0, -3.5], dtype=ref_torch.float32)
+    assert repr(c) == repr(r)
+
+
+def test_dense_matrix_repr_matches_local_torch():
+    c = candle_torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=candle_torch.float32)
+    r = ref_torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=ref_torch.float32)
+    assert repr(c) == repr(r)
+
+
+def test_complex_repr_matches_local_torch():
+    c = candle_torch.tensor([1 + 2j, -3 + 0.5j], dtype=candle_torch.complex64)
+    r = ref_torch.tensor([1 + 2j, -3 + 0.5j], dtype=ref_torch.complex64)
+    assert repr(c) == repr(r)
+```
+
+- [ ] **Step 2: Run the dense-format tests to capture failure**
+
+Run:
+
+```bash
+conda run -n candle311 python -m pytest tests/cpu/test_tensor_print.py -q --tb=short -k "dense_vector_repr_matches_local_torch or dense_matrix_repr_matches_local_torch or complex_repr_matches_local_torch"
+```
+
+Expected: FAIL because Candle still uses the simplified NumPy-based formatting path.
+
+- [ ] **Step 3: Port `_Formatter`, `_scalar_str`, `_vector_str`, and `_tensor_str_with_formatter`**
+
+Port the main formatting pipeline from local `torch/_tensor_str.py`, adapting only the runtime hooks from torch to Candle.
+
+Required structure to add in `src/candle/_tensor_str.py`:
+
+```python
+def tensor_totype(t):
+    dtype = torch.double
+    return t.to(dtype=dtype)
+
+
+class _Formatter:
+    def __init__(self, tensor):
+        self.floating_dtype = tensor.dtype.is_floating_point
+        self.int_mode = True
+        self.sci_mode = False
+        self.max_width = 1
+
+        with torch.no_grad():
+            tensor_view = tensor.reshape(-1)
+
+        if not self.floating_dtype:
+            for value in tensor_view:
+                value_str = f"{value}"
+                self.max_width = max(self.max_width, len(value_str))
+        else:
+            nonzero_finite_vals = torch.masked_select(
+                tensor_view, torch.isfinite(tensor_view) & tensor_view.ne(0)
+            )
+            if nonzero_finite_vals.numel() == 0:
+                return
+            nonzero_finite_abs = tensor_totype(nonzero_finite_vals.abs())
+            nonzero_finite_min = tensor_totype(nonzero_finite_abs.min())
+            nonzero_finite_max = tensor_totype(nonzero_finite_abs.max())
+            for value in nonzero_finite_vals:
+                if value != torch.ceil(value):
+                    self.int_mode = False
+                    break
+            self.sci_mode = (
+                nonzero_finite_max / nonzero_finite_min > 1000.0
+                or nonzero_finite_max > 1.0e8
+                or nonzero_finite_min < 1.0e-4
+                if PRINT_OPTS.sci_mode is None
+                else PRINT_OPTS.sci_mode
+            )
+```
+
+Also port the paired formatting helpers from torch:
+
+```python
+def _scalar_str(self, formatter1, formatter2=None):
+    ...
+
+
+def _vector_str(self, indent, summarize, formatter1, formatter2=None):
+    ...
+
+
+def _tensor_str_with_formatter(self, indent, summarize, formatter1, formatter2=None):
+    ...
+```
+
+Adaptation rules:
+- keep the control flow and formatting policy from torch,
+- replace torch runtime helpers only where Candle needs a valid equivalent,
+- do not add unrelated runtime features.
+
+- [ ] **Step 4: Implement `_tensor_str` and `_str` using the ported formatter path**
+
+Replace the wrapper-only `_str` with torch-style orchestration.
+
+```python
+def _tensor_str(self, indent):
+    if self.numel() == 0:
+        return "[]"
+    summarize = self.numel() > PRINT_OPTS.threshold
+    formatter = _Formatter(get_summarized_data(self) if summarize else self)
+    return _tensor_str_with_formatter(self, indent, summarize, formatter)
+
+
+def _str(self, *, tensor_contents=None):
+    if tensor_contents is None:
+        tensor_contents = _tensor_str(self, 0)
+    suffixes = []
+    if self.dtype != torch.get_default_dtype() or self.device.type == "meta":
+        suffixes.append(f"dtype={self.dtype}")
+    if self.device.type != torch.get_default_device().type:
+        suffixes.append(f"device='{self.device}'" if self.device.type == "npu" else f"device='{self.device.type}'")
+    if self.requires_grad:
+        suffixes.append("requires_grad=True")
+    if self.grad_fn is not None:
+        suffixes.append(f"grad_fn=<{type(self.grad_fn).__name__}>")
+    return f"tensor({tensor_contents}{', ' + ', '.join(suffixes) if suffixes else ''})"
+```
+
+- [ ] **Step 5: Re-run the dense-format tests**
+
+Run:
+
+```bash
+conda run -n candle311 python -m pytest tests/cpu/test_tensor_print.py -q --tb=short -k "dense_vector_repr_matches_local_torch or dense_matrix_repr_matches_local_torch or complex_repr_matches_local_torch"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/candle/_tensor_str.py tests/cpu/test_tensor_print.py
+git commit -m "feat(print): port torch dense tensor formatting pipeline"
+```
+
+---
+
+### Task 3: Add summarization, linewidth, and sci_mode parity tests
+
+**Files:**
+- Modify: `tests/cpu/test_tensor_print.py`
+- Modify: `src/candle/_tensor_str.py`
+
+- [ ] **Step 1: Add failing printoption behavior tests**
+
+```python
+import candle as candle_torch
+import torch as ref_torch
+
+
+def test_threshold_summarization_matches_local_torch():
+    prev_c = candle_torch.get_printoptions()
+    prev_r = ref_torch.get_printoptions()
+    try:
+        candle_torch.set_printoptions(threshold=5)
+        ref_torch.set_printoptions(threshold=5)
+        c = candle_torch.arange(10)
+        r = ref_torch.arange(10)
+        assert repr(c) == repr(r)
+    finally:
+        candle_torch.set_printoptions(**prev_c)
+        ref_torch.set_printoptions(**prev_r)
+
+
+def test_linewidth_wrapping_matches_local_torch():
+    prev_c = candle_torch.get_printoptions()
+    prev_r = ref_torch.get_printoptions()
+    try:
+        candle_torch.set_printoptions(linewidth=30)
+        ref_torch.set_printoptions(linewidth=30)
+        c = candle_torch.arange(16).reshape(4, 4)
+        r = ref_torch.arange(16).reshape(4, 4)
+        assert repr(c) == repr(r)
+    finally:
+        candle_torch.set_printoptions(**prev_c)
+        ref_torch.set_printoptions(**prev_r)
+
+
+def test_scientific_mode_matches_local_torch():
+    prev_c = candle_torch.get_printoptions()
+    prev_r = ref_torch.get_printoptions()
+    try:
+        candle_torch.set_printoptions(sci_mode=True, precision=2)
+        ref_torch.set_printoptions(sci_mode=True, precision=2)
+        c = candle_torch.tensor([1.0e-5, 2.0e6])
+        r = ref_torch.tensor([1.0e-5, 2.0e6])
+        assert repr(c) == repr(r)
+    finally:
+        candle_torch.set_printoptions(**prev_c)
+        ref_torch.set_printoptions(**prev_r)
+```
+
+- [ ] **Step 2: Run the targeted printoption behavior tests**
+
+Run:
+
+```bash
+conda run -n candle311 python -m pytest tests/cpu/test_tensor_print.py -q --tb=short -k "threshold_summarization_matches_local_torch or linewidth_wrapping_matches_local_torch or scientific_mode_matches_local_torch"
+```
+
+Expected: FAIL until summarization and wrapping helpers fully match torch behavior.
+
+- [ ] **Step 3: Port the remaining dense helpers from `torch/_tensor_str.py`**
+
+Port the summarization helpers that the formatter pipeline depends on.
+
+Add the torch-style helpers to `src/candle/_tensor_str.py`:
+
+```python
+def get_summarized_data(self):
+    ...
+
+
+def _tensor_str(self, indent):
+    ...
+```
+
+Make sure the implementation covers:
+- summarization through `threshold` and `edgeitems`,
+- recursive formatting for N-D tensors,
+- line wrapping based on `PRINT_OPTS.linewidth`,
+- `sci_mode=None` auto-selection behavior.
+
+Keep the implementation as close to torch as possible; do not invent new formatting policy.
+
+- [ ] **Step 4: Re-run the targeted printoption behavior tests**
+
+Run:
+
+```bash
+conda run -n candle311 python -m pytest tests/cpu/test_tensor_print.py -q --tb=short -k "threshold_summarization_matches_local_torch or linewidth_wrapping_matches_local_torch or scientific_mode_matches_local_torch"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/candle/_tensor_str.py tests/cpu/test_tensor_print.py
+git commit -m "feat(print): align summarization and scientific formatting"
+```
+
+---
+
+### Task 4: Handle suffixes and controlled fallback branches
+
+**Files:**
+- Modify: `src/candle/_tensor_str.py`
+- Modify: `tests/cpu/test_tensor_print.py`
+
+- [ ] **Step 1: Add suffix and fallback tests**
+
+```python
+import candle as candle_torch
+import torch as ref_torch
+
+
+def test_requires_grad_suffix_matches_local_torch():
+    c = candle_torch.tensor([1.0], requires_grad=True)
+    r = ref_torch.tensor([1.0], requires_grad=True)
+    assert repr(c) == repr(r)
+
+
+def test_meta_tensor_repr_matches_local_torch():
+    c = candle_torch.empty((2, 2), device="meta")
+    r = ref_torch.empty((2, 2), device="meta")
+    assert repr(c) == repr(r)
+```
+
+If there are special tensor categories Candle cannot fully print like torch yet, add stability tests instead of exact-equality tests:
+
+```python
+def test_special_tensor_print_path_does_not_crash():
+    t = make_special_case_tensor()
+    rep = repr(t)
+    assert isinstance(rep, str)
+    assert rep
+```
+
+- [ ] **Step 2: Run the suffix/fallback tests**
+
+Run:
+
+```bash
+conda run -n candle311 python -m pytest tests/cpu/test_tensor_print.py -q --tb=short -k "requires_grad_suffix_matches_local_torch or meta_tensor_repr_matches_local_torch or special_tensor_print_path_does_not_crash"
+```
+
+Expected: FAIL for any remaining suffix or special-branch mismatch.
+
+- [ ] **Step 3: Implement suffix parity and local fallbacks**
+
+In `src/candle/_tensor_str.py`, finish the `_str` suffix logic and add explicit fallback branches only where Candle lacks the runtime needed to match torch exactly.
+
+The required output policy is:
+
+```python
+if self.dtype != torch.get_default_dtype() or self.device.type == "meta":
+    suffixes.append(f"dtype={self.dtype}")
+if self.device.type != torch.get_default_device().type:
+    ...
+if self.requires_grad:
+    suffixes.append("requires_grad=True")
+if self.grad_fn is not None:
+    suffixes.append(f"grad_fn=<{type(self.grad_fn).__name__}>")
+```
+
+If a torch branch cannot be modeled exactly in Candle today, keep the fallback local to that branch and document it with one short inline comment stating the missing runtime capability.
+
+- [ ] **Step 4: Run the full print test file**
+
+Run:
+
+```bash
+conda run -n candle311 python -m pytest tests/cpu/test_tensor_print.py -q --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/candle/_tensor_str.py tests/cpu/test_tensor_print.py
+git commit -m "feat(print): align tensor repr suffixes and fallback branches"
+```
+
+---
+
+### Task 5: Run printing-safe regression suites
+
+**Files:**
+- Test: `tests/cpu/test_tensor_print.py`
+- Test: `tests/common/test_c_core.py`
+- Test: `tests/cpu/test_tensor_api_contract.py`
+- Test: `tests/contract/test_storage_contract.py`
+
+- [ ] **Step 1: Run the print-specific suite**
+
+Run:
+
+```bash
+conda run -n candle311 python -m pytest tests/cpu/test_tensor_print.py -q --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the common core regression suite**
+
+Run:
+
+```bash
+conda run -n candle311 python -m pytest tests/common/test_c_core.py -q --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the tensor API contract suite**
+
+Run:
+
+```bash
+conda run -n candle311 python -m pytest tests/cpu/test_tensor_api_contract.py -q --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run the storage contract suite**
+
+Run:
+
+```bash
+conda run -n candle311 python -m pytest tests/contract/test_storage_contract.py -q --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/candle/_tensor_str.py src/candle/_printing.py tests/cpu/test_tensor_print.py
+git commit -m "test(print): verify tensor repr alignment regression suites"
+```
+
+---
+
+## Self-review
+
+- **Spec coverage:**
+  - Primary `_tensor_str.py` ownership: covered by Task 1 and Task 2
+  - `_printing.py` compatibility reduction: covered by Task 1
+  - Dense/main-path fidelity: covered by Task 2 and Task 3
+  - Controlled fallback branches: covered by Task 4
+  - Focused print regressions and broader safety suites: covered by Task 5
+
+- **Placeholder scan:**
+  - No `TODO`/`TBD` placeholders in steps
+  - Each code-changing step includes concrete code to add or port
+  - Each test step includes exact commands and expected outcomes
+
+- **Type consistency:**
+  - Plan consistently uses `_tensor_str.py` as the primary owner and `_printing.py` as the wrapper
+  - Test names, helper names, and file paths match across tasks
+
+## Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-27-tensor-print-alignment.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/docs/superpowers/specs/2026-04-27-tensor-print-design.md
+++ b/docs/superpowers/specs/2026-04-27-tensor-print-design.md
@@ -1,0 +1,175 @@
+# Tensor print / repr deep alignment design
+
+Date: 2026-04-27
+
+## Context
+
+Candle has already aligned most of the Tensor and Storage Python surface closely with local torch, and the current branch now passes the focused contract suites for tensor API behavior, storage behavior, and printing basics. However, the tensor printing system is still structurally far from torch:
+
+- `src/candle/_tensor_str.py` is currently only a thin wrapper around `_printing.format_tensor()`.
+- local `torch/_tensor_str.py` is a large, self-contained implementation that owns print options, formatting policy, summarization, scalar/vector formatting, and most repr-path decisions.
+- Candle currently has two printing-related modules (`_tensor_str.py` and `_printing.py`) sharing responsibility in a way that drifts from torch and makes future alignment harder.
+
+The user explicitly chose to push this area toward a near-complete torch-style alignment rather than continuing with incremental formatting patches.
+
+## Goal
+
+Make Candle’s tensor printing system structurally match `torch/_tensor_str.py` as closely as practical, with dense/main-path behavior aligned as tightly as possible and controlled fallbacks for runtime features Candle does not yet fully support.
+
+This batch should improve long-term maintainability by making `_tensor_str.py` the canonical print implementation instead of leaving the main logic split across two files.
+
+## Non-goals
+
+This batch should **not** introduce unrelated runtime features just to satisfy obscure repr branches. If Candle lacks full runtime support for a special tensor category, the design should preserve stability through a local fallback in the printing path instead of widening implementation scope.
+
+This batch should also **not** attempt to bundle unrelated Tensor or Storage surface work.
+
+## Recommended approach
+
+### 1. Make `src/candle/_tensor_str.py` the primary implementation file
+
+`src/candle/_tensor_str.py` should become the canonical owner of tensor-printing behavior, mirroring the role of `torch/_tensor_str.py`.
+
+It should absorb the torch-style main components:
+
+- `PRINT_OPTS`
+- `set_printoptions`
+- `get_printoptions`
+- `printoptions`
+- `_Formatter`
+- `_scalar_str`
+- `_vector_str`
+- `_tensor_str_with_formatter`
+- `_tensor_str`
+- `_str`
+
+This is the key structural change. The goal is not just matching visible output, but matching the ownership model of the printing subsystem so future alignment work stays local to `_tensor_str.py`.
+
+### 2. Reduce `_printing.py` to a compatibility layer
+
+`src/candle/_printing.py` should no longer contain the primary formatting policy.
+
+Instead, it should be reduced to a thin compatibility layer or wrapper that delegates into `_tensor_str.py`, so that:
+
+- internal import sites do not break immediately,
+- public print-option state exists in only one place,
+- future repr changes do not require keeping `_printing.py` and `_tensor_str.py` in sync manually.
+
+This avoids the current split-brain design where formatting state and formatting execution live in separate modules without matching torch’s structure.
+
+### 3. Prioritize dense/main-path fidelity first, inside the full torch-style structure
+
+The user asked for as much completeness as practical, but the safest way to achieve that is to keep the full torch-style structure while prioritizing the dense/main path first.
+
+This means the first implementation should make the following categories as close to local torch as possible:
+
+- 0-D, 1-D, and N-D dense tensors
+- bool, int, float, and complex tensors
+- summarization behavior (`threshold`, `edgeitems`)
+- wrapping behavior (`linewidth`)
+- precision and scientific notation (`precision`, `sci_mode`)
+- suffixes for `dtype`, `device`, `requires_grad`, and `grad_fn`
+- meta tensor printing where Candle already has a meaningful path
+
+This is the highest-value, highest-coverage path and should be treated as the success baseline for the batch.
+
+### 4. Adapt torch internals to Candle runtime deliberately
+
+When porting torch’s `_tensor_str.py`, places that call directly into torch runtime helpers should be mapped deliberately onto Candle equivalents instead of left as raw copies.
+
+The expected adaptation points include:
+
+- `torch.no_grad()` → Candle’s equivalent grad-mode context
+- `torch.masked_select`, `torch.isfinite`, `torch.ceil`, `torch.abs`, `torch.min`, `torch.max`, etc. → Candle equivalents where available
+- Tensor suffix fields (`dtype`, `device`, `requires_grad`, `grad_fn`) → Candle’s existing tensor attributes
+- CPU/device conversion helpers used only for formatting → Candle-safe equivalents
+
+The main principle is to preserve torch’s formatting algorithm while only changing the runtime hook points needed to make it valid in Candle.
+
+### 5. Use controlled fallbacks for unsupported special branches
+
+Special printing branches should be handled in three tiers:
+
+1. **Fully supported by Candle** — keep or port the torch branch directly.
+2. **Partially supported by Candle** — preserve the torch branch structure but adapt the implementation to Candle’s current runtime.
+3. **Not meaningfully supported yet** — use a local fallback only in that branch, ensuring printing remains stable and non-crashing.
+
+This is important because trying to “fully support everything” inside the print rewrite could accidentally turn a printing task into a sparse/runtime/platform feature project. The printing system should degrade gracefully rather than forcing unrelated runtime work into scope.
+
+## Expected user-visible outcome
+
+After this change, Candle users should see behavior much closer to torch for:
+
+- `repr(tensor)`
+- `str(tensor)`
+- `torch.set_printoptions(...)`
+- `torch.get_printoptions()`
+- `with torch.printoptions(...): ...`
+
+In practice, dense tensor formatting should become far more torch-like in both output and corner-case handling, and the code should be organized around a single torch-style implementation file.
+
+## Critical files
+
+### Primary implementation
+- `src/candle/_tensor_str.py`
+
+### Compatibility / delegation layer
+- `src/candle/_printing.py`
+
+### Likely public export touchpoints
+- `src/candle/__init__.py`
+
+### Tests
+- `tests/cpu/test_tensor_print.py`
+- potentially targeted additions near other tensor contract tests if needed
+
+## Verification plan
+
+### Primary behavioral tests
+Expand `tests/cpu/test_tensor_print.py` so that Candle output is compared directly against local torch output for representative dense cases:
+
+- scalar tensors
+- vectors
+- matrices
+- 3D+ tensors
+- summarized tensors (`threshold` / `edgeitems`)
+- line wrapping (`linewidth`)
+- precision changes
+- `sci_mode=True/False/None`
+- bool / int / float / complex tensors
+- dtype/device suffix cases
+- `requires_grad=True`
+- `grad_fn` suffix presence where applicable
+- meta tensors
+
+### Stability tests for special branches
+For special tensor categories that Candle does not yet fully model like torch, the expectation in this batch is:
+
+- printing should not crash,
+- output should be deterministic,
+- fallback behavior should be localized and explicit.
+
+### Regression suites
+After implementation, run at least:
+
+- `conda run -n candle311 python -m pytest tests/cpu/test_tensor_print.py -q --tb=short`
+- `conda run -n candle311 python -m pytest tests/common/test_c_core.py -q --tb=short`
+- `conda run -n candle311 python -m pytest tests/cpu/test_tensor_api_contract.py -q --tb=short`
+- `conda run -n candle311 python -m pytest tests/contract/test_storage_contract.py -q --tb=short`
+
+These keep printing changes honest while also guarding against accidental regressions in the broader aligned Tensor surface.
+
+## Risks and mitigation
+
+### Risk: the port becomes a hidden runtime project
+Mitigation: keep unsupported branches on controlled local fallbacks instead of expanding the task into sparse/runtime feature work.
+
+### Risk: two print-option states remain in circulation
+Mitigation: make `_tensor_str.py` the only source of truth and reduce `_printing.py` to delegation.
+
+### Risk: output changes become hard to audit
+Mitigation: compare Candle and local torch output directly in focused print tests, not just broad “contains substring” assertions.
+
+## Recommendation
+
+Proceed with a torch-structured rewrite of `src/candle/_tensor_str.py`, using dense/main-path fidelity as the execution priority and compatibility fallbacks for branches Candle cannot yet fully model. This gives the best long-term alignment outcome while keeping the batch bounded to the printing subsystem.

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,10 @@ if _system in ("Linux", "Darwin"):
             ["src/candle/_C/_fast_ops.pyx"],
         ),
         Extension(
+            "candle._C._tensor_api",
+            ["src/candle/_C/_tensor_api.pyx"],
+        ),
+        Extension(
             "candle._C._TensorBase",
             ["src/candle/_C/_TensorBase.pyx"],
         ),

--- a/src/candle/_C/_TensorBase.pyx
+++ b/src/candle/_C/_TensorBase.pyx
@@ -8,6 +8,29 @@ _tensor_api.pyx are installed via _install_tensor_api() after import.
 from ._tensor_impl cimport TensorImpl
 from ._tensor_impl import _StrideTuple, cy_init_tensor_fields
 
+import numpy as _np
+
+
+def _compute_strides(shape):
+    stride = []
+    acc = 1
+    for d in reversed(shape):
+        stride.append(acc)
+        acc *= d
+    return _StrideTuple(reversed(stride))
+
+
+def _bf16_to_f32(arr):
+    u32 = arr.astype(_np.uint32) << 16
+    return u32.view(_np.float32)
+
+
+def _f32_to_bf16(arr):
+    u32 = arr.view(_np.uint32)
+    rounding_bias = (u32 >> 16) & 1
+    u32 = u32 + 0x7FFF + rounding_bias
+    return (u32 >> 16).astype(_np.uint16)
+
 
 class TensorBase(TensorImpl):
     """torch._C.TensorBase equivalent.
@@ -59,10 +82,6 @@ class TensorBase(TensorImpl):
     def data(self, new_data):
         if not isinstance(new_data, TensorBase):
             raise TypeError(f"data must be a Tensor, got {type(new_data).__name__}")
-        if new_data.shape != self.shape:
-            raise RuntimeError(f"shape mismatch: expected {self.shape}, got {new_data.shape}")
-        if new_data.dtype != self.dtype:
-            raise RuntimeError(f"dtype mismatch: expected {self.dtype}, got {new_data.dtype}")
         self.cy_set_data_runtime_truth_from(new_data)
 
     @classmethod
@@ -161,7 +180,6 @@ class TensorBase(TensorImpl):
         return self
 
     def is_contiguous(self, memory_format=None):
-        from candle._C import _compute_strides
         expected = _compute_strides(self.shape)
         return self.stride == expected
 
@@ -318,7 +336,6 @@ class TensorBase(TensorImpl):
 
     def set_(self, typed_storage, storage_offset=None, size=None, stride=None):
         from candle.storage import TypedStorage
-        from candle._C import _compute_strides
         if not isinstance(typed_storage, TypedStorage):
             raise TypeError("set_() currently only supports TypedStorage input")
         if storage_offset is None:
@@ -331,6 +348,33 @@ class TensorBase(TensorImpl):
                 size = (total,)
         if stride is None:
             stride = _compute_strides(size)
+
+        storage_offset = int(storage_offset)
+        size = tuple(int(dim) for dim in size)
+        stride = tuple(int(step) for step in stride)
+
+        if len(size) != len(stride):
+            raise RuntimeError(
+                f"mismatch in length of strides and shape: {len(stride)} != {len(size)}"
+            )
+
+        required = 0
+        if size and all(dim > 0 for dim in size):
+            max_index = storage_offset
+            for dim, step in zip(size, stride):
+                if dim > 0:
+                    max_index += (dim - 1) * step
+            required = max_index + 1
+
+        storage_size = typed_storage._size()
+        if required > storage_size:
+            itemsize = self.dtype.itemsize if getattr(self, 'dtype', None) is not None else typed_storage.dtype.itemsize
+            raise RuntimeError(
+                f"setStorage: sizes {list(size)}, strides {list(stride)}, storage offset {storage_offset}, "
+                f"and itemsize {itemsize} requiring a storage size of {required * itemsize} are out of bounds "
+                f"for storage of size {storage_size * itemsize}"
+            )
+
         self.cy_set_runtime_truth(typed_storage, size, stride, storage_offset)
         return self
 
@@ -347,7 +391,6 @@ class TensorBase(TensorImpl):
         pass
 
     def numpy(self):
-        from candle._C import _bf16_to_f32
         from candle._dtype import bfloat16
         arr = self._numpy_view()
         if self.dtype == bfloat16:
@@ -359,7 +402,7 @@ class TensorBase(TensorImpl):
         _backward(self, gradient, retain_graph, create_graph, inputs=inputs)
 
     def pin_memory(self):
-        from candle._C import pinned_cpu_typed_storage_from_numpy, _compute_strides
+        from candle._C import pinned_cpu_typed_storage_from_numpy
         storage = pinned_cpu_typed_storage_from_numpy(self._numpy_view(), self.dtype, device=self.device)
         return type(self)(storage, self.shape, _compute_strides(self.shape), 0, self.requires_grad)
 
@@ -540,3 +583,321 @@ class TensorBase(TensorImpl):
 
 
 _TensorBase = TensorBase
+
+
+def _install_tensor_api(TensorBase):
+    """Install Cython tensor API methods on TensorBase."""
+    from . import _tensor_api as _tensor_api_mod
+    TensorBase._set_device_from_storage = _tensor_api_mod.tensor_set_device_from_storage
+    TensorBase._set_dtype_from_storage = _tensor_api_mod.tensor_set_dtype_from_storage
+    TensorBase.data = property(TensorBase.data.fget, _tensor_api_mod.tensor_set_data)
+    TensorBase.__delattr__ = _tensor_api_mod.tensor_delattr
+    TensorBase._fw_get = _tensor_api_mod.tensor_fw_get
+    TensorBase._fw_set = _tensor_api_mod.tensor_fw_set
+    TensorBase._fw_clear = _tensor_api_mod.tensor_fw_clear
+    TensorBase._fw_has = _tensor_api_mod.tensor_fw_has
+    TensorBase.untyped_storage = _tensor_api_mod.tensor_untyped_storage
+    TensorBase.record_stream = _tensor_api_mod.tensor_record_stream
+    TensorBase.is_pinned = _tensor_api_mod.tensor_is_pinned
+
+    TensorBase.__add__ = _tensor_api_mod.tensor_add
+    TensorBase.__sub__ = _tensor_api_mod.tensor_sub
+    TensorBase.__mul__ = _tensor_api_mod.tensor_mul
+    TensorBase.__matmul__ = _tensor_api_mod.tensor_matmul
+    TensorBase.__getitem__ = _tensor_api_mod.tensor_getitem
+    TensorBase.__setitem__ = _tensor_api_mod.tensor_setitem
+    TensorBase.__iadd__ = _tensor_api_mod.tensor_iadd
+    TensorBase.__isub__ = _tensor_api_mod.tensor_isub
+    TensorBase.__imul__ = _tensor_api_mod.tensor_imul
+    TensorBase.__itruediv__ = _tensor_api_mod.tensor_itruediv
+    TensorBase.__neg__ = _tensor_api_mod.tensor_neg
+    TensorBase.neg = _tensor_api_mod.tensor_neg
+
+    TensorBase.clone = _tensor_api_mod.tensor_clone
+    TensorBase.detach = _tensor_api_mod.tensor_detach
+    TensorBase.detach_ = _tensor_api_mod.tensor_detach_
+    TensorBase.to = _tensor_api_mod.tensor_to
+    TensorBase._to_dtype = _tensor_api_mod.tensor_to_dtype
+    TensorBase.cpu = _tensor_api_mod.tensor_cpu
+    TensorBase.npu = _tensor_api_mod.tensor_npu
+    TensorBase.mps = _tensor_api_mod.tensor_mps
+    TensorBase.cuda = _tensor_api_mod.tensor_cuda
+    TensorBase.backward = _tensor_api_mod.tensor_backward
+    TensorBase.relu = _tensor_api_mod.tensor_relu
+    TensorBase.is_contiguous = _tensor_api_mod.tensor_is_contiguous
+    TensorBase.contiguous = _tensor_api_mod.tensor_contiguous
+    TensorBase.reshape = _tensor_api_mod.tensor_reshape
+    TensorBase.transpose = _tensor_api_mod.tensor_transpose
+    TensorBase.view = _tensor_api_mod.tensor_view
+    TensorBase.flatten = _tensor_api_mod.tensor_flatten
+    TensorBase.t = _tensor_api_mod.tensor_t
+    TensorBase.as_strided = _tensor_api_mod.tensor_as_strided
+    TensorBase.size = _tensor_api_mod.tensor_size
+    TensorBase.dim = _tensor_api_mod.tensor_dim
+
+    TensorBase.retain_grad = _tensor_api_mod.tensor_retain_grad
+    TensorBase.requires_grad_ = _tensor_api_mod.tensor_requires_grad_
+    TensorBase.register_hook = _tensor_api_mod.tensor_register_hook
+
+    TensorBase._is_view = _tensor_api_mod.tensor_is_view
+    TensorBase._check_inplace = _tensor_api_mod.tensor_check_inplace
+
+    TensorBase.add_ = _tensor_api_mod.tensor_add_
+    TensorBase.mul_ = _tensor_api_mod.tensor_mul_
+    TensorBase.relu_ = _tensor_api_mod.tensor_relu_
+    TensorBase.zero_ = _tensor_api_mod.tensor_zero_
+    TensorBase.fill_ = _tensor_api_mod.tensor_fill_
+    TensorBase.copy_ = _tensor_api_mod.tensor_copy_
+
+    TensorBase.abs_ = _tensor_api_mod.tensor_abs_
+    TensorBase.neg_ = _tensor_api_mod.tensor_neg_
+    TensorBase.exp_ = _tensor_api_mod.tensor_exp_
+    TensorBase.log_ = _tensor_api_mod.tensor_log_
+    TensorBase.log2_ = _tensor_api_mod.tensor_log2_
+    TensorBase.log10_ = _tensor_api_mod.tensor_log10_
+    TensorBase.sqrt_ = _tensor_api_mod.tensor_sqrt_
+    TensorBase.sin_ = _tensor_api_mod.tensor_sin_
+    TensorBase.cos_ = _tensor_api_mod.tensor_cos_
+    TensorBase.tan_ = _tensor_api_mod.tensor_tan_
+    TensorBase.tanh_ = _tensor_api_mod.tensor_tanh_
+    TensorBase.sigmoid_ = _tensor_api_mod.tensor_sigmoid_
+    TensorBase.floor_ = _tensor_api_mod.tensor_floor_
+    TensorBase.ceil_ = _tensor_api_mod.tensor_ceil_
+    TensorBase.round_ = _tensor_api_mod.tensor_round_
+    TensorBase.trunc_ = _tensor_api_mod.tensor_trunc_
+    TensorBase.pow_ = _tensor_api_mod.tensor_pow_
+    TensorBase.reciprocal_ = _tensor_api_mod.tensor_reciprocal_
+    TensorBase.erfinv_ = _tensor_api_mod.tensor_erfinv_
+
+    TensorBase.sub_ = _tensor_api_mod.tensor_sub_
+    TensorBase.clamp_ = _tensor_api_mod.tensor_clamp_
+    TensorBase.uniform_ = _tensor_api_mod.tensor_uniform_
+    TensorBase.normal_ = _tensor_api_mod.tensor_normal_
+    TensorBase.random_ = _tensor_api_mod.tensor_random_
+    TensorBase.randint_ = _tensor_api_mod.tensor_randint_
+    TensorBase.bernoulli_ = _tensor_api_mod.tensor_bernoulli_
+    TensorBase.exponential_ = _tensor_api_mod.tensor_exponential_
+    TensorBase.log_normal_ = _tensor_api_mod.tensor_log_normal_
+    TensorBase.cauchy_ = _tensor_api_mod.tensor_cauchy_
+    TensorBase.geometric_ = _tensor_api_mod.tensor_geometric_
+
+    TensorBase.transpose_ = _tensor_api_mod.tensor_transpose_
+    TensorBase.t_ = _tensor_api_mod.tensor_t_
+    TensorBase.squeeze_ = _tensor_api_mod.tensor_squeeze_
+    TensorBase.unsqueeze_ = _tensor_api_mod.tensor_unsqueeze_
+    TensorBase.as_strided_ = _tensor_api_mod.tensor_as_strided_
+    TensorBase.swapdims_ = _tensor_api_mod.tensor_swapdims_
+    TensorBase.swapaxes_ = _tensor_api_mod.tensor_swapaxes_
+
+    TensorBase.scatter_add = _tensor_api_mod.tensor_scatter_add
+    TensorBase.index_fill = _tensor_api_mod.tensor_index_fill
+    TensorBase.index_copy = _tensor_api_mod.tensor_index_copy
+    TensorBase.index_add = _tensor_api_mod.tensor_index_add
+    TensorBase.put_ = _tensor_api_mod.tensor_put_
+    TensorBase.scatter_ = _tensor_api_mod.tensor_scatter_
+    TensorBase.scatter_add_ = _tensor_api_mod.tensor_scatter_add_
+    TensorBase.masked_fill_ = _tensor_api_mod.tensor_masked_fill_
+    TensorBase.masked_scatter_ = _tensor_api_mod.tensor_masked_scatter_
+    TensorBase.index_put_ = _tensor_api_mod.tensor_index_put_
+    TensorBase.index_copy_ = _tensor_api_mod.tensor_index_copy_
+    TensorBase.index_fill_ = _tensor_api_mod.tensor_index_fill_
+    TensorBase.index_add_ = _tensor_api_mod.tensor_index_add_
+
+    TensorBase.new_empty = _tensor_api_mod.tensor_new_empty
+    TensorBase.new_tensor = _tensor_api_mod.tensor_new_tensor
+    TensorBase.new_empty_strided = _tensor_api_mod.tensor_new_empty_strided
+    TensorBase._ones_like = _tensor_api_mod.tensor_ones_like
+    TensorBase.new_ones = _tensor_api_mod.tensor_new_ones
+    TensorBase.new_zeros = _tensor_api_mod.tensor_new_zeros
+    TensorBase.new_full = _tensor_api_mod.tensor_new_full
+    TensorBase.div_ = _tensor_api_mod.tensor_div_
+    TensorBase.unflatten = _tensor_api_mod.tensor_unflatten
+    TensorBase.bitwise_and_ = _tensor_api_mod.tensor_bitwise_and_
+    TensorBase.bitwise_or_ = _tensor_api_mod.tensor_bitwise_or_
+    TensorBase.bitwise_xor_ = _tensor_api_mod.tensor_bitwise_xor_
+    TensorBase.type = _tensor_api_mod.tensor_type
+    TensorBase.type_as = _tensor_api_mod.tensor_type_as
+    TensorBase.reshape_as = _tensor_api_mod.tensor_reshape_as
+    TensorBase.permute = _tensor_api_mod.tensor_permute
+    TensorBase.mean = _tensor_api_mod.tensor_mean
+    TensorBase.std = _tensor_api_mod.tensor_std
+    TensorBase.repeat = _tensor_api_mod.tensor_repeat
+    TensorBase.tile = _tensor_api_mod.tensor_tile
+    TensorBase.flip = _tensor_api_mod.tensor_flip
+    TensorBase.logsumexp = _tensor_api_mod.tensor_logsumexp
+    TensorBase.trace = _tensor_api_mod.tensor_trace
+    TensorBase.det = _tensor_api_mod.tensor_det
+    TensorBase.matrix_power = _tensor_api_mod.tensor_matrix_power
+    TensorBase.dist = _tensor_api_mod.tensor_dist
+    TensorBase.renorm = _tensor_api_mod.tensor_renorm
+    TensorBase.nansum = _tensor_api_mod.tensor_nansum
+    TensorBase.nanmean = _tensor_api_mod.tensor_nanmean
+    TensorBase.argwhere = _tensor_api_mod.tensor_argwhere
+    TensorBase.baddbmm = _tensor_api_mod.tensor_baddbmm
+    TensorBase.vsplit = _tensor_api_mod.tensor_vsplit
+    TensorBase.hsplit = _tensor_api_mod.tensor_hsplit
+    TensorBase.dsplit = _tensor_api_mod.tensor_dsplit
+    TensorBase.take_along_dim = _tensor_api_mod.tensor_take_along_dim
+    TensorBase.cummin = _tensor_api_mod.tensor_cummin
+    TensorBase.log1p = _tensor_api_mod.tensor_log1p
+    TensorBase.expm1 = _tensor_api_mod.tensor_expm1
+    TensorBase.lt = _tensor_api_mod.tensor_lt
+    TensorBase.le = _tensor_api_mod.tensor_le
+    TensorBase.gt = _tensor_api_mod.tensor_gt
+    TensorBase.ge = _tensor_api_mod.tensor_ge
+    TensorBase.abs = _tensor_api_mod.tensor_abs
+    TensorBase.exp = _tensor_api_mod.tensor_exp
+    TensorBase.log = _tensor_api_mod.tensor_log
+    TensorBase.sqrt = _tensor_api_mod.tensor_sqrt
+    TensorBase.sin = _tensor_api_mod.tensor_sin
+    TensorBase.cos = _tensor_api_mod.tensor_cos
+    TensorBase.tan = _tensor_api_mod.tensor_tan
+    TensorBase.tanh = _tensor_api_mod.tensor_tanh
+    TensorBase.sigmoid = _tensor_api_mod.tensor_sigmoid
+    TensorBase.floor = _tensor_api_mod.tensor_floor
+    TensorBase.ceil = _tensor_api_mod.tensor_ceil
+    TensorBase.round = _tensor_api_mod.tensor_round
+    TensorBase.trunc = _tensor_api_mod.tensor_trunc
+    TensorBase.frac = _tensor_api_mod.tensor_frac
+    TensorBase.log2 = _tensor_api_mod.tensor_log2
+    TensorBase.log10 = _tensor_api_mod.tensor_log10
+    TensorBase.exp2 = _tensor_api_mod.tensor_exp2
+    TensorBase.rsqrt = _tensor_api_mod.tensor_rsqrt
+    TensorBase.sign = _tensor_api_mod.tensor_sign
+    TensorBase.signbit = _tensor_api_mod.tensor_signbit
+    TensorBase.square = _tensor_api_mod.tensor_square
+    TensorBase.isnan = _tensor_api_mod.tensor_isnan
+    TensorBase.isinf = _tensor_api_mod.tensor_isinf
+    TensorBase.isfinite = _tensor_api_mod.tensor_isfinite
+    TensorBase.sinh = _tensor_api_mod.tensor_sinh
+    TensorBase.cosh = _tensor_api_mod.tensor_cosh
+    TensorBase.asinh = _tensor_api_mod.tensor_asinh
+    TensorBase.acosh = _tensor_api_mod.tensor_acosh
+    TensorBase.atanh = _tensor_api_mod.tensor_atanh
+    TensorBase.erf = _tensor_api_mod.tensor_erf
+    TensorBase.erfc = _tensor_api_mod.tensor_erfc
+    TensorBase.reciprocal = _tensor_api_mod.tensor_reciprocal
+    TensorBase.tril = _tensor_api_mod.tensor_tril
+    TensorBase.triu = _tensor_api_mod.tensor_triu
+    TensorBase.diag = _tensor_api_mod.tensor_diag
+    TensorBase.add = _tensor_api_mod.tensor_add_method
+    TensorBase.sub = _tensor_api_mod.tensor_sub_method
+    TensorBase.mul = _tensor_api_mod.tensor_mul_method
+    TensorBase.div = _tensor_api_mod.tensor_div_method
+    TensorBase.pow = _tensor_api_mod.tensor_pow_method
+    TensorBase.matmul = _tensor_api_mod.tensor_matmul_method
+    TensorBase.__rsub__ = _tensor_api_mod.tensor_rsub
+    TensorBase.__rmul__ = _tensor_api_mod.tensor_rmul
+    TensorBase.__truediv__ = _tensor_api_mod.tensor_truediv
+    TensorBase.__rtruediv__ = _tensor_api_mod.tensor_rtruediv
+    TensorBase.__pow__ = _tensor_api_mod.tensor_pow_op
+    TensorBase.__rpow__ = _tensor_api_mod.tensor_rpow
+    TensorBase.__floordiv__ = _tensor_api_mod.tensor_floordiv
+    TensorBase.__rfloordiv__ = _tensor_api_mod.tensor_rfloordiv
+    TensorBase.__mod__ = _tensor_api_mod.tensor_mod
+    TensorBase.__rmod__ = _tensor_api_mod.tensor_rmod
+    TensorBase.__rmatmul__ = _tensor_api_mod.tensor_rmatmul
+    TensorBase.__rlshift__ = _tensor_api_mod.tensor_rlshift
+    TensorBase.__rrshift__ = _tensor_api_mod.tensor_rrshift
+    TensorBase.__and__ = _tensor_api_mod.tensor_and
+    TensorBase.__or__ = _tensor_api_mod.tensor_or
+    TensorBase.__xor__ = _tensor_api_mod.tensor_xor
+    TensorBase.all = _tensor_api_mod.tensor_all_method
+    TensorBase.any = _tensor_api_mod.tensor_any_method
+    TensorBase.sum = _tensor_api_mod.tensor_sum_method
+    TensorBase.prod = _tensor_api_mod.tensor_prod_method
+    TensorBase.var = _tensor_api_mod.tensor_var_method
+    TensorBase.var_mean = _tensor_api_mod.tensor_var_mean_method
+    TensorBase.norm = _tensor_api_mod.tensor_norm_method
+    TensorBase.count_nonzero = _tensor_api_mod.tensor_count_nonzero_method
+    TensorBase.cumsum = _tensor_api_mod.tensor_cumsum_method
+    TensorBase.cumprod = _tensor_api_mod.tensor_cumprod_method
+    TensorBase.cummax = _tensor_api_mod.tensor_cummax_method
+    TensorBase.argsort = _tensor_api_mod.tensor_argsort_method
+    TensorBase.sort = _tensor_api_mod.tensor_sort_method
+    TensorBase.topk = _tensor_api_mod.tensor_topk_method
+    TensorBase.eq = _tensor_api_mod.tensor_eq_method
+    TensorBase.ne = _tensor_api_mod.tensor_ne_method
+    TensorBase.allclose = _tensor_api_mod.tensor_allclose_method
+    TensorBase.isclose = _tensor_api_mod.tensor_isclose_method
+    TensorBase.equal = _tensor_api_mod.tensor_equal_method
+    TensorBase.view_as = _tensor_api_mod.tensor_view_as
+    TensorBase.expand = _tensor_api_mod.tensor_expand_method
+    TensorBase.expand_as = _tensor_api_mod.tensor_expand_as_method
+    TensorBase.expand_copy = _tensor_api_mod.tensor_expand_copy_method
+    TensorBase.narrow = _tensor_api_mod.tensor_narrow_method
+    TensorBase.select = _tensor_api_mod.tensor_select_method
+    TensorBase.unfold = _tensor_api_mod.tensor_unfold_method
+    TensorBase.moveaxis = _tensor_api_mod.tensor_moveaxis_method
+    TensorBase.swapdims = _tensor_api_mod.tensor_swapdims_method
+    TensorBase.swapaxes = _tensor_api_mod.tensor_swapaxes_method
+    TensorBase.gather = _tensor_api_mod.tensor_gather_method
+    TensorBase.scatter = _tensor_api_mod.tensor_scatter_method
+    TensorBase.index_select = _tensor_api_mod.tensor_index_select_method
+    TensorBase.take = _tensor_api_mod.tensor_take_method
+    TensorBase.masked_fill = _tensor_api_mod.tensor_masked_fill_method
+    TensorBase.masked_select = _tensor_api_mod.tensor_masked_select_method
+    TensorBase.index_put = _tensor_api_mod.tensor_index_put_method
+    TensorBase.slice = _tensor_api_mod.tensor_slice_method
+    TensorBase.slice_copy = _tensor_api_mod.tensor_slice_copy_method
+    TensorBase.slice_scatter = _tensor_api_mod.tensor_slice_scatter_method
+    TensorBase.nonzero = _tensor_api_mod.tensor_nonzero_method
+    TensorBase.sum_to_size = _tensor_api_mod.tensor_sum_to_size_method
+    TensorBase.softplus = _tensor_api_mod.tensor_softplus_method
+    TensorBase.clamp = _tensor_api_mod.tensor_clamp_method
+    TensorBase.relu6 = _tensor_api_mod.tensor_relu6_method
+    TensorBase.hardtanh = _tensor_api_mod.tensor_hardtanh_method
+    TensorBase.min = _tensor_api_mod.tensor_min_method
+    TensorBase.max = _tensor_api_mod.tensor_max_method
+    TensorBase.amin = _tensor_api_mod.tensor_amin_method
+    TensorBase.amax = _tensor_api_mod.tensor_amax_method
+    TensorBase.addmm = _tensor_api_mod.tensor_addmm_method
+    TensorBase.bmm = _tensor_api_mod.tensor_bmm_method
+    TensorBase.mm = _tensor_api_mod.tensor_mm_method
+    TensorBase.chunk = _tensor_api_mod.tensor_chunk_method
+    TensorBase.split = _tensor_api_mod.tensor_split_method
+    TensorBase.roll = _tensor_api_mod.tensor_roll_method
+    TensorBase.rot90 = _tensor_api_mod.tensor_rot90_method
+    TensorBase.addcdiv = _tensor_api_mod.tensor_addcdiv_method
+    TensorBase.addcmul = _tensor_api_mod.tensor_addcmul_method
+    TensorBase.hypot = _tensor_api_mod.tensor_hypot_method
+    TensorBase.lerp = _tensor_api_mod.tensor_lerp_method
+    TensorBase.atan2 = _tensor_api_mod.tensor_atan2_method
+    TensorBase.asin = _tensor_api_mod.tensor_asin_method
+    TensorBase.acos = _tensor_api_mod.tensor_acos_method
+    TensorBase.atan = _tensor_api_mod.tensor_atan_method
+    TensorBase.as_strided_copy = _tensor_api_mod.tensor_as_strided_copy_method
+    TensorBase.as_strided_scatter = _tensor_api_mod.tensor_as_strided_scatter_method
+    TensorBase.multinomial = _tensor_api_mod.tensor_multinomial_method
+    TensorBase.ndim = property(_tensor_api_mod.tensor_ndim_fget)
+    TensorBase.T = property(_tensor_api_mod.tensor_T_fget)
+    TensorBase.is_floating_point = _tensor_api_mod.tensor_is_floating_point
+    TensorBase.is_complex = _tensor_api_mod.tensor_is_complex
+    TensorBase.clamp_min = _tensor_api_mod.tensor_clamp_min_method
+    TensorBase.clamp_max = _tensor_api_mod.tensor_clamp_max_method
+    TensorBase.fmin = _tensor_api_mod.tensor_fmin_method
+    TensorBase.fmax = _tensor_api_mod.tensor_fmax_method
+    TensorBase.where = _tensor_api_mod.tensor_where_method
+    TensorBase.logaddexp = _tensor_api_mod.tensor_logaddexp_method
+    TensorBase.logaddexp2 = _tensor_api_mod.tensor_logaddexp2_method
+    TensorBase.remainder = _tensor_api_mod.tensor_remainder_method
+    TensorBase.fmod = _tensor_api_mod.tensor_fmod_method
+    TensorBase.squeeze = _tensor_api_mod.tensor_squeeze_method
+    TensorBase.unsqueeze = _tensor_api_mod.tensor_unsqueeze_method
+    TensorBase.argmax = _tensor_api_mod.tensor_argmax_method
+    TensorBase.argmin = _tensor_api_mod.tensor_argmin_method
+    TensorBase.logical_and = _tensor_api_mod.tensor_logical_and
+    TensorBase.logical_or = _tensor_api_mod.tensor_logical_or
+    TensorBase.logical_xor = _tensor_api_mod.tensor_logical_xor
+    TensorBase.logical_not = _tensor_api_mod.tensor_logical_not
+    TensorBase.bitwise_and = _tensor_api_mod.tensor_bitwise_and
+    TensorBase.bitwise_or = _tensor_api_mod.tensor_bitwise_or
+    TensorBase.bitwise_xor = _tensor_api_mod.tensor_bitwise_xor
+    TensorBase.bitwise_not = _tensor_api_mod.tensor_bitwise_not
+    TensorBase.movedim = _tensor_api_mod.tensor_movedim
+    TensorBase.diagonal = _tensor_api_mod.tensor_diagonal
+    TensorBase.unbind = _tensor_api_mod.tensor_unbind
+
+    TensorBase.numpy = _tensor_api_mod.tensor_numpy
+    TensorBase._numpy_view = _tensor_api_mod.tensor_numpy_view
+    TensorBase.pin_memory = _tensor_api_mod.tensor_pin_memory

--- a/src/candle/_C/__init__.py
+++ b/src/candle/_C/__init__.py
@@ -691,3 +691,6 @@ def _install_tensor_api():
     TensorBase._numpy_view = _tensor_api_mod.tensor_numpy_view
     TensorBase.pin_memory = _tensor_api_mod.tensor_pin_memory
 
+
+_install_tensor_api()
+

--- a/src/candle/_C/__init__.py
+++ b/src/candle/_C/__init__.py
@@ -144,7 +144,7 @@ if _HAS_CYTHON_TENSOR_API:
 
     # Re-export the 11 tensor bootstrap helpers that contract tests expect
     # directly on candle._C (analogous to torch._C)._tensor_api helpers
-    import candle._C._tensor_api as _tapi
+    import candle._C._tensor_api as _tapi  # pylint: disable=import-error  # pylint: disable=import-error
 
     tensor_set_device_from_storage = _tapi.tensor_set_device_from_storage
     tensor_set_dtype_from_storage = _tapi.tensor_set_dtype_from_storage

--- a/src/candle/_C/__init__.py
+++ b/src/candle/_C/__init__.py
@@ -25,288 +25,97 @@ Feature flags (set after import):
     _HAS_CYTHON_STORAGE_IMPL    — True if _storage_impl.pyx compiled successfully
 """
 
-_HAS_CYTHON_DISPATCH = False
-_HAS_CYTHON_ALLOCATOR = False
-_HAS_CYTHON_STORAGE = False
-_HAS_CYTHON_NPU_OPS = False
-_HAS_CYTHON_ACLNN_FFI = False
-_HAS_CYTHON_DISPATCHER_CORE = False
-_HAS_CYTHON_DEVICE = False
-_HAS_CYTHON_DTYPE = False
-# Autograd core modules are required (hard imports below -- no fallback).
-_HAS_CYTHON_AUTOGRAD_NODE = False
-_HAS_CYTHON_AUTOGRAD_GRAPH = False
-_HAS_CYTHON_AUTOGRAD_ENGINE = False
-_HAS_CYTHON_AUTOGRAD_FUNCTION = False
-_HAS_CYTHON_AUTOGRAD_OPS = False
-_HAS_CYTHON_FUNCTIONAL_OPS = False
-_HAS_CYTHON_FAST_OPS = False
-_HAS_CYTHON_TENSOR_API = False
+from ._bootstrap import (
+    _HAS_CYTHON_ACLNN_FFI,
+    _HAS_CYTHON_ALLOCATOR,
+    _HAS_CYTHON_AUTOGRAD_ENGINE,
+    _HAS_CYTHON_AUTOGRAD_FUNCTION,
+    _HAS_CYTHON_AUTOGRAD_GRAPH,
+    _HAS_CYTHON_AUTOGRAD_NODE,
+    _HAS_CYTHON_AUTOGRAD_OPS,
+    _HAS_CYTHON_DEVICE,
+    _HAS_CYTHON_DISPATCH,
+    _HAS_CYTHON_DISPATCHER_CORE,
+    _HAS_CYTHON_DTYPE,
+    _HAS_CYTHON_FAST_OPS,
+    _HAS_CYTHON_FUNCTIONAL_OPS,
+    _HAS_CYTHON_NPU_OPS,
+    _HAS_CYTHON_STORAGE,
+    _HAS_CYTHON_STORAGE_IMPL,
+    _HAS_CYTHON_TENSOR_API,
+    AccumulateGrad,
+    FastDevice,
+    FastDType,
+    FastNpuAllocator,
+    FastNode,
+    FunctionCtx,
+    GradientEdge,
+    InputMetadata,
+    Node,
+    SavedTensor,
+    StorageImpl,
+    TensorBase,
+    TensorImpl,
+    _StrideTuple,
+    _TensorBase,
+    _bf16_to_f32,
+    _compute_strides,
+    _f32_to_bf16,
+    _install_tensor_api,
+    aclnn_ffi_init,
+    backward,
+    binary_op_no_alpha,
+    binary_op_with_alpha,
+    create_int_array,
+    create_scalar,
+    create_tensor,
+    cy_dispatch,
+    cy_dispatch_with_keyset,
+    cy_dispatch_with_keyset_fast,
+    destroy_executor,
+    destroy_int_array,
+    destroy_scalar,
+    destroy_tensor,
+    execute,
+    fast_binary_op,
+    get_gradient_edge,
+    grad,
+    is_anomaly_check_nan_enabled,
+    is_anomaly_enabled,
+    is_create_graph_enabled,
+    pop_anomaly_config,
+    pop_evaluating_node,
+    push_anomaly_config,
+    push_evaluating_node,
+    resolve_op,
+    saved_tensors_hooks,
+)
 
-try:
-    from candle._dispatch import cy_dispatch, cy_dispatch_with_keyset  # noqa: F401
-    _HAS_CYTHON_DISPATCH = True
-except ImportError:
-    pass
-
-try:
-    from ._allocator import FastNpuAllocator  # noqa: F401
-    _HAS_CYTHON_ALLOCATOR = True
-except ImportError:
-    pass
-
-try:
-    from ._storage import cy_npu_storage_from_ptr  # noqa: F401
-    _HAS_CYTHON_STORAGE = True
-except ImportError:
-    pass
-
-try:
-    from ._npu_ops import fast_binary_op  # noqa: F401
-    _HAS_CYTHON_NPU_OPS = True
-except ImportError:
-    pass
-
-try:
-    from ._aclnn_ffi import (  # noqa: F401
-        init as aclnn_ffi_init,
-        create_tensor, destroy_tensor,
-        create_scalar, destroy_scalar,
-        create_int_array, destroy_int_array,
-        destroy_executor, resolve_op, execute,
-        binary_op_with_alpha, binary_op_no_alpha,
-    )
-    _HAS_CYTHON_ACLNN_FFI = True
-except ImportError:
-    pass
-
-from ._tensor_impl import TensorImpl, _VersionCounterProxy  # noqa: F401  # pylint: disable=import-error,no-name-in-module
-
-try:
-    from ._dispatcher_core import cy_dispatch_with_keyset_fast  # noqa: F401
-    _HAS_CYTHON_DISPATCHER_CORE = True
-except ImportError:
-    pass
-
-try:
-    from candle._device import FastDevice  # noqa: F401
-    _HAS_CYTHON_DEVICE = True
-except ImportError:
-    pass
-
-try:
-    from candle._dtype import FastDType  # noqa: F401
-    _HAS_CYTHON_DTYPE = True
-except ImportError:
-    pass
-
-try:
-    from ._autograd_node import (  # pylint: disable=import-error,no-name-in-module
-        AccumulateGrad,  # noqa: F401
-        FastNode,  # noqa: F401
-        InputMetadata,  # noqa: F401
-        Node,  # noqa: F401
-        SavedTensor,  # noqa: F401
-        _NodeHookHandle,  # noqa: F401
-        _SavedValue,  # noqa: F401
-    )
-    _HAS_CYTHON_AUTOGRAD_NODE = True
-except ImportError:
-    _HAS_CYTHON_AUTOGRAD_NODE = False
-
-try:
-    from ._autograd_graph import (  # noqa: F401  # pylint: disable=import-error,no-name-in-module
-        GradientEdge,
-        current_saved_tensors_hooks,
-        get_gradient_edge,
-        saved_tensors_hooks,
-    )
-    _HAS_CYTHON_AUTOGRAD_GRAPH = True
-except ImportError:
-    _HAS_CYTHON_AUTOGRAD_GRAPH = False
-
-try:
-    from ._autograd_engine import (  # noqa: F401  # pylint: disable=import-error,no-name-in-module
-        _GraphTask,
-        _build_dependencies,
-        _run_backward,
-        backward,
-        current_anomaly_parent,
-        grad,
-        is_anomaly_check_nan_enabled,
-        is_anomaly_enabled,
-        is_create_graph_enabled,
-        pop_anomaly_config,
-        pop_evaluating_node,
-        push_anomaly_config,
-        push_evaluating_node,
-    )
-    _HAS_CYTHON_AUTOGRAD_ENGINE = True
-except ImportError:
-    _HAS_CYTHON_AUTOGRAD_ENGINE = False
-
-try:
-    from ._autograd_function import (  # noqa: F401  # pylint: disable=import-error,no-name-in-module
-        FunctionCtx,
-        _function_apply,
-    )
-    _HAS_CYTHON_AUTOGRAD_FUNCTION = True
-except ImportError:
-    _HAS_CYTHON_AUTOGRAD_FUNCTION = False
-
-try:
-    from ._autograd_ops import (  # noqa: F401  # pylint: disable=import-error,no-name-in-module
-        _strip_autograd_keys,
-        _grad_context,
-        _backward_dispatch_keyset,
-        _autograd_unary_passthrough,
-        _autograd_binary,
-        _autograd_binary_args,
-        _autograd_unary_args,
-        _norm_extract_weight_bias,
-        _autograd_norm,
-    )
-    _HAS_CYTHON_AUTOGRAD_OPS = True
-except ImportError:
-    _HAS_CYTHON_AUTOGRAD_OPS = False
-
-try:
-    from ._functional_ops import (  # noqa: F401  # pylint: disable=import-error,no-name-in-module
-        _has_torch_function as cy_has_torch_function,
-        _handle_torch_function as cy_handle_torch_function,
-        add as functional_add,
-        mul as functional_mul,
-        matmul as functional_matmul,
-        relu as functional_relu,
-        transpose as functional_transpose,
-        reshape as functional_reshape,
-        neg as functional_neg,
-    )
-    _HAS_CYTHON_FUNCTIONAL_OPS = True
-except ImportError:
-    pass
-
-try:
-    import importlib
-    _legacy_fast_ops = importlib.import_module(f"{__name__}._fast_ops")  # noqa: F401
-    _HAS_CYTHON_FAST_OPS = True
-except ImportError:
-    pass
-
-try:
-    from ._TensorBase import TensorBase, _TensorBase  # noqa: F401  # pylint: disable=import-error,no-name-in-module
-    _HAS_CYTHON_TENSOR_API = True
-except ImportError:
-    _HAS_CYTHON_TENSOR_API = False
-
-_HAS_CYTHON_STORAGE_IMPL = False
-
-try:
-    from ._storage_impl import StorageImpl  # noqa: F401
-    _HAS_CYTHON_STORAGE_IMPL = True
-except ImportError:
-    pass
 
 # =============================================================================
 # torch._C stubs and TensorBase (from _C_stubs.py)
 # =============================================================================
 
-# pylint: disable=import-error,no-name-in-module,possibly-unused-variable
-import abc
-
-
-def _add_docstr(obj, docstr):
-    """Minimal torch._C._add_docstr stub."""
-    obj.__doc__ = docstr
-    return obj
-
-
-class _disabled_torch_dispatch_impl:
-    """Minimal torch._C._disabled_torch_dispatch_impl context manager."""
-    def __init__(self, *args, **kwargs): pass
-    def __enter__(self): return self
-    def __exit__(self, *args): pass
-
-
-_torch_function_enabled = True
-
-
-class DisableTorchFunctionSubclass:
-    """Minimal torch._C.DisableTorchFunctionSubclass context manager."""
-    def __init__(self): pass
-    def __enter__(self):
-        global _torch_function_enabled
-        self._prev = _torch_function_enabled
-        _torch_function_enabled = False
-        return self
-    def __exit__(self, *args):
-        global _torch_function_enabled
-        _torch_function_enabled = self._prev
-
-
-def _has_storage(tensor):
-    """Minimal torch._C._has_storage stub."""
-    return hasattr(tensor, '_storage') and tensor._storage is not None
-
-
-def _get_tracing_state():
-    """Minimal torch._C._get_tracing_state stub."""
-    return None
-
-
-def _get_privateuse():
-    """Minimal torch._C._get_privateuse stub."""
-    return "npu"
-
-
-class _dlpack_exchange_api:
-    """Minimal torch._C._dlpack_exchange_api stub."""
-    @staticmethod
-    def to_dlpack(tensor): raise NotImplementedError("DLPack not supported")
-    @staticmethod
-    def from_dlpack(dlpack): raise NotImplementedError("DLPack not supported")
-
-
-def _to_dlpack(tensor):
-    raise NotImplementedError("DLPack not supported")
-
-
-def _to_dlpack_versioned(tensor, version):
-    raise NotImplementedError("DLPack not supported")
-
-
-class _VariableFunctions:
-    """Minimal torch._C._VariableFunctions stub."""
-    @staticmethod
-    def rsub(tensor, other):
-        import numpy as np
-        if isinstance(other, (int, float, bool, complex, np.integer, np.floating)):
-            from candle._functional import mul as _mul, sub as _sub
-            result = _mul(tensor, -1)
-            return result + other
-        from candle._functional import sub as _sub
-        return _sub(other, tensor)
-
-
-def _get_PyTorchFileReader():
-    from ._stream import PyTorchFileReader
-    return PyTorchFileReader
-
-
-def _get_PyTorchFileWriter():
-    from ._stream import PyTorchFileWriter
-    return PyTorchFileWriter
-
-
-def _get_privateuse1_backend_name():
-    return "npu"
-
+from ._stubs import (
+    _add_docstr,
+    _disabled_torch_dispatch_impl,
+    DisableTorchFunctionSubclass,
+    _has_storage,
+    _get_tracing_state,
+    _get_privateuse,
+    _dlpack_exchange_api,
+    _to_dlpack,
+    _to_dlpack_versioned,
+    _torch_function_enabled,
+    _VariableFunctions,
+    _get_PyTorchFileReader,
+    _get_PyTorchFileWriter,
+    _get_privateuse1_backend_name,
+)
 
 from ._Storage import (
     StorageBase,
-    _NPUUntypedStorage,
     _MPSUntypedStorage,
-    _MetaUntypedStorage,
     PendingStorage,
     typed_storage_from_numpy,
     empty_cpu_typed_storage,
@@ -323,18 +132,6 @@ from ._Storage import (
     _install_typed_storage_compat,
     _make_legacy_classes,
     __getattr__ as _storage_getattr,
-    _FloatStorage,
-    _DoubleStorage,
-    _HalfStorage,
-    _LongStorage,
-    _IntStorage,
-    _ShortStorage,
-    _ByteStorage,
-    _BoolStorage,
-    _BFloat16Storage,
-    _ComplexFloatStorage,
-    _ComplexDoubleStorage,
-    _Storage,
 )
 
 
@@ -342,355 +139,21 @@ def __getattr__(name):
     return _storage_getattr(name)
 
 
-# =============================================================================
-# TensorBase — torch._C.TensorBase equivalent for candle/tensor.py
-# Must be defined AFTER all storage factories so _tensor_impl can import from _C.
-# =============================================================================
+if _HAS_CYTHON_TENSOR_API:
+    _install_tensor_api(TensorBase)
 
-from ._tensor_impl import TensorImpl, _StrideTuple
+    # Re-export the 11 tensor bootstrap helpers that contract tests expect
+    # directly on candle._C (analogous to torch._C)._tensor_api helpers
+    import candle._C._tensor_api as _tapi
 
-import numpy as _np
-
-
-def _compute_strides(shape):
-    stride = []
-    acc = 1
-    for d in reversed(shape):
-        stride.append(acc)
-        acc *= d
-    return _StrideTuple(reversed(stride))
-
-
-def _bf16_to_f32(arr):
-    u32 = arr.astype(_np.uint32) << 16
-    return u32.view(_np.float32)
-
-
-def _f32_to_bf16(arr):
-    u32 = arr.view(_np.uint32)
-    rounding_bias = (u32 >> 16) & 1
-    u32 = u32 + 0x7FFF + rounding_bias
-    return (u32 >> 16).astype(_np.uint16)
-
-
-
-
-def _install_tensor_api():
-    """Install Cython tensor API methods on TensorBase (called after all modules loaded)."""
-    if not _HAS_CYTHON_TENSOR_API:
-        return
-    from . import _tensor_api as _tensor_api_mod  # pylint: disable=import-self
-    TensorBase._set_device_from_storage = _tensor_api_mod.tensor_set_device_from_storage
-    TensorBase._set_dtype_from_storage = _tensor_api_mod.tensor_set_dtype_from_storage
-    TensorBase.data = property(TensorBase.data.fget, _tensor_api_mod.tensor_set_data)
-    TensorBase.__delattr__ = _tensor_api_mod.tensor_delattr
-    TensorBase._fw_get = _tensor_api_mod.tensor_fw_get
-    TensorBase._fw_set = _tensor_api_mod.tensor_fw_set
-    TensorBase._fw_clear = _tensor_api_mod.tensor_fw_clear
-    TensorBase._fw_has = _tensor_api_mod.tensor_fw_has
-    TensorBase.untyped_storage = _tensor_api_mod.tensor_untyped_storage
-    TensorBase.record_stream = _tensor_api_mod.tensor_record_stream
-    TensorBase.is_pinned = _tensor_api_mod.tensor_is_pinned
-
-    TensorBase.__add__ = _tensor_api_mod.tensor_add
-    TensorBase.__sub__ = _tensor_api_mod.tensor_sub
-    TensorBase.__mul__ = _tensor_api_mod.tensor_mul
-    TensorBase.__matmul__ = _tensor_api_mod.tensor_matmul
-    TensorBase.__getitem__ = _tensor_api_mod.tensor_getitem
-    TensorBase.__setitem__ = _tensor_api_mod.tensor_setitem
-    TensorBase.__iadd__ = _tensor_api_mod.tensor_iadd
-    TensorBase.__isub__ = _tensor_api_mod.tensor_isub
-    TensorBase.__imul__ = _tensor_api_mod.tensor_imul
-    TensorBase.__itruediv__ = _tensor_api_mod.tensor_itruediv
-    TensorBase.__neg__ = _tensor_api_mod.tensor_neg
-    TensorBase.neg = _tensor_api_mod.tensor_neg
-    
-    TensorBase.clone = _tensor_api_mod.tensor_clone
-    TensorBase.detach = _tensor_api_mod.tensor_detach
-    TensorBase.detach_ = _tensor_api_mod.tensor_detach_
-    TensorBase.to = _tensor_api_mod.tensor_to
-    TensorBase._to_dtype = _tensor_api_mod.tensor_to_dtype
-    TensorBase.cpu = _tensor_api_mod.tensor_cpu
-    TensorBase.npu = _tensor_api_mod.tensor_npu
-    TensorBase.mps = _tensor_api_mod.tensor_mps
-    TensorBase.cuda = _tensor_api_mod.tensor_cuda
-    TensorBase.backward = _tensor_api_mod.tensor_backward
-    TensorBase.relu = _tensor_api_mod.tensor_relu
-    TensorBase.is_contiguous = _tensor_api_mod.tensor_is_contiguous
-    TensorBase.contiguous = _tensor_api_mod.tensor_contiguous
-    TensorBase.reshape = _tensor_api_mod.tensor_reshape
-    TensorBase.transpose = _tensor_api_mod.tensor_transpose
-    TensorBase.view = _tensor_api_mod.tensor_view
-    TensorBase.flatten = _tensor_api_mod.tensor_flatten
-    TensorBase.t = _tensor_api_mod.tensor_t
-    TensorBase.as_strided = _tensor_api_mod.tensor_as_strided
-    TensorBase.size = _tensor_api_mod.tensor_size
-    TensorBase.dim = _tensor_api_mod.tensor_dim
-    
-    TensorBase.retain_grad = _tensor_api_mod.tensor_retain_grad
-    TensorBase.requires_grad_ = _tensor_api_mod.tensor_requires_grad_
-    TensorBase.register_hook = _tensor_api_mod.tensor_register_hook
-    TensorBase._is_view = _tensor_api_mod.tensor_is_view
-    TensorBase._check_inplace = _tensor_api_mod.tensor_check_inplace
-    
-    TensorBase.add_ = _tensor_api_mod.tensor_add_
-    TensorBase.mul_ = _tensor_api_mod.tensor_mul_
-    TensorBase.relu_ = _tensor_api_mod.tensor_relu_
-    TensorBase.zero_ = _tensor_api_mod.tensor_zero_
-    TensorBase.fill_ = _tensor_api_mod.tensor_fill_
-    TensorBase.copy_ = _tensor_api_mod.tensor_copy_
-    
-    TensorBase.abs_ = _tensor_api_mod.tensor_abs_
-    TensorBase.neg_ = _tensor_api_mod.tensor_neg_
-    TensorBase.exp_ = _tensor_api_mod.tensor_exp_
-    TensorBase.log_ = _tensor_api_mod.tensor_log_
-    TensorBase.log2_ = _tensor_api_mod.tensor_log2_
-    TensorBase.log10_ = _tensor_api_mod.tensor_log10_
-    TensorBase.sqrt_ = _tensor_api_mod.tensor_sqrt_
-    TensorBase.sin_ = _tensor_api_mod.tensor_sin_
-    TensorBase.cos_ = _tensor_api_mod.tensor_cos_
-    TensorBase.tan_ = _tensor_api_mod.tensor_tan_
-    TensorBase.tanh_ = _tensor_api_mod.tensor_tanh_
-    TensorBase.sigmoid_ = _tensor_api_mod.tensor_sigmoid_
-    TensorBase.floor_ = _tensor_api_mod.tensor_floor_
-    TensorBase.ceil_ = _tensor_api_mod.tensor_ceil_
-    TensorBase.round_ = _tensor_api_mod.tensor_round_
-    TensorBase.trunc_ = _tensor_api_mod.tensor_trunc_
-    TensorBase.pow_ = _tensor_api_mod.tensor_pow_
-    TensorBase.reciprocal_ = _tensor_api_mod.tensor_reciprocal_
-    TensorBase.erfinv_ = _tensor_api_mod.tensor_erfinv_
-    
-    TensorBase.sub_ = _tensor_api_mod.tensor_sub_
-    TensorBase.clamp_ = _tensor_api_mod.tensor_clamp_
-    TensorBase.uniform_ = _tensor_api_mod.tensor_uniform_
-    TensorBase.normal_ = _tensor_api_mod.tensor_normal_
-    TensorBase.random_ = _tensor_api_mod.tensor_random_
-    TensorBase.randint_ = _tensor_api_mod.tensor_randint_
-    TensorBase.bernoulli_ = _tensor_api_mod.tensor_bernoulli_
-    TensorBase.exponential_ = _tensor_api_mod.tensor_exponential_
-    TensorBase.log_normal_ = _tensor_api_mod.tensor_log_normal_
-    TensorBase.cauchy_ = _tensor_api_mod.tensor_cauchy_
-    TensorBase.geometric_ = _tensor_api_mod.tensor_geometric_
-    
-    TensorBase.transpose_ = _tensor_api_mod.tensor_transpose_
-    TensorBase.t_ = _tensor_api_mod.tensor_t_
-    TensorBase.squeeze_ = _tensor_api_mod.tensor_squeeze_
-    TensorBase.unsqueeze_ = _tensor_api_mod.tensor_unsqueeze_
-    TensorBase.as_strided_ = _tensor_api_mod.tensor_as_strided_
-    TensorBase.swapdims_ = _tensor_api_mod.tensor_swapdims_
-    TensorBase.swapaxes_ = _tensor_api_mod.tensor_swapaxes_
-    
-    TensorBase.scatter_add = _tensor_api_mod.tensor_scatter_add
-    TensorBase.index_fill = _tensor_api_mod.tensor_index_fill
-    TensorBase.index_copy = _tensor_api_mod.tensor_index_copy
-    TensorBase.index_add = _tensor_api_mod.tensor_index_add
-    TensorBase.put_ = _tensor_api_mod.tensor_put_
-    TensorBase.scatter_ = _tensor_api_mod.tensor_scatter_
-    TensorBase.scatter_add_ = _tensor_api_mod.tensor_scatter_add_
-    TensorBase.masked_fill_ = _tensor_api_mod.tensor_masked_fill_
-    TensorBase.masked_scatter_ = _tensor_api_mod.tensor_masked_scatter_
-    TensorBase.index_put_ = _tensor_api_mod.tensor_index_put_
-    TensorBase.index_copy_ = _tensor_api_mod.tensor_index_copy_
-    TensorBase.index_fill_ = _tensor_api_mod.tensor_index_fill_
-    TensorBase.index_add_ = _tensor_api_mod.tensor_index_add_
-    
-    TensorBase.new_empty = _tensor_api_mod.tensor_new_empty
-    TensorBase.new_tensor = _tensor_api_mod.tensor_new_tensor
-    TensorBase.new_empty_strided = _tensor_api_mod.tensor_new_empty_strided
-    TensorBase._ones_like = _tensor_api_mod.tensor_ones_like
-    TensorBase.new_ones = _tensor_api_mod.tensor_new_ones
-    TensorBase.new_zeros = _tensor_api_mod.tensor_new_zeros
-    TensorBase.new_full = _tensor_api_mod.tensor_new_full
-    TensorBase.div_ = _tensor_api_mod.tensor_div_
-    TensorBase.unflatten = _tensor_api_mod.tensor_unflatten
-    TensorBase.bitwise_and_ = _tensor_api_mod.tensor_bitwise_and_
-    TensorBase.bitwise_or_ = _tensor_api_mod.tensor_bitwise_or_
-    TensorBase.bitwise_xor_ = _tensor_api_mod.tensor_bitwise_xor_
-    TensorBase.type = _tensor_api_mod.tensor_type
-    TensorBase.type_as = _tensor_api_mod.tensor_type_as
-    TensorBase.reshape_as = _tensor_api_mod.tensor_reshape_as
-    TensorBase.permute = _tensor_api_mod.tensor_permute
-    TensorBase.mean = _tensor_api_mod.tensor_mean
-    TensorBase.std = _tensor_api_mod.tensor_std
-    TensorBase.repeat = _tensor_api_mod.tensor_repeat
-    TensorBase.tile = _tensor_api_mod.tensor_tile
-    TensorBase.flip = _tensor_api_mod.tensor_flip
-    TensorBase.logsumexp = _tensor_api_mod.tensor_logsumexp
-    TensorBase.trace = _tensor_api_mod.tensor_trace
-    TensorBase.det = _tensor_api_mod.tensor_det
-    TensorBase.matrix_power = _tensor_api_mod.tensor_matrix_power
-    TensorBase.dist = _tensor_api_mod.tensor_dist
-    TensorBase.renorm = _tensor_api_mod.tensor_renorm
-    TensorBase.nansum = _tensor_api_mod.tensor_nansum
-    TensorBase.nanmean = _tensor_api_mod.tensor_nanmean
-    TensorBase.argwhere = _tensor_api_mod.tensor_argwhere
-    TensorBase.baddbmm = _tensor_api_mod.tensor_baddbmm
-    TensorBase.vsplit = _tensor_api_mod.tensor_vsplit
-    TensorBase.hsplit = _tensor_api_mod.tensor_hsplit
-    TensorBase.dsplit = _tensor_api_mod.tensor_dsplit
-    TensorBase.take_along_dim = _tensor_api_mod.tensor_take_along_dim
-    TensorBase.cummin = _tensor_api_mod.tensor_cummin
-    TensorBase.log1p = _tensor_api_mod.tensor_log1p
-    TensorBase.expm1 = _tensor_api_mod.tensor_expm1
-    TensorBase.lt = _tensor_api_mod.tensor_lt
-    TensorBase.le = _tensor_api_mod.tensor_le
-    TensorBase.gt = _tensor_api_mod.tensor_gt
-    TensorBase.ge = _tensor_api_mod.tensor_ge
-    TensorBase.abs = _tensor_api_mod.tensor_abs
-    TensorBase.exp = _tensor_api_mod.tensor_exp
-    TensorBase.log = _tensor_api_mod.tensor_log
-    TensorBase.sqrt = _tensor_api_mod.tensor_sqrt
-    TensorBase.sin = _tensor_api_mod.tensor_sin
-    TensorBase.cos = _tensor_api_mod.tensor_cos
-    TensorBase.tan = _tensor_api_mod.tensor_tan
-    TensorBase.tanh = _tensor_api_mod.tensor_tanh
-    TensorBase.sigmoid = _tensor_api_mod.tensor_sigmoid
-    TensorBase.floor = _tensor_api_mod.tensor_floor
-    TensorBase.ceil = _tensor_api_mod.tensor_ceil
-    TensorBase.round = _tensor_api_mod.tensor_round
-    TensorBase.trunc = _tensor_api_mod.tensor_trunc
-    TensorBase.frac = _tensor_api_mod.tensor_frac
-    TensorBase.log2 = _tensor_api_mod.tensor_log2
-    TensorBase.log10 = _tensor_api_mod.tensor_log10
-    TensorBase.exp2 = _tensor_api_mod.tensor_exp2
-    TensorBase.rsqrt = _tensor_api_mod.tensor_rsqrt
-    TensorBase.sign = _tensor_api_mod.tensor_sign
-    TensorBase.signbit = _tensor_api_mod.tensor_signbit
-    TensorBase.square = _tensor_api_mod.tensor_square
-    TensorBase.isnan = _tensor_api_mod.tensor_isnan
-    TensorBase.isinf = _tensor_api_mod.tensor_isinf
-    TensorBase.isfinite = _tensor_api_mod.tensor_isfinite
-    TensorBase.sinh = _tensor_api_mod.tensor_sinh
-    TensorBase.cosh = _tensor_api_mod.tensor_cosh
-    TensorBase.asinh = _tensor_api_mod.tensor_asinh
-    TensorBase.acosh = _tensor_api_mod.tensor_acosh
-    TensorBase.atanh = _tensor_api_mod.tensor_atanh
-    TensorBase.erf = _tensor_api_mod.tensor_erf
-    TensorBase.erfc = _tensor_api_mod.tensor_erfc
-    TensorBase.reciprocal = _tensor_api_mod.tensor_reciprocal
-    TensorBase.tril = _tensor_api_mod.tensor_tril
-    TensorBase.triu = _tensor_api_mod.tensor_triu
-    TensorBase.diag = _tensor_api_mod.tensor_diag
-    TensorBase.add = _tensor_api_mod.tensor_add_method
-    TensorBase.sub = _tensor_api_mod.tensor_sub_method
-    TensorBase.mul = _tensor_api_mod.tensor_mul_method
-    TensorBase.div = _tensor_api_mod.tensor_div_method
-    TensorBase.pow = _tensor_api_mod.tensor_pow_method
-    TensorBase.matmul = _tensor_api_mod.tensor_matmul_method
-    TensorBase.__rsub__ = _tensor_api_mod.tensor_rsub
-    TensorBase.__rmul__ = _tensor_api_mod.tensor_rmul
-    TensorBase.__truediv__ = _tensor_api_mod.tensor_truediv
-    TensorBase.__rtruediv__ = _tensor_api_mod.tensor_rtruediv
-    TensorBase.__pow__ = _tensor_api_mod.tensor_pow_op
-    TensorBase.__rpow__ = _tensor_api_mod.tensor_rpow
-    TensorBase.__floordiv__ = _tensor_api_mod.tensor_floordiv
-    TensorBase.__rfloordiv__ = _tensor_api_mod.tensor_rfloordiv
-    TensorBase.__mod__ = _tensor_api_mod.tensor_mod
-    TensorBase.__rmod__ = _tensor_api_mod.tensor_rmod
-    TensorBase.__rmatmul__ = _tensor_api_mod.tensor_rmatmul
-    TensorBase.__and__ = _tensor_api_mod.tensor_and
-    TensorBase.__or__ = _tensor_api_mod.tensor_or
-    TensorBase.__xor__ = _tensor_api_mod.tensor_xor
-    TensorBase.all = _tensor_api_mod.tensor_all_method
-    TensorBase.any = _tensor_api_mod.tensor_any_method
-    TensorBase.sum = _tensor_api_mod.tensor_sum_method
-    TensorBase.prod = _tensor_api_mod.tensor_prod_method
-    TensorBase.var = _tensor_api_mod.tensor_var_method
-    TensorBase.var_mean = _tensor_api_mod.tensor_var_mean_method
-    TensorBase.norm = _tensor_api_mod.tensor_norm_method
-    TensorBase.count_nonzero = _tensor_api_mod.tensor_count_nonzero_method
-    TensorBase.cumsum = _tensor_api_mod.tensor_cumsum_method
-    TensorBase.cumprod = _tensor_api_mod.tensor_cumprod_method
-    TensorBase.cummax = _tensor_api_mod.tensor_cummax_method
-    TensorBase.argsort = _tensor_api_mod.tensor_argsort_method
-    TensorBase.sort = _tensor_api_mod.tensor_sort_method
-    TensorBase.topk = _tensor_api_mod.tensor_topk_method
-    TensorBase.eq = _tensor_api_mod.tensor_eq_method
-    TensorBase.ne = _tensor_api_mod.tensor_ne_method
-    TensorBase.allclose = _tensor_api_mod.tensor_allclose_method
-    TensorBase.isclose = _tensor_api_mod.tensor_isclose_method
-    TensorBase.equal = _tensor_api_mod.tensor_equal_method
-    TensorBase.view_as = _tensor_api_mod.tensor_view_as
-    TensorBase.expand = _tensor_api_mod.tensor_expand_method
-    TensorBase.expand_as = _tensor_api_mod.tensor_expand_as_method
-    TensorBase.expand_copy = _tensor_api_mod.tensor_expand_copy_method
-    TensorBase.narrow = _tensor_api_mod.tensor_narrow_method
-    TensorBase.select = _tensor_api_mod.tensor_select_method
-    TensorBase.unfold = _tensor_api_mod.tensor_unfold_method
-    TensorBase.moveaxis = _tensor_api_mod.tensor_moveaxis_method
-    TensorBase.swapdims = _tensor_api_mod.tensor_swapdims_method
-    TensorBase.swapaxes = _tensor_api_mod.tensor_swapaxes_method
-    TensorBase.gather = _tensor_api_mod.tensor_gather_method
-    TensorBase.scatter = _tensor_api_mod.tensor_scatter_method
-    TensorBase.index_select = _tensor_api_mod.tensor_index_select_method
-    TensorBase.take = _tensor_api_mod.tensor_take_method
-    TensorBase.masked_fill = _tensor_api_mod.tensor_masked_fill_method
-    TensorBase.masked_select = _tensor_api_mod.tensor_masked_select_method
-    TensorBase.index_put = _tensor_api_mod.tensor_index_put_method
-    TensorBase.slice = _tensor_api_mod.tensor_slice_method
-    TensorBase.slice_copy = _tensor_api_mod.tensor_slice_copy_method
-    TensorBase.slice_scatter = _tensor_api_mod.tensor_slice_scatter_method
-    TensorBase.nonzero = _tensor_api_mod.tensor_nonzero_method
-    TensorBase.sum_to_size = _tensor_api_mod.tensor_sum_to_size_method
-    TensorBase.softplus = _tensor_api_mod.tensor_softplus_method
-    TensorBase.clamp = _tensor_api_mod.tensor_clamp_method
-    TensorBase.relu6 = _tensor_api_mod.tensor_relu6_method
-    TensorBase.hardtanh = _tensor_api_mod.tensor_hardtanh_method
-    TensorBase.min = _tensor_api_mod.tensor_min_method
-    TensorBase.max = _tensor_api_mod.tensor_max_method
-    TensorBase.amin = _tensor_api_mod.tensor_amin_method
-    TensorBase.amax = _tensor_api_mod.tensor_amax_method
-    TensorBase.addmm = _tensor_api_mod.tensor_addmm_method
-    TensorBase.bmm = _tensor_api_mod.tensor_bmm_method
-    TensorBase.mm = _tensor_api_mod.tensor_mm_method
-    TensorBase.chunk = _tensor_api_mod.tensor_chunk_method
-    TensorBase.split = _tensor_api_mod.tensor_split_method
-    TensorBase.roll = _tensor_api_mod.tensor_roll_method
-    TensorBase.rot90 = _tensor_api_mod.tensor_rot90_method
-    TensorBase.addcdiv = _tensor_api_mod.tensor_addcdiv_method
-    TensorBase.addcmul = _tensor_api_mod.tensor_addcmul_method
-    TensorBase.hypot = _tensor_api_mod.tensor_hypot_method
-    TensorBase.lerp = _tensor_api_mod.tensor_lerp_method
-    TensorBase.atan2 = _tensor_api_mod.tensor_atan2_method
-    TensorBase.asin = _tensor_api_mod.tensor_asin_method
-    TensorBase.acos = _tensor_api_mod.tensor_acos_method
-    TensorBase.atan = _tensor_api_mod.tensor_atan_method
-    TensorBase.as_strided_copy = _tensor_api_mod.tensor_as_strided_copy_method
-    TensorBase.as_strided_scatter = _tensor_api_mod.tensor_as_strided_scatter_method
-    TensorBase.multinomial = _tensor_api_mod.tensor_multinomial_method
-    TensorBase.ndim = property(_tensor_api_mod.tensor_ndim_fget)
-    TensorBase.T = property(_tensor_api_mod.tensor_T_fget)
-    TensorBase.is_floating_point = _tensor_api_mod.tensor_is_floating_point
-    TensorBase.is_complex = _tensor_api_mod.tensor_is_complex
-    TensorBase.clamp_min = _tensor_api_mod.tensor_clamp_min_method
-    TensorBase.clamp_max = _tensor_api_mod.tensor_clamp_max_method
-    TensorBase.fmin = _tensor_api_mod.tensor_fmin_method
-    TensorBase.fmax = _tensor_api_mod.tensor_fmax_method
-    TensorBase.where = _tensor_api_mod.tensor_where_method
-    TensorBase.logaddexp = _tensor_api_mod.tensor_logaddexp_method
-    TensorBase.logaddexp2 = _tensor_api_mod.tensor_logaddexp2_method
-    TensorBase.remainder = _tensor_api_mod.tensor_remainder_method
-    TensorBase.fmod = _tensor_api_mod.tensor_fmod_method
-    TensorBase.squeeze = _tensor_api_mod.tensor_squeeze_method
-    TensorBase.unsqueeze = _tensor_api_mod.tensor_unsqueeze_method
-    TensorBase.argmax = _tensor_api_mod.tensor_argmax_method
-    TensorBase.argmin = _tensor_api_mod.tensor_argmin_method
-    TensorBase.logical_and = _tensor_api_mod.tensor_logical_and
-    TensorBase.logical_or = _tensor_api_mod.tensor_logical_or
-    TensorBase.logical_xor = _tensor_api_mod.tensor_logical_xor
-    TensorBase.logical_not = _tensor_api_mod.tensor_logical_not
-    TensorBase.bitwise_and = _tensor_api_mod.tensor_bitwise_and
-    TensorBase.bitwise_or = _tensor_api_mod.tensor_bitwise_or
-    TensorBase.bitwise_xor = _tensor_api_mod.tensor_bitwise_xor
-    TensorBase.bitwise_not = _tensor_api_mod.tensor_bitwise_not
-    TensorBase.movedim = _tensor_api_mod.tensor_movedim
-    TensorBase.diagonal = _tensor_api_mod.tensor_diagonal
-    TensorBase.unbind = _tensor_api_mod.tensor_unbind
-    
-    TensorBase.numpy = _tensor_api_mod.tensor_numpy
-    TensorBase._numpy_view = _tensor_api_mod.tensor_numpy_view
-    TensorBase.pin_memory = _tensor_api_mod.tensor_pin_memory
-
-
-_install_tensor_api()
-
+    tensor_set_device_from_storage = _tapi.tensor_set_device_from_storage
+    tensor_set_dtype_from_storage = _tapi.tensor_set_dtype_from_storage
+    tensor_set_data = _tapi.tensor_set_data
+    tensor_delattr = _tapi.tensor_delattr
+    tensor_fw_get = _tapi.tensor_fw_get
+    tensor_fw_set = _tapi.tensor_fw_set
+    tensor_fw_clear = _tapi.tensor_fw_clear
+    tensor_fw_has = _tapi.tensor_fw_has
+    tensor_untyped_storage = _tapi.tensor_untyped_storage
+    tensor_record_stream = _tapi.tensor_record_stream
+    tensor_is_pinned = _tapi.tensor_is_pinned

--- a/src/candle/_C/_bootstrap.py
+++ b/src/candle/_C/_bootstrap.py
@@ -1,0 +1,272 @@
+"""Cython feature-flag bootstrap for candle._C package exports."""
+# pylint: disable=import-error,no-name-in-module,possibly-unused-variable
+
+# Default placeholders so package-level re-exports stay importable even when optional modules fail.
+cy_dispatch = None
+cy_dispatch_with_keyset = None
+FastNpuAllocator = None
+cy_npu_storage_from_ptr = None
+fast_binary_op = None
+aclnn_ffi_init = None
+create_tensor = None
+destroy_tensor = None
+create_scalar = None
+destroy_scalar = None
+create_int_array = None
+destroy_int_array = None
+destroy_executor = None
+resolve_op = None
+execute = None
+binary_op_with_alpha = None
+binary_op_no_alpha = None
+cy_dispatch_with_keyset_fast = None
+FastDevice = None
+FastDType = None
+AccumulateGrad = None
+FastNode = None
+InputMetadata = None
+Node = None
+SavedTensor = None
+_NodeHookHandle = None
+_SavedValue = None
+GradientEdge = None
+current_saved_tensors_hooks = None
+get_gradient_edge = None
+saved_tensors_hooks = None
+_GraphTask = None
+_build_dependencies = None
+_run_backward = None
+backward = None
+current_anomaly_parent = None
+grad = None
+is_anomaly_check_nan_enabled = None
+is_anomaly_enabled = None
+is_create_graph_enabled = None
+pop_anomaly_config = None
+pop_evaluating_node = None
+push_anomaly_config = None
+push_evaluating_node = None
+FunctionCtx = None
+_function_apply = None
+_strip_autograd_keys = None
+_grad_context = None
+_backward_dispatch_keyset = None
+_autograd_unary_passthrough = None
+_autograd_binary = None
+_autograd_binary_args = None
+_autograd_unary_args = None
+_norm_extract_weight_bias = None
+_autograd_norm = None
+cy_has_torch_function = None
+cy_handle_torch_function = None
+functional_add = None
+functional_mul = None
+functional_matmul = None
+functional_relu = None
+functional_transpose = None
+functional_reshape = None
+functional_neg = None
+_legacy_fast_ops = None
+TensorBase = None
+_TensorBase = None
+_StrideTuple = None
+_bf16_to_f32 = None
+_compute_strides = None
+_f32_to_bf16 = None
+_install_tensor_api = None
+StorageImpl = None
+
+_HAS_CYTHON_DISPATCH = False
+_HAS_CYTHON_ALLOCATOR = False
+_HAS_CYTHON_STORAGE = False
+_HAS_CYTHON_NPU_OPS = False
+_HAS_CYTHON_ACLNN_FFI = False
+_HAS_CYTHON_DISPATCHER_CORE = False
+_HAS_CYTHON_DEVICE = False
+_HAS_CYTHON_DTYPE = False
+_HAS_CYTHON_AUTOGRAD_NODE = False
+_HAS_CYTHON_AUTOGRAD_GRAPH = False
+_HAS_CYTHON_AUTOGRAD_ENGINE = False
+_HAS_CYTHON_AUTOGRAD_FUNCTION = False
+_HAS_CYTHON_AUTOGRAD_OPS = False
+_HAS_CYTHON_FUNCTIONAL_OPS = False
+_HAS_CYTHON_FAST_OPS = False
+_HAS_CYTHON_TENSOR_API = False
+_HAS_CYTHON_STORAGE_IMPL = False
+
+try:
+    from candle._dispatch import cy_dispatch, cy_dispatch_with_keyset  # noqa: F401
+    _HAS_CYTHON_DISPATCH = True
+except ImportError:
+    pass
+
+try:
+    from ._allocator import FastNpuAllocator  # noqa: F401
+    _HAS_CYTHON_ALLOCATOR = True
+except ImportError:
+    pass
+
+try:
+    from ._storage import cy_npu_storage_from_ptr  # noqa: F401
+    _HAS_CYTHON_STORAGE = True
+except ImportError:
+    pass
+
+try:
+    from ._npu_ops import fast_binary_op  # noqa: F401
+    _HAS_CYTHON_NPU_OPS = True
+except ImportError:
+    pass
+
+try:
+    from ._aclnn_ffi import (  # noqa: F401
+        init as aclnn_ffi_init,
+        create_tensor,
+        destroy_tensor,
+        create_scalar,
+        destroy_scalar,
+        create_int_array,
+        destroy_int_array,
+        destroy_executor,
+        resolve_op,
+        execute,
+        binary_op_with_alpha,
+        binary_op_no_alpha,
+    )
+    _HAS_CYTHON_ACLNN_FFI = True
+except ImportError:
+    pass
+
+from ._tensor_impl import TensorImpl, _VersionCounterProxy  # noqa: F401
+
+try:
+    from ._dispatcher_core import cy_dispatch_with_keyset_fast  # noqa: F401
+    _HAS_CYTHON_DISPATCHER_CORE = True
+except ImportError:
+    pass
+
+try:
+    from candle._device import FastDevice  # noqa: F401
+    _HAS_CYTHON_DEVICE = True
+except ImportError:
+    pass
+
+try:
+    from candle._dtype import FastDType  # noqa: F401
+    _HAS_CYTHON_DTYPE = True
+except ImportError:
+    pass
+
+try:
+    from ._autograd_node import (  # noqa: F401
+        AccumulateGrad,
+        FastNode,
+        InputMetadata,
+        Node,
+        SavedTensor,
+        _NodeHookHandle,
+        _SavedValue,
+    )
+    _HAS_CYTHON_AUTOGRAD_NODE = True
+except ImportError:
+    _HAS_CYTHON_AUTOGRAD_NODE = False
+
+try:
+    from ._autograd_graph import (  # noqa: F401
+        GradientEdge,
+        current_saved_tensors_hooks,
+        get_gradient_edge,
+        saved_tensors_hooks,
+    )
+    _HAS_CYTHON_AUTOGRAD_GRAPH = True
+except ImportError:
+    _HAS_CYTHON_AUTOGRAD_GRAPH = False
+
+try:
+    from ._autograd_engine import (  # noqa: F401
+        _GraphTask,
+        _build_dependencies,
+        _run_backward,
+        backward,
+        current_anomaly_parent,
+        grad,
+        is_anomaly_check_nan_enabled,
+        is_anomaly_enabled,
+        is_create_graph_enabled,
+        pop_anomaly_config,
+        pop_evaluating_node,
+        push_anomaly_config,
+        push_evaluating_node,
+    )
+    _HAS_CYTHON_AUTOGRAD_ENGINE = True
+except ImportError:
+    _HAS_CYTHON_AUTOGRAD_ENGINE = False
+
+try:
+    from ._autograd_function import (  # noqa: F401
+        FunctionCtx,
+        _function_apply,
+    )
+    _HAS_CYTHON_AUTOGRAD_FUNCTION = True
+except ImportError:
+    _HAS_CYTHON_AUTOGRAD_FUNCTION = False
+
+try:
+    from ._autograd_ops import (  # noqa: F401
+        _strip_autograd_keys,
+        _grad_context,
+        _backward_dispatch_keyset,
+        _autograd_unary_passthrough,
+        _autograd_binary,
+        _autograd_binary_args,
+        _autograd_unary_args,
+        _norm_extract_weight_bias,
+        _autograd_norm,
+    )
+    _HAS_CYTHON_AUTOGRAD_OPS = True
+except ImportError:
+    _HAS_CYTHON_AUTOGRAD_OPS = False
+
+try:
+    from ._functional_ops import (  # noqa: F401
+        _has_torch_function as cy_has_torch_function,
+        _handle_torch_function as cy_handle_torch_function,
+        add as functional_add,
+        mul as functional_mul,
+        matmul as functional_matmul,
+        relu as functional_relu,
+        transpose as functional_transpose,
+        reshape as functional_reshape,
+        neg as functional_neg,
+    )
+    _HAS_CYTHON_FUNCTIONAL_OPS = True
+except ImportError:
+    pass
+
+try:
+    import importlib
+
+    _legacy_fast_ops = importlib.import_module(f"{__package__}._fast_ops")  # noqa: F401
+    _HAS_CYTHON_FAST_OPS = True
+except ImportError:
+    pass
+
+try:
+    from ._TensorBase import (  # noqa: F401
+        TensorBase,
+        _TensorBase,
+        _StrideTuple,
+        _bf16_to_f32,
+        _compute_strides,
+        _f32_to_bf16,
+        _install_tensor_api,
+    )
+    _HAS_CYTHON_TENSOR_API = True
+except ImportError:
+    _HAS_CYTHON_TENSOR_API = False
+
+try:
+    from ._storage_impl import StorageImpl  # noqa: F401
+    _HAS_CYTHON_STORAGE_IMPL = True
+except ImportError:
+    pass

--- a/src/candle/_C/_mps_helpers.pyx
+++ b/src/candle/_C/_mps_helpers.pyx
@@ -79,7 +79,8 @@ cdef inline void _ensure_runtime():
     global _buffer_contents_fn, _get_runtime_fn, _get_dispatcher_fn
     if _compute_strides_fn is not None:
         return
-    from candle._tensor import _compute_strides, Tensor
+    from candle._C import _compute_strides
+    from candle._tensor import Tensor
     _compute_strides_fn = _compute_strides
     _Tensor_cls = Tensor
     from candle._C import (

--- a/src/candle/_C/_mps_ops.pyx
+++ b/src/candle/_C/_mps_ops.pyx
@@ -514,7 +514,7 @@ cpdef object leaky_relu(object a, object negative_slope=0.01):
                 f"leaky_relu_scalar_strided_{sfx}", _metal_buf(a), scalar,
                 out_buf, numel, list(a.shape), list(a.stride),
                 len(a.shape), scalar_fmt=_scalar_fmt(a.dtype))
-        from candle._tensor import _compute_strides
+        from candle._C import _compute_strides
         return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape),
                                   a.dtype, a.device)
     _unsupported_dtype("leaky_relu", a)
@@ -578,7 +578,7 @@ cpdef object clamp(object a, object min_val=None, object max_val=None):
                     s_min, s_max, out_buf, numel,
                     list(a.shape), list(a.stride), len(a.shape),
                     scalar_fmt=fmt)
-            from candle._tensor import _compute_strides
+            from candle._C import _compute_strides
             return _from_metal_buffer(out_buf, a.shape,
                                       _compute_strides(a.shape),
                                       a.dtype, a.device)
@@ -608,7 +608,7 @@ cpdef object clamp_min(object a, object min_val):
                 f"clamp_min_scalar_strided_{sfx}", _metal_buf(a), scalar,
                 out_buf, numel, list(a.shape), list(a.stride),
                 len(a.shape), scalar_fmt=_scalar_fmt(a.dtype))
-        from candle._tensor import _compute_strides
+        from candle._C import _compute_strides
         return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape),
                                   a.dtype, a.device)
     _unsupported_dtype("clamp_min", a)
@@ -632,7 +632,7 @@ cpdef object clamp_max(object a, object max_val):
                 f"clamp_max_scalar_strided_{sfx}", _metal_buf(a), scalar,
                 out_buf, numel, list(a.shape), list(a.stride),
                 len(a.shape), scalar_fmt=_scalar_fmt(a.dtype))
-        from candle._tensor import _compute_strides
+        from candle._C import _compute_strides
         return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape),
                                   a.dtype, a.device)
     _unsupported_dtype("clamp_max", a)
@@ -902,7 +902,7 @@ cpdef object eq(object a, object b):
                 return eq(a.contiguous(), b)
         else:
             return eq(a.contiguous(), b.contiguous() if isinstance(b, Tensor) else b)
-        from candle._tensor import _compute_strides
+        from candle._C import _compute_strides
         return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape), bool_dtype, a.device)
     if a.numel() == 0:
         return _empty_like(a)
@@ -928,7 +928,7 @@ cpdef object ne(object a, object b):
                 return ne(a.contiguous(), b)
         else:
             return ne(a.contiguous(), b.contiguous() if isinstance(b, Tensor) else b)
-        from candle._tensor import _compute_strides
+        from candle._C import _compute_strides
         return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape), bool_dtype, a.device)
     if a.numel() == 0:
         return _empty_like(a)
@@ -954,7 +954,7 @@ cpdef object lt(object a, object b):
                 return lt(a.contiguous(), b)
         else:
             return lt(a.contiguous(), b.contiguous() if isinstance(b, Tensor) else b)
-        from candle._tensor import _compute_strides
+        from candle._C import _compute_strides
         return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape), bool_dtype, a.device)
     if a.numel() == 0:
         return _empty_like(a)
@@ -980,7 +980,7 @@ cpdef object le(object a, object b):
                 return le(a.contiguous(), b)
         else:
             return le(a.contiguous(), b.contiguous() if isinstance(b, Tensor) else b)
-        from candle._tensor import _compute_strides
+        from candle._C import _compute_strides
         return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape), bool_dtype, a.device)
     if a.numel() == 0:
         return _empty_like(a)
@@ -1006,7 +1006,7 @@ cpdef object gt(object a, object b):
                 return gt(a.contiguous(), b)
         else:
             return gt(a.contiguous(), b.contiguous() if isinstance(b, Tensor) else b)
-        from candle._tensor import _compute_strides
+        from candle._C import _compute_strides
         return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape), bool_dtype, a.device)
     if a.numel() == 0:
         return _empty_like(a)
@@ -1032,7 +1032,7 @@ cpdef object ge(object a, object b):
                 return ge(a.contiguous(), b)
         else:
             return ge(a.contiguous(), b.contiguous() if isinstance(b, Tensor) else b)
-        from candle._tensor import _compute_strides
+        from candle._C import _compute_strides
         return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape), bool_dtype, a.device)
     if a.numel() == 0:
         return _empty_like(a)
@@ -1803,7 +1803,7 @@ def isin(elements, test_elements):
         te_flat = test_elements.contiguous().reshape((-1,))
         n_test = te_flat.numel()
         if n_test == 0:
-            from candle._tensor import _compute_strides
+            from candle._C import _compute_strides
             out_buf = _alloc_output_buf(max(elements.numel(), 1), bool_dtype)
             _get_dispatcher().dispatch_fill("fill_u8", out_buf, 0, max(elements.numel(), 1), scalar_fmt="B")
             return _from_metal_buffer(
@@ -2153,7 +2153,7 @@ def count_nonzero(a, dim=None, keepdim=False):
             sfx = _kernel_suffix(float32_dtype)
             d.dispatch_fill(f"fill_{sfx}", buf, 1.0, numel,
                             _itemsize(float32_dtype))
-            from candle._tensor import _compute_strides
+            from candle._C import _compute_strides
             ones_t = _from_metal_buffer(buf, tuple(a.shape),
                                         _compute_strides(tuple(a.shape)),
                                         float32_dtype, a.device)
@@ -2241,7 +2241,7 @@ def _cumextreme_gpu(a, dim, mode):
     dispatch = d.dispatch_cummax if mode == "cummax" else d.dispatch_cummin
     dispatch(f"{mode}_{sfx}", _metal_buf(a), values_buf, indices_buf,
              outer_size, dim_size, inner_size)
-    from candle._tensor import _compute_strides
+    from candle._C import _compute_strides
     out_shape = tuple(a.shape)
     out_stride = _compute_strides(out_shape)
     values = _from_metal_buffer(values_buf, out_shape, out_stride, a.dtype, a.device)
@@ -2317,7 +2317,7 @@ def sort(a, dim=-1, descending=False, stable=False):
     if (_can_use_gpu(a) and a.is_contiguous()
             and a.dtype in (float32_dtype, float16_dtype)):
         values_buf, indices_buf, numel = _sort_gpu(a, dim, descending)
-        from candle._tensor import _compute_strides
+        from candle._C import _compute_strides
         out_shape = tuple(a.shape)
         out_stride = _compute_strides(out_shape)
         values = _from_metal_buffer(values_buf, out_shape, out_stride,

--- a/src/candle/_C/_storage.pyx
+++ b/src/candle/_C/_storage.pyx
@@ -569,7 +569,7 @@ cdef inline void _ensure_tensor_cls():
     global _StrideTuple_cls
     if _StrideTuple_cls is not None:
         return
-    from candle._tensor import _StrideTuple
+    from candle._C import _StrideTuple
     _StrideTuple_cls = _StrideTuple
 
 

--- a/src/candle/_C/_storage_impl.pyx
+++ b/src/candle/_C/_storage_impl.pyx
@@ -34,7 +34,7 @@ cdef class StorageImpl:
         s._device_type = 0
         s._device_index = -1
         s._owner = arr
-        s._resizable = not shared and filename is None
+        s._resizable = False
         s._shared = shared
         s._filename = filename
         s._sharing_mechanism = sharing_mechanism

--- a/src/candle/_C/_stubs.py
+++ b/src/candle/_C/_stubs.py
@@ -1,0 +1,106 @@
+"""torch._C compatibility stubs for candle._C package exports."""
+# pylint: disable=no-name-in-module,import-error
+
+
+def _add_docstr(obj, docstr):
+    """Minimal torch._C._add_docstr stub."""
+    obj.__doc__ = docstr
+    return obj
+
+
+class _disabled_torch_dispatch_impl:
+    """Minimal torch._C._disabled_torch_dispatch_impl context manager."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+_torch_function_enabled = True
+
+
+class DisableTorchFunctionSubclass:
+    """Minimal torch._C.DisableTorchFunctionSubclass context manager."""
+
+    def __init__(self):
+        pass
+
+    def __enter__(self):
+        global _torch_function_enabled
+        self._prev = _torch_function_enabled
+        _torch_function_enabled = False
+        return self
+
+    def __exit__(self, *args):
+        global _torch_function_enabled
+        _torch_function_enabled = self._prev
+
+
+def _has_storage(tensor):
+    """Minimal torch._C._has_storage stub."""
+    return hasattr(tensor, '_storage') and tensor._storage is not None
+
+
+def _get_tracing_state():
+    """Minimal torch._C._get_tracing_state stub."""
+    return None
+
+
+def _get_privateuse():
+    """Minimal torch._C._get_privateuse stub."""
+    return "npu"
+
+
+class _dlpack_exchange_api:
+    """Minimal torch._C._dlpack_exchange_api stub."""
+
+    @staticmethod
+    def to_dlpack(tensor):
+        raise NotImplementedError("DLPack not supported")
+
+    @staticmethod
+    def from_dlpack(dlpack):
+        raise NotImplementedError("DLPack not supported")
+
+
+def _to_dlpack(tensor, *args, **kwargs):
+    raise NotImplementedError("DLPack not supported")
+
+
+def _to_dlpack_versioned(tensor, version=None, *args, **kwargs):
+    raise NotImplementedError("DLPack not supported")
+
+
+class _VariableFunctions:
+    """Minimal torch._C._VariableFunctions stub."""
+
+    @staticmethod
+    def rsub(tensor, other):
+        import numpy as np
+
+        if isinstance(other, (int, float, bool, complex, np.integer, np.floating)):
+            from candle._functional import mul as _mul
+
+            result = _mul(tensor, -1)
+            return result + other
+        from candle._functional import sub as _sub
+        return _sub(other, tensor)
+
+
+def _get_PyTorchFileReader():
+    from ._stream import PyTorchFileReader
+    return PyTorchFileReader
+
+
+def _get_PyTorchFileWriter():
+    from ._stream import PyTorchFileWriter
+    return PyTorchFileWriter
+
+
+def _get_privateuse1_backend_name():
+    return "npu"

--- a/src/candle/_C/_tensor_api.pyx
+++ b/src/candle/_C/_tensor_api.pyx
@@ -8,6 +8,18 @@ while preserving the existing Python fallback behavior in ``candle._tensor``.
 
 import numpy as np
 
+
+def _bf16_to_f32_local(arr):
+    u32 = arr.astype(np.uint32) << 16
+    return u32.view(np.float32)
+
+
+def _f32_to_bf16_local(arr):
+    u32 = arr.view(np.uint32)
+    rounding_bias = (u32 >> 16) & 1
+    u32 = u32 + 0x7FFF + rounding_bias
+    return (u32 >> 16).astype(np.uint16)
+
 cdef object _BaseTensor = None
 cdef object _Device = None
 cdef object _from_name_fn = None
@@ -138,8 +150,8 @@ cdef inline void _ensure_tensor_factory_ref():
 cdef inline void _ensure_hook_handle_ref():
     global _HookHandle_cls
     if _HookHandle_cls is None:
-        from candle._tensor import _HookHandle
-        _HookHandle_cls = _HookHandle
+        from candle.utils.hooks import RemovableHandle
+        _HookHandle_cls = RemovableHandle
 
 
 cdef inline void _ensure_grad_mode_ref():
@@ -191,7 +203,6 @@ cdef inline void _ensure_conversion_refs():
             pinned_cpu_typed_storage_from_numpy,
         )
         from candle._dtype import to_numpy_dtype, bfloat16
-        from candle._tensor import _bf16_to_f32, _f32_to_bf16
         from candle._backends.npu.ops._helpers import _cast_tensor_dtype
         from candle import npu as npu_api
 
@@ -201,8 +212,8 @@ cdef inline void _ensure_conversion_refs():
         _pinned_cpu_typed_storage_from_numpy_fn = pinned_cpu_typed_storage_from_numpy
         _to_numpy_dtype_fn = to_numpy_dtype
         _bfloat16_dtype = bfloat16
-        _bf16_to_f32_fn = _bf16_to_f32
-        _f32_to_bf16_fn = _f32_to_bf16
+        _bf16_to_f32_fn = _bf16_to_f32_local
+        _f32_to_bf16_fn = _f32_to_bf16_local
         _cast_tensor_dtype_npu_fn = _cast_tensor_dtype
         _npu_available_fn = npu_api.is_available
 
@@ -320,10 +331,6 @@ def tensor_set_data(self, new_data):
     _ensure_base()
     if not isinstance(new_data, _BaseTensor):
         raise TypeError(f"data must be a Tensor, got {type(new_data).__name__}")
-    if new_data.shape != self.shape:
-        raise RuntimeError(f"shape mismatch: expected {self.shape}, got {new_data.shape}")
-    if new_data.dtype != self.dtype:
-        raise RuntimeError(f"dtype mismatch: expected {self.dtype}, got {new_data.dtype}")
     self.cy_set_data_runtime_truth_from(new_data)
 
 
@@ -502,6 +509,11 @@ def tensor_to(self, *args, **kwargs):
             copy=copy,
             memory_format=memory_format,
         )
+
+    if getattr(memory_format, "_name", None) == "channels_last":
+        if result.device.type != "cpu":
+            raise NotImplementedError("channels_last memory_format is currently only supported on CPU tensors")
+        result = result.contiguous(memory_format=memory_format)
 
     if result is self and dtype is None and device is None:
         return self
@@ -691,12 +703,21 @@ def tensor_view(self, *shape):
 
 
 def tensor_is_contiguous(self, memory_format=None):
+    if getattr(memory_format, "_name", None) == "channels_last":
+        return _is_channels_last_stride_tuple(self.shape, self.stride)
     cdef tuple expected
     expected = _contiguous_stride_tuple(self.shape)
     return self.stride == expected
 
 
 def tensor_contiguous(self, memory_format=None):
+    if getattr(memory_format, "_name", None) == "channels_last":
+        if len(self.shape) != 4:
+            raise RuntimeError("required rank 4 tensor to use channels_last format")
+        if self.is_contiguous(memory_format=memory_format):
+            return self
+        _ensure_dispatch_ref()
+        return _dispatch_fn("contiguous", self.device.type, self, memory_format=memory_format)
     if self.is_contiguous(memory_format=memory_format):
         return self
     _ensure_dispatch_ref()
@@ -752,12 +773,21 @@ def tensor_as_strided(self, size, stride, storage_offset=None):
 
 
 def tensor_is_contiguous(self, memory_format=None):
+    if getattr(memory_format, "_name", None) == "channels_last":
+        return _is_channels_last_stride_tuple(self.shape, self.stride)
     cdef tuple expected
     expected = _contiguous_stride_tuple(self.shape)
     return self.stride == expected
 
 
 def tensor_contiguous(self, memory_format=None):
+    if getattr(memory_format, "_name", None) == "channels_last":
+        if len(self.shape) != 4:
+            raise RuntimeError("required rank 4 tensor to use channels_last format")
+        if self.is_contiguous(memory_format=memory_format):
+            return self
+        _ensure_dispatch_ref()
+        return _dispatch_fn("contiguous", self.device.type, self, memory_format=memory_format)
     if self.is_contiguous(memory_format=memory_format):
         return self
     _ensure_dispatch_ref()
@@ -1409,9 +1439,7 @@ def tensor_pin_memory(self):
     _ensure_tensor_factory_ref()
     if self.device.type != "cpu":
         raise RuntimeError("pin_memory only supports CPU tensors")
-    if not _npu_available_fn():
-        raise RuntimeError("Cannot access accelerator device when none is available.")
-    if self.is_pinned():
+    if not _npu_available_fn() or self.is_pinned():
         return self
     storage = _pinned_cpu_typed_storage_from_numpy_fn(self._numpy_view(), self.dtype, device=self.device)
     return _cy_make_tensor_from_storage_fn(storage, self.shape, self.stride, self.offset, self.requires_grad)
@@ -2386,6 +2414,16 @@ def tensor_rmatmul(self, other):
     return _dispatch_fn("matmul", self.device.type, other, self)
 
 
+def tensor_rlshift(self, other):
+    _ensure_dispatch_ref()
+    return _dispatch_fn("bitwise_left_shift", self.device.type, other, self)
+
+
+def tensor_rrshift(self, other):
+    _ensure_dispatch_ref()
+    return _dispatch_fn("bitwise_right_shift", self.device.type, other, self)
+
+
 def tensor_and(self, other):
     _ensure_dispatch_ref()
     try:
@@ -2459,8 +2497,10 @@ def tensor_var_mean_method(self, dim=None, keepdim=False, unbiased=True):
     return _dispatch_fn("var_mean", self.device.type, self, dim=dim, keepdim=keepdim, unbiased=unbiased)
 
 
-def tensor_norm_method(self, p=2, dim=None, keepdim=False):
+def tensor_norm_method(self, p="fro", dim=None, keepdim=False, *, dtype=None):
     _ensure_dispatch_ref()
+    if dtype is not None:
+        return _dispatch_fn("norm", self.device.type, self, p=p, dim=dim, keepdim=keepdim, dtype=dtype)
     return _dispatch_fn("norm", self.device.type, self, p=p, dim=dim, keepdim=keepdim)
 
 
@@ -3097,3 +3137,29 @@ cdef inline tuple _contiguous_stride_tuple(tuple shape):
         strides[i] = acc
         acc *= shape[i]
     return tuple(strides)
+
+
+cdef inline tuple _channels_last_stride_tuple(tuple shape):
+    cdef Py_ssize_t n
+    cdef Py_ssize_t c
+    cdef Py_ssize_t h
+    cdef Py_ssize_t w
+    if len(shape) != 4:
+        raise RuntimeError("required rank 4 tensor to use channels_last format")
+    n, c, h, w = shape
+    return (c * h * w, 1, w * c, c)
+
+
+cdef inline bint _is_channels_last_stride_tuple(object shape, object stride):
+    cdef tuple order = (1, 3, 2, 0)
+    cdef Py_ssize_t expected = 1
+    cdef Py_ssize_t dim
+    if len(shape) != 4:
+        return False
+    for dim in order:
+        if shape[dim] == 1:
+            continue
+        if stride[dim] != expected:
+            return False
+        expected *= shape[dim]
+    return True

--- a/src/candle/_C/_tensor_impl.pyx
+++ b/src/candle/_C/_tensor_impl.pyx
@@ -44,7 +44,7 @@ cdef object _StrideTuple_cls = None
 cdef inline object _coerce_stride_tuple(object stride):
     global _StrideTuple_cls
     if _StrideTuple_cls is None:
-        from candle._tensor import _StrideTuple
+        from candle._C import _StrideTuple
         _StrideTuple_cls = _StrideTuple
     if isinstance(stride, _StrideTuple_cls):
         return stride

--- a/src/candle/__init__.py
+++ b/src/candle/__init__.py
@@ -76,7 +76,6 @@ def is_storage(obj):
         hasattr(obj, '_untyped_storage') and hasattr(obj, 'dtype')
     )
 from . import _C  # must load before _tensor (storage.py needs torch._C)
-_C._install_tensor_api()
 from . import _VF
 from . import _tensor_str
 from ._tensor import Tensor

--- a/src/candle/__init__.py
+++ b/src/candle/__init__.py
@@ -559,7 +559,7 @@ def cond(input, p=None):
     return linalg.cond(input, p)
 
 
-from ._printing import set_printoptions, get_printoptions
+from ._printing import set_printoptions, get_printoptions, printoptions
 from ._dispatch import (
     pipeline_context,
     functionalize_context,
@@ -856,6 +856,7 @@ __all__ = [
     # printing
     "set_printoptions",
     "get_printoptions",
+    "printoptions",
     # pipeline
     "pipeline",
     "pipeline_context",

--- a/src/candle/_backends/cpu/ops.py
+++ b/src/candle/_backends/cpu/ops.py
@@ -17,7 +17,8 @@ from ..._dtype import int64 as int64_dtype
 from ..._dtype import from_numpy_dtype
 from ..._dtype import to_numpy_dtype
 from ..._C import typed_storage_from_numpy
-from ..._tensor import Tensor, _StrideTuple
+from ..._C import _StrideTuple
+from ..._tensor import Tensor
 from ..._C._tensor_impl import cy_make_tensor_from_storage, cy_make_view_tensor  # pylint: disable=import-error,no-name-in-module
 
 
@@ -35,6 +36,26 @@ def _from_numpy(arr, dtype, device):
     storage = typed_storage_from_numpy(arr, dtype, device=device)
     stride = tuple(np.array(arr.strides) // arr.itemsize)
     return cy_make_tensor_from_storage(storage, arr.shape, stride, 0, False)
+
+
+def _channels_last_stride(shape):
+    if len(shape) != 4:
+        raise RuntimeError("required rank 4 tensor to use channels_last format")
+    n, c, h, w = shape
+    return (c * h * w, 1, w * c, c)
+
+
+def _is_channels_last_stride(shape, stride):
+    if len(shape) != 4:
+        return False
+    expected = 1
+    for dim in (1, 3, 2, 0):
+        if shape[dim] == 1:
+            continue
+        if stride[dim] != expected:
+            return False
+        expected *= shape[dim]
+    return True
 
 
 def _dtype_of(value):
@@ -1327,9 +1348,18 @@ def div_(a, b):
     return a
 
 
-def contiguous(a):
+def contiguous(a, memory_format=None):
     if a.device.type != "cpu":
         raise ValueError("CPU contiguous expects CPU tensors")
+    if getattr(memory_format, "_name", None) == "channels_last":
+        if len(a.shape) != 4:
+            raise RuntimeError("required rank 4 tensor to use channels_last format")
+        if _is_channels_last_stride(a.shape, a.stride):
+            return a
+        arr = np.ascontiguousarray(np.transpose(_to_numpy(a), (0, 2, 3, 1)))
+        storage = typed_storage_from_numpy(arr.reshape(-1), a.dtype, device=a.device)
+        stride = _channels_last_stride(a.shape)
+        return cy_make_tensor_from_storage(storage, a.shape, stride, 0, False)
     arr = np.ascontiguousarray(_to_numpy(a))
     return _from_numpy(arr, a.dtype, a.device)
 
@@ -2499,7 +2529,8 @@ def norm_(a, p=2, dim=None, keepdim=False):
             dim = tuple(dim)
         out = np.linalg.norm(arr, ord=p, axis=dim, keepdims=keepdim)
     else:
-        out = np.linalg.norm(arr.ravel(), ord=p)
+        ord_value = 2 if p == "fro" else p
+        out = np.linalg.norm(arr.ravel(), ord=ord_value)
         if keepdim:
             out = np.full([1] * arr.ndim, out)
     from ..._dtype import float32 as f32
@@ -2508,6 +2539,7 @@ def norm_(a, p=2, dim=None, keepdim=False):
     if hasattr(out, "flags") and not out.flags['C_CONTIGUOUS']:
         out = np.ascontiguousarray(out)
     return _from_numpy(out, out_dtype, a.device)
+
 
 
 def prod_(a, dim=None, keepdim=False):

--- a/src/candle/_backends/mps/ops/_helpers.py
+++ b/src/candle/_backends/mps/ops/_helpers.py
@@ -42,7 +42,7 @@ def _can_use_gpu(t):
 
 def _empty_like(t):
     """Return an empty contiguous tensor with the same shape/dtype/device."""
-    from ...._tensor import _compute_strides
+    from ...._C import _compute_strides
     shape = tuple(t.shape)
     stride = tuple(_compute_strides(shape))
     buf = _cy_alloc_output_buf(max(t.numel(), 1), t.dtype)
@@ -177,7 +177,7 @@ def _gpu_reduce_single_dim(a, dim, op_name, keepdim):
                           outer, reduce_size, inner, out_numel)
 
     out_shape = _cy_reduce_shape(tuple(a.shape), dim, keepdim)
-    from ...._tensor import _compute_strides
+    from ...._C import _compute_strides
     out_stride = tuple(_compute_strides(out_shape))
 
     if op_name in ("argmax", "argmin"):

--- a/src/candle/_backends/mps/ops/activation.py
+++ b/src/candle/_backends/mps/ops/activation.py
@@ -71,7 +71,7 @@ def leaky_relu(a, negative_slope=0.01):
                 f"leaky_relu_scalar_strided_{sfx}", _metal_buf(a), scalar,
                 out_buf, numel, list(a.shape), list(a.stride),
                 len(a.shape), scalar_fmt=_scalar_fmt(a.dtype))
-        from ...._tensor import _compute_strides
+        from ...._C import _compute_strides
         return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape),
                                   a.dtype, a.device)
     _unsupported_dtype("leaky_relu", a)
@@ -132,7 +132,7 @@ def clamp(a, min_val=None, max_val=None):
                     s_min, s_max, out_buf, numel,
                     list(a.shape), list(a.stride), len(a.shape),
                     scalar_fmt=fmt)
-            from ...._tensor import _compute_strides
+            from ...._C import _compute_strides
             return _from_metal_buffer(out_buf, a.shape,
                                       _compute_strides(a.shape),
                                       a.dtype, a.device)
@@ -161,7 +161,7 @@ def clamp_min(a, min_val):
                 f"clamp_min_scalar_strided_{sfx}", _metal_buf(a), scalar,
                 out_buf, numel, list(a.shape), list(a.stride),
                 len(a.shape), scalar_fmt=_scalar_fmt(a.dtype))
-        from ...._tensor import _compute_strides
+        from ...._C import _compute_strides
         return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape),
                                   a.dtype, a.device)
     _unsupported_dtype("clamp_min", a)
@@ -184,7 +184,7 @@ def clamp_max(a, max_val):
                 f"clamp_max_scalar_strided_{sfx}", _metal_buf(a), scalar,
                 out_buf, numel, list(a.shape), list(a.stride),
                 len(a.shape), scalar_fmt=_scalar_fmt(a.dtype))
-        from ...._tensor import _compute_strides
+        from ...._C import _compute_strides
         return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape),
                                   a.dtype, a.device)
     _unsupported_dtype("clamp_max", a)

--- a/src/candle/_backends/mps/ops/comparison.py
+++ b/src/candle/_backends/mps/ops/comparison.py
@@ -69,7 +69,7 @@ def eq(a, b):
                 return eq(a.contiguous(), b)
         else:
             return eq(a.contiguous(), b.contiguous() if isinstance(b, Tensor) else b)
-        from ...._tensor import _compute_strides
+        from ...._C import _compute_strides
         return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape), bool_dtype, a.device)
     if a.numel() == 0:
         return _empty_like(a)
@@ -94,7 +94,7 @@ def ne(a, b):
                 return ne(a.contiguous(), b)
         else:
             return ne(a.contiguous(), b.contiguous() if isinstance(b, Tensor) else b)
-        from ...._tensor import _compute_strides
+        from ...._C import _compute_strides
         return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape), bool_dtype, a.device)
     if a.numel() == 0:
         return _empty_like(a)
@@ -119,7 +119,7 @@ def lt(a, b):
                 return lt(a.contiguous(), b)
         else:
             return lt(a.contiguous(), b.contiguous() if isinstance(b, Tensor) else b)
-        from ...._tensor import _compute_strides
+        from ...._C import _compute_strides
         return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape), bool_dtype, a.device)
     if a.numel() == 0:
         return _empty_like(a)
@@ -144,7 +144,7 @@ def le(a, b):
                 return le(a.contiguous(), b)
         else:
             return le(a.contiguous(), b.contiguous() if isinstance(b, Tensor) else b)
-        from ...._tensor import _compute_strides
+        from ...._C import _compute_strides
         return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape), bool_dtype, a.device)
     if a.numel() == 0:
         return _empty_like(a)
@@ -169,7 +169,7 @@ def gt(a, b):
                 return gt(a.contiguous(), b)
         else:
             return gt(a.contiguous(), b.contiguous() if isinstance(b, Tensor) else b)
-        from ...._tensor import _compute_strides
+        from ...._C import _compute_strides
         return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape), bool_dtype, a.device)
     if a.numel() == 0:
         return _empty_like(a)
@@ -194,7 +194,7 @@ def ge(a, b):
                 return ge(a.contiguous(), b)
         else:
             return ge(a.contiguous(), b.contiguous() if isinstance(b, Tensor) else b)
-        from ...._tensor import _compute_strides
+        from ...._C import _compute_strides
         return _from_metal_buffer(out_buf, a.shape, _compute_strides(a.shape), bool_dtype, a.device)
     if a.numel() == 0:
         return _empty_like(a)

--- a/src/candle/_backends/mps/ops/elementwise.py
+++ b/src/candle/_backends/mps/ops/elementwise.py
@@ -285,7 +285,7 @@ def isin(elements, test_elements):
         te_flat = test_elements.contiguous().reshape((-1,))
         n_test = te_flat.numel()
         if n_test == 0:
-            from candle._tensor import _compute_strides
+            from candle._C import _compute_strides
             out_buf = _alloc_output_buf(max(elements.numel(), 1), bool_dtype)
             _get_dispatcher().dispatch_fill("fill_u8", out_buf, 0, max(elements.numel(), 1), scalar_fmt="B")
             return _from_metal_buffer(

--- a/src/candle/_backends/mps/ops/linalg.py
+++ b/src/candle/_backends/mps/ops/linalg.py
@@ -42,7 +42,7 @@ def matmul(a, b, out=None):
                     _metal_buf(a), _metal_buf(b),
                     M, K, N, dtype_code, _itemsize(a.dtype))
                 if out_buf is not None:
-                    from ...._tensor import _compute_strides
+                    from ...._C import _compute_strides
                     out_shape = (M, N)
                     out_stride = _compute_strides(out_shape)
                     return _return(_from_metal_buffer(out_buf, out_shape, out_stride,

--- a/src/candle/_backends/mps/ops/norm.py
+++ b/src/candle/_backends/mps/ops/norm.py
@@ -99,7 +99,7 @@ def batch_norm(input, running_mean, running_var, weight=None, bias=None,
             var_buf, weight_buf, bias_buf, out_buf,
             C, spatial_size, float(eps), has_weight, has_bias, total)
 
-        from ...._tensor import _compute_strides
+        from ...._C import _compute_strides
         out_shape = tuple(input.shape)
         out_stride = _compute_strides(out_shape)
         return _from_metal_buffer(out_buf, out_shape, out_stride, input.dtype, input.device)
@@ -227,7 +227,7 @@ def layer_norm(input, normalized_shape, weight=None, bias=None, eps=1e-5):
             f"layer_norm_{sfx}", _metal_buf(input), weight_buf, bias_buf,
             out_buf, outer_size, inner_size, float(eps), has_weight, has_bias)
 
-        from ...._tensor import _compute_strides
+        from ...._C import _compute_strides
         out_shape = tuple(input.shape)
         out_stride = _compute_strides(out_shape)
         return _from_metal_buffer(out_buf, out_shape, out_stride, input.dtype, input.device)
@@ -341,7 +341,7 @@ def rms_norm(input, normalized_shape, weight=None, eps=1e-6):
             f"rms_norm_{sfx}", _metal_buf(input), weight_buf,
             out_buf, outer_size, inner_size, float(eps), has_weight)
 
-        from ...._tensor import _compute_strides
+        from ...._C import _compute_strides
         out_shape = tuple(input.shape)
         out_stride = _compute_strides(out_shape)
         return _from_metal_buffer(out_buf, out_shape, out_stride, input.dtype, input.device)

--- a/src/candle/_backends/mps/ops/reduce.py
+++ b/src/candle/_backends/mps/ops/reduce.py
@@ -334,7 +334,7 @@ def count_nonzero(a, dim=None, keepdim=False):
             sfx = _kernel_suffix(float32_dtype)
             d.dispatch_fill(f"fill_{sfx}", buf, 1.0, numel,
                             _itemsize(float32_dtype))
-            from ...._tensor import _compute_strides
+            from ...._C import _compute_strides
             ones_t = _from_metal_buffer(buf, tuple(a.shape),
                                         _compute_strides(tuple(a.shape)),
                                         float32_dtype, a.device)
@@ -422,7 +422,7 @@ def _cumextreme_gpu(a, dim, mode):
     dispatch = d.dispatch_cummax if mode == "cummax" else d.dispatch_cummin
     dispatch(f"{mode}_{sfx}", _metal_buf(a), values_buf, indices_buf,
              outer_size, dim_size, inner_size)
-    from ...._tensor import _compute_strides
+    from ...._C import _compute_strides
     out_shape = tuple(a.shape)
     out_stride = _compute_strides(out_shape)
     values = _from_metal_buffer(values_buf, out_shape, out_stride, a.dtype, a.device)
@@ -498,7 +498,7 @@ def sort(a, dim=-1, descending=False, stable=False):
     if (_can_use_gpu(a) and a.is_contiguous()
             and a.dtype in (float32_dtype, float16_dtype)):
         values_buf, indices_buf, numel = _sort_gpu(a, dim, descending)
-        from ...._tensor import _compute_strides
+        from ...._C import _compute_strides
         out_shape = tuple(a.shape)
         out_stride = _compute_strides(out_shape)
         values = _from_metal_buffer(values_buf, out_shape, out_stride,

--- a/src/candle/_backends/mps/ops/shape.py
+++ b/src/candle/_backends/mps/ops/shape.py
@@ -48,7 +48,7 @@ def flip(a, dims):
             flip_packed = struct.pack(f"{ndim}I", *flip_mask)
             d.dispatch_flip(f"flip_{sfx}", _metal_buf(a), out_buf,
                             shape_packed, flip_packed, ndim, total)
-            from ...._tensor import _compute_strides
+            from ...._C import _compute_strides
             out_shape = tuple(a.shape)
             return _from_metal_buffer(out_buf, out_shape,
                                       _compute_strides(out_shape),
@@ -90,7 +90,7 @@ def roll(a, shifts, dims=None):
             shifts_packed = struct.pack(f"{ndim}i", *shift_arr)
             d.dispatch_roll(f"roll_{sfx}", _metal_buf(a), out_buf,
                             shape_packed, shifts_packed, ndim, total)
-            from ...._tensor import _compute_strides
+            from ...._C import _compute_strides
             out_shape = tuple(a.shape)
             return _from_metal_buffer(out_buf, out_shape,
                                       _compute_strides(out_shape),
@@ -377,7 +377,7 @@ def diag(a, diagonal_offset=0):
         sz = n + (diagonal_offset if diagonal_offset >= 0 else -diagonal_offset)
         total = sz * sz
         out_buf = _alloc_output_buf(total, a.dtype)
-        from ...._tensor import _compute_strides
+        from ...._C import _compute_strides
         out_shape = (sz, sz)
         out_stride = _compute_strides(out_shape)
         out = _from_metal_buffer(out_buf, out_shape, out_stride, a.dtype, a.device)
@@ -1111,7 +1111,7 @@ def flatten(a, start_dim=0, end_dim=-1):
         total *= s
     new_shape = tuple(s if s != -1 else total // known for s in new_shape)
     if _can_use_gpu(a) and a.is_contiguous():
-        from ...._tensor import _compute_strides
+        from ...._C import _compute_strides
         return _from_metal_buffer(_metal_buf(a), new_shape, _compute_strides(new_shape), a.dtype, a.device)
     # Non-contiguous GPU: make contiguous and retry
     if _can_use_gpu(a):
@@ -1125,7 +1125,7 @@ def unflatten(a, dim, sizes):
     d = dim if dim >= 0 else dim + ndim
     new_shape = a.shape[:d] + tuple(sizes) + a.shape[d + 1:]
     if _can_use_gpu(a) and a.is_contiguous():
-        from ...._tensor import _compute_strides
+        from ...._C import _compute_strides
         return _from_metal_buffer(_metal_buf(a), new_shape, _compute_strides(new_shape), a.dtype, a.device)
     # Non-contiguous GPU: make contiguous and retry
     if _can_use_gpu(a):

--- a/src/candle/_backends/npu/ops/shape.py
+++ b/src/candle/_backends/npu/ops/shape.py
@@ -3002,7 +3002,7 @@ def _validate_as_strided_storage_npu(a, size, stride, offset):
 
 def as_strided_npu(a, size, stride, storage_offset=None):
     """In-place metadata modification — same semantics as CPU as_strided_."""
-    from ...._tensor import _StrideTuple
+    from ...._C import _StrideTuple
     offset = a.offset if storage_offset is None else int(storage_offset)
     size = tuple(int(s) for s in size)
     stride = tuple(int(s) for s in stride)

--- a/src/candle/_dispatch/schemas.py
+++ b/src/candle/_dispatch/schemas.py
@@ -402,10 +402,11 @@ def register_schemas():
         "sin", "cos", "tan", "tanh", "sigmoid", "floor", "ceil", "round", "trunc", "frac",
         "log2", "log10", "exp2", "rsqrt", "reciprocal", "sign", "signbit", "isnan", "isinf", "isfinite",
         "sinh", "cosh", "asinh", "acosh", "atanh", "erf", "erfc", "softplus",
-        "relu6", "contiguous", "gelu", "silu", "mish",
+        "relu6", "gelu", "silu", "mish",
         "square",
     ))
     registry.register_schema("hardtanh", "hardtanh(Tensor input, Scalar min_val=-1.0, Scalar max_val=1.0) -> Tensor")
+    registry.register_schema("contiguous", "contiguous(Tensor input, *, MemoryFormat? memory_format=None) -> Tensor")
     registry.register_schema("softmax", "softmax(Tensor input, int dim=-1, Dtype? dtype=None) -> Tensor")
     registry.register_schema("log_softmax", "log_softmax(Tensor input, int dim=-1, Dtype? dtype=None) -> Tensor")
     registry.register_schema("dropout", "dropout(Tensor input, float p=0.5, bool training=True) -> Tensor")
@@ -472,7 +473,7 @@ def register_schemas():
             "unexpected": "{name}() received an invalid combination of arguments - got {got}, but expected one of:\n * (Tensor input, tuple of ints dim, bool unbiased = True, bool keepdim = False, *, Tensor out = None)\n * (Tensor input, tuple of ints dim = None, *, Number correction = None, bool keepdim = False, Tensor out = None)\n * (Tensor input, bool unbiased = True)\n      didn't match because some of the keywords were incorrect: dim\n * (Tensor input, tuple of names dim, bool unbiased = True, bool keepdim = False, *, Tensor out = None)\n * (Tensor input, tuple of names dim, *, Number correction = None, bool keepdim = False, Tensor out = None)\n",
         },
     )
-    registry.register_schema("norm", "norm(Tensor input, Any p=2, int[]? dim=None, bool keepdim=False) -> Tensor")
+    registry.register_schema("norm", "norm(Tensor input, Any p=2, int[]? dim=None, bool keepdim=False, *, Dtype? dtype=None) -> Tensor")
     registry.register_error_overrides(
         "norm",
         {

--- a/src/candle/_functional.py
+++ b/src/candle/_functional.py
@@ -1016,11 +1016,43 @@ def tensor(data, *, dtype=None, device=None, requires_grad=False):
     return dispatch("tensor", dev, data, dtype=dtype, requires_grad=requires_grad)
 
 
+def _unsupported_memory_format(name, memory_format):
+    raise TypeError(
+        f"{name}() received an invalid combination of arguments - memory_format {memory_format} is not supported"
+    )
+
+
+def _apply_output_memory_format(output, *, memory_format=None, source=None):
+    name = getattr(memory_format, "_name", None)
+
+    if memory_format is None:
+        if source is not None and source.is_contiguous(memory_format=getattr(__import__('candle'), 'channels_last')):
+            return output.contiguous(memory_format=getattr(__import__('candle'), 'channels_last'))
+        return output
+
+    if name == "contiguous_format":
+        return output
+
+    if name == "channels_last":
+        return output.contiguous(memory_format=memory_format)
+
+    if name == "preserve_format":
+        if source is None:
+            raise RuntimeError("unsupported memory format Preserve")
+        if source.is_contiguous(memory_format=getattr(__import__('candle'), 'channels_last')):
+            return output.contiguous(memory_format=getattr(__import__('candle'), 'channels_last'))
+        return output
+
+    return output
+
+
 def zeros(*shape, dtype=None, device=None, memory_format=None):
     if len(shape) == 1 and isinstance(shape[0], (tuple, list)):
         shape = shape[0]
+    if memory_format is not None:
+        _unsupported_memory_format("zeros", memory_format)
     dev = _as_device(device)
-    return dispatch("zeros", dev, shape, dtype=dtype, memory_format=memory_format)
+    return dispatch("zeros", dev, shape, dtype=dtype)
 
 
 def zeros_like(input, *, dtype=None, device=None, memory_format=None):
@@ -1028,35 +1060,43 @@ def zeros_like(input, *, dtype=None, device=None, memory_format=None):
         dtype = input.dtype
     if device is None:
         device = input.device
-    return zeros(input.shape, dtype=dtype, device=device, memory_format=memory_format)
+    out = zeros(input.shape, dtype=dtype, device=device)
+    return _apply_output_memory_format(out, memory_format=memory_format, source=input)
 
 
 def ones(*shape, dtype=None, device=None, memory_format=None):
     if len(shape) == 1 and isinstance(shape[0], (tuple, list)):
         shape = shape[0]
+    if memory_format is not None:
+        _unsupported_memory_format("ones", memory_format)
     dev = _as_device(device)
-    return dispatch("ones", dev, shape, dtype=dtype, memory_format=memory_format)
+    return dispatch("ones", dev, shape, dtype=dtype)
 
 
 def empty(*shape, dtype=None, device=None, memory_format=None):
     if len(shape) == 1 and isinstance(shape[0], (tuple, list)):
         shape = shape[0]
     dev = _as_device(device)
-    return dispatch("empty", dev, shape, dtype=dtype, memory_format=memory_format)
+    out = dispatch("empty", dev, shape, dtype=dtype, memory_format=None)
+    return _apply_output_memory_format(out, memory_format=memory_format)
 
 
 def randn(*shape, dtype=None, device=None, memory_format=None, generator=None):
     if len(shape) == 1 and isinstance(shape[0], (tuple, list)):
         shape = shape[0]
+    if memory_format is not None:
+        _unsupported_memory_format("randn", memory_format)
     dev = _as_device(device)
-    return dispatch("randn", dev, shape, dtype=dtype, memory_format=memory_format, generator=generator)
+    return dispatch("randn", dev, shape, dtype=dtype, generator=generator)
 
 
 def rand(*shape, dtype=None, device=None, memory_format=None, generator=None):
     if len(shape) == 1 and isinstance(shape[0], (tuple, list)):
         shape = shape[0]
+    if memory_format is not None:
+        _unsupported_memory_format("rand", memory_format)
     dev = _as_device(device)
-    return dispatch("rand", dev, shape, dtype=dtype, memory_format=memory_format, generator=generator)
+    return dispatch("rand", dev, shape, dtype=dtype, generator=generator)
 
 
 def randint(low, high=None, size=None, *, dtype=None, device=None, requires_grad=False, generator=None):
@@ -1323,7 +1363,8 @@ def ones_like(input, *, dtype=None, device=None, memory_format=None):
         dtype = input.dtype
     if device is None:
         device = input.device
-    return ones(input.shape, dtype=dtype, device=device, memory_format=memory_format)
+    out = ones(input.shape, dtype=dtype, device=device)
+    return _apply_output_memory_format(out, memory_format=memory_format, source=input)
 
 
 def empty_like(input, *, dtype=None, device=None, memory_format=None):
@@ -1331,7 +1372,8 @@ def empty_like(input, *, dtype=None, device=None, memory_format=None):
         dtype = input.dtype
     if device is None:
         device = input.device
-    return empty(input.shape, dtype=dtype, device=device, memory_format=memory_format)
+    out = empty(input.shape, dtype=dtype, device=device)
+    return _apply_output_memory_format(out, memory_format=memory_format, source=input)
 
 
 def full_like(input, fill_value, *, dtype=None, device=None, memory_format=None):
@@ -1339,7 +1381,8 @@ def full_like(input, fill_value, *, dtype=None, device=None, memory_format=None)
         dtype = input.dtype
     if device is None:
         device = input.device
-    return full(input.shape, fill_value, dtype=dtype, device=device)
+    out = full(input.shape, fill_value, dtype=dtype, device=device)
+    return _apply_output_memory_format(out, memory_format=memory_format, source=input)
 
 
 def randn_like(input, *, dtype=None, device=None, memory_format=None, generator=None):
@@ -1347,7 +1390,8 @@ def randn_like(input, *, dtype=None, device=None, memory_format=None, generator=
         dtype = input.dtype
     if device is None:
         device = input.device
-    return randn(input.shape, dtype=dtype, device=device, memory_format=memory_format, generator=generator)
+    out = randn(input.shape, dtype=dtype, device=device, generator=generator)
+    return _apply_output_memory_format(out, memory_format=memory_format, source=input)
 
 
 def rand_like(input, *, dtype=None, device=None, memory_format=None, generator=None):
@@ -1355,7 +1399,8 @@ def rand_like(input, *, dtype=None, device=None, memory_format=None, generator=N
         dtype = input.dtype
     if device is None:
         device = input.device
-    return rand(input.shape, dtype=dtype, device=device, memory_format=memory_format, generator=generator)
+    out = rand(input.shape, dtype=dtype, device=device, generator=generator)
+    return _apply_output_memory_format(out, memory_format=memory_format, source=input)
 
 
 def randint_like(input, low=0, high=None, *, dtype=None, device=None, memory_format=None):

--- a/src/candle/_printing.py
+++ b/src/candle/_printing.py
@@ -1,60 +1,7 @@
-from dataclasses import asdict, dataclass
-import math
-import numpy as np
-
-from ._dtype import float32
-from ._device import _default_device
+from ._tensor_str import _str, get_printoptions, printoptions, set_printoptions
 
 
-@dataclass
-class PrintOptions:
-    precision: int = 4
-    threshold: float = 1000
-    edgeitems: int = 3
-    linewidth: int = 80
-    sci_mode: bool | None = None
-
-
-_PRINT_OPTIONS = PrintOptions()
-
-
-_PROFILES = {
-    "default": {"precision": 4, "threshold": 1000, "edgeitems": 3},
-    "short": {"precision": 2, "threshold": 1000, "edgeitems": 2},
-    "full": {"threshold": math.inf},
-}
-
-
-def get_printoptions():
-    return asdict(_PRINT_OPTIONS)
-
-
-def set_printoptions(
-    precision=None,
-    threshold=None,
-    edgeitems=None,
-    linewidth=None,
-    sci_mode=None,
-    profile=None,
-):
-    if profile is not None:
-        if profile not in _PROFILES:
-            raise ValueError(f"Unknown profile: {profile}")
-        for key, value in _PROFILES[profile].items():
-            setattr(_PRINT_OPTIONS, key, value)
-    if precision is not None:
-        _PRINT_OPTIONS.precision = precision
-    if threshold is not None:
-        _PRINT_OPTIONS.threshold = threshold
-    if edgeitems is not None:
-        _PRINT_OPTIONS.edgeitems = edgeitems
-    if linewidth is not None:
-        _PRINT_OPTIONS.linewidth = linewidth
-    if sci_mode is not None:
-        _PRINT_OPTIONS.sci_mode = sci_mode
-
-
-def format_tensor(tensor):
+def format_tensor(tensor, tensor_contents=None):
     if getattr(tensor, "_pending", False):
         from ._dispatch.pipeline import current_pipeline
 
@@ -62,55 +9,4 @@ def format_tensor(tensor):
         if pipe is not None:
             pipe.flush()
 
-    if tensor.device.type == "meta":
-        data_repr = "..."
-    else:
-        if tensor.device.type == "cpu":
-            view = tensor._numpy_view()
-        else:
-            view = tensor.to("cpu")._numpy_view()
-        data_repr = _format_array(view, _PRINT_OPTIONS)
-
-    suffixes = []
-    if tensor.dtype != float32 or tensor.device.type == "meta":
-        suffixes.append(f"dtype={repr(tensor.dtype)}")
-    if tensor.device.type != _default_device.type:
-        device_label = tensor.device.type
-        if tensor.device.type == "npu":
-            device_label = str(tensor.device)
-        suffixes.append(f"device='{device_label}'")
-    if tensor.requires_grad:
-        suffixes.append("requires_grad=True")
-    if tensor.grad_fn is not None:
-        suffixes.append(f"grad_fn=<{type(tensor.grad_fn).__name__}>")
-
-    if suffixes:
-        return f"tensor({data_repr}, {', '.join(suffixes)})"
-    return f"tensor({data_repr})"
-
-
-def _format_array(arr, options):
-    formatter = None
-    floatmode = None
-    if options.sci_mode is True:
-        def _format_float(value):
-            return np.format_float_scientific(
-                value, precision=options.precision, unique=False
-            )
-        formatter = {"float_kind": _format_float}
-    elif options.sci_mode is False:
-        floatmode = "fixed"
-
-    kwargs = {
-        "precision": options.precision,
-        "threshold": options.threshold,
-        "edgeitems": options.edgeitems,
-        "separator": ", ",
-        "prefix": "tensor(",
-        "formatter": formatter,
-        "floatmode": floatmode,
-    }
-    try:
-        return np.array2string(arr, max_line_width=options.linewidth, **kwargs)
-    except TypeError:
-        return np.array2string(arr, linewidth=options.linewidth, **kwargs)
+    return _str(tensor, tensor_contents=tensor_contents)

--- a/src/candle/_tensor.py
+++ b/src/candle/_tensor.py
@@ -43,7 +43,7 @@ def _handle_torch_function_and_wrap_type_error_to_not_implemented(
             # See https://github.com/pytorch/pytorch/issues/75462
             sargs = self, *args
             if has_torch_function(sargs):
-                return handle_torch_function(wrapped, sargs, self, *args, **kwargs)
+                return handle_torch_function(wrapped, sargs, *sargs, **kwargs)
             return f(self, *args, **kwargs)
         except TypeError:
             return NotImplemented
@@ -161,7 +161,7 @@ class Tensor(torch._C.TensorBase):
             if (
                 self.is_sparse
                 or self.device.type
-                in ["lazy", "mps", "meta", "ipu"]
+                in ["lazy", "xla", "mtia", "mps", "maia", "meta", "ipu"]
                 or (
                     not torch._C._has_storage(self)
                     and self.device.type == torch._C._get_privateuse1_backend_name()
@@ -334,7 +334,7 @@ class Tensor(torch._C.TensorBase):
             torch.serialization._serialization_tls.materialize_fake_tensors
         )
 
-        if (
+        if self.device.type in ["xla", "maia", "mtia"] or (
             not torch._C._has_storage(self)
             and self.device.type == torch._C._get_privateuse1_backend_name()
         ):
@@ -660,7 +660,8 @@ class Tensor(torch._C.TensorBase):
 
         return index(self, positions, dims)
 
-    def register_hook(self, hook):
+    register_hook = _C._add_docstr(
+        _C.TensorBase.register_hook,
         r"""Registers a backward hook.
 
         The hook will be called every time a gradient with respect to the
@@ -692,24 +693,8 @@ class Tensor(torch._C.TensorBase):
             [torch.FloatTensor of size (3,)]
 
             >>> h.remove()  # removes the hook
-        """
-        if has_torch_function_unary(self):
-            return handle_torch_function(Tensor.register_hook, (self,), self, hook)
-        if not self.requires_grad:
-            raise RuntimeError(
-                "cannot register a hook on a tensor that doesn't require gradient"
-            )
-        if self._backward_hooks is None:
-            self._backward_hooks = OrderedDict()
-            if self.grad_fn is not None:
-                if hasattr(self.grad_fn, '_register_hook_dict'):
-                    self.grad_fn._register_hook_dict(self)
-
-        from torch.utils.hooks import RemovableHandle
-
-        handle = RemovableHandle(self._backward_hooks)
-        self._backward_hooks[handle.id] = hook
-        return handle
+        """,
+    )
 
     def register_post_accumulate_grad_hook(self, hook):
         r"""Registers a backward hook that runs after grad accumulation.
@@ -894,20 +879,6 @@ class Tensor(torch._C.TensorBase):
         else:
             return self.flip(0)
 
-    def norm(
-        self,
-        p: float | str | None = "fro",
-        dim=None,
-        keepdim=False,
-        dtype=None,
-    ):
-        r"""See :func:`torch.linalg.norm`"""
-        if has_torch_function_unary(self):
-            return handle_torch_function(
-                Tensor.norm, (self,), self, p=p, dim=dim, keepdim=keepdim, dtype=dtype
-            )
-        return torch.norm(self, p, dim, keepdim, dtype=dtype)
-
     def solve(self, other):
         from torch._linalg_utils import solve
 
@@ -1050,27 +1021,6 @@ class Tensor(torch._C.TensorBase):
 
         return Resize.apply(self, tensor.size())
 
-    def split(self, split_size, dim=0):
-        r"""See :func:`torch.split`"""
-        if has_torch_function_unary(self):
-            return handle_torch_function(
-                Tensor.split, (self,), self, split_size, dim=dim
-            )
-        if isinstance(split_size, Tensor):
-            try:
-                split_size = int(split_size)
-            except ValueError:
-                pass
-
-        if isinstance(split_size, (int, torch.SymInt)):
-            return torch._VF.split(self, split_size, dim)  # type: ignore[attr-defined]
-        else:
-            return torch._VF.split_with_sizes(
-                self,
-                split_size,
-                dim,
-            )
-
     def unique(self, sorted=True, return_inverse=False, return_counts=False, dim=None):
         r"""Returns the unique elements of the input tensor.
 
@@ -1113,15 +1063,9 @@ class Tensor(torch._C.TensorBase):
         )
 
     @_handle_torch_function_and_wrap_type_error_to_not_implemented
-    def __rsub__(self, other: Union["Tensor", int, float, bool, complex]) -> "Tensor":
-        return _C._VariableFunctions.rsub(self, other)
-
-    @_handle_torch_function_and_wrap_type_error_to_not_implemented
     def __rdiv__(self, other: Union["Tensor", int, float, bool, complex]) -> "Tensor":
         return self.reciprocal() * other
 
-    __rtruediv__ = __rdiv__
-    __itruediv__ = _C.TensorBase.__idiv__
 
     # pyrefly: ignore [bad-override]
     __pow__ = cast(
@@ -1138,10 +1082,6 @@ class Tensor(torch._C.TensorBase):
         _C.TensorBase.pow_
     )
 
-    @_handle_torch_function_and_wrap_type_error_to_not_implemented
-    def __rmod__(self, other: Union["Tensor", int, float, bool, complex]) -> "Tensor":
-        return torch.remainder(other, self)
-
     def __format__(self, format_spec):
         if has_torch_function_unary(self):
             return handle_torch_function(Tensor.__format__, (self,), self, format_spec)
@@ -1150,36 +1090,6 @@ class Tensor(torch._C.TensorBase):
             # requires gradients to a python number. It is ok for formatting.
             return self.detach().item().__format__(format_spec)
         return object.__format__(self, format_spec)
-
-    @_handle_torch_function_and_wrap_type_error_to_not_implemented
-    def __rpow__(self, other: Union["Tensor", int, float, bool, complex]) -> "Tensor":
-        return torch.pow(other, self)
-
-    @_handle_torch_function_and_wrap_type_error_to_not_implemented
-    def __floordiv__(self, other: Union["Tensor", int, float, bool]) -> "Tensor":  # type: ignore[override]
-        # TODO(rec): the superclass says it accepts complex here,
-        # but torch.floor_divide says it doesn't.
-        return torch.floor_divide(self, other)
-
-    @_handle_torch_function_and_wrap_type_error_to_not_implemented
-    def __rfloordiv__(self, other: Union["Tensor", int, float, bool]) -> "Tensor":  # type: ignore[override]
-        return torch.floor_divide(other, self)
-
-    @_handle_torch_function_and_wrap_type_error_to_not_implemented
-    def __rlshift__(
-        self, other: Union["Tensor", int, float, bool, complex]
-    ) -> "Tensor":
-        return torch.bitwise_left_shift(other, self)
-
-    @_handle_torch_function_and_wrap_type_error_to_not_implemented
-    def __rrshift__(
-        self, other: Union["Tensor", int, float, bool, complex]
-    ) -> "Tensor":
-        return torch.bitwise_right_shift(other, self)
-
-    @_handle_torch_function_and_wrap_type_error_to_not_implemented
-    def __rmatmul__(self, other: "Tensor") -> "Tensor":
-        return torch.matmul(other, self)
 
     __pos__ = _C.TensorBase.positive
     __neg__ = _C.TensorBase.neg
@@ -1433,28 +1343,6 @@ class Tensor(torch._C.TensorBase):
         return super().align_to(
             [name for name in names if not is_ellipsis(name)], ellipsis_idx
         )
-
-    def unflatten(self, dim, sizes):  # type: ignore[override]
-        r"""
-        unflatten(dim, sizes) -> Tensor
-
-        See :func:`torch.unflatten`.
-
-        """
-        if has_torch_function_unary(self):
-            return handle_torch_function(Tensor.unflatten, (self,), self, dim, sizes)
-
-        if not sizes:
-            raise RuntimeError("unflatten: sizes must be non-empty")
-
-        names = None
-        if isinstance(sizes, OrderedDict) or (
-            isinstance(sizes, (tuple, list)) and isinstance(sizes[0], (tuple, list))
-        ):
-            names, sizes = unzip_namedshape(sizes)
-            return super().unflatten(dim, sizes, names)
-        else:
-            return super().unflatten(dim, sizes)
 
     def rename_(self, *names, **rename_map):
         """In-place version of :meth:`~Tensor.rename`."""
@@ -1863,7 +1751,3 @@ def _convert(ret, cls):
         ret = type(ret)(_convert(r, cls) for r in ret)
 
     return ret
-
-
-# Re-export candle-specific symbols for backward compatibility
-from ._C import _StrideTuple, _compute_strides, _bf16_to_f32, _f32_to_bf16  # noqa: E402,F401

--- a/src/candle/_tensor_str.py
+++ b/src/candle/_tensor_str.py
@@ -67,7 +67,7 @@ def printoptions(**kwargs):
 
 
 def _str(self, *, tensor_contents=None):
-    from ._dtype import complex64, float32
+    from ._dtype import complex64, float32, int64
     from ._device import _default_device
 
     if tensor_contents is None:
@@ -83,7 +83,7 @@ def _str(self, *, tensor_contents=None):
         data_repr = tensor_contents
 
     suffixes = []
-    if (self.dtype != float32 and self.dtype != complex64) or self.device.type == "meta":
+    if (self.dtype not in (float32, complex64, int64)) or self.device.type == "meta":
         suffixes.append(f"dtype={repr(self.dtype)}")
     if self.device.type != _default_device.type:
         device_label = self.device.type
@@ -171,6 +171,9 @@ def _format_array(arr, options):
         "floatmode": floatmode,
     }
     try:
-        return np.array2string(arr, max_line_width=options.linewidth, **kwargs)
+        result = np.array2string(arr, max_line_width=options.linewidth, **kwargs)
     except TypeError:
-        return np.array2string(arr, linewidth=options.linewidth, **kwargs)
+        result = np.array2string(arr, linewidth=options.linewidth, **kwargs)
+    # Torch uses double-space before ellipsis; match its summarization separator
+    result = result.replace(", ...", ",  ...")
+    return result

--- a/src/candle/_tensor_str.py
+++ b/src/candle/_tensor_str.py
@@ -1,25 +1,129 @@
-"""Minimal torch._tensor_str stub for candle compatibility."""
-import numpy as np
+# mypy: allow-untyped-defs
+import contextlib
+import dataclasses
+import math
+from typing import Any
 
 
-def _str(self, tensor_contents=None):
-    """Return a string representation of the tensor."""
-    if self.numel() == 0:
-        return "tensor([])"
+@dataclasses.dataclass
+class __PrinterOptions:
+    precision: int = 4
+    threshold: float = 1000
+    edgeitems: int = 3
+    linewidth: int = 80
+    sci_mode: bool | None = None
 
-    # Build the header
-    header = "tensor("
 
-    # Get numpy representation
-    arr = self.numpy()
+PRINT_OPTS = __PrinterOptions()
 
-    # Format the array
-    with np.printoptions(threshold=1000, linewidth=80, precision=4):
-        body = np.array2string(arr, separator=", ")
 
-    # Indent multi-line arrays
-    if "\n" in body:
-        body = body.replace("\n", "\n" + " " * 7)
-        return header + "\n" + " " * 7 + body + ")"
+def set_printoptions(
+    precision=None,
+    threshold=None,
+    edgeitems=None,
+    linewidth=None,
+    profile=None,
+    sci_mode=None,
+):
+    if profile is not None:
+        if profile == "default":
+            PRINT_OPTS.precision = 4
+            PRINT_OPTS.threshold = 1000
+            PRINT_OPTS.edgeitems = 3
+            PRINT_OPTS.linewidth = 80
+        elif profile == "short":
+            PRINT_OPTS.precision = 2
+            PRINT_OPTS.threshold = 1000
+            PRINT_OPTS.edgeitems = 2
+            PRINT_OPTS.linewidth = 80
+        elif profile == "full":
+            PRINT_OPTS.precision = 4
+            PRINT_OPTS.threshold = math.inf
+            PRINT_OPTS.edgeitems = 3
+            PRINT_OPTS.linewidth = 80
+    if precision is not None:
+        PRINT_OPTS.precision = precision
+    if threshold is not None:
+        PRINT_OPTS.threshold = threshold
+    if edgeitems is not None:
+        PRINT_OPTS.edgeitems = edgeitems
+    if linewidth is not None:
+        PRINT_OPTS.linewidth = linewidth
+    PRINT_OPTS.sci_mode = sci_mode
 
-    return header + body + ")"
+
+def get_printoptions() -> dict[str, Any]:
+    return dataclasses.asdict(PRINT_OPTS)
+
+
+@contextlib.contextmanager
+def printoptions(**kwargs):
+    old_kwargs = get_printoptions()
+    set_printoptions(**kwargs)
+    try:
+        yield
+    finally:
+        set_printoptions(**old_kwargs)
+
+
+def _str(self, *, tensor_contents=None):
+    from ._dtype import float32
+    from ._device import _default_device
+
+    if tensor_contents is None:
+        if self.device.type == "meta":
+            data_repr = "..."
+        else:
+            if self.device.type == "cpu":
+                view = self._numpy_view()
+            else:
+                view = self.to("cpu")._numpy_view()
+            data_repr = _format_array(view, PRINT_OPTS)
+    else:
+        data_repr = tensor_contents
+
+    suffixes = []
+    if self.dtype != float32 or self.device.type == "meta":
+        suffixes.append(f"dtype={repr(self.dtype)}")
+    if self.device.type != _default_device.type:
+        device_label = self.device.type
+        if self.device.type == "npu":
+            device_label = str(self.device)
+        suffixes.append(f"device='{device_label}'")
+    if self.requires_grad:
+        suffixes.append("requires_grad=True")
+    if self.grad_fn is not None:
+        suffixes.append(f"grad_fn=<{type(self.grad_fn).__name__}>")
+
+    if suffixes:
+        return f"tensor({data_repr}, {', '.join(suffixes)})"
+    return f"tensor({data_repr})"
+
+
+def _format_array(arr, options):
+    import numpy as np
+
+    formatter = None
+    floatmode = None
+    if options.sci_mode is True:
+        def _format_float(value):
+            return np.format_float_scientific(
+                value, precision=options.precision, unique=False
+            )
+        formatter = {"float_kind": _format_float}
+    elif options.sci_mode is False:
+        floatmode = "fixed"
+
+    kwargs = {
+        "precision": options.precision,
+        "threshold": options.threshold,
+        "edgeitems": options.edgeitems,
+        "separator": ", ",
+        "prefix": "tensor(",
+        "formatter": formatter,
+        "floatmode": floatmode,
+    }
+    try:
+        return np.array2string(arr, max_line_width=options.linewidth, **kwargs)
+    except TypeError:
+        return np.array2string(arr, linewidth=options.linewidth, **kwargs)

--- a/src/candle/_tensor_str.py
+++ b/src/candle/_tensor_str.py
@@ -67,7 +67,7 @@ def printoptions(**kwargs):
 
 
 def _str(self, *, tensor_contents=None):
-    from ._dtype import float32
+    from ._dtype import complex64, float32
     from ._device import _default_device
 
     if tensor_contents is None:
@@ -83,7 +83,7 @@ def _str(self, *, tensor_contents=None):
         data_repr = tensor_contents
 
     suffixes = []
-    if self.dtype != float32 or self.device.type == "meta":
+    if (self.dtype != float32 and self.dtype != complex64) or self.device.type == "meta":
         suffixes.append(f"dtype={repr(self.dtype)}")
     if self.device.type != _default_device.type:
         device_label = self.device.type
@@ -100,11 +100,58 @@ def _str(self, *, tensor_contents=None):
     return f"tensor({data_repr})"
 
 
+def _format_real_scalar(value, options):
+    import numpy as np
+
+    if options.sci_mode is True:
+        return np.format_float_scientific(value, precision=options.precision, unique=False)
+    if options.sci_mode is False:
+        return f"{value:.{options.precision}f}"
+    out = np.format_float_positional(
+        value,
+        precision=options.precision,
+        unique=False,
+        fractional=False,
+        trim='-'
+    )
+    if "e" not in out and "." not in out:
+        out += "."
+    return out
+
+
+def _format_complex_scalar(value, options, real_width):
+    real_str = _format_real_scalar(value.real, options).rjust(real_width)
+    imag_str = f"{abs(value.imag):.{options.precision}f}j"
+    if value.imag >= 0:
+        return f"{real_str}+{imag_str}"
+    return f"{real_str}-{imag_str}"
+
+
+def _format_complex_array(arr, options, real_width):
+    import numpy as np
+
+    if arr.ndim == 0:
+        return _format_complex_scalar(arr.item(), options, real_width)
+
+    if arr.ndim == 1:
+        items = [_format_complex_scalar(v, options, real_width) for v in arr.tolist()]
+        return "[" + ", ".join(items) + "]"
+
+    slices = [_format_complex_array(np.asarray(arr[i]), options, real_width) for i in range(arr.shape[0])]
+    joiner = ",\n" + " " * 8
+    return "[" + joiner.join(slices) + "]"
+
+
 def _format_array(arr, options):
     import numpy as np
 
+    if np.iscomplexobj(arr):
+        flat = np.asarray(arr).reshape(-1)
+        real_width = max(len(_format_real_scalar(v.real, options)) for v in flat) if flat.size else 1
+        return _format_complex_array(np.asarray(arr), options, real_width)
+
     formatter = None
-    floatmode = None
+    floatmode = "maxprec_equal"
     if options.sci_mode is True:
         def _format_float(value):
             return np.format_float_scientific(

--- a/tests/common/test_c_core.py
+++ b/tests/common/test_c_core.py
@@ -404,7 +404,7 @@ class TestNpuOpsCimports:
     def test_npu_ops_cimports_storage_impl(self):
         from pathlib import Path
 
-        npu_ops_pyx = Path(__file__).resolve().parents[2] / "src/candle/_cython/_npu_ops.pyx"
+        npu_ops_pyx = Path(__file__).resolve().parents[2] / "src/candle/_C/_npu_ops.pyx"
         text = npu_ops_pyx.read_text(encoding="utf-8")
         assert "from candle._C._storage_impl cimport StorageImpl" in text
 
@@ -949,6 +949,39 @@ class TestTensorLayoutMethodProviders:
         assert view.shape == (3, 2)
         assert view.stride() == (1, 3)
         assert view._storage is base._storage
+
+    def test_tensor_api_layout_methods_support_channels_last_cpu(self):
+        import candle as torch
+
+        x = torch.randn(2, 3, 4, 5)
+        assert x.is_contiguous() is True
+        assert x.is_contiguous(memory_format=torch.channels_last) is False
+
+        y = x.contiguous(memory_format=torch.channels_last)
+        assert y.shape == (2, 3, 4, 5)
+        assert y.stride() == (60, 1, 15, 3)
+        assert y.is_contiguous() is False
+        assert y.is_contiguous(memory_format=torch.channels_last) is True
+        assert y.contiguous(memory_format=torch.channels_last) is y
+        assert y.contiguous().shape == x.shape
+        assert y.contiguous().stride() == x.stride()
+
+        z = x.to(memory_format=torch.channels_last)
+        assert z.stride() == (60, 1, 15, 3)
+        assert z.is_contiguous(memory_format=torch.channels_last) is True
+
+        a = torch.randn(6)
+        assert a.is_contiguous(memory_format=torch.channels_last) is False
+        try:
+            a.contiguous(memory_format=torch.channels_last)
+            assert False, "expected rank-4 channels_last error"
+        except RuntimeError as e:
+            assert "required rank 4 tensor" in str(e)
+        try:
+            a.to(memory_format=torch.channels_last)
+            assert False, "expected rank-4 channels_last error"
+        except RuntimeError as e:
+            assert "required rank 4 tensor" in str(e)
 
 
 class TestTensorAutogradMethodProviders:
@@ -1579,17 +1612,13 @@ class TestTensorDataSetterProvider:
         assert x.offset == 0
         assert x._version_counter.value == 1
 
-        try:
-            x.data = torch.ones((3, 2), dtype=torch.float32)
-            assert False, "expected shape mismatch"
-        except RuntimeError as e:
-            assert "shape mismatch" in str(e)
+        x.data = torch.ones((3, 2), dtype=torch.float32)
+        assert x.shape == (3, 2)
+        assert x.dtype == torch.float32
 
-        try:
-            x.data = torch.ones((2, 3), dtype=torch.float64)
-            assert False, "expected dtype mismatch"
-        except RuntimeError as e:
-            assert "dtype mismatch" in str(e)
+        x.data = torch.ones((2, 3), dtype=torch.float64)
+        assert x.shape == (2, 3)
+        assert x.dtype == torch.float64
 
 
 class TestTensorMiscHelperMethodProviders:

--- a/tests/cpu/test_tensor_api_contract.py
+++ b/tests/cpu/test_tensor_api_contract.py
@@ -241,6 +241,564 @@ class TestClone:
         assert a.clone().dtype == a.dtype
 
     def test_device_preserved(self):
+        a = torch.tensor([1.0, 2.0], device="cpu")
+        assert a.clone().device.type == "cpu"
+
+    def test_grad_fn_when_requires_grad(self):
+        a = torch.tensor([1.0, 2.0], requires_grad=True)
+        assert a.clone().grad_fn is not None
+
+
+# ===========================================================================
+# 7. detach
+# ===========================================================================
+
+class TestDetach:
+
+    def test_detach_returns_tensor(self):
+        a = torch.tensor([1.0, 2.0], requires_grad=True)
+        out = a.detach()
+        assert isinstance(out, Tensor)
+
+    def test_detach_disables_requires_grad(self):
+        a = torch.tensor([1.0, 2.0], requires_grad=True)
+        assert a.detach().requires_grad is False
+
+    def test_detach_preserves_values(self):
+        a = torch.tensor([1.0, 2.0], requires_grad=True)
+        _allclose(a.detach(), [1.0, 2.0])
+
+    def test_detach_has_no_grad_fn(self):
+        a = torch.tensor([1.0, 2.0], requires_grad=True)
+        assert a.detach().grad_fn is None
+
+    def test_detach_shape_preserved(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]], requires_grad=True)
+        assert a.detach().shape == (2, 2)
+
+
+# ===========================================================================
+# 8. to
+# ===========================================================================
+
+class TestTo:
+
+    def test_returns_tensor(self):
+        a = torch.tensor([1.0, 2.0, 3.0])
+        assert isinstance(a.to("cpu"), Tensor)
+
+    def test_cpu_values_preserved(self):
+        a = torch.tensor([1.0, 2.0, 3.0])
+        _allclose(a.to("cpu"), [1.0, 2.0, 3.0])
+
+    def test_dtype_change(self):
+        a = torch.tensor([1.0, 2.0, 3.0])
+        assert a.to(torch.float64).dtype == torch.float64
+
+    def test_dtype_change_values(self):
+        a = torch.tensor([1.0, 2.0, 3.0])
+        _allclose(a.to(torch.float64), [1.0, 2.0, 3.0])
+
+    def test_dtype_kwarg(self):
+        a = torch.tensor([1.0, 2.0, 3.0])
+        assert a.to(dtype=torch.float64).dtype == torch.float64
+
+    def test_device_kwarg(self):
+        a = torch.tensor([1.0, 2.0, 3.0])
+        assert a.to(device="cpu").device.type == "cpu"
+
+    def test_shape_preserved_after_to(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        assert a.to("cpu").shape == (2, 2)
+
+    def test_channels_last_non_4d_is_false_for_is_contiguous(self):
+        a = torch.tensor([1.0, 2.0, 3.0])
+        assert a.is_contiguous(memory_format=torch.channels_last) is False
+
+    def test_channels_last_non_4d_contiguous_raises(self):
+        a = torch.tensor([1.0, 2.0, 3.0])
+        with pytest.raises(RuntimeError, match="required rank 4 tensor"):
+            a.contiguous(memory_format=torch.channels_last)
+
+    def test_channels_last_non_4d_to_raises(self):
+        a = torch.tensor([1.0, 2.0, 3.0])
+        with pytest.raises(RuntimeError, match="required rank 4 tensor"):
+            a.to(memory_format=torch.channels_last)
+
+    def test_channels_last_4d_contiguous_and_stride(self):
+        a = torch.randn(2, 3, 4, 5)
+        assert a.is_contiguous() is True
+        assert a.is_contiguous(memory_format=torch.channels_last) is False
+        b = a.contiguous(memory_format=torch.channels_last)
+        assert b.shape == (2, 3, 4, 5)
+        assert b.stride() == (60, 1, 15, 3)
+        assert b.is_contiguous() is False
+        assert b.is_contiguous(memory_format=torch.channels_last) is True
+        _allclose(b.contiguous(), a.flatten().tolist())
+
+    def test_to_channels_last_4d_contiguous_and_stride(self):
+        a = torch.randn(2, 3, 4, 5)
+        b = a.to(memory_format=torch.channels_last)
+        assert b.shape == (2, 3, 4, 5)
+        assert b.stride() == (60, 1, 15, 3)
+        assert b.is_contiguous(memory_format=torch.channels_last) is True
+
+
+class TestCreationMemoryFormat:
+
+    def test_empty_supports_channels_last(self):
+        x = torch.empty((2, 3, 4, 5), memory_format=torch.channels_last)
+        assert x.stride() == (60, 1, 15, 3)
+        assert x.is_contiguous() is False
+        assert x.is_contiguous(memory_format=torch.channels_last) is True
+
+    def test_empty_rejects_preserve_format(self):
+        with pytest.raises(RuntimeError, match="unsupported memory format Preserve"):
+            torch.empty((2, 3, 4, 5), memory_format=torch.preserve_format)
+
+    def test_empty_like_preserves_channels_last_by_default(self):
+        base = torch.empty((2, 3, 4, 5), memory_format=torch.channels_last)
+        out = torch.empty_like(base)
+        assert out.stride() == (60, 1, 15, 3)
+        assert out.is_contiguous(memory_format=torch.channels_last) is True
+
+    def test_full_like_preserves_channels_last_by_default(self):
+        base = torch.empty((2, 3, 4, 5), memory_format=torch.channels_last)
+        out = torch.full_like(base, 1.0)
+        assert out.stride() == (60, 1, 15, 3)
+        assert out.is_contiguous(memory_format=torch.channels_last) is True
+
+    def test_empty_like_contiguous_format_from_channels_last(self):
+        base = torch.empty((2, 3, 4, 5), memory_format=torch.channels_last)
+        out = torch.empty_like(base, memory_format=torch.contiguous_format)
+        assert out.stride() == (60, 20, 5, 1)
+        assert out.is_contiguous() is True
+        assert out.is_contiguous(memory_format=torch.channels_last) is False
+
+    def test_zeros_rejects_memory_format(self):
+        with pytest.raises(TypeError):
+            torch.zeros((2, 3, 4, 5), memory_format=torch.channels_last)
+
+    def test_ones_rejects_memory_format(self):
+        with pytest.raises(TypeError):
+            torch.ones((2, 3, 4, 5), memory_format=torch.channels_last)
+
+    def test_randn_rejects_memory_format(self):
+        with pytest.raises(TypeError):
+            torch.randn((2, 3, 4, 5), memory_format=torch.channels_last)
+
+    def test_rand_rejects_memory_format(self):
+        with pytest.raises(TypeError):
+            torch.rand((2, 3, 4, 5), memory_format=torch.channels_last)
+
+    def test_basic(self):
+        a = torch.tensor([-1.0, 0.0, 2.0])
+        _allclose(a.relu(), [0.0, 0.0, 2.0])
+
+    def test_returns_tensor(self):
+        assert isinstance(torch.tensor([-1.0]).relu(), Tensor)
+
+    def test_shape_preserved(self):
+        a = torch.tensor([[-1.0, 2.0], [3.0, -4.0]])
+        assert a.relu().shape == (2, 2)
+
+    def test_does_not_modify_original(self):
+        a = torch.tensor([-1.0, 2.0])
+        _ = a.relu()
+        _allclose(a, [-1.0, 2.0])
+
+    def test_grad_fn_when_requires_grad(self):
+        a = torch.tensor([-1.0, 2.0], requires_grad=True)
+        assert a.relu().grad_fn is not None
+
+
+# ===========================================================================
+# 10. reshape
+# ===========================================================================
+
+class TestReshape:
+
+    def test_basic_shape(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        assert a.reshape(4).shape == (4,)
+
+    def test_values_preserved(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        _allclose(a.reshape(4), [1.0, 2.0, 3.0, 4.0])
+
+    def test_returns_tensor(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        assert isinstance(a.reshape(4), Tensor)
+
+    def test_infer_dimension(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        assert a.reshape(-1).shape == (4,)
+
+    def test_grad_fn_when_requires_grad(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]], requires_grad=True)
+        assert a.reshape(4).grad_fn is not None
+
+
+# ===========================================================================
+# 11. transpose
+# ===========================================================================
+
+class TestTranspose:
+
+    def test_shape_swapped(self):
+        a = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        assert a.transpose(0, 1).shape == (3, 2)
+
+    def test_values_transposed(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        _allclose(a.transpose(0, 1), [1.0, 3.0, 2.0, 4.0])
+
+    def test_returns_tensor(self):
+        a = torch.tensor([[1.0, 2.0]])
+        assert isinstance(a.transpose(0, 1), Tensor)
+
+    def test_no_copy_semantics_not_required_but_shape_correct(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        b = a.transpose(0, 1)
+        assert b.shape == (2, 2)
+
+    def test_grad_fn_when_requires_grad(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]], requires_grad=True)
+        assert a.transpose(0, 1).grad_fn is not None
+
+
+# ===========================================================================
+# 12. view
+# ===========================================================================
+
+class TestView:
+
+    def test_basic_shape(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        assert a.view(4).shape == (4,)
+
+    def test_values_preserved(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        _allclose(a.view(4), [1.0, 2.0, 3.0, 4.0])
+
+    def test_returns_tensor(self):
+        a = torch.tensor([[1.0, 2.0]])
+        assert isinstance(a.view(2), Tensor)
+
+    def test_requires_contiguous_input(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        b = a.transpose(0, 1)
+        with pytest.raises(RuntimeError):
+            b.view(4)
+
+    def test_grad_fn_when_requires_grad(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]], requires_grad=True)
+        assert a.view(4).grad_fn is not None
+
+
+# ===========================================================================
+# 13. backward
+# ===========================================================================
+
+class TestBackward:
+
+    def test_scalar_backward_populates_grad(self):
+        x = torch.tensor([3.0], requires_grad=True)
+        y = x * x
+        y.backward()
+        assert x.grad is not None
+        _allclose(x.grad, [6.0])
+
+    def test_backward_with_external_gradient(self):
+        x = torch.tensor([2.0, 3.0], requires_grad=True)
+        y = x * 2.0
+        y.backward(torch.tensor([1.0, 1.0]))
+        _allclose(x.grad, [2.0, 2.0])
+
+    def test_backward_returns_none(self):
+        x = torch.tensor([3.0], requires_grad=True)
+        y = x * x
+        assert y.backward() is None
+
+
+# ===========================================================================
+# 14. property stability
+# ===========================================================================
+
+class TestPropertyStability:
+
+    def test_shape_device_dtype_exist(self):
+        x = torch.tensor([[1.0, 2.0]])
+        assert x.shape == (1, 2)
+        assert x.device.type == "cpu"
+        assert x.dtype == torch.float32
+
+    def test_grad_default_none(self):
+        x = torch.tensor([1.0, 2.0])
+        assert x.grad is None
+
+    def test_grad_after_backward(self):
+        x = torch.tensor([2.0], requires_grad=True)
+        y = x * x
+        y.backward()
+        assert x.grad is not None
+
+    def test_requires_grad_roundtrip(self):
+        x = torch.tensor([1.0], requires_grad=True)
+        assert x.requires_grad is True
+
+
+# ===========================================================================
+# 15. __torch_function__ forwarding path
+# ===========================================================================
+
+class TestTensorMethodTorchFunctionPath:
+
+    class Wrapper(Tensor):
+        called = None
+
+        @classmethod
+        def __torch_function__(cls, func, types, args=(), kwargs=None):
+            cls.called = func.__name__
+            return torch.tensor([123.0])
+
+    def setup_method(self):
+        self.Wrapper.called = None
+
+    def test___add___uses_torch_function(self):
+        x = torch.tensor([1.0]).as_subclass(self.Wrapper)
+        out = x + torch.tensor([2.0])
+        assert self.Wrapper.called == "__add__"
+        _allclose(out, [123.0])
+
+    def test_clone_uses_torch_function(self):
+        x = torch.tensor([1.0]).as_subclass(self.Wrapper)
+        out = x.clone()
+        assert self.Wrapper.called == "clone"
+        _allclose(out, [123.0])
+
+    def test_relu_uses_torch_function(self):
+        x = torch.tensor([1.0]).as_subclass(self.Wrapper)
+        out = x.relu()
+        assert self.Wrapper.called == "relu"
+        _allclose(out, [123.0])
+
+# 1. __add__
+# ===========================================================================
+
+class TestDunderAdd:
+
+    def test_basic_values(self):
+        a = torch.tensor([1.0, 2.0, 3.0])
+        b = torch.tensor([4.0, 5.0, 6.0])
+        _allclose(a + b, [5.0, 7.0, 9.0])
+
+    def test_returns_tensor(self):
+        a = torch.tensor([1.0])
+        b = torch.tensor([2.0])
+        assert isinstance(a + b, Tensor)
+
+    def test_shape_preserved(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        b = torch.tensor([[0.1, 0.2], [0.3, 0.4]])
+        assert (a + b).shape == (2, 2)
+
+    def test_scalar_rhs(self):
+        a = torch.tensor([1.0, 2.0, 3.0])
+        _allclose(a + 10.0, [11.0, 12.0, 13.0])
+
+    def test_scalar_lhs_radd_not_supported(self):
+        # Current behavior: float.__add__(Tensor) falls back to NotImplemented and
+        # Tensor has no __radd__, so Python raises TypeError.
+        # This test locks that behavior; if __radd__ is added later, update it.
+        a = torch.tensor([1.0, 2.0, 3.0])
+        with pytest.raises(TypeError):
+            _ = 10.0 + a
+
+    def test_does_not_modify_inputs(self):
+        a = torch.tensor([1.0, 2.0])
+        b = torch.tensor([3.0, 4.0])
+        _ = a + b
+        _allclose(a, [1.0, 2.0])
+        _allclose(b, [3.0, 4.0])
+
+    def test_grad_fn_when_requires_grad(self):
+        a = torch.tensor([1.0, 2.0], requires_grad=True)
+        b = torch.tensor([3.0, 4.0])
+        assert (a + b).grad_fn is not None
+
+    def test_no_grad_fn_without_requires_grad(self):
+        a = torch.tensor([1.0, 2.0])
+        b = torch.tensor([3.0, 4.0])
+        assert (a + b).grad_fn is None
+
+
+# ===========================================================================
+# 2. __mul__
+# ===========================================================================
+
+class TestDunderMul:
+
+    def test_basic_values(self):
+        a = torch.tensor([2.0, 3.0, 4.0])
+        b = torch.tensor([5.0, 6.0, 7.0])
+        _allclose(a * b, [10.0, 18.0, 28.0])
+
+    def test_returns_tensor(self):
+        assert isinstance(torch.tensor([2.0]) * torch.tensor([3.0]), Tensor)
+
+    def test_scalar_rhs(self):
+        a = torch.tensor([1.0, 2.0, 3.0])
+        _allclose(a * 3.0, [3.0, 6.0, 9.0])
+
+    def test_scalar_lhs_rmul(self):
+        a = torch.tensor([1.0, 2.0, 3.0])
+        _allclose(3.0 * a, [3.0, 6.0, 9.0])
+
+    def test_shape_preserved(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        b = torch.tensor([[2.0, 2.0], [2.0, 2.0]])
+        assert (a * b).shape == (2, 2)
+
+    def test_does_not_modify_inputs(self):
+        a = torch.tensor([1.0, 2.0])
+        b = torch.tensor([3.0, 4.0])
+        _ = a * b
+        _allclose(a, [1.0, 2.0])
+        _allclose(b, [3.0, 4.0])
+
+    def test_grad_fn_when_requires_grad(self):
+        a = torch.tensor([2.0, 3.0], requires_grad=True)
+        b = torch.tensor([4.0, 5.0])
+        assert (a * b).grad_fn is not None
+
+
+# ===========================================================================
+# 3. __matmul__
+# ===========================================================================
+
+class TestDunderMatmul:
+
+    def test_2d_identity(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        b = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+        _allclose(a @ b, [1.0, 2.0, 3.0, 4.0])
+
+    def test_returns_tensor(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        b = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+        assert isinstance(a @ b, Tensor)
+
+    def test_output_shape(self):
+        a = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])  # (2,3)
+        b = torch.tensor([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])  # (3,2)
+        assert (a @ b).shape == (2, 2)
+
+    def test_mv(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        v = torch.tensor([1.0, 1.0])
+        _allclose(a @ v, [3.0, 7.0])
+
+    def test_grad_fn_when_requires_grad(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]], requires_grad=True)
+        b = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+        assert (a @ b).grad_fn is not None
+
+    def test_rmatmul(self):
+        # b.__rmatmul__(a) computes matmul(a, b) per Python's reflected op protocol
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        b = torch.tensor([[0.0, 1.0], [1.0, 0.0]])
+        out = b.__rmatmul__(a)   # == matmul(a, b)
+        assert isinstance(out, Tensor)
+        assert out.shape == (2, 2)
+        # a @ b = [[2, 1], [4, 3]], distinct from b @ a = [[3, 4], [1, 2]]
+        _allclose(out, [2.0, 1.0, 4.0, 3.0])
+
+
+# ===========================================================================
+# 4. __iadd__
+# ===========================================================================
+
+class TestDunderIadd:
+
+    def test_basic(self):
+        a = torch.tensor([1.0, 2.0, 3.0])
+        a += torch.tensor([4.0, 5.0, 6.0])
+        _allclose(a, [5.0, 7.0, 9.0])
+
+    def test_returns_same_object(self):
+        a = torch.tensor([1.0, 2.0])
+        orig_id = id(a)
+        a += torch.tensor([1.0, 1.0])
+        assert id(a) == orig_id
+
+    def test_scalar(self):
+        a = torch.tensor([1.0, 2.0, 3.0])
+        a += 10.0
+        _allclose(a, [11.0, 12.0, 13.0])
+
+    def test_raises_for_leaf_with_requires_grad(self):
+        a = torch.tensor([1.0, 2.0], requires_grad=True)
+        with pytest.raises(RuntimeError):
+            a += torch.tensor([1.0, 1.0])
+
+
+# ===========================================================================
+# 5. __imul__
+# ===========================================================================
+
+class TestDunderImul:
+
+    def test_basic(self):
+        a = torch.tensor([2.0, 3.0, 4.0])
+        a *= torch.tensor([5.0, 6.0, 7.0])
+        _allclose(a, [10.0, 18.0, 28.0])
+
+    def test_returns_same_object(self):
+        a = torch.tensor([1.0, 2.0])
+        orig_id = id(a)
+        a *= torch.tensor([2.0, 2.0])
+        assert id(a) == orig_id
+
+    def test_scalar(self):
+        a = torch.tensor([1.0, 2.0, 3.0])
+        a *= 3.0
+        _allclose(a, [3.0, 6.0, 9.0])
+
+    def test_raises_for_leaf_with_requires_grad(self):
+        a = torch.tensor([1.0, 2.0], requires_grad=True)
+        with pytest.raises(RuntimeError):
+            a *= torch.tensor([2.0, 2.0])
+
+
+# ===========================================================================
+# 6. clone
+# ===========================================================================
+
+class TestClone:
+
+    def test_values_match(self):
+        a = torch.tensor([1.0, 2.0, 3.0])
+        _allclose(a.clone(), [1.0, 2.0, 3.0])
+
+    def test_returns_tensor(self):
+        assert isinstance(torch.tensor([1.0, 2.0]).clone(), Tensor)
+
+    def test_is_copy_not_alias(self):
+        a = torch.tensor([1.0, 2.0, 3.0])
+        b = a.clone()
+        b += torch.tensor([10.0, 10.0, 10.0])
+        _allclose(a, [1.0, 2.0, 3.0])  # original unchanged
+
+    def test_shape_preserved(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        assert a.clone().shape == (2, 2)
+
+    def test_dtype_preserved(self):
+        a = torch.tensor([1.0, 2.0])
+        assert a.clone().dtype == a.dtype
+
+    def test_device_preserved(self):
         a = torch.tensor([1.0, 2.0])
         assert a.clone().device.type == a.device.type
 

--- a/tests/cpu/test_tensor_print.py
+++ b/tests/cpu/test_tensor_print.py
@@ -97,3 +97,51 @@ def test_complex_repr_matches_local_torch():
     c = torch.tensor([1 + 2j, -3 + 0.5j], dtype=torch.complex64)
     r = ref_torch.tensor([1 + 2j, -3 + 0.5j], dtype=ref_torch.complex64)
     assert repr(c) == repr(r)
+
+
+def test_threshold_summarization_matches_local_torch():
+    from torch._tensor_str import get_printoptions as ref_get, set_printoptions as ref_set
+
+    prev_c = torch.get_printoptions()
+    prev_r = ref_get()
+    try:
+        torch.set_printoptions(threshold=5)
+        ref_set(threshold=5)
+        c = torch.arange(10)
+        r = ref_torch.arange(10)
+        assert repr(c) == repr(r)
+    finally:
+        torch.set_printoptions(**prev_c)
+        ref_set(**prev_r)
+
+
+def test_linewidth_wrapping_matches_local_torch():
+    from torch._tensor_str import get_printoptions as ref_get, set_printoptions as ref_set
+
+    prev_c = torch.get_printoptions()
+    prev_r = ref_get()
+    try:
+        torch.set_printoptions(linewidth=30)
+        ref_set(linewidth=30)
+        c = torch.arange(16).reshape(4, 4)
+        r = ref_torch.arange(16).reshape(4, 4)
+        assert repr(c) == repr(r)
+    finally:
+        torch.set_printoptions(**prev_c)
+        ref_set(**prev_r)
+
+
+def test_scientific_mode_matches_local_torch():
+    from torch._tensor_str import get_printoptions as ref_get, set_printoptions as ref_set
+
+    prev_c = torch.get_printoptions()
+    prev_r = ref_get()
+    try:
+        torch.set_printoptions(sci_mode=True, precision=2)
+        ref_set(sci_mode=True, precision=2)
+        c = torch.tensor([1.0e-5, 2.0e6])
+        r = ref_torch.tensor([1.0e-5, 2.0e6])
+        assert repr(c) == repr(r)
+    finally:
+        torch.set_printoptions(**prev_c)
+        ref_set(**prev_r)

--- a/tests/cpu/test_tensor_print.py
+++ b/tests/cpu/test_tensor_print.py
@@ -54,3 +54,27 @@ def test_tensor_repr_npu_index():
     t = torch.ones((1,), device="npu:1")
     rep = repr(t)
     assert "device='npu:1'" in rep
+
+
+def test_printoptions_state_lives_in_tensor_str_module():
+    from candle import _tensor_str
+
+    prev = torch.get_printoptions()
+    try:
+        torch.set_printoptions(precision=2, linewidth=70)
+        opts = torch.get_printoptions()
+        assert opts["precision"] == 2
+        assert opts["linewidth"] == 70
+        assert _tensor_str.get_printoptions()["precision"] == 2
+        assert _tensor_str.get_printoptions()["linewidth"] == 70
+    finally:
+        torch.set_printoptions(**prev)
+
+
+def test_printoptions_context_restores_state():
+    prev = torch.get_printoptions()
+    with torch.printoptions(precision=2, sci_mode=True):
+        inside = torch.get_printoptions()
+        assert inside["precision"] == 2
+        assert inside["sci_mode"] is True
+    assert torch.get_printoptions() == prev

--- a/tests/cpu/test_tensor_print.py
+++ b/tests/cpu/test_tensor_print.py
@@ -1,4 +1,5 @@
 import candle as torch
+import torch as ref_torch
 
 
 def test_tensor_repr_cpu_default_dtype():
@@ -78,3 +79,21 @@ def test_printoptions_context_restores_state():
         assert inside["precision"] == 2
         assert inside["sci_mode"] is True
     assert torch.get_printoptions() == prev
+
+
+def test_dense_vector_repr_matches_local_torch():
+    c = torch.tensor([1.23456, 2.0, -3.5], dtype=torch.float32)
+    r = ref_torch.tensor([1.23456, 2.0, -3.5], dtype=ref_torch.float32)
+    assert repr(c) == repr(r)
+
+
+def test_dense_matrix_repr_matches_local_torch():
+    c = torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float32)
+    r = ref_torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=ref_torch.float32)
+    assert repr(c) == repr(r)
+
+
+def test_complex_repr_matches_local_torch():
+    c = torch.tensor([1 + 2j, -3 + 0.5j], dtype=torch.complex64)
+    r = ref_torch.tensor([1 + 2j, -3 + 0.5j], dtype=ref_torch.complex64)
+    assert repr(c) == repr(r)


### PR DESCRIPTION
## Summary

- Move print option ownership to _tensor_str.py
- Port torch dense tensor formatting pipeline
- Add torch-compatible channels_last memory_format for CPU
- Fix Tensor.data setter semantics
- Move norm/split/unflatten/reflected operators into _tensor_api provider
- Fix storage_impl resizable flag and _C bootstrap exports

## Test plan

- [x] tests/common/test_c_core.py - 128 passed, 1 skipped
- [x] tests/cpu/test_tensor_api_contract.py - 102 passed
- [x] tests/contract/test_storage_contract.py - 6 passed
- [x] tests/cpu/test_tensor_print.py - 14 passed
- [x] Cython build verified on Linux aarch64 with Python 3.11

🤖 Generated with Claude Code