### PR TITLE
refactor(tensor): route legacy helpers through candle internals

### DIFF
--- a/src/candle/_functional.py
+++ b/src/candle/_functional.py
@@ -1864,7 +1864,7 @@ def square(a):
 # ---------------------------------------------------------------------------
 
 def clone(a, *, memory_format=None):
-    return a.clone(memory_format=memory_format) if memory_format else a.clone()
+    return a.clone(memory_format=memory_format)
 
 
 def detach(a):
@@ -1872,7 +1872,7 @@ def detach(a):
 
 
 def contiguous(a, memory_format=None):
-    return a.contiguous(memory_format=memory_format) if memory_format else a.contiguous()
+    return a.contiguous(memory_format=memory_format)
 
 
 def index_add(a, dim, index, source, *, alpha=1.0):

--- a/src/candle/_linalg_utils.py
+++ b/src/candle/_linalg_utils.py
@@ -1,0 +1,25 @@
+"""Legacy Tensor linalg method helpers."""
+
+from . import linalg
+
+
+def solve(input, other):
+    return linalg.solve(other, input)
+
+
+def lstsq(input, other):
+    return linalg.lstsq(other, input)
+
+
+def eig(input, eigenvectors=False):
+    values, vectors = linalg.eig(input)
+    if eigenvectors:
+        return values, vectors
+    return values, None
+
+
+def _symeig(input, eigenvectors=False):
+    values, vectors = linalg.eigh(input)
+    if eigenvectors:
+        return values, vectors
+    return values, None

--- a/src/candle/_prims_common.py
+++ b/src/candle/_prims_common.py
@@ -1,3 +1,11 @@
 """Minimal torch._prims_common stub for candle."""
 from typing import Union
+
 DeviceLikeType = Union[str, "candle._device.device", int]
+
+
+def compute_elementwise_output_logical_to_physical_perm(tensor, ambiguity_check=False):
+    del ambiguity_check
+    strides = tuple(tensor.stride())
+    perm = tuple(sorted(range(len(strides)), key=lambda dim: (-strides[dim], dim)))
+    return perm, False

--- a/src/candle/_tensor.py
+++ b/src/candle/_tensor.py
@@ -320,7 +320,7 @@ class Tensor(torch._C.TensorBase):
     def _reduce_ex_internal(self, proto):
         check_serializing_named_tensor(self)
 
-        from torch.utils.hooks import warn_if_has_hooks
+        from candle.utils.hooks import warn_if_has_hooks
 
         # See Note [Don't serialize hooks]
         warn_if_has_hooks(self)
@@ -754,7 +754,7 @@ class Tensor(torch._C.TensorBase):
                 OrderedDict()
             )
 
-        from torch.utils.hooks import RemovableHandle
+        from candle.utils.hooks import RemovableHandle
 
         handle = RemovableHandle(self._post_accumulate_grad_hooks)
         self._post_accumulate_grad_hooks[handle.id] = hook
@@ -882,22 +882,22 @@ class Tensor(torch._C.TensorBase):
             return self.flip(0)
 
     def solve(self, other):
-        from torch._linalg_utils import solve
+        from candle._linalg_utils import solve
 
         return solve(self, other)
 
     def lstsq(self, other):
-        from torch._linalg_utils import lstsq
+        from candle._linalg_utils import lstsq
 
         return lstsq(self, other)
 
     def eig(self, eigenvectors=False):
-        from torch._linalg_utils import eig
+        from candle._linalg_utils import eig
 
         return eig(self, eigenvectors=eigenvectors)
 
     def symeig(self, eigenvectors=False):
-        from torch._linalg_utils import _symeig
+        from candle._linalg_utils import _symeig
 
         return _symeig(self, eigenvectors=eigenvectors)
 
@@ -1011,7 +1011,7 @@ class Tensor(torch._C.TensorBase):
         if has_torch_function_unary(self):
             return handle_torch_function(Tensor.resize, (self,), self, *sizes)
         warnings.warn("non-inplace resize is deprecated", stacklevel=2)
-        from torch.autograd._functions import Resize
+        from candle.autograd._functions import Resize
 
         return Resize.apply(self, sizes)
 
@@ -1019,7 +1019,7 @@ class Tensor(torch._C.TensorBase):
         if has_torch_function_variadic(self, tensor):
             return handle_torch_function(Tensor.resize_as, (self, tensor), self, tensor)
         warnings.warn("non-inplace resize_as is deprecated", stacklevel=2)
-        from torch.autograd._functions import Resize
+        from candle.autograd._functions import Resize
 
         return Resize.apply(self, tensor.size())
 
@@ -1512,19 +1512,13 @@ class Tensor(torch._C.TensorBase):
               If any two dimensions have the same stride, swapping these dimensions won't
               change how data is accessed, leading to multiple correct dimension orders.
             """
-            from torch.fx.experimental.symbolic_shapes import guard_or_false
-
             sizes = tensor.size()
             strides = tensor.stride()
 
-            # Check if there are any duplicate strides
             has_duplicate_strides = any(
-                guard_or_false(earlier == later)
-                for earlier, later in itertools.pairwise(strides)
+                earlier == later for earlier, later in itertools.pairwise(strides)
             )
-
-            # Check if there are any singleton dimensions
-            has_singleton_dims = any(guard_or_false(size == 1) for size in sizes)
+            has_singleton_dims = any(size == 1 for size in sizes)
 
             return has_duplicate_strides or has_singleton_dims
 
@@ -1542,7 +1536,7 @@ class Tensor(torch._C.TensorBase):
                 "The tensor does not have unique dim order, or cannot map to exact one of the given memory formats."
             )
 
-        import torch._prims_common as utils
+        from . import _prims_common as utils
 
         out_perm, raise_ambiguity = (
             utils.compute_elementwise_output_logical_to_physical_perm(
@@ -1715,7 +1709,7 @@ class Tensor(torch._C.TensorBase):
         if has_torch_function_unary(self):
             return handle_torch_function(Tensor.__dlpack_device__, (self,), self)
 
-        from torch.utils.dlpack import DLDeviceType
+        from candle.utils.dlpack import DLDeviceType
 
         device = self.device
         idx = device.index if device.index is not None else 0

--- a/src/candle/utils/dlpack.py
+++ b/src/candle/utils/dlpack.py
@@ -1,0 +1,17 @@
+"""Minimal torch.utils.dlpack compatibility helpers for candle."""
+
+import enum
+
+
+class DLDeviceType(enum.IntEnum):
+    kDLCPU = 1
+    kDLCUDA = 2
+    kDLCUDAHost = 3
+    kDLOpenCL = 4
+    kDLVulkan = 7
+    kDLMetal = 8
+    kDLVPI = 9
+    kDLROCM = 10
+    kDLROCMHost = 11
+    kDLExtDev = 12
+    kDLOneAPI = 14

--- a/src/candle/utils/hooks.py
+++ b/src/candle/utils/hooks.py
@@ -1,5 +1,7 @@
 """Minimal torch.utils.hooks stub for candle compatibility."""
 
+import warnings
+
 
 class RemovableHandle:
     """A handle which provides the capability to remove a hook."""
@@ -18,3 +20,9 @@ class RemovableHandle:
 
     def __setstate__(self, state):
         self.id, self.hooks_dict = state
+
+
+def warn_if_has_hooks(tensor):
+    hooks = getattr(tensor, "_backward_hooks", None)
+    if hooks:
+        warnings.warn("backward hooks are not serialized", stacklevel=2)

--- a/tests/cpu/test_tensor_api_contract.py
+++ b/tests/cpu/test_tensor_api_contract.py
@@ -11,6 +11,8 @@ Coverage:
   5. backward
   6. Property stability: .grad, .shape, .device, .dtype
 """
+import builtins
+
 import pytest
 import candle as torch
 from candle._tensor import Tensor
@@ -1250,6 +1252,156 @@ def test_size_and_dim_contracts():
     assert a.dim() == 2
     with pytest.raises(IndexError):
         a.size(2)
+
+
+class _MemoryFormatRecorder:
+    seen = object()
+
+    def clone(self, *, memory_format):
+        self.seen = memory_format
+        return self
+
+    def contiguous(self, memory_format):
+        self.seen = memory_format
+        return self
+
+
+def test_top_level_clone_passes_none_memory_format():
+    x = _MemoryFormatRecorder()
+    assert torch.clone(x) is x
+    assert x.seen is None
+
+
+def test_top_level_contiguous_passes_none_memory_format():
+    x = _MemoryFormatRecorder()
+    assert torch.contiguous(x) is x
+    assert x.seen is None
+
+
+def test_dim_order_uses_candle_prims_common(monkeypatch):
+    real_import = builtins.__import__
+
+    def reject_external_torch_prims(name, *args, **kwargs):
+        if name == "torch._prims_common":
+            raise AssertionError("dim_order should use candle._prims_common")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", reject_external_torch_prims)
+
+    assert torch.empty((2, 3, 4, 5)).dim_order() == (0, 1, 2, 3)
+
+
+def test_dim_order_ambiguity_check_does_not_import_torch_fx(monkeypatch):
+    real_import = builtins.__import__
+
+    def reject_external_torch_fx(name, *args, **kwargs):
+        if name == "torch.fx.experimental.symbolic_shapes":
+            raise AssertionError("dim_order should not import torch.fx")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", reject_external_torch_fx)
+
+    assert torch.empty((2, 3, 4, 5)).dim_order(ambiguity_check=True) == (0, 1, 2, 3)
+
+
+def test_register_post_accumulate_grad_hook_uses_candle_hooks(monkeypatch):
+    real_import = builtins.__import__
+
+    def reject_external_torch_hooks(name, *args, **kwargs):
+        if name == "torch.utils.hooks":
+            raise AssertionError("register_post_accumulate_grad_hook should use candle.utils.hooks")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", reject_external_torch_hooks)
+
+    x = torch.tensor([1.0], requires_grad=True)
+    x._post_accumulate_grad_hooks = None
+    handle = x.register_post_accumulate_grad_hook(lambda grad: None)
+    assert handle.id in x._post_accumulate_grad_hooks
+    handle.remove()
+    assert handle.id not in x._post_accumulate_grad_hooks
+
+
+def test_reduce_ex_uses_candle_hook_warning(monkeypatch):
+    real_import = builtins.__import__
+
+    def reject_external_torch_hooks(name, *args, **kwargs):
+        if name == "torch.utils.hooks":
+            raise AssertionError("Tensor.__reduce_ex__ should use candle.utils.hooks")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", reject_external_torch_hooks)
+
+    x = torch.tensor([1.0])
+    with pytest.raises(AttributeError, match="_serialization_tls"):
+        x._reduce_ex_internal(4)
+
+
+def test_dlpack_device_uses_candle_enum(monkeypatch):
+    real_import = builtins.__import__
+
+    def reject_external_torch_dlpack(name, *args, **kwargs):
+        if name == "torch.utils.dlpack":
+            raise AssertionError("Tensor.__dlpack_device__ should not import torch.utils.dlpack")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", reject_external_torch_dlpack)
+
+    device_type, index = torch.tensor([1.0]).__dlpack_device__()
+    assert int(device_type) == 1
+    assert index == 0
+
+
+def test_legacy_tensor_linalg_methods_use_candle_linalg(monkeypatch):
+    real_import = builtins.__import__
+
+    def reject_external_torch_linalg_utils(name, *args, **kwargs):
+        if name == "torch._linalg_utils":
+            raise AssertionError("legacy Tensor linalg methods should not import torch._linalg_utils")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", reject_external_torch_linalg_utils)
+
+    a = torch.tensor([[3.0, 1.0], [1.0, 2.0]])
+    b = torch.tensor([[9.0], [8.0]])
+    assert b.solve(a).shape == (2, 1)
+    assert b.lstsq(a).solution.shape == (2, 1)
+    assert a.eig(eigenvectors=True)[0].shape == (2,)
+    assert a.symeig(eigenvectors=True)[0].shape == (2,)
+
+
+def test_tensor_resize_uses_candle_resize_helper(monkeypatch):
+    real_import = builtins.__import__
+
+    def reject_external_torch_resize(name, *args, **kwargs):
+        if name == "torch.autograd._functions":
+            raise AssertionError("Tensor.resize should not import torch.autograd._functions")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", reject_external_torch_resize)
+
+    x = torch.tensor([1.0, 2.0, 3.0, 4.0])
+    out = x.resize(2, 2)
+    assert out.shape == (2, 2)
+    assert out.tolist() == [[1.0, 2.0], [3.0, 4.0]]
+    assert out is not x
+
+
+def test_tensor_resize_as_uses_candle_resize_helper(monkeypatch):
+    real_import = builtins.__import__
+
+    def reject_external_torch_resize(name, *args, **kwargs):
+        if name == "torch.autograd._functions":
+            raise AssertionError("Tensor.resize_as should not import torch.autograd._functions")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", reject_external_torch_resize)
+
+    x = torch.tensor([1.0, 2.0, 3.0, 4.0])
+    out = x.resize_as(torch.empty((2, 2)))
+    assert out.shape == (2, 2)
+    assert out.tolist() == [[1.0, 2.0], [3.0, 4.0]]
+    assert out is not x
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Remove remaining Python truthiness branching in top-level clone/contiguous memory_format wrappers.
- Route legacy Tensor helper paths through Candle-owned internals instead of external torch runtime imports.
- Add focused contract tests covering wrapper pass-through and import-free Tensor helper paths.

## Test plan
- [x] `conda run -n candle311 python -m pytest tests/cpu/test_tensor_api_contract.py -q --tb=short`
- [x] `conda run -n candle311 python -m pytest tests/cpu/test_tensor_api_contract.py tests/cpu/test_linalg.py -q --tb=short`
- [x] `conda run -n candle311 pylint src/candle/ --rcfile=.github/pylint.conf`
- [x] `git diff --check`
- [x] `conda run -n candle311 python -m pytest tests/cpu/ tests/contract/ -q --tb=short`

🤖 Generated with [Claude Code](https://claude.com/claude-code)