### PR TITLE
refactor(autograd): move once_differentiable into Cython

### DIFF
--- a/src/candle/_C/_autograd_function.pyx
+++ b/src/candle/_C/_autograd_function.pyx
@@ -23,6 +23,13 @@ class FunctionMeta(type):
         else:
             cls._new_style = False
 
+
+def once_differentiable(fn):
+    def wrapper(*args, **kwargs):
+        return fn(*args, **kwargs)
+
+    return wrapper
+
 cdef class FunctionCtx:
     """Context object passed to Function.forward() for saving state needed by backward()."""
     cdef public object _to_save

--- a/src/candle/autograd/function.py
+++ b/src/candle/autograd/function.py
@@ -2,6 +2,7 @@ from .._C._autograd_function import (  # pylint: disable=import-error,no-name-in
     FunctionCtx,
     FunctionMeta,
     _function_apply,
+    once_differentiable,
 )
 
 
@@ -30,10 +31,3 @@ class Function(metaclass=FunctionMeta):
 
 class InplaceFunction(Function):
     pass
-
-
-def once_differentiable(fn):
-    def wrapper(*args, **kwargs):
-        return fn(*args, **kwargs)
-
-    return wrapper

--- a/tests/cpu/test_autograd_function.py
+++ b/tests/cpu/test_autograd_function.py
@@ -4,7 +4,7 @@ import pytest
 import numpy as np
 import candle as torch
 from candle._C import _autograd_function
-from candle.autograd import Function
+from candle.autograd import Function, function
 from candle.autograd.engine import backward, grad
 
 
@@ -20,6 +20,10 @@ def _allclose(t, expected, atol=1e-6):
 def test_function_meta_lives_in_compiled_c_boundary():
     assert isinstance(_autograd_function.__loader__, importlib.machinery.ExtensionFileLoader)
     assert type(Function).__module__ == "candle._C._autograd_function"
+
+
+def test_once_differentiable_lives_in_compiled_c_boundary():
+    assert function.once_differentiable.__module__ == "candle._C._autograd_function"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Move `once_differentiable` from the Python autograd Function surface into `candle._C._autograd_function`
- Re-export it from `candle.autograd.function` to keep the public surface unchanged and thin
- Add a boundary regression test that prevents moving the decorator back to Python

## Test plan
- [x] `conda run -n candle311 python setup.py build_ext --inplace`
- [x] `conda run -n candle311 python -m pytest tests/cpu/test_autograd_function.py -q --tb=short`
- [x] `conda run -n candle311 python -m pytest tests/cpu/ tests/contract/ -q --tb=short`
- [x] `conda run -n candle311 pylint src/candle/ --rcfile=.github/pylint.conf`
- [x] `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
