### PR TITLE
Move forward AD state into Cython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,10 @@ if _system in ("Linux", "Darwin"):
             ["src/candle/_C/_grad_mode_state.pyx"],
         ),
         Extension(
+            "candle._C._forward_ad",
+            ["src/candle/_C/_forward_ad.pyx"],
+        ),
+        Extension(
             "candle._C._functional_ops",
             ["src/candle/_C/_functional_ops.pyx"],
         ),

--- a/src/candle/_C/__init__.py
+++ b/src/candle/_C/__init__.py
@@ -20,6 +20,7 @@ Feature flags (set after import):
     _HAS_CYTHON_AUTOGRAD_FUNCTION — always True (hard import, no fallback)
     _HAS_CYTHON_AUTOGRAD_OPS    — always True (hard import, no fallback)
     _HAS_CYTHON_GRAD_MODE_STATE — always True (hard import, no fallback)
+    _HAS_CYTHON_FORWARD_AD      — always True (hard import, no fallback)
     _HAS_CYTHON_FUNCTIONAL_OPS  — True if _functional_ops.pyx compiled successfully
     _HAS_CYTHON_FAST_OPS        — True if _fast_ops.pyx compiled successfully
     _HAS_CYTHON_TENSOR_API      — True if _tensor_api.pyx compiled successfully
@@ -35,6 +36,7 @@ from ._bootstrap import (
     _HAS_CYTHON_AUTOGRAD_NODE,
     _HAS_CYTHON_AUTOGRAD_OPS,
     _HAS_CYTHON_GRAD_MODE_STATE,
+    _HAS_CYTHON_FORWARD_AD,
     _HAS_CYTHON_DEVICE,
     _HAS_CYTHON_DISPATCH,
     _HAS_CYTHON_DISPATCHER_CORE,

--- a/src/candle/_C/_bootstrap.py
+++ b/src/candle/_C/_bootstrap.py
@@ -90,6 +90,7 @@ _HAS_CYTHON_AUTOGRAD_ENGINE = False
 _HAS_CYTHON_AUTOGRAD_FUNCTION = False
 _HAS_CYTHON_AUTOGRAD_OPS = False
 _HAS_CYTHON_GRAD_MODE_STATE = False
+_HAS_CYTHON_FORWARD_AD = False
 _HAS_CYTHON_FUNCTIONAL_OPS = False
 _HAS_CYTHON_FAST_OPS = False
 _HAS_CYTHON_TENSOR_API = False
@@ -245,6 +246,26 @@ try:
     _HAS_CYTHON_GRAD_MODE_STATE = True
 except ImportError:
     _HAS_CYTHON_GRAD_MODE_STATE = False
+
+try:
+    from ._forward_ad import (  # noqa: F401
+        _JVP_RULES,
+        _STATE as _FORWARD_AD_STATE,
+        _current_level,
+        _disabled_levels,
+        _level_stack,
+        dual_level,
+        enter_dual_level,
+        exit_dual_level,
+        get_jvp,
+        get_tangent,
+        is_level_disabled,
+        register_jvp,
+        temporarily_disable,
+    )
+    _HAS_CYTHON_FORWARD_AD = True
+except ImportError:
+    _HAS_CYTHON_FORWARD_AD = False
 
 try:
     from ._functional_ops import (  # noqa: F401

--- a/src/candle/_C/_forward_ad.pyx
+++ b/src/candle/_C/_forward_ad.pyx
@@ -1,0 +1,93 @@
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""Cython-owned forward-mode AD state and JVP registry."""
+
+import threading
+
+_STATE = threading.local()
+_JVP_RULES = {}
+
+
+def _level_stack():
+    stack = getattr(_STATE, "levels", None)
+    if stack is None:
+        stack = []
+        _STATE.levels = stack
+    return stack
+
+
+def _current_level():
+    stack = _level_stack()
+    if not stack:
+        return -1
+    return stack[len(stack) - 1]
+
+
+def _disabled_levels():
+    disabled = getattr(_STATE, "disabled", None)
+    if disabled is None:
+        disabled = set()
+        _STATE.disabled = disabled
+    return disabled
+
+
+class temporarily_disable:
+    def __init__(self, level):
+        self.level = level
+
+    def __enter__(self):
+        _disabled_levels().add(self.level)
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        _disabled_levels().discard(self.level)
+        return False
+
+
+def is_level_disabled(level):
+    return level in _disabled_levels()
+
+
+def get_tangent(tensor, level):
+    if is_level_disabled(level):
+        return None
+    return tensor._fw_get(level)
+
+
+def register_jvp(op_name, fn):
+    _JVP_RULES[op_name] = fn
+
+
+def get_jvp(op_name):
+    return _JVP_RULES.get(op_name)
+
+
+def enter_dual_level():
+    stack = _level_stack()
+    level = stack[len(stack) - 1] + 1 if stack else 0
+    stack.append(level)
+    return level
+
+
+def exit_dual_level(*, level=None):
+    stack = _level_stack()
+    if not stack:
+        raise RuntimeError(
+            "Trying to exit a forward AD level but no level is currently active."
+        )
+    current = stack[len(stack) - 1]
+    target = current if level is None else level
+    if target != current:
+        raise RuntimeError(
+            "Trying to exit a forward AD level that was not the last one that was created."
+        )
+    stack.pop()
+
+
+class dual_level:
+    def __enter__(self):
+        self.level = enter_dual_level()
+        return self.level
+
+    def __exit__(self, exc_type, exc, tb):
+        exit_dual_level(level=self.level)
+        return False

--- a/src/candle/autograd/forward_ad.py
+++ b/src/candle/autograd/forward_ad.py
@@ -1,5 +1,20 @@
-import threading
 from collections import namedtuple
+
+from .._C._forward_ad import (  # pylint: disable=import-error,no-name-in-module
+    _STATE,
+    _JVP_RULES,
+    _current_level,
+    _disabled_levels,
+    _level_stack,
+    dual_level,
+    enter_dual_level,
+    exit_dual_level,
+    get_jvp,
+    get_tangent,
+    is_level_disabled,
+    register_jvp,
+    temporarily_disable,
+)
 
 
 _UnpackedDualTensor = namedtuple("_UnpackedDualTensor", ["primal", "tangent"])
@@ -7,56 +22,6 @@ _UnpackedDualTensor = namedtuple("_UnpackedDualTensor", ["primal", "tangent"])
 
 class UnpackedDualTensor(_UnpackedDualTensor):
     pass
-
-
-_STATE = threading.local()
-_JVP_RULES = {}
-
-
-def _level_stack():
-    stack = getattr(_STATE, "levels", None)
-    if stack is None:
-        stack = []
-        _STATE.levels = stack
-    return stack
-
-
-def _current_level():
-    stack = _level_stack()
-    if not stack:
-        return -1
-    return stack[-1]
-
-
-def _disabled_levels():
-    disabled = getattr(_STATE, "disabled", None)
-    if disabled is None:
-        disabled = set()
-        _STATE.disabled = disabled
-    return disabled
-
-
-class temporarily_disable:
-    def __init__(self, level):
-        self.level = level
-
-    def __enter__(self):
-        _disabled_levels().add(self.level)
-        return self
-
-    def __exit__(self, exc_type, exc, tb):
-        _disabled_levels().discard(self.level)
-        return False
-
-
-def is_level_disabled(level):
-    return level in _disabled_levels()
-
-
-def get_tangent(tensor, level):
-    if is_level_disabled(level):
-        return None
-    return tensor._fw_get(level)
 
 
 def _tangent_or_zero(tangent, like):
@@ -96,46 +61,6 @@ def _view_jvp(x, shape, *, _tangents):
 def _reshape_jvp(x, shape, *, _tangents):
     tangent = _tangent_or_zero(_tangents[0], x)
     return tangent.reshape(shape)
-
-
-def register_jvp(op_name, fn):
-    _JVP_RULES[op_name] = fn
-
-
-def get_jvp(op_name):
-    return _JVP_RULES.get(op_name)
-
-
-def enter_dual_level():
-    stack = _level_stack()
-    level = stack[-1] + 1 if stack else 0
-    stack.append(level)
-    return level
-
-
-def exit_dual_level(*, level=None):
-    stack = _level_stack()
-    if not stack:
-        raise RuntimeError(
-            "Trying to exit a forward AD level but no level is currently active."
-        )
-    current = stack[-1]
-    target = current if level is None else level
-    if target != current:
-        raise RuntimeError(
-            "Trying to exit a forward AD level that was not the last one that was created."
-        )
-    stack.pop()
-
-
-class dual_level:
-    def __enter__(self):
-        self.level = enter_dual_level()
-        return self.level
-
-    def __exit__(self, exc_type, exc, tb):
-        exit_dual_level(level=self.level)
-        return False
 
 
 def _validate_tangent(tensor, tangent):

--- a/tests/cpu/test_forward_ad.py
+++ b/tests/cpu/test_forward_ad.py
@@ -1,6 +1,65 @@
+import importlib.machinery
+import threading
+
 import pytest
 import candle
+from candle._C import _forward_ad
 from candle.autograd import forward_ad
+
+
+def test_forward_ad_state_lives_in_compiled_c_boundary():
+    assert isinstance(_forward_ad.__loader__, importlib.machinery.ExtensionFileLoader)
+    assert forward_ad.enter_dual_level.__module__ == "candle._C._forward_ad"
+    assert forward_ad.exit_dual_level.__module__ == "candle._C._forward_ad"
+    assert forward_ad.get_jvp.__module__ == "candle._C._forward_ad"
+    assert forward_ad.register_jvp.__module__ == "candle._C._forward_ad"
+    assert forward_ad.temporarily_disable.__module__ == "candle._C._forward_ad"
+
+
+def test_forward_ad_level_stack_is_thread_local():
+    parent_states = []
+    child_states = []
+
+    with forward_ad.dual_level() as parent_level:
+        parent_states.append((parent_level, forward_ad._current_level()))
+
+        def _worker():
+            child_states.append(forward_ad._current_level())
+            with forward_ad.dual_level() as child_level:
+                child_states.append((child_level, forward_ad._current_level()))
+            child_states.append(forward_ad._current_level())
+
+        t = threading.Thread(target=_worker)
+        t.start()
+        t.join()
+        parent_states.append(forward_ad._current_level())
+
+    assert parent_states == [(0, 0), 0]
+    assert child_states == [-1, (0, 0), -1]
+
+
+def test_forward_ad_disabled_levels_are_thread_local():
+    child_states = []
+
+    with forward_ad.dual_level() as level:
+        with forward_ad.temporarily_disable(level):
+            assert forward_ad.is_level_disabled(level) is True
+
+            def _worker():
+                child_states.append(forward_ad.is_level_disabled(level))
+
+            t = threading.Thread(target=_worker)
+            t.start()
+            t.join()
+
+    assert child_states == [False]
+
+
+def test_forward_ad_jvp_registry_is_shared_with_dispatcher():
+    sentinel = object()
+    forward_ad.register_jvp("__test_forward_ad_registry__", sentinel)
+    assert _forward_ad.get_jvp("__test_forward_ad_registry__") is sentinel
+    assert forward_ad.get_jvp("__test_forward_ad_registry__") is sentinel
 
 
 def test_forward_ad_level_stack_and_make_unpack():


### PR DESCRIPTION
## Summary
- Move forward-AD level tracking, disabled-level state, and JVP registry into `candle._C._forward_ad`
- Keep Python JVP formulas plus `make_dual` / `unpack_dual` unchanged for this batch
- Add boundary/thread-local/registry tests for the compiled `_C` implementation

## Test plan
- [x] red: `PYTHONPATH="$PWD/src" conda run -n candle311 python -m pytest tests/cpu/test_forward_ad.py::test_forward_ad_state_lives_in_compiled_c_boundary -q --tb=short` failed before `_C._forward_ad` existed
- [x] `PYTHONPATH="$PWD/src" conda run -n candle311 python setup.py build_ext --inplace`
- [x] `PYTHONPATH="$PWD/src" conda run -n candle311 python -m pytest tests/cpu/test_forward_ad.py -q --tb=short`
- [x] `PYTHONPATH="$PWD/src" conda run -n candle311 python -m pytest tests/cpu/test_forward_ad.py tests/cpu/test_forward_ad_contract.py tests/cpu/test_dispatch_autograd_wrappers.py tests/cpu/test_dispatch_redispatch.py -q --tb=short`
- [x] `PYTHONPATH="$PWD/src" conda run -n candle311 python -m pytest tests/cpu/ tests/contract/ -q --tb=short`
- [x] `PYTHONPATH="$PWD/src" conda run -n candle311 pylint src/candle/ --rcfile=.github/pylint.conf`
- [x] `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)