### PR TITLE
refactor(autograd): move FunctionMeta into Cython

### DIFF
--- a/src/candle/_C/_autograd_function.pyx
+++ b/src/candle/_C/_autograd_function.pyx
@@ -4,10 +4,24 @@
 Provides FunctionCtx (the ctx object passed to forward/backward),
 and the core Function.apply() execution path.
 
-FunctionMeta (the metaclass that detects old-style vs new-style forward)
-stays in Python because inspect.signature() interop is simpler there.
+FunctionMeta detects old-style vs new-style forward declarations at subclass creation time.
 """
 
+
+
+class FunctionMeta(type):
+    """Metaclass that detects old-style (ctx as first param) vs new-style forward."""
+
+    def __init__(cls, name, bases, attrs):
+        import inspect
+
+        super().__init__(name, bases, attrs)
+        if "forward" in attrs:
+            sig = inspect.signature(attrs["forward"])
+            params = list(sig.parameters.keys())
+            cls._new_style = not (params and params[0] == "ctx")
+        else:
+            cls._new_style = False
 
 cdef class FunctionCtx:
     """Context object passed to Function.forward() for saving state needed by backward()."""

--- a/src/candle/autograd/function.py
+++ b/src/candle/autograd/function.py
@@ -1,24 +1,8 @@
-import inspect
-
-from .._C._autograd_function import FunctionCtx, _function_apply  # pylint: disable=import-error,no-name-in-module
-
-
-class FunctionMeta(type):
-    """Metaclass that detects old-style (ctx as first param) vs new-style forward."""
-
-    def __init__(cls, name, bases, attrs):
-        super().__init__(name, bases, attrs)
-        if "forward" in attrs:
-            sig = inspect.signature(attrs["forward"])
-            params = list(sig.parameters.keys())
-            # Old-style: forward(ctx, ...) where first param is named 'ctx'
-            # New-style: forward(...) with no 'ctx' first param
-            if params and params[0] == "ctx":
-                cls._new_style = False
-            else:
-                cls._new_style = True
-        else:
-            cls._new_style = False
+from .._C._autograd_function import (  # pylint: disable=import-error,no-name-in-module
+    FunctionCtx,
+    FunctionMeta,
+    _function_apply,
+)
 
 
 class Function(metaclass=FunctionMeta):

--- a/tests/cpu/test_autograd_function.py
+++ b/tests/cpu/test_autograd_function.py
@@ -1,6 +1,9 @@
+import importlib.machinery
+
 import pytest
 import numpy as np
 import candle as torch
+from candle._C import _autograd_function
 from candle.autograd import Function
 from candle.autograd.engine import backward, grad
 
@@ -12,6 +15,11 @@ from candle.autograd.engine import backward, grad
 def _allclose(t, expected, atol=1e-6):
     arr = t._numpy_view().flatten()
     return np.allclose(arr, expected, atol=atol)
+
+
+def test_function_meta_lives_in_compiled_c_boundary():
+    assert isinstance(_autograd_function.__loader__, importlib.machinery.ExtensionFileLoader)
+    assert type(Function).__module__ == "candle._C._autograd_function"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Move custom autograd `FunctionMeta` old/new-style forward detection into `candle._C._autograd_function`
- Keep `candle.autograd.function` as a thin public surface that imports the compiled metaclass
- Add a CPU contract check that `Function` uses the compiled metaclass boundary

## Test plan
- [x] `conda run -n candle311 python setup.py build_ext --inplace`
- [x] `conda run -n candle311 python -m pytest tests/cpu/test_autograd_function.py -q --tb=short`
- [x] `conda run -n candle311 python -m pytest tests/cpu/ tests/contract/ -q --tb=short`
- [x] `pylint src/candle/ --rcfile=.github/pylint.conf`
- [x] `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
