### PR TITLE
Allocate like memory_format layouts directly

### DIFF
--- a/src/candle/_backends/cpu/creation.py
+++ b/src/candle/_backends/cpu/creation.py
@@ -78,14 +78,14 @@ def linspace_create(start, end, steps, dtype=None, device=None):
     return cy_make_tensor_from_storage(storage, arr.shape, stride, 0, False)
 
 
-def full_create(shape, fill_value, dtype=None, device=None):
+def full_create(shape, fill_value, dtype=None, device=None, memory_format=None):
     shape = tuple(shape)
     storage = typed_storage_from_numpy(
         np.full(shape, fill_value, dtype=to_numpy_dtype(dtype)),
         dtype,
         device=device,
     )
-    stride = _contiguous_stride(shape)
+    stride = _resolve_stride(shape, memory_format)
     return cy_make_tensor_from_storage(storage, shape, stride, 0, False)
 
 
@@ -148,7 +148,7 @@ def rand_create(shape, dtype=None, device=None, requires_grad=False, memory_form
     return cy_make_tensor_from_storage(storage, shape, stride, 0, requires_grad)
 
 
-def randint_create(low, high=None, size=None, dtype=None, device=None, requires_grad=False, generator=None, **kwargs):
+def randint_create(low, high=None, size=None, dtype=None, device=None, requires_grad=False, generator=None, memory_format=None, **kwargs):
     """torch.randint(low=0, high, size, ...) — fills with random integers from [low, high)."""
     from ..._dtype import int64 as int64_dtype
     if high is None:
@@ -163,7 +163,7 @@ def randint_create(low, high=None, size=None, dtype=None, device=None, requires_
     arr = rng.randint(int(low), int(high), size=size).astype(np.int64)
     out_dtype = dtype if dtype is not None else int64_dtype
     storage = typed_storage_from_numpy(arr, out_dtype, device=device)
-    stride = _contiguous_stride(size)
+    stride = _resolve_stride(size, memory_format)
     return cy_make_tensor_from_storage(storage, size, stride, 0, requires_grad)
 
 

--- a/src/candle/_backends/meta/creation.py
+++ b/src/candle/_backends/meta/creation.py
@@ -72,9 +72,9 @@ def linspace_create_meta(start, end, steps, dtype=None, device=None):
     return cy_make_tensor_from_storage(storage, arr.shape, stride, 0, False)
 
 
-def full_create_meta(shape, fill_value, dtype=None, device=None):
+def full_create_meta(shape, fill_value, dtype=None, device=None, memory_format=None):
     shape = tuple(shape)
-    stride = _contiguous_stride(shape)
+    stride = _resolve_stride(shape, memory_format)
     storage = meta_typed_storage_from_shape(shape, dtype, device=device)
     return cy_make_tensor_from_storage(storage, shape, stride, 0, False)
 

--- a/src/candle/_backends/mps/creation.py
+++ b/src/candle/_backends/mps/creation.py
@@ -78,7 +78,8 @@ def empty_create(shape, dtype=None, device=None, requires_grad=False, memory_for
     return cy_make_tensor_from_storage(storage, shape, stride, 0, requires_grad)
 
 
-def full_create(shape, fill_value, dtype=None, device=None):
+def full_create(shape, fill_value, dtype=None, device=None, memory_format=None):
+    _reject_unsupported_memory_format(memory_format)
     shape = tuple(shape)
     arr = np.full(shape, fill_value, dtype=to_numpy_dtype(dtype))
     storage = mps_typed_storage_from_numpy(arr.ravel(), dtype, device=device)
@@ -191,7 +192,8 @@ def rand_create(shape, dtype=None, device=None, requires_grad=False, memory_form
     return cy_make_tensor_from_storage(storage, shape, stride, 0, requires_grad)
 
 
-def randint_create(low, high=None, size=None, dtype=None, device=None, requires_grad=False, generator=None, **kwargs):
+def randint_create(low, high=None, size=None, dtype=None, device=None, requires_grad=False, generator=None, memory_format=None, **kwargs):
+    _reject_unsupported_memory_format(memory_format)
     from ..._dtype import int32 as i32, int64 as i64
     if high is None:
         low, high = 0, low

--- a/src/candle/_backends/npu/creation.py
+++ b/src/candle/_backends/npu/creation.py
@@ -170,7 +170,8 @@ def arange_create(start, end, step=1, dtype=None, device=None):
     return _wrap_tensor(storage, shape, stride, requires_grad=False)
 
 
-def full_create(shape, fill_value, dtype=None, device=None):
+def full_create(shape, fill_value, dtype=None, device=None, memory_format=None):
+    _reject_unsupported_memory_format(memory_format)
     dtype = _resolve_dtype(dtype)
     if isinstance(shape, int):
         shape = (shape,)
@@ -340,7 +341,8 @@ def randperm_create(n, dtype=None, device=None, requires_grad=False, generator=N
     return _wrap_tensor(storage, shape, stride, requires_grad=False)
 
 
-def randint_create(low, high=None, size=None, dtype=None, device=None, requires_grad=False, generator=None, **kwargs):
+def randint_create(low, high=None, size=None, dtype=None, device=None, requires_grad=False, generator=None, memory_format=None, **kwargs):
+    _reject_unsupported_memory_format(memory_format)
     if high is None:
         low, high = 0, low
     if size is None:
@@ -646,7 +648,8 @@ def arange_create(start, end, step=1, dtype=None, device=None):
     return _wrap_tensor(storage, shape, stride, requires_grad=False)
 
 
-def full_create(shape, fill_value, dtype=None, device=None):
+def full_create(shape, fill_value, dtype=None, device=None, memory_format=None):
+    _reject_unsupported_memory_format(memory_format)
     dtype = _resolve_dtype(dtype)
     if isinstance(shape, int):
         shape = (shape,)
@@ -751,8 +754,9 @@ def range_create(start, end, step=1, dtype=None, device=None):
     return _wrap_tensor(storage, shape, stride, requires_grad=False)
 
 
-def randint_create(low, high=None, size=None, dtype=None, device=None, requires_grad=False, generator=None, **kwargs):
+def randint_create(low, high=None, size=None, dtype=None, device=None, requires_grad=False, generator=None, memory_format=None, **kwargs):
     """Create a tensor filled with random integers from [low, high) on NPU."""
+    _reject_unsupported_memory_format(memory_format)
     from ..._dtype import int64 as int64_dtype, float32 as f32
     if high is None:
         low, high = 0, low

--- a/src/candle/_creation.py
+++ b/src/candle/_creation.py
@@ -100,10 +100,10 @@ def linspace(start, end, steps, dtype=None, device=None, requires_grad=False):
     return _apply_requires_grad(out, requires_grad)
 
 
-def full(*args, dtype=None, device=None, requires_grad=False):
+def full(*args, dtype=None, device=None, requires_grad=False, memory_format=None):
     if dtype is None:
         dtype = _get_default_dtype()
-    out = full_dispatch(*args, dtype=dtype, device=device)
+    out = full_dispatch(*args, dtype=dtype, device=device, memory_format=memory_format)
     return _apply_requires_grad(out, requires_grad)
 
 
@@ -141,11 +141,11 @@ def rand(*shape, dtype=None, device=None, memory_format=None, generator=None, re
     return _apply_requires_grad(out, requires_grad)
 
 
-def randint(low, high=None, size=None, *, dtype=None, device=None, generator=None):
+def randint(low, high=None, size=None, *, dtype=None, device=None, generator=None, memory_format=None):
     if size is None and isinstance(high, (tuple, list)):
         size = high
         high = None
-    return randint_dispatch(low, high=high, size=size, dtype=dtype, device=device, generator=generator)
+    return randint_dispatch(low, high=high, size=size, dtype=dtype, device=device, generator=generator, memory_format=memory_format)
 
 
 def randperm(n, *, dtype=None, device=None, generator=None):

--- a/src/candle/_dispatch/schemas.py
+++ b/src/candle/_dispatch/schemas.py
@@ -251,7 +251,7 @@ def register_schemas():
     registry.register_schema("empty", "empty(int[] size, *, Dtype? dtype=None, Device? device=None, MemoryFormat? memory_format=None) -> Tensor")
     registry.register_schema("arange", "arange(Scalar start, Scalar end, Scalar step=1, Dtype? dtype=None) -> Tensor")
     registry.register_schema("linspace", "linspace(Scalar start, Scalar end, int steps, Dtype? dtype=None) -> Tensor")
-    registry.register_schema("full", "full(int[] size, Scalar fill_value, Dtype? dtype=None) -> Tensor")
+    registry.register_schema("full", "full(int[] size, Scalar fill_value, Dtype? dtype=None, MemoryFormat? memory_format=None) -> Tensor")
     registry.register_schema("logspace", "logspace(Scalar start, Scalar end, int steps, Dtype? dtype=None) -> Tensor")
     registry.register_schema("eye", "eye(int n, int? m=None, Dtype? dtype=None, Tensor? out=None) -> Tensor")
     registry.register_schema("range", "range(Scalar start, Scalar end, Scalar step=1, Dtype? dtype=None) -> Tensor")
@@ -552,7 +552,7 @@ def register_schemas():
     registry.register_schema("randint_", "randint_(Tensor(a!) self, int low, int? high=None, *, Generator? generator=None) -> Tensor")
 
     # New creation ops
-    registry.register_schema("randint", "randint(int low, int? high=None, int[]? size=None, Dtype? dtype=None, bool requires_grad=False, Generator? generator=None) -> Tensor")
+    registry.register_schema("randint", "randint(int low, int? high=None, int[]? size=None, Dtype? dtype=None, bool requires_grad=False, Generator? generator=None, MemoryFormat? memory_format=None) -> Tensor")
     registry.register_schema("randperm", "randperm(int n, Dtype? dtype=None, bool requires_grad=False, Generator? generator=None) -> Tensor")
 
     # random_ in-place op

--- a/src/candle/_functional.py
+++ b/src/candle/_functional.py
@@ -1027,17 +1027,14 @@ def _unsupported_memory_format(name, memory_format):
     )
 
 
-def _clone_with_memory_format(output, *, source=None, memory_format=None):
+def _memory_format_for_like(input, memory_format):
     name = getattr(memory_format, "_name", None)
     if memory_format is None or name == "preserve_format":
-        if source is not None:
-            from . import channels_last
-            if source.is_contiguous(memory_format=channels_last):
-                return output.clone(memory_format=channels_last)
-        return output
-    if name == "contiguous_format":
-        return output
-    return output.clone(memory_format=memory_format)
+        from . import channels_last
+        if input.is_contiguous(memory_format=channels_last):
+            return channels_last
+        return None
+    return memory_format
 
 
 def zeros(*shape, dtype=None, device=None, memory_format=None):
@@ -1053,8 +1050,7 @@ def zeros_like(input, *, dtype=None, device=None, memory_format=None):
         dtype = input.dtype
     if device is None:
         device = input.device
-    out = zeros(input.shape, dtype=dtype, device=device)
-    return _clone_with_memory_format(out, source=input, memory_format=memory_format)
+    return zeros(input.shape, dtype=dtype, device=device, memory_format=_memory_format_for_like(input, memory_format))
 
 
 def ones(*shape, dtype=None, device=None, memory_format=None):
@@ -1089,9 +1085,9 @@ def rand(*shape, dtype=None, device=None, memory_format=None, generator=None):
     return dispatch("rand", dev, shape, dtype=dtype, memory_format=memory_format, generator=generator)
 
 
-def randint(low, high=None, size=None, *, dtype=None, device=None, requires_grad=False, generator=None):
+def randint(low, high=None, size=None, *, dtype=None, device=None, requires_grad=False, generator=None, memory_format=None):
     dev = _as_device(device)
-    return dispatch("randint", dev, low, high=high, size=size, dtype=dtype, requires_grad=requires_grad, generator=generator)
+    return dispatch("randint", dev, low, high=high, size=size, dtype=dtype, requires_grad=requires_grad, generator=generator, memory_format=memory_format)
 
 
 def randperm(n, *, dtype=None, device=None, requires_grad=False, generator=None):
@@ -1111,7 +1107,7 @@ def linspace(start, end, steps, dtype=None, device=None):
     return dispatch("linspace", dev, start, end, steps, dtype=dtype)
 
 
-def full(*args, dtype=None, device=None):
+def full(*args, dtype=None, device=None, memory_format=None):
     if len(args) >= 2 and not isinstance(args[-1], (tuple, list, int)):
         # full(shape, fill_value) or full(d1, d2, ..., fill_value)
         *shape_args, fill_value = args
@@ -1124,7 +1120,8 @@ def full(*args, dtype=None, device=None):
     else:
         shape = tuple(shape_args)
     dev = _as_device(device)
-    return dispatch("full", dev, shape, fill_value, dtype=dtype)
+    _unsupported_memory_format("full", memory_format)
+    return dispatch("full", dev, shape, fill_value, dtype=dtype, memory_format=memory_format)
 
 
 def to(a, device=None, dtype=None, non_blocking=False, copy=False, memory_format=None):
@@ -1353,8 +1350,7 @@ def ones_like(input, *, dtype=None, device=None, memory_format=None):
         dtype = input.dtype
     if device is None:
         device = input.device
-    out = ones(input.shape, dtype=dtype, device=device)
-    return _clone_with_memory_format(out, source=input, memory_format=memory_format)
+    return ones(input.shape, dtype=dtype, device=device, memory_format=_memory_format_for_like(input, memory_format))
 
 
 def empty_like(input, *, dtype=None, device=None, memory_format=None):
@@ -1362,8 +1358,7 @@ def empty_like(input, *, dtype=None, device=None, memory_format=None):
         dtype = input.dtype
     if device is None:
         device = input.device
-    out = empty(input.shape, dtype=dtype, device=device)
-    return _clone_with_memory_format(out, source=input, memory_format=memory_format)
+    return empty(input.shape, dtype=dtype, device=device, memory_format=_memory_format_for_like(input, memory_format))
 
 
 def full_like(input, fill_value, *, dtype=None, device=None, memory_format=None):
@@ -1371,8 +1366,7 @@ def full_like(input, fill_value, *, dtype=None, device=None, memory_format=None)
         dtype = input.dtype
     if device is None:
         device = input.device
-    out = full(input.shape, fill_value, dtype=dtype, device=device)
-    return _clone_with_memory_format(out, source=input, memory_format=memory_format)
+    return full(input.shape, fill_value, dtype=dtype, device=device, memory_format=_memory_format_for_like(input, memory_format))
 
 
 def randn_like(input, *, dtype=None, device=None, memory_format=None, generator=None):
@@ -1380,8 +1374,7 @@ def randn_like(input, *, dtype=None, device=None, memory_format=None, generator=
         dtype = input.dtype
     if device is None:
         device = input.device
-    out = randn(input.shape, dtype=dtype, device=device, generator=generator)
-    return _clone_with_memory_format(out, source=input, memory_format=memory_format)
+    return randn(input.shape, dtype=dtype, device=device, memory_format=_memory_format_for_like(input, memory_format), generator=generator)
 
 
 def rand_like(input, *, dtype=None, device=None, memory_format=None, generator=None):
@@ -1389,8 +1382,7 @@ def rand_like(input, *, dtype=None, device=None, memory_format=None, generator=N
         dtype = input.dtype
     if device is None:
         device = input.device
-    out = rand(input.shape, dtype=dtype, device=device, generator=generator)
-    return _clone_with_memory_format(out, source=input, memory_format=memory_format)
+    return rand(input.shape, dtype=dtype, device=device, memory_format=_memory_format_for_like(input, memory_format), generator=generator)
 
 
 def randint_like(input, low=0, high=None, *, dtype=None, device=None, memory_format=None):
@@ -1398,8 +1390,7 @@ def randint_like(input, low=0, high=None, *, dtype=None, device=None, memory_for
         dtype = input.dtype
     if device is None:
         device = input.device
-    out = randint(low, high, size=input.shape, dtype=dtype, device=device)
-    return _clone_with_memory_format(out, source=input, memory_format=memory_format)
+    return randint(low, high, size=input.shape, dtype=dtype, device=device, memory_format=_memory_format_for_like(input, memory_format))
 
 
 def rms_norm(input, normalized_shape, weight=None, eps=1e-6):

--- a/tests/contract/test_memory_format_backend_boundaries.py
+++ b/tests/contract/test_memory_format_backend_boundaries.py
@@ -56,19 +56,34 @@ def test_contiguous_format_to_makes_channels_last_tensor_row_major():
 
 def test_backend_creation_functions_reject_channels_last_before_allocation():
     creation_cases = (
-        (mps_creation, "mps", ("empty_create", "zeros_create", "ones_create", "randn_create", "rand_create")),
+        (mps_creation, "mps", ("empty_create", "zeros_create", "ones_create", "randn_create", "rand_create", "randint_create")),
         (cuda_creation, "cuda", ("empty_create", "zeros_create", "ones_create")),
-        (npu_creation, "npu", ("empty_create", "zeros_create", "ones_create", "randn_create", "rand_create")),
+        (npu_creation, "npu", ("empty_create", "zeros_create", "ones_create", "randn_create", "rand_create", "randint_create", "full_create")),
     )
     for creation_module, device_type, names in creation_cases:
         for name in names:
             create = getattr(creation_module, name)
             with pytest.raises(NotImplementedError, match="channels_last|memory format"):
-                create(
-                    (2, 3, 4, 5),
-                    device=device(device_type),
-                    memory_format=torch.channels_last,
-                )
+                if name == "full_create":
+                    create(
+                        (2, 3, 4, 5),
+                        1.0,
+                        device=device(device_type),
+                        memory_format=torch.channels_last,
+                    )
+                elif name == "randint_create":
+                    create(
+                        10,
+                        size=(2, 3, 4, 5),
+                        device=device(device_type),
+                        memory_format=torch.channels_last,
+                    )
+                else:
+                    create(
+                        (2, 3, 4, 5),
+                        device=device(device_type),
+                        memory_format=torch.channels_last,
+                    )
 
 
 def test_npu_like_and_new_creation_helpers_reject_channels_last_before_allocation():

--- a/tests/cpu/test_tensor_api_contract.py
+++ b/tests/cpu/test_tensor_api_contract.py
@@ -395,6 +395,21 @@ class TestCreationMemoryFormat:
         assert x.stride() == (60, 1, 15, 3)
         assert x.is_contiguous(memory_format=torch.channels_last) is True
 
+    def test_randint_supports_channels_last(self):
+        x = torch.randint(10, (2, 3, 4, 5), memory_format=torch.channels_last)
+        assert x.stride() == (60, 1, 15, 3)
+        assert x.is_contiguous(memory_format=torch.channels_last) is True
+
+    def test_full_supports_channels_last(self):
+        x = torch.full((2, 3, 4, 5), 1.0, memory_format=torch.channels_last)
+        assert x.stride() == (60, 1, 15, 3)
+        assert x.is_contiguous(memory_format=torch.channels_last) is True
+
+    def test_meta_full_supports_channels_last(self):
+        x = torch.full((2, 3, 4, 5), 1.0, device="meta", memory_format=torch.channels_last)
+        assert x.stride() == (60, 1, 15, 3)
+        assert x.is_contiguous(memory_format=torch.channels_last) is True
+
     def test_ones_like_preserves_channels_last_by_default(self):
         base = torch.empty((2, 3, 4, 5), memory_format=torch.channels_last)
         out = torch.ones_like(base)
@@ -422,6 +437,18 @@ class TestCreationMemoryFormat:
     def test_randint_like_preserves_channels_last_by_default(self):
         base = torch.empty((2, 3, 4, 5), memory_format=torch.channels_last)
         out = torch.randint_like(base, high=10)
+        assert out.stride() == (60, 1, 15, 3)
+        assert out.is_contiguous(memory_format=torch.channels_last) is True
+
+    def test_like_creation_memory_format_is_applied_during_creation(self, monkeypatch):
+        base = torch.empty((2, 3, 4, 5), memory_format=torch.channels_last)
+
+        def _fail_clone(*args, **kwargs):
+            raise AssertionError("like creation should not relayout by cloning after allocation")
+
+        monkeypatch.setattr(type(base), "clone", _fail_clone)
+
+        out = torch.zeros_like(base)
         assert out.stride() == (60, 1, 15, 3)
         assert out.is_contiguous(memory_format=torch.channels_last) is True
 


### PR DESCRIPTION
## Summary
- Move `*_like` memory_format handling into creation dispatch so channels_last layouts are allocated directly instead of relayouting via clone.
- Extend `full` and `randint` memory_format plumbing for CPU/meta channels_last creation.
- Add MPS/NPU guard coverage for unsupported full/randint channels_last requests before allocation.

## Test plan
- [x] `conda run -n candle311 python -m pytest tests/cpu/test_tensor_api_contract.py tests/contract/test_memory_format_backend_boundaries.py tests/cpu/test_creation.py -q --tb=short`
- [x] `conda run -n candle311 pylint src/candle/ --rcfile=.github/pylint.conf`
- [x] `conda run -n candle311 python -m pytest tests/cpu/ tests/contract/ -q --tb=short`
- [x] `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)