### PR TITLE
Align channels_last memory_format semantics

### DIFF
--- a/src/candle/_C/_TensorBase.pyx
+++ b/src/candle/_C/_TensorBase.pyx
@@ -535,9 +535,9 @@ class TensorBase(TensorImpl):
         from candle._functional import neg as neg_dispatch
         return neg_dispatch(self)
 
-    def clone(self):
-        from candle._functional import clone as clone_dispatch
-        return clone_dispatch(self)
+    def clone(self, *, memory_format=None):
+        from . import _tensor_api as _tensor_api_mod
+        return _tensor_api_mod.tensor_clone(self, memory_format=memory_format)
 
     def to(self, *args, **kwargs):
         from candle._functional import to as to_dispatch

--- a/src/candle/_C/_tensor_api.pyx
+++ b/src/candle/_C/_tensor_api.pyx
@@ -431,8 +431,62 @@ def tensor_neg(self):
     return _neg_fn(self)
 
 
-def tensor_clone(self):
+cdef inline object _normalize_memory_format(object memory_format):
+    cdef object name
+    if memory_format is None:
+        return None
+    name = getattr(memory_format, "_name", None)
+    if name in ("contiguous_format", "channels_last", "preserve_format"):
+        return memory_format
+    raise TypeError(
+        f"received an invalid combination of arguments - memory_format {memory_format} is not supported"
+    )
+
+
+cdef inline object _memory_format_name(object memory_format):
+    if memory_format is None:
+        return None
+    return getattr(memory_format, "_name", None)
+
+
+def tensor_clone(self, *, memory_format=None):
+    cdef object fmt_name
+    cdef object out
+    cdef object _cl
+
     _ensure_functional_refs()
+
+    memory_format = _normalize_memory_format(memory_format)
+    fmt_name = _memory_format_name(memory_format)
+
+    # Determine effective format: preserve_format/None inherits source layout.
+    if fmt_name == "preserve_format" or memory_format is None:
+        out = _to_dispatch_fn(self, self.device, copy=True)
+        if _is_channels_last_stride_tuple(self.shape, self.stride):
+            # Source was channels_last — relayout the copy.
+            import candle as _candle_mod
+            _cl = getattr(_candle_mod, "channels_last", None)
+            if _cl is not None:
+                out = out.contiguous(memory_format=_cl)
+        return out
+
+    if fmt_name == "contiguous_format":
+        # Always produce a contiguous (row-major) tensor.
+        out = _to_dispatch_fn(self, self.device, copy=True)
+        if _is_channels_last_stride_tuple(out.shape, out.stride):
+            out = out.contiguous()
+        return out
+
+    if fmt_name == "channels_last":
+        # Produce a channels_last copy regardless of source layout.
+        out = _to_dispatch_fn(self, self.device, copy=True)
+        import candle as _candle_mod
+        _cl = getattr(_candle_mod, "channels_last", None)
+        if _cl is not None:
+            out = out.contiguous(memory_format=_cl)
+        return out
+
+    # Unknown memory_format — plain copy.
     return _to_dispatch_fn(self, self.device, copy=True)
 
 
@@ -464,6 +518,8 @@ def tensor_to(self, *args, **kwargs):
     cdef object result = self
     cdef object arg
     cdef object dt
+    cdef object fmt_name
+    cdef object target_device
 
     _ensure_device_ref()
     _ensure_dtype_ref()
@@ -473,7 +529,8 @@ def tensor_to(self, *args, **kwargs):
 
     non_blocking = kwargs.get("non_blocking", False)
     copy = kwargs.get("copy", False)
-    memory_format = kwargs.get("memory_format", None)
+    memory_format = _normalize_memory_format(kwargs.get("memory_format", None))
+    fmt_name = _memory_format_name(memory_format)
 
     for arg in args:
         if isinstance(arg, _Device):
@@ -497,6 +554,14 @@ def tensor_to(self, *args, **kwargs):
     if "dtype" in kwargs:
         dtype = kwargs["dtype"]
 
+    target_device = device if device is not None else self.device
+    if (
+        fmt_name == "channels_last"
+        or (fmt_name == "preserve_format" and _is_channels_last_stride_tuple(self.shape, self.stride))
+    ):
+        if target_device.type not in ("cpu", "meta"):
+            raise NotImplementedError("channels_last memory_format is currently only supported on CPU and meta tensors")
+
     if dtype is not None and dtype != self.dtype:
         result = result._to_dtype(dtype)
 
@@ -510,12 +575,22 @@ def tensor_to(self, *args, **kwargs):
             memory_format=memory_format,
         )
 
-    if getattr(memory_format, "_name", None) == "channels_last":
-        if result.device.type != "cpu":
-            raise NotImplementedError("channels_last memory_format is currently only supported on CPU tensors")
+    if fmt_name == "channels_last":
         result = result.contiguous(memory_format=memory_format)
 
-    if result is self and dtype is None and device is None:
+    if fmt_name == "preserve_format":
+        # preserve_format: keep the source tensor's current memory layout.
+        if _is_channels_last_stride_tuple(self.shape, self.stride):
+            import candle as _candle_mod
+            _cl = getattr(_candle_mod, "channels_last", None)
+            if _cl is not None:
+                result = result.contiguous(memory_format=_cl)
+        # else: result is already contiguous (default), nothing to do.
+
+    if fmt_name == "contiguous_format" and _is_channels_last_stride_tuple(result.shape, result.stride):
+        result = result.contiguous()
+
+    if result is self and dtype is None and device is None and fmt_name != "contiguous_format":
         return self
     return result
 
@@ -702,74 +777,6 @@ def tensor_view(self, *shape):
     return v
 
 
-def tensor_is_contiguous(self, memory_format=None):
-    if getattr(memory_format, "_name", None) == "channels_last":
-        return _is_channels_last_stride_tuple(self.shape, self.stride)
-    cdef tuple expected
-    expected = _contiguous_stride_tuple(self.shape)
-    return self.stride == expected
-
-
-def tensor_contiguous(self, memory_format=None):
-    if getattr(memory_format, "_name", None) == "channels_last":
-        if len(self.shape) != 4:
-            raise RuntimeError("required rank 4 tensor to use channels_last format")
-        if self.is_contiguous(memory_format=memory_format):
-            return self
-        _ensure_dispatch_ref()
-        return _dispatch_fn("contiguous", self.device.type, self, memory_format=memory_format)
-    if self.is_contiguous(memory_format=memory_format):
-        return self
-    _ensure_dispatch_ref()
-    return _dispatch_fn("contiguous", self.device.type, self)
-
-
-def tensor_flatten(self, start_dim=0, end_dim=-1):
-    cdef Py_ssize_t ndim = len(self.shape)
-    cdef Py_ssize_t i
-    cdef Py_ssize_t flattened = 1
-    cdef tuple new_shape
-
-    if self.requires_grad:
-        _ensure_dispatch_ref()
-        return _dispatch_fn("flatten", self.device.type, self, start_dim, end_dim)
-    if ndim == 0:
-        return self.reshape((1,))
-    if start_dim < 0:
-        start_dim += ndim
-    if end_dim < 0:
-        end_dim += ndim
-    if start_dim < 0 or start_dim >= ndim:
-        raise IndexError("Dimension out of range")
-    if end_dim < 0 or end_dim >= ndim:
-        raise IndexError("Dimension out of range")
-    if start_dim > end_dim:
-        raise RuntimeError("flatten() has invalid args: start_dim cannot come after end_dim")
-
-    for i in range(start_dim, end_dim + 1):
-        flattened *= self.shape[i]
-    new_shape = self.shape[:start_dim] + (flattened,) + self.shape[end_dim + 1:]
-    return self.reshape(new_shape)
-
-
-def tensor_t(self):
-    cdef Py_ssize_t ndim = len(self.shape)
-    cdef object v
-    if ndim > 2:
-        raise RuntimeError(f"t() expects a tensor with <= 2 dimensions, but self is {ndim}D")
-    if ndim < 2:
-        return self
-    if self.requires_grad:
-        _ensure_dispatch_ref()
-        return _dispatch_fn("transpose", self.device.type, self, 0, 1)
-    v = self.cy_transpose(0, 1)
-    return _annotate_transpose_view(self, v)
-
-
-def tensor_as_strided(self, size, stride, storage_offset=None):
-    cdef object offset = storage_offset if storage_offset is not None else self.offset
-    _ensure_view_factory_ref()
-    return _cy_make_view_tensor_fn(self, self._storage, tuple(size), tuple(stride), offset)
 
 
 def tensor_is_contiguous(self, memory_format=None):
@@ -782,6 +789,8 @@ def tensor_is_contiguous(self, memory_format=None):
 
 def tensor_contiguous(self, memory_format=None):
     if getattr(memory_format, "_name", None) == "channels_last":
+        if self.device.type not in ("cpu", "meta"):
+            raise NotImplementedError("channels_last memory_format is currently only supported on CPU and meta tensors")
         if len(self.shape) != 4:
             raise RuntimeError("required rank 4 tensor to use channels_last format")
         if self.is_contiguous(memory_format=memory_format):
@@ -1445,10 +1454,12 @@ def tensor_pin_memory(self):
     return _cy_make_tensor_from_storage_fn(storage, self.shape, self.stride, self.offset, self.requires_grad)
 
 
-def tensor_new_empty(self, size, *, dtype=None, device=None, requires_grad=False):
+def tensor_new_empty(self, size, *, dtype=None, device=None, requires_grad=False, memory_format=None):
     from candle._creation import empty
     cdef object dt = dtype if dtype is not None else self.dtype
     cdef object dev = device if device is not None else self.device
+    if memory_format is not None:
+        raise TypeError("new_empty() got an unexpected keyword argument 'memory_format'")
     return empty(size, dtype=dt, device=dev)
 
 
@@ -1502,21 +1513,25 @@ def tensor_ones_like(self):
     return tensor
 
 
-def tensor_new_ones(self, size, dtype=None, device=None):
+def tensor_new_ones(self, size, dtype=None, device=None, memory_format=None):
     from candle._creation import ones
     if dtype is None:
         dtype = self.dtype
     if device is None:
         device = self.device
+    if memory_format is not None:
+        raise TypeError("new_ones() got an unexpected keyword argument 'memory_format'")
     return ones(size, dtype=dtype, device=device)
 
 
-def tensor_new_zeros(self, size, dtype=None, device=None):
+def tensor_new_zeros(self, size, dtype=None, device=None, memory_format=None):
     from candle._creation import zeros
     if dtype is None:
         dtype = self.dtype
     if device is None:
         device = self.device
+    if memory_format is not None:
+        raise TypeError("new_zeros() got an unexpected keyword argument 'memory_format'")
     return zeros(size, dtype=dtype, device=device)
 
 

--- a/src/candle/_backends/cpu/creation.py
+++ b/src/candle/_backends/cpu/creation.py
@@ -14,6 +14,22 @@ def _contiguous_stride(shape):
     return tuple(reversed(stride))
 
 
+def _channels_last_stride(shape):
+    if len(shape) != 4:
+        raise RuntimeError("required rank 4 tensor to use channels_last format")
+    _, c, h, w = shape
+    return (c * h * w, 1, w * c, c)
+
+
+def _resolve_stride(shape, memory_format):
+    name = getattr(memory_format, "_name", None)
+    if name in (None, "contiguous_format"):
+        return _contiguous_stride(shape)
+    if name == "channels_last":
+        return _channels_last_stride(shape)
+    raise RuntimeError(f"unsupported memory format {memory_format}")
+
+
 def tensor_create(data, dtype=None, device=None, requires_grad=False, memory_format=None):
     arr = np.array(data, dtype=to_numpy_dtype(dtype))
     storage = typed_storage_from_numpy(arr, dtype, device=device)
@@ -26,7 +42,7 @@ def zeros_create(shape, dtype=None, device=None, requires_grad=False, memory_for
         shape = (shape,)
     shape = tuple(shape)
     storage = typed_storage_from_numpy(np.zeros(shape, dtype=to_numpy_dtype(dtype)), dtype, device=device)
-    stride = _contiguous_stride(shape)
+    stride = _resolve_stride(shape, memory_format)
     return cy_make_tensor_from_storage(storage, shape, stride, 0, requires_grad)
 
 
@@ -35,7 +51,7 @@ def ones_create(shape, dtype=None, device=None, requires_grad=False, memory_form
         shape = (shape,)
     shape = tuple(shape)
     storage = typed_storage_from_numpy(np.ones(shape, dtype=to_numpy_dtype(dtype)), dtype, device=device)
-    stride = _contiguous_stride(shape)
+    stride = _resolve_stride(shape, memory_format)
     return cy_make_tensor_from_storage(storage, shape, stride, 0, requires_grad)
 
 
@@ -44,7 +60,7 @@ def empty_create(shape, dtype=None, device=None, requires_grad=False, memory_for
         shape = (shape,)
     shape = tuple(shape)
     storage = typed_storage_from_numpy(np.empty(shape, dtype=to_numpy_dtype(dtype)), dtype, device=device)
-    stride = _contiguous_stride(shape)
+    stride = _resolve_stride(shape, memory_format)
     return cy_make_tensor_from_storage(storage, shape, stride, 0, requires_grad)
 
 
@@ -112,7 +128,7 @@ def randn_create(shape, dtype=None, device=None, requires_grad=False, memory_for
         arr = np.array(arr)
     arr = arr.astype(to_numpy_dtype(dtype))
     storage = typed_storage_from_numpy(arr, dtype, device=device)
-    stride = _contiguous_stride(shape)
+    stride = _resolve_stride(shape, memory_format)
     return cy_make_tensor_from_storage(storage, shape, stride, 0, requires_grad)
 
 
@@ -128,7 +144,7 @@ def rand_create(shape, dtype=None, device=None, requires_grad=False, memory_form
         arr = np.array(arr)
     arr = arr.astype(to_numpy_dtype(dtype))
     storage = typed_storage_from_numpy(arr, dtype, device=device)
-    stride = _contiguous_stride(shape)
+    stride = _resolve_stride(shape, memory_format)
     return cy_make_tensor_from_storage(storage, shape, stride, 0, requires_grad)
 
 

--- a/src/candle/_backends/cuda/creation.py
+++ b/src/candle/_backends/cuda/creation.py
@@ -15,6 +15,13 @@ def _contiguous_stride(shape):
     return tuple(reversed(stride))
 
 
+def _reject_unsupported_memory_format(memory_format):
+    name = getattr(memory_format, "_name", None)
+    if name in (None, "contiguous_format"):
+        return
+    raise NotImplementedError("channels_last memory_format is currently only supported on CPU and meta tensors")
+
+
 def tensor_create(data, dtype=None, device=None, requires_grad=False, memory_format=None):
     arr = np.array(data, dtype=to_numpy_dtype(dtype))
     storage = cuda_typed_storage_from_numpy(arr, dtype, device=device)
@@ -23,6 +30,7 @@ def tensor_create(data, dtype=None, device=None, requires_grad=False, memory_for
 
 
 def zeros_create(shape, dtype=None, device=None, requires_grad=False, memory_format=None):
+    _reject_unsupported_memory_format(memory_format)
     if isinstance(shape, int):
         shape = (shape,)
     shape = tuple(shape)
@@ -32,6 +40,7 @@ def zeros_create(shape, dtype=None, device=None, requires_grad=False, memory_for
 
 
 def ones_create(shape, dtype=None, device=None, requires_grad=False, memory_format=None):
+    _reject_unsupported_memory_format(memory_format)
     if isinstance(shape, int):
         shape = (shape,)
     shape = tuple(shape)
@@ -41,6 +50,7 @@ def ones_create(shape, dtype=None, device=None, requires_grad=False, memory_form
 
 
 def empty_create(shape, dtype=None, device=None, requires_grad=False, memory_format=None):
+    _reject_unsupported_memory_format(memory_format)
     if isinstance(shape, int):
         shape = (shape,)
     shape = tuple(shape)

--- a/src/candle/_backends/meta/creation.py
+++ b/src/candle/_backends/meta/creation.py
@@ -14,6 +14,22 @@ def _contiguous_stride(shape):
     return tuple(reversed(stride))
 
 
+def _channels_last_stride(shape):
+    if len(shape) != 4:
+        raise RuntimeError("required rank 4 tensor to use channels_last format")
+    _, c, h, w = shape
+    return (c * h * w, 1, w * c, c)
+
+
+def _resolve_stride(shape, memory_format):
+    name = getattr(memory_format, "_name", None)
+    if name in (None, "contiguous_format"):
+        return _contiguous_stride(shape)
+    if name == "channels_last":
+        return _channels_last_stride(shape)
+    raise RuntimeError(f"unsupported memory format {memory_format}")
+
+
 def tensor_create_meta(data, dtype=None, device=None, requires_grad=False):
     arr = np.array(data, dtype=to_numpy_dtype(dtype))
     stride = tuple(np.array(arr.strides) // arr.itemsize)
@@ -23,21 +39,21 @@ def tensor_create_meta(data, dtype=None, device=None, requires_grad=False):
 
 def zeros_create_meta(shape, dtype=None, device=None, requires_grad=False, memory_format=None):
     shape = tuple(shape)
-    stride = _contiguous_stride(shape)
+    stride = _resolve_stride(shape, memory_format)
     storage = meta_typed_storage_from_shape(shape, dtype, device=device)
     return cy_make_tensor_from_storage(storage, shape, stride, 0, requires_grad)
 
 
 def ones_create_meta(shape, dtype=None, device=None, requires_grad=False, memory_format=None):
     shape = tuple(shape)
-    stride = _contiguous_stride(shape)
+    stride = _resolve_stride(shape, memory_format)
     storage = meta_typed_storage_from_shape(shape, dtype, device=device)
     return cy_make_tensor_from_storage(storage, shape, stride, 0, requires_grad)
 
 
 def empty_create_meta(shape, dtype=None, device=None, requires_grad=False, memory_format=None):
     shape = tuple(shape)
-    stride = _contiguous_stride(shape)
+    stride = _resolve_stride(shape, memory_format)
     storage = meta_typed_storage_from_shape(shape, dtype, device=device)
     return cy_make_tensor_from_storage(storage, shape, stride, 0, requires_grad)
 
@@ -88,11 +104,11 @@ def range_create_meta(start, end, step=1, dtype=None, device=None):
     return cy_make_tensor_from_storage(storage, arr.shape, stride, 0, False)
 
 
-def randn_create_meta(shape, dtype=None, device=None, requires_grad=False, memory_format=None):
+def randn_create_meta(shape, dtype=None, device=None, requires_grad=False, memory_format=None, generator=None):
     if isinstance(shape, int):
         shape = (shape,)
     shape = tuple(shape)
-    stride = _contiguous_stride(shape)
+    stride = _resolve_stride(shape, memory_format)
     storage = meta_typed_storage_from_shape(shape, dtype, device=device)
     return cy_make_tensor_from_storage(storage, shape, stride, 0, requires_grad)
 

--- a/src/candle/_backends/meta/ops.py
+++ b/src/candle/_backends/meta/ops.py
@@ -17,8 +17,16 @@ def _contiguous_stride(shape):
     return tuple(reversed(stride))
 
 
-def _meta_tensor(shape, dtype, device):
-    stride = _contiguous_stride(shape)
+def _channels_last_stride(shape):
+    if len(shape) != 4:
+        raise RuntimeError("required rank 4 tensor to use channels_last format")
+    _, c, h, w = shape
+    return (c * h * w, 1, w * c, c)
+
+
+def _meta_tensor(shape, dtype, device, stride=None):
+    if stride is None:
+        stride = _contiguous_stride(shape)
     storage = meta_typed_storage_from_shape(shape, dtype)
     return cy_make_tensor_from_storage(storage, shape, stride, 0, False)
 
@@ -572,7 +580,9 @@ def _meta_nonzero_meta(a, as_tuple=False):
 
 
 
-def _meta_contiguous_meta(a):
+def _meta_contiguous_meta(a, memory_format=None):
+    if getattr(memory_format, "_name", None) == "channels_last":
+        return _meta_tensor(a.shape, a.dtype, a.device, _channels_last_stride(a.shape))
     return _meta_tensor(a.shape, a.dtype, a.device)
 
 

--- a/src/candle/_backends/mps/creation.py
+++ b/src/candle/_backends/mps/creation.py
@@ -16,6 +16,13 @@ def _contiguous_stride(shape):
     return tuple(reversed(stride))
 
 
+def _reject_unsupported_memory_format(memory_format):
+    name = getattr(memory_format, "_name", None)
+    if name in (None, "contiguous_format"):
+        return
+    raise NotImplementedError("channels_last memory_format is currently only supported on CPU and meta tensors")
+
+
 def _get_mps_generator(generator=None):
     """Return an MPS Philox generator (user-provided or default)."""
     if generator is not None and hasattr(generator, 'device') and generator.device.type == 'mps':
@@ -39,6 +46,7 @@ def tensor_create(data, dtype=None, device=None, requires_grad=False, memory_for
 
 
 def zeros_create(shape, dtype=None, device=None, requires_grad=False, memory_format=None):
+    _reject_unsupported_memory_format(memory_format)
     if isinstance(shape, int):
         shape = (shape,)
     shape = tuple(shape)
@@ -49,6 +57,7 @@ def zeros_create(shape, dtype=None, device=None, requires_grad=False, memory_for
 
 
 def ones_create(shape, dtype=None, device=None, requires_grad=False, memory_format=None):
+    _reject_unsupported_memory_format(memory_format)
     if isinstance(shape, int):
         shape = (shape,)
     shape = tuple(shape)
@@ -59,6 +68,7 @@ def ones_create(shape, dtype=None, device=None, requires_grad=False, memory_form
 
 
 def empty_create(shape, dtype=None, device=None, requires_grad=False, memory_format=None):
+    _reject_unsupported_memory_format(memory_format)
     if isinstance(shape, int):
         shape = (shape,)
     shape = tuple(shape)
@@ -118,6 +128,7 @@ def range_create(start, end, step=1, dtype=None, device=None):
 
 
 def randn_create(shape, dtype=None, device=None, requires_grad=False, memory_format=None, generator=None):
+    _reject_unsupported_memory_format(memory_format)
     if isinstance(shape, int):
         shape = (shape,)
     shape = tuple(shape)
@@ -149,6 +160,7 @@ def randn_create(shape, dtype=None, device=None, requires_grad=False, memory_for
 
 
 def rand_create(shape, dtype=None, device=None, requires_grad=False, memory_format=None, generator=None):
+    _reject_unsupported_memory_format(memory_format)
     if isinstance(shape, int):
         shape = (shape,)
     shape = tuple(shape)

--- a/src/candle/_backends/npu/creation.py
+++ b/src/candle/_backends/npu/creation.py
@@ -15,6 +15,13 @@ def _wrap_tensor(storage, shape, stride, requires_grad):
     return cy_make_tensor_from_storage(storage, tuple(shape), stride, 0, requires_grad)
 
 
+def _reject_unsupported_memory_format(memory_format):
+    name = getattr(memory_format, "_name", None)
+    if name in (None, "contiguous_format"):
+        return
+    raise NotImplementedError("channels_last memory_format is currently only supported on CPU and meta tensors")
+
+
 def _require_inplace_one_zero():
     if not aclnn.ones_zero_symbols_ok():
         raise RuntimeError("aclnnInplaceOne/Zero not available")
@@ -31,6 +38,7 @@ def tensor_create(data, dtype=None, device=None, requires_grad=False, memory_for
 
 
 def zeros_create(shape, dtype=None, device=None, requires_grad=False, memory_format=None):
+    _reject_unsupported_memory_format(memory_format)
     runtime = npu_runtime.get_runtime((device.index if hasattr(device, "index") else None) or 0)
     stream = npu_state.current_stream((device.index if hasattr(device, "index") else None) or 0)
     _require_inplace_one_zero()
@@ -47,6 +55,7 @@ def zeros_create(shape, dtype=None, device=None, requires_grad=False, memory_for
 
 
 def ones_create(shape, dtype=None, device=None, requires_grad=False, memory_format=None):
+    _reject_unsupported_memory_format(memory_format)
     runtime = npu_runtime.get_runtime((device.index if hasattr(device, "index") else None) or 0)
     stream = npu_state.current_stream((device.index if hasattr(device, "index") else None) or 0)
     _require_inplace_one_zero()
@@ -63,6 +72,7 @@ def ones_create(shape, dtype=None, device=None, requires_grad=False, memory_form
 
 
 def empty_create(shape, dtype=None, device=None, requires_grad=False, memory_format=None):
+    _reject_unsupported_memory_format(memory_format)
     runtime = npu_runtime.get_runtime((device.index if hasattr(device, "index") else None) or 0)
     stream = npu_state.current_stream((device.index if hasattr(device, "index") else None) or 0)
     if isinstance(shape, int):
@@ -78,6 +88,7 @@ def empty_create(shape, dtype=None, device=None, requires_grad=False, memory_for
 
 def randn_create(shape, dtype=None, device=None, requires_grad=False, memory_format=None, generator=None):
     """Create a tensor filled with random numbers from N(0,1) on NPU."""
+    _reject_unsupported_memory_format(memory_format)
     if isinstance(shape, int):
         shape = (shape,)
     shape = tuple(shape)
@@ -91,6 +102,7 @@ def randn_create(shape, dtype=None, device=None, requires_grad=False, memory_for
 
 def rand_create(shape, dtype=None, device=None, requires_grad=False, memory_format=None, generator=None):
     """Create a tensor filled with random numbers from U(0,1) on NPU."""
+    _reject_unsupported_memory_format(memory_format)
     if isinstance(shape, int):
         shape = (shape,)
     shape = tuple(shape)
@@ -274,30 +286,36 @@ def scalar_tensor_create(data, dtype=None, device=None, requires_grad=False):
 
 
 def zeros_like_create(other, dtype=None, device=None, requires_grad=False, memory_format=None):
+    _reject_unsupported_memory_format(memory_format)
     return zeros_create(other.shape, dtype=dtype or other.dtype, device=device or other.device,
                        requires_grad=requires_grad)
 
 
 def ones_like_create(other, dtype=None, device=None, requires_grad=False, memory_format=None):
+    _reject_unsupported_memory_format(memory_format)
     return ones_create(other.shape, dtype=dtype or other.dtype, device=device or other.device,
                       requires_grad=requires_grad)
 
 
 def full_like_create(other, fill_value, dtype=None, device=None, requires_grad=False, memory_format=None):
+    _reject_unsupported_memory_format(memory_format)
     return full_create(other.shape, fill_value, dtype=dtype or other.dtype, device=device or other.device)
 
 
 def empty_like_create(other, dtype=None, device=None, requires_grad=False, memory_format=None):
+    _reject_unsupported_memory_format(memory_format)
     return empty_create(other.shape, dtype=dtype or other.dtype, device=device or other.device,
                        requires_grad=requires_grad)
 
 
 def randn_like_create(other, dtype=None, device=None, requires_grad=False, memory_format=None, generator=None):
+    _reject_unsupported_memory_format(memory_format)
     return randn_create(other.shape, dtype=dtype or other.dtype, device=device or other.device,
                        requires_grad=requires_grad, generator=generator)
 
 
 def rand_like_create(other, dtype=None, device=None, requires_grad=False, memory_format=None, generator=None):
+    _reject_unsupported_memory_format(memory_format)
     return rand_create(other.shape, dtype=dtype or other.dtype, device=device or other.device,
                       requires_grad=requires_grad, generator=generator)
 
@@ -344,6 +362,7 @@ def randint_create(low, high=None, size=None, dtype=None, device=None, requires_
 
 
 def new_empty_create(tensor, shape, dtype=None, device=None, requires_grad=False, memory_format=None):
+    _reject_unsupported_memory_format(memory_format)
     if shape is None:
         shape = ()
     return empty_create(shape, dtype=dtype or tensor.dtype, device=device or tensor.device,
@@ -357,6 +376,7 @@ def new_full_create(tensor, shape, fill_value, dtype=None, device=None, requires
 
 
 def new_zeros_create(tensor, shape, dtype=None, device=None, requires_grad=False, memory_format=None):
+    _reject_unsupported_memory_format(memory_format)
     if shape is None:
         shape = ()
     return zeros_create(shape, dtype=dtype or tensor.dtype, device=device or tensor.device,
@@ -364,6 +384,7 @@ def new_zeros_create(tensor, shape, dtype=None, device=None, requires_grad=False
 
 
 def new_ones_create(tensor, shape, dtype=None, device=None, requires_grad=False, memory_format=None):
+    _reject_unsupported_memory_format(memory_format)
     if shape is None:
         shape = ()
     return ones_create(shape, dtype=dtype or tensor.dtype, device=device or tensor.device,
@@ -493,6 +514,7 @@ def tensor_create(data, dtype=None, device=None, requires_grad=False, memory_for
 
 
 def zeros_create(shape, dtype=None, device=None, requires_grad=False, memory_format=None):
+    _reject_unsupported_memory_format(memory_format)
     runtime = npu_runtime.get_runtime((device.index if hasattr(device, "index") else None) or 0)
     stream = npu_state.current_stream((device.index if hasattr(device, "index") else None) or 0)
     _require_inplace_one_zero()
@@ -509,6 +531,7 @@ def zeros_create(shape, dtype=None, device=None, requires_grad=False, memory_for
 
 
 def ones_create(shape, dtype=None, device=None, requires_grad=False, memory_format=None):
+    _reject_unsupported_memory_format(memory_format)
     runtime = npu_runtime.get_runtime((device.index if hasattr(device, "index") else None) or 0)
     stream = npu_state.current_stream((device.index if hasattr(device, "index") else None) or 0)
     _require_inplace_one_zero()
@@ -525,6 +548,7 @@ def ones_create(shape, dtype=None, device=None, requires_grad=False, memory_form
 
 
 def empty_create(shape, dtype=None, device=None, requires_grad=False, memory_format=None):
+    _reject_unsupported_memory_format(memory_format)
     runtime = npu_runtime.get_runtime((device.index if hasattr(device, "index") else None) or 0)
     stream = npu_state.current_stream((device.index if hasattr(device, "index") else None) or 0)
     if isinstance(shape, int):
@@ -540,6 +564,7 @@ def empty_create(shape, dtype=None, device=None, requires_grad=False, memory_for
 
 def randn_create(shape, dtype=None, device=None, requires_grad=False, memory_format=None, generator=None):
     """Create a tensor filled with random numbers from N(0,1) on NPU."""
+    _reject_unsupported_memory_format(memory_format)
     if isinstance(shape, int):
         shape = (shape,)
     shape = tuple(shape)
@@ -553,6 +578,7 @@ def randn_create(shape, dtype=None, device=None, requires_grad=False, memory_for
 
 def rand_create(shape, dtype=None, device=None, requires_grad=False, memory_format=None, generator=None):
     """Create a tensor filled with random numbers from U(0,1) on NPU."""
+    _reject_unsupported_memory_format(memory_format)
     if isinstance(shape, int):
         shape = (shape,)
     shape = tuple(shape)

--- a/src/candle/_functional.py
+++ b/src/candle/_functional.py
@@ -1017,42 +1017,35 @@ def tensor(data, *, dtype=None, device=None, requires_grad=False):
 
 
 def _unsupported_memory_format(name, memory_format):
+    if memory_format is None:
+        return
+    fmt_name = getattr(memory_format, "_name", None)
+    if fmt_name in ("channels_last", "contiguous_format"):
+        return
     raise TypeError(
         f"{name}() received an invalid combination of arguments - memory_format {memory_format} is not supported"
     )
 
 
-def _apply_output_memory_format(output, *, memory_format=None, source=None):
+def _clone_with_memory_format(output, *, source=None, memory_format=None):
     name = getattr(memory_format, "_name", None)
-
-    if memory_format is None:
-        if source is not None and source.is_contiguous(memory_format=getattr(__import__('candle'), 'channels_last')):
-            return output.contiguous(memory_format=getattr(__import__('candle'), 'channels_last'))
+    if memory_format is None or name == "preserve_format":
+        if source is not None:
+            from . import channels_last
+            if source.is_contiguous(memory_format=channels_last):
+                return output.clone(memory_format=channels_last)
         return output
-
     if name == "contiguous_format":
         return output
-
-    if name == "channels_last":
-        return output.contiguous(memory_format=memory_format)
-
-    if name == "preserve_format":
-        if source is None:
-            raise RuntimeError("unsupported memory format Preserve")
-        if source.is_contiguous(memory_format=getattr(__import__('candle'), 'channels_last')):
-            return output.contiguous(memory_format=getattr(__import__('candle'), 'channels_last'))
-        return output
-
-    return output
+    return output.clone(memory_format=memory_format)
 
 
 def zeros(*shape, dtype=None, device=None, memory_format=None):
     if len(shape) == 1 and isinstance(shape[0], (tuple, list)):
         shape = shape[0]
-    if memory_format is not None:
-        _unsupported_memory_format("zeros", memory_format)
+    _unsupported_memory_format("zeros", memory_format)
     dev = _as_device(device)
-    return dispatch("zeros", dev, shape, dtype=dtype)
+    return dispatch("zeros", dev, shape, dtype=dtype, memory_format=memory_format)
 
 
 def zeros_like(input, *, dtype=None, device=None, memory_format=None):
@@ -1061,42 +1054,39 @@ def zeros_like(input, *, dtype=None, device=None, memory_format=None):
     if device is None:
         device = input.device
     out = zeros(input.shape, dtype=dtype, device=device)
-    return _apply_output_memory_format(out, memory_format=memory_format, source=input)
+    return _clone_with_memory_format(out, source=input, memory_format=memory_format)
 
 
 def ones(*shape, dtype=None, device=None, memory_format=None):
     if len(shape) == 1 and isinstance(shape[0], (tuple, list)):
         shape = shape[0]
-    if memory_format is not None:
-        _unsupported_memory_format("ones", memory_format)
+    _unsupported_memory_format("ones", memory_format)
     dev = _as_device(device)
-    return dispatch("ones", dev, shape, dtype=dtype)
+    return dispatch("ones", dev, shape, dtype=dtype, memory_format=memory_format)
 
 
 def empty(*shape, dtype=None, device=None, memory_format=None):
     if len(shape) == 1 and isinstance(shape[0], (tuple, list)):
         shape = shape[0]
+    _unsupported_memory_format("empty", memory_format)
     dev = _as_device(device)
-    out = dispatch("empty", dev, shape, dtype=dtype, memory_format=None)
-    return _apply_output_memory_format(out, memory_format=memory_format)
+    return dispatch("empty", dev, shape, dtype=dtype, memory_format=memory_format)
 
 
 def randn(*shape, dtype=None, device=None, memory_format=None, generator=None):
     if len(shape) == 1 and isinstance(shape[0], (tuple, list)):
         shape = shape[0]
-    if memory_format is not None:
-        _unsupported_memory_format("randn", memory_format)
+    _unsupported_memory_format("randn", memory_format)
     dev = _as_device(device)
-    return dispatch("randn", dev, shape, dtype=dtype, generator=generator)
+    return dispatch("randn", dev, shape, dtype=dtype, memory_format=memory_format, generator=generator)
 
 
 def rand(*shape, dtype=None, device=None, memory_format=None, generator=None):
     if len(shape) == 1 and isinstance(shape[0], (tuple, list)):
         shape = shape[0]
-    if memory_format is not None:
-        _unsupported_memory_format("rand", memory_format)
+    _unsupported_memory_format("rand", memory_format)
     dev = _as_device(device)
-    return dispatch("rand", dev, shape, dtype=dtype, generator=generator)
+    return dispatch("rand", dev, shape, dtype=dtype, memory_format=memory_format, generator=generator)
 
 
 def randint(low, high=None, size=None, *, dtype=None, device=None, requires_grad=False, generator=None):
@@ -1364,7 +1354,7 @@ def ones_like(input, *, dtype=None, device=None, memory_format=None):
     if device is None:
         device = input.device
     out = ones(input.shape, dtype=dtype, device=device)
-    return _apply_output_memory_format(out, memory_format=memory_format, source=input)
+    return _clone_with_memory_format(out, source=input, memory_format=memory_format)
 
 
 def empty_like(input, *, dtype=None, device=None, memory_format=None):
@@ -1373,7 +1363,7 @@ def empty_like(input, *, dtype=None, device=None, memory_format=None):
     if device is None:
         device = input.device
     out = empty(input.shape, dtype=dtype, device=device)
-    return _apply_output_memory_format(out, memory_format=memory_format, source=input)
+    return _clone_with_memory_format(out, source=input, memory_format=memory_format)
 
 
 def full_like(input, fill_value, *, dtype=None, device=None, memory_format=None):
@@ -1382,7 +1372,7 @@ def full_like(input, fill_value, *, dtype=None, device=None, memory_format=None)
     if device is None:
         device = input.device
     out = full(input.shape, fill_value, dtype=dtype, device=device)
-    return _apply_output_memory_format(out, memory_format=memory_format, source=input)
+    return _clone_with_memory_format(out, source=input, memory_format=memory_format)
 
 
 def randn_like(input, *, dtype=None, device=None, memory_format=None, generator=None):
@@ -1391,7 +1381,7 @@ def randn_like(input, *, dtype=None, device=None, memory_format=None, generator=
     if device is None:
         device = input.device
     out = randn(input.shape, dtype=dtype, device=device, generator=generator)
-    return _apply_output_memory_format(out, memory_format=memory_format, source=input)
+    return _clone_with_memory_format(out, source=input, memory_format=memory_format)
 
 
 def rand_like(input, *, dtype=None, device=None, memory_format=None, generator=None):
@@ -1400,7 +1390,7 @@ def rand_like(input, *, dtype=None, device=None, memory_format=None, generator=N
     if device is None:
         device = input.device
     out = rand(input.shape, dtype=dtype, device=device, generator=generator)
-    return _apply_output_memory_format(out, memory_format=memory_format, source=input)
+    return _clone_with_memory_format(out, source=input, memory_format=memory_format)
 
 
 def randint_like(input, low=0, high=None, *, dtype=None, device=None, memory_format=None):
@@ -1408,7 +1398,8 @@ def randint_like(input, low=0, high=None, *, dtype=None, device=None, memory_for
         dtype = input.dtype
     if device is None:
         device = input.device
-    return randint(low, high, size=input.shape, dtype=dtype, device=device)
+    out = randint(low, high, size=input.shape, dtype=dtype, device=device)
+    return _clone_with_memory_format(out, source=input, memory_format=memory_format)
 
 
 def rms_norm(input, normalized_shape, weight=None, eps=1e-6):

--- a/tests/common/test_c_core.py
+++ b/tests/common/test_c_core.py
@@ -983,6 +983,29 @@ class TestTensorLayoutMethodProviders:
         except RuntimeError as e:
             assert "required rank 4 tensor" in str(e)
 
+    def test_tensor_api_clone_memory_format_channels_last_cpu(self):
+        import candle as torch
+
+        x = torch.empty((2, 3, 4, 5), memory_format=torch.channels_last)
+        y = x.clone(memory_format=torch.contiguous_format)
+        z = x.clone(memory_format=torch.preserve_format)
+
+        assert y.stride() == (60, 20, 5, 1)
+        assert y.is_contiguous() is True
+        assert y.is_contiguous(memory_format=torch.channels_last) is False
+        assert z.stride() == (60, 1, 15, 3)
+        assert z.is_contiguous(memory_format=torch.channels_last) is True
+
+    def test_tensor_api_to_memory_format_supports_meta_channels_last_metadata(self):
+        import candle as torch
+
+        x = torch.empty((2, 3, 4, 5), memory_format=torch.channels_last)
+        y = x.to("meta", memory_format=torch.channels_last)
+
+        assert y.device.type == "meta"
+        assert y.stride() == (60, 1, 15, 3)
+        assert y.is_contiguous(memory_format=torch.channels_last) is True
+
 
 class TestTensorAutogradMethodProviders:
     """Autograd state Tensor methods should be served from the Cython tensor API layer."""
@@ -1507,6 +1530,27 @@ class TestTensorFactoryHelperMethodProviders:
 
         assert base.type() == "torch.Float32Tensor"
         assert base.type(torch.float64).dtype == torch.float64
+
+    def test_new_empty_rejects_memory_format(self):
+        import candle as torch
+
+        base = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+        with pytest.raises(TypeError, match="memory_format"):
+            base.new_empty((2, 2), memory_format=torch.channels_last)
+
+    def test_new_ones_rejects_memory_format(self):
+        import candle as torch
+
+        base = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+        with pytest.raises(TypeError, match="memory_format"):
+            base.new_ones((2, 2), memory_format=torch.channels_last)
+
+    def test_new_zeros_rejects_memory_format(self):
+        import candle as torch
+
+        base = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+        with pytest.raises(TypeError, match="memory_format"):
+            base.new_zeros((2, 2), memory_format=torch.channels_last)
 
 
 

--- a/tests/contract/test_memory_format_backend_boundaries.py
+++ b/tests/contract/test_memory_format_backend_boundaries.py
@@ -1,0 +1,94 @@
+import pytest
+
+import candle as torch
+from candle._backends.cuda import creation as cuda_creation
+from candle._backends.mps import creation as mps_creation
+from candle._backends.npu import creation as npu_creation
+from candle._device import device
+
+
+def test_meta_empty_supports_channels_last_stride():
+    x = torch.empty((2, 3, 4, 5), device="meta", memory_format=torch.channels_last)
+    assert x.stride() == (60, 1, 15, 3)
+    assert x.is_contiguous(memory_format=torch.channels_last) is True
+
+
+def test_meta_to_channels_last_preserves_layout_metadata():
+    x = torch.empty((2, 3, 4, 5), device="meta")
+    y = x.to(memory_format=torch.channels_last)
+    assert y.stride() == (60, 1, 15, 3)
+    assert y.is_contiguous(memory_format=torch.channels_last) is True
+
+
+def test_preserve_format_rejects_channels_last_relayout_to_non_cpu_meta(monkeypatch):
+    x = torch.empty((2, 3, 4, 5), memory_format=torch.channels_last)
+
+    def _fail_copy(*args, **kwargs):
+        raise AssertionError("preserve_format should reject before device copy")
+
+    monkeypatch.setattr(npu_creation.npu_runtime, "_copy_cpu_to_npu", _fail_copy)
+
+    with pytest.raises(NotImplementedError, match="channels_last|memory_format"):
+        x.to("npu", memory_format=torch.preserve_format)
+
+
+def test_channels_last_to_non_cpu_rejects_before_copy(monkeypatch):
+    x = torch.empty((2, 3, 4, 5))
+
+    def _fail_copy(*args, **kwargs):
+        raise AssertionError("channels_last should reject before device copy")
+
+    monkeypatch.setattr(npu_creation.npu_runtime, "_copy_cpu_to_npu", _fail_copy)
+
+    with pytest.raises(NotImplementedError, match="channels_last|memory_format"):
+        x.to("npu", memory_format=torch.channels_last)
+
+
+def test_contiguous_format_to_makes_channels_last_tensor_row_major():
+    x = torch.empty((2, 3, 4, 5), memory_format=torch.channels_last)
+    y = x.to(memory_format=torch.contiguous_format)
+
+    assert y is not x
+    assert y.stride() == (60, 20, 5, 1)
+    assert y.is_contiguous() is True
+    assert y.is_contiguous(memory_format=torch.channels_last) is False
+
+
+def test_backend_creation_functions_reject_channels_last_before_allocation():
+    creation_cases = (
+        (mps_creation, "mps", ("empty_create", "zeros_create", "ones_create", "randn_create", "rand_create")),
+        (cuda_creation, "cuda", ("empty_create", "zeros_create", "ones_create")),
+        (npu_creation, "npu", ("empty_create", "zeros_create", "ones_create", "randn_create", "rand_create")),
+    )
+    for creation_module, device_type, names in creation_cases:
+        for name in names:
+            create = getattr(creation_module, name)
+            with pytest.raises(NotImplementedError, match="channels_last|memory format"):
+                create(
+                    (2, 3, 4, 5),
+                    device=device(device_type),
+                    memory_format=torch.channels_last,
+                )
+
+
+def test_npu_like_and_new_creation_helpers_reject_channels_last_before_allocation():
+    class _FakeTensor:
+        shape = (2, 3, 4, 5)
+        dtype = torch.float32
+        device = device("npu")
+
+    base = _FakeTensor()
+
+    helper_cases = (
+        (npu_creation.empty_like_create, (base,)),
+        (npu_creation.zeros_like_create, (base,)),
+        (npu_creation.ones_like_create, (base,)),
+        (npu_creation.randn_like_create, (base,)),
+        (npu_creation.rand_like_create, (base,)),
+        (npu_creation.new_empty_create, (base, (2, 3, 4, 5))),
+        (npu_creation.new_zeros_create, (base, (2, 3, 4, 5))),
+        (npu_creation.new_ones_create, (base, (2, 3, 4, 5))),
+    )
+    for create, args in helper_cases:
+        with pytest.raises(NotImplementedError, match="channels_last|memory format"):
+            create(*args, memory_format=torch.channels_last)

--- a/tests/cpu/test_tensor_api_contract.py
+++ b/tests/cpu/test_tensor_api_contract.py
@@ -353,7 +353,7 @@ class TestCreationMemoryFormat:
         assert x.is_contiguous(memory_format=torch.channels_last) is True
 
     def test_empty_rejects_preserve_format(self):
-        with pytest.raises(RuntimeError, match="unsupported memory format Preserve"):
+        with pytest.raises(TypeError, match="memory_format"):
             torch.empty((2, 3, 4, 5), memory_format=torch.preserve_format)
 
     def test_empty_like_preserves_channels_last_by_default(self):
@@ -375,21 +375,75 @@ class TestCreationMemoryFormat:
         assert out.is_contiguous() is True
         assert out.is_contiguous(memory_format=torch.channels_last) is False
 
-    def test_zeros_rejects_memory_format(self):
-        with pytest.raises(TypeError):
-            torch.zeros((2, 3, 4, 5), memory_format=torch.channels_last)
+    def test_zeros_supports_channels_last(self):
+        x = torch.zeros((2, 3, 4, 5), memory_format=torch.channels_last)
+        assert x.stride() == (60, 1, 15, 3)
+        assert x.is_contiguous(memory_format=torch.channels_last) is True
 
-    def test_ones_rejects_memory_format(self):
-        with pytest.raises(TypeError):
-            torch.ones((2, 3, 4, 5), memory_format=torch.channels_last)
+    def test_ones_supports_channels_last(self):
+        x = torch.ones((2, 3, 4, 5), memory_format=torch.channels_last)
+        assert x.stride() == (60, 1, 15, 3)
+        assert x.is_contiguous(memory_format=torch.channels_last) is True
 
-    def test_randn_rejects_memory_format(self):
-        with pytest.raises(TypeError):
-            torch.randn((2, 3, 4, 5), memory_format=torch.channels_last)
+    def test_randn_supports_channels_last(self):
+        x = torch.randn((2, 3, 4, 5), memory_format=torch.channels_last)
+        assert x.stride() == (60, 1, 15, 3)
+        assert x.is_contiguous(memory_format=torch.channels_last) is True
 
-    def test_rand_rejects_memory_format(self):
-        with pytest.raises(TypeError):
-            torch.rand((2, 3, 4, 5), memory_format=torch.channels_last)
+    def test_rand_supports_channels_last(self):
+        x = torch.rand((2, 3, 4, 5), memory_format=torch.channels_last)
+        assert x.stride() == (60, 1, 15, 3)
+        assert x.is_contiguous(memory_format=torch.channels_last) is True
+
+    def test_ones_like_preserves_channels_last_by_default(self):
+        base = torch.empty((2, 3, 4, 5), memory_format=torch.channels_last)
+        out = torch.ones_like(base)
+        assert out.stride() == (60, 1, 15, 3)
+        assert out.is_contiguous(memory_format=torch.channels_last) is True
+
+    def test_randn_like_preserves_channels_last_by_default(self):
+        base = torch.empty((2, 3, 4, 5), memory_format=torch.channels_last)
+        out = torch.randn_like(base)
+        assert out.stride() == (60, 1, 15, 3)
+        assert out.is_contiguous(memory_format=torch.channels_last) is True
+
+    def test_ones_like_contiguous_format_from_channels_last(self):
+        base = torch.empty((2, 3, 4, 5), memory_format=torch.channels_last)
+        out = torch.ones_like(base, memory_format=torch.contiguous_format)
+        assert out.stride() == (60, 20, 5, 1)
+        assert out.is_contiguous() is True
+
+    def test_rand_like_contiguous_format_from_channels_last(self):
+        base = torch.empty((2, 3, 4, 5), memory_format=torch.channels_last)
+        out = torch.rand_like(base, memory_format=torch.contiguous_format)
+        assert out.stride() == (60, 20, 5, 1)
+        assert out.is_contiguous() is True
+
+    def test_randint_like_preserves_channels_last_by_default(self):
+        base = torch.empty((2, 3, 4, 5), memory_format=torch.channels_last)
+        out = torch.randint_like(base, high=10)
+        assert out.stride() == (60, 1, 15, 3)
+        assert out.is_contiguous(memory_format=torch.channels_last) is True
+
+    def test_clone_channels_last_from_contiguous(self):
+        base = torch.empty((2, 3, 4, 5))
+        out = base.clone(memory_format=torch.channels_last)
+        assert out.stride() == (60, 1, 15, 3)
+        assert out.is_contiguous() is False
+        assert out.is_contiguous(memory_format=torch.channels_last) is True
+
+    def test_clone_preserve_format_from_channels_last(self):
+        base = torch.empty((2, 3, 4, 5), memory_format=torch.channels_last)
+        out = base.clone(memory_format=torch.preserve_format)
+        assert out.stride() == (60, 1, 15, 3)
+        assert out.is_contiguous(memory_format=torch.channels_last) is True
+
+    def test_clone_contiguous_format_from_channels_last(self):
+        base = torch.empty((2, 3, 4, 5), memory_format=torch.channels_last)
+        out = base.clone(memory_format=torch.contiguous_format)
+        assert out.stride() == (60, 20, 5, 1)
+        assert out.is_contiguous() is True
+        assert out.is_contiguous(memory_format=torch.channels_last) is False
 
     def test_basic(self):
         a = torch.tensor([-1.0, 0.0, 2.0])


### PR DESCRIPTION
## Summary
- Add CPU/meta `channels_last` layout handling for creation, clone, contiguous, and to(memory_format=...) paths.
- Reject unsupported MPS/CUDA/NPU channels_last creation and relayout requests before allocation or device copy.
- Add contract coverage for backend memory_format boundaries and Tensor factory behavior.

## Test plan
- [x] `conda run -n candle311 python -m pytest tests/cpu/ tests/contract/ -q --tb=short`
- [x] `conda run -n candle311 pylint src/candle/ --rcfile=.github/pylint.conf`
- [x] `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)