### PR TITLE
refactor(autograd): move graph Node virtual type into Cython

### DIFF
--- a/src/candle/_C/_autograd_graph.pyx
+++ b/src/candle/_C/_autograd_graph.pyx
@@ -18,11 +18,32 @@ def get_gradient_edge(tensor):
     return GradientEdge(tensor.grad_fn, tensor.output_nr)
 
 
+class _NodeMeta(type):
+    def __instancecheck__(cls, instance):
+        return hasattr(instance, "next_functions") and hasattr(instance, "name")
+
+    def __subclasscheck__(cls, subclass):
+        if not isinstance(subclass, type):
+            raise TypeError("issubclass() arg 1 must be a class")
+        return any(
+            hasattr(base, "next_functions") and hasattr(base, "name")
+            for base in subclass.__mro__
+        )
+
+
+class Node(metaclass=_NodeMeta):
+    """Virtual base class for autograd Nodes.
+
+    Mirrors torch.autograd.graph.Node behavior where `isinstance` and
+    `issubclass` are True for autograd nodes, but Node is not in the
+    concrete class MRO.
+    """
+
 def current_saved_tensors_hooks():
     stack = get_stack()
     if not stack:
         return None
-    return stack[-1]
+    return stack[len(stack) - 1]
 
 
 @contextlib.contextmanager

--- a/src/candle/autograd/graph.py
+++ b/src/candle/autograd/graph.py
@@ -1,32 +1,10 @@
 from .._C._autograd_graph import (  # pylint: disable=import-error,no-name-in-module
     GradientEdge,
+    Node,
     current_saved_tensors_hooks,
     get_gradient_edge,
     saved_tensors_hooks,
 )
 
 
-__all__ = ["saved_tensors_hooks", "GradientEdge", "get_gradient_edge"]
-
-
-class _NodeMeta(type):
-    def __instancecheck__(cls, instance):
-        return hasattr(instance, "next_functions") and hasattr(instance, "name")
-
-    def __subclasscheck__(cls, subclass):
-        return hasattr(subclass, "__mro__") and any(
-            hasattr(base, "next_functions") and hasattr(base, "name")
-            for base in subclass.__mro__
-        )
-
-
-class Node(metaclass=_NodeMeta):
-    """Virtual base class for autograd Nodes.
-
-    Mirrors torch.autograd.graph.Node behavior where `isinstance` and
-    `issubclass` are True for autograd nodes, but Node is not in the
-    concrete class MRO.
-    """
-
-
-__all__.append("Node")
+__all__ = ["saved_tensors_hooks", "GradientEdge", "get_gradient_edge", "Node"]

--- a/tests/contract/test_autograd_graph_node.py
+++ b/tests/contract/test_autograd_graph_node.py
@@ -1,7 +1,15 @@
+import importlib.machinery
 import weakref
+
 import pytest
 import candle as torch
+from candle._C import _autograd_graph
 from candle.autograd.graph import Node
+
+
+def test_autograd_graph_node_lives_in_compiled_c_boundary():
+    assert isinstance(_autograd_graph.__loader__, importlib.machinery.ExtensionFileLoader)
+    assert Node.__module__ == "candle._C._autograd_graph"
 
 
 def test_autograd_graph_node_virtual_base():
@@ -9,6 +17,11 @@ def test_autograd_graph_node_virtual_base():
     y = (x * x).sum()
     assert isinstance(y.grad_fn, Node)
     assert issubclass(type(y.grad_fn), Node)
+
+
+def test_autograd_graph_node_subclasscheck_requires_type():
+    with pytest.raises(TypeError):
+        issubclass(object(), Node)
 
 
 def test_autograd_graph_node_exposes_saved_tensors():


### PR DESCRIPTION
## Summary
- Move `candle.autograd.graph.Node` virtual base/type-check mechanism into `candle._C._autograd_graph`
- Keep `candle.autograd.graph` as a thin public re-export surface
- Add boundary and `issubclass` contract coverage for the compiled Node type

## Test plan
- [x] `source ~/anaconda3/etc/profile.d/conda.sh && conda run -n candle311 python setup.py build_ext --inplace`
- [x] `source ~/anaconda3/etc/profile.d/conda.sh && conda run -n candle311 python -m pytest tests/contract/test_autograd_graph_node.py -q --tb=short` — 11 passed
- [x] `source ~/anaconda3/etc/profile.d/conda.sh && conda run -n candle311 python -m pytest tests/cpu/ tests/contract/ -q --tb=short` — 2970 passed, 30 skipped
- [x] `source ~/anaconda3/etc/profile.d/conda.sh && conda run -n candle311 pylint src/candle/ --rcfile=.github/pylint.conf` — 10.00/10
- [x] `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)