### PR TITLE
fix(print): align tensor repr suffixes with torch

### DIFF
--- a/src/candle/_tensor_str.py
+++ b/src/candle/_tensor_str.py
@@ -67,7 +67,9 @@ def printoptions(**kwargs):
 
 
 def _str(self, *, tensor_contents=None):
-    from ._dtype import complex64, float32, int64
+    from . import get_default_dtype
+    from ._dtype import bool as bool_dtype
+    from ._dtype import complex64, complex128, float64, int64
     from ._device import _default_device
 
     if tensor_contents is None:
@@ -82,18 +84,26 @@ def _str(self, *, tensor_contents=None):
     else:
         data_repr = tensor_contents
 
+    default_dtype = get_default_dtype()
+    default_complex_dtype = complex128 if default_dtype is float64 else complex64
+    has_default_dtype = self.dtype in (default_dtype, default_complex_dtype, int64, bool_dtype)
+
     suffixes = []
-    if (self.dtype not in (float32, complex64, int64)) or self.device.type == "meta":
-        suffixes.append(f"dtype={repr(self.dtype)}")
     if self.device.type != _default_device.type:
         device_label = self.device.type
         if self.device.type == "npu":
             device_label = str(self.device)
         suffixes.append(f"device='{device_label}'")
-    if self.requires_grad:
-        suffixes.append("requires_grad=True")
+    if self.device.type == "meta":
+        suffixes.append("size=" + str(tuple(self.shape)))
+        if self.dtype != default_dtype:
+            suffixes.append(f"dtype={repr(self.dtype)}")
+    elif not has_default_dtype:
+        suffixes.append(f"dtype={repr(self.dtype)}")
     if self.grad_fn is not None:
         suffixes.append(f"grad_fn=<{type(self.grad_fn).__name__}>")
+    elif self.requires_grad:
+        suffixes.append("requires_grad=True")
 
     if suffixes:
         return f"tensor({data_repr}, {', '.join(suffixes)})"

--- a/tests/cpu/test_tensor_print.py
+++ b/tests/cpu/test_tensor_print.py
@@ -23,7 +23,8 @@ def test_tensor_repr_meta_includes_device():
     assert rep.startswith("tensor(")
     assert "..." in rep
     assert "device='meta'" in rep
-    assert "dtype=torch.float32" in rep
+    assert "size=(2, 2)" in rep
+    assert "dtype=" not in rep
 
 
 def test_tensor_repr_respects_precision():
@@ -145,3 +146,25 @@ def test_scientific_mode_matches_local_torch():
     finally:
         torch.set_printoptions(**prev_c)
         ref_set(**prev_r)
+
+
+def test_meta_tensor_repr_matches_local_torch():
+    c = torch.empty((2, 2), device="meta")
+    r = ref_torch.empty((2, 2), device="meta")
+    assert repr(c) == repr(r)
+
+
+def test_bool_tensor_repr_matches_local_torch():
+    c = torch.tensor([True, False], dtype=torch.bool)
+    r = ref_torch.tensor([True, False], dtype=ref_torch.bool)
+    assert repr(c) == repr(r)
+
+
+def test_non_leaf_grad_suffix_matches_torch_shape():
+    c = torch.tensor([1.0], requires_grad=True) + 1
+    r = ref_torch.tensor([1.0], requires_grad=True) + 1
+    c_repr = repr(c)
+    r_repr = repr(r)
+    assert "grad_fn=<" in c_repr
+    assert "requires_grad=True" not in r_repr
+    assert "requires_grad=True" not in c_repr


### PR DESCRIPTION
## Summary
- Align tensor repr suffix handling with torch for default dtypes, bool tensors, and meta tensors.
- Suppress `requires_grad=True` when a non-leaf `grad_fn` suffix is present.
- Add local torch parity tests for meta, bool, and non-leaf grad repr cases.

## Test plan
- [x] `PYTHONPATH=/home/jenkins/lvyufeng/candle/.worktrees/tensor-print-alignment/src conda run -n candle311 python -m pytest tests/cpu/test_tensor_print.py -q --tb=short`
- [x] `conda run -n candle311 pylint src/candle/ --rcfile=.github/pylint.conf`
- [x] `PYTHONPATH=/home/jenkins/lvyufeng/candle/.worktrees/tensor-print-alignment/src conda run -n candle311 python -m pytest tests/cpu/ tests/contract/ -v --tb=short`

🤖 Generated with [Claude Code](https://claude.com/claude-code)