### PR TITLE
refactor(autograd): move forward AD dual helpers into Cython

### DIFF
--- a/src/candle/_C/_bootstrap.py
+++ b/src/candle/_C/_bootstrap.py
@@ -260,8 +260,11 @@ try:
         get_jvp,
         get_tangent,
         is_level_disabled,
+        make_dual,
         register_jvp,
+        set_unpacked_dual_type,
         temporarily_disable,
+        unpack_dual,
     )
     _HAS_CYTHON_FORWARD_AD = True
 except ImportError:

--- a/src/candle/_C/_forward_ad.pyx
+++ b/src/candle/_C/_forward_ad.pyx
@@ -5,6 +5,12 @@ import threading
 
 _STATE = threading.local()
 _JVP_RULES = {}
+_UNPACKED_DUAL_TYPE = None
+
+
+def set_unpacked_dual_type(unpacked_dual_type):
+    global _UNPACKED_DUAL_TYPE
+    _UNPACKED_DUAL_TYPE = unpacked_dual_type
 
 
 def _level_stack():
@@ -91,3 +97,45 @@ class dual_level:
     def __exit__(self, exc_type, exc, tb):
         exit_dual_level(level=self.level)
         return False
+
+
+def _validate_tangent(tensor, tangent):
+    if not (tensor.is_floating_point() or tensor.is_complex()):
+        raise ValueError(
+            f"Expected primal to be floating point or complex, but got: {tensor.dtype}"
+        )
+    if not (tangent.is_floating_point() or tangent.is_complex()):
+        raise ValueError(
+            f"Expected tangent to be floating point or complex, but got: {tangent.dtype}"
+        )
+    if tensor.shape != tangent.shape:
+        raise RuntimeError(
+            f"Expected tangent to have the same shape as primal, but got: {tangent.shape}"
+        )
+    if tensor.dtype != tangent.dtype:
+        raise RuntimeError(
+            f"Expected tangent to have the same dtype as primal, but got: {tangent.dtype}"
+        )
+
+
+def make_dual(tensor, tangent, *, level=None):
+    if level is None:
+        level = _current_level()
+    if level < 0:
+        raise RuntimeError(
+            "Trying to create a dual Tensor for forward AD but no level exists, make sure to enter_dual_level() first."
+        )
+    _validate_tangent(tensor, tangent)
+    tensor._fw_set(level, tangent)
+    return tensor
+
+
+def unpack_dual(tensor, *, level=None):
+    unpacked_dual_type = _UNPACKED_DUAL_TYPE
+    if unpacked_dual_type is None:
+        raise RuntimeError("UnpackedDualTensor type has not been registered")
+    if level is None:
+        level = _current_level()
+    if level < 0:
+        return unpacked_dual_type(tensor, None)
+    return unpacked_dual_type(tensor, get_tangent(tensor, level))

--- a/src/candle/autograd/forward_ad.py
+++ b/src/candle/autograd/forward_ad.py
@@ -12,8 +12,11 @@ from .._C._forward_ad import (  # pylint: disable=import-error,no-name-in-module
     get_jvp,
     get_tangent,
     is_level_disabled,
+    make_dual,
     register_jvp,
+    set_unpacked_dual_type,
     temporarily_disable,
+    unpack_dual,
 )
 
 
@@ -63,43 +66,7 @@ def _reshape_jvp(x, shape, *, _tangents):
     return tangent.reshape(shape)
 
 
-def _validate_tangent(tensor, tangent):
-    if not (tensor.is_floating_point() or tensor.is_complex()):
-        raise ValueError(
-            f"Expected primal to be floating point or complex, but got: {tensor.dtype}"
-        )
-    if not (tangent.is_floating_point() or tangent.is_complex()):
-        raise ValueError(
-            f"Expected tangent to be floating point or complex, but got: {tangent.dtype}"
-        )
-    if tensor.shape != tangent.shape:
-        raise RuntimeError(
-            f"Expected tangent to have the same shape as primal, but got: {tangent.shape}"
-        )
-    if tensor.dtype != tangent.dtype:
-        raise RuntimeError(
-            f"Expected tangent to have the same dtype as primal, but got: {tangent.dtype}"
-        )
-
-
-def make_dual(tensor, tangent, *, level=None):
-    if level is None:
-        level = _current_level()
-    if level < 0:
-        raise RuntimeError(
-            "Trying to create a dual Tensor for forward AD but no level exists, make sure to enter_dual_level() first."
-        )
-    _validate_tangent(tensor, tangent)
-    tensor._fw_set(level, tangent)
-    return tensor
-
-
-def unpack_dual(tensor, *, level=None):
-    if level is None:
-        level = _current_level()
-    if level < 0:
-        return UnpackedDualTensor(tensor, None)
-    return UnpackedDualTensor(tensor, get_tangent(tensor, level))
+set_unpacked_dual_type(UnpackedDualTensor)
 
 
 __all__ = [

--- a/tests/cpu/test_forward_ad.py
+++ b/tests/cpu/test_forward_ad.py
@@ -16,6 +16,21 @@ def test_forward_ad_state_lives_in_compiled_c_boundary():
     assert forward_ad.temporarily_disable.__module__ == "candle._C._forward_ad"
 
 
+def test_forward_ad_dual_helpers_live_in_compiled_c_boundary():
+    assert forward_ad.make_dual.__module__ == "candle._C._forward_ad"
+    assert forward_ad.unpack_dual.__module__ == "candle._C._forward_ad"
+
+
+def test_forward_ad_unpack_dual_requires_registered_public_type():
+    x = candle.rand(2)
+    _forward_ad.set_unpacked_dual_type(None)
+    try:
+        with pytest.raises(RuntimeError, match="UnpackedDualTensor"):
+            _forward_ad.unpack_dual(x)
+    finally:
+        _forward_ad.set_unpacked_dual_type(forward_ad.UnpackedDualTensor)
+
+
 def test_forward_ad_level_stack_is_thread_local():
     parent_states = []
     child_states = []


### PR DESCRIPTION
## Summary
- Move forward AD `make_dual` and `unpack_dual` mechanics into `candle._C._forward_ad`
- Keep `candle.autograd.forward_ad` as the public Python surface with `UnpackedDualTensor` registration
- Add boundary regression coverage for compiled dual helpers and public type registration

## Test plan
- [x] `source ~/anaconda3/etc/profile.d/conda.sh && conda run -n candle311 python setup.py build_ext --inplace`
- [x] `source ~/anaconda3/etc/profile.d/conda.sh && conda run -n candle311 python -m pytest tests/cpu/test_forward_ad.py -q --tb=short`
- [x] `source ~/anaconda3/etc/profile.d/conda.sh && conda run -n candle311 python -m pytest tests/cpu/ tests/contract/ -q --tb=short` — 2968 passed, 30 skipped
- [x] `source ~/anaconda3/etc/profile.d/conda.sh && conda run -n candle311 pylint src/candle/ --rcfile=.github/pylint.conf` — 10.00/10
- [x] `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)