### PR TITLE
refactor(autograd): move anomaly helpers into Cython

### DIFF
--- a/src/candle/_C/_autograd_engine.pyx
+++ b/src/candle/_C/_autograd_engine.pyx
@@ -3,7 +3,11 @@
 
 from collections import deque
 from contextlib import nullcontext
+import sys
 import threading
+import traceback
+import warnings
+import weakref
 
 from candle.autograd.grad_mode import no_grad
 
@@ -82,6 +86,56 @@ def pop_evaluating_node():
     return stack.pop()
 
 
+def annotate_node_creation(node):
+    if not is_anomaly_enabled():
+        return
+    parent = current_anomaly_parent()
+    node._anomaly_parent = None if parent is None else weakref.ref(parent)
+    frames = traceback.format_stack()
+    if len(frames) > 1:
+        frames = frames[:len(frames) - 1]
+    node._anomaly_trace = "".join(frames)
+
+
+def _warn_or_stderr(message):
+    try:
+        warnings.warn(message, UserWarning)
+    except Warning as exc:
+        print(f"{type(exc).__name__}: {exc}", file=sys.stderr)
+
+
+def _node_trace_message(node, *, previous):
+    trace = getattr(node, "_anomaly_trace", None)
+    node_name = node.name()
+    if previous:
+        prefix = f"\nPrevious calculation was induced by {node_name}. "
+        if trace:
+            return prefix + "Traceback of forward call that induced the previous calculation:\n" + trace
+        return prefix + (
+            "No forward pass information available. Enable detect anomaly during forward pass for more information."
+        )
+    prefix = f"Error detected in {node_name}. "
+    if trace:
+        return prefix + "Traceback of forward call that caused the error:\n" + trace
+    return prefix + (
+        "No forward pass information available. Enable detect anomaly during forward pass for more information."
+    )
+
+
+def report_anomaly(node):
+    if not is_anomaly_enabled():
+        return
+    seen = set()
+    current = node
+    previous = False
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        _warn_or_stderr(_node_trace_message(current, previous=previous))
+        parent_ref = getattr(current, "_anomaly_parent", None)
+        current = None if parent_ref is None else parent_ref()
+        previous = True
+
+
 def _grad_has_nan(grad):
     if grad is None:
         return False
@@ -98,7 +152,6 @@ cdef void _check_anomaly_nan(object node, object grads, bint check_nan):
         return
     for idx, grad in enumerate(grads):
         if _grad_has_nan(grad):
-            from candle.autograd.anomaly_mode import report_anomaly
             report_anomaly(node)
             raise RuntimeError(
                 f"Function '{node.name()}' returned nan values in its {idx}th output."
@@ -242,7 +295,6 @@ cdef class _GraphTask:
                 try:
                     grads = node.backward(grad)
                 except Exception:
-                    from candle.autograd.anomaly_mode import report_anomaly
                     report_anomaly(node)
                     raise
                 finally:

--- a/src/candle/_C/_autograd_function.pyx
+++ b/src/candle/_C/_autograd_function.pyx
@@ -87,7 +87,7 @@ def _function_apply(cls, args, kwargs):
     from candle._tensor import Tensor
     from candle.autograd.grad_mode import is_grad_enabled
     from candle._C._autograd_node import Node, InputMetadata
-    from candle.autograd.anomaly_mode import annotate_node_creation
+    from candle._C._autograd_engine import annotate_node_creation
 
     cdef tuple needs_input_grad = tuple(
         isinstance(a, Tensor) and a.requires_grad for a in args

--- a/src/candle/_C/_autograd_ops.pyx
+++ b/src/candle/_C/_autograd_ops.pyx
@@ -55,7 +55,7 @@ def _backward_dispatch_keyset(raw_keyset, autograd_keyset):
 def _autograd_unary_passthrough(name):
     """Wrapper factory for ops that just pass through to device and record grad_fn."""
     from candle.autograd.grad_mode import GradMode
-    from candle.autograd.anomaly_mode import annotate_node_creation
+    from candle._C._autograd_engine import annotate_node_creation
     from candle._dispatch.dispatcher import current_dispatch_keyset, redispatch
     from candle._C._autograd_node import Node
 
@@ -83,7 +83,7 @@ def _autograd_unary_passthrough(name):
 def _autograd_binary(name, backward_impl, *, save_inputs=True):
     """Wrapper factory for binary ops (two tensor inputs, no extra args)."""
     from candle.autograd.grad_mode import GradMode
-    from candle.autograd.anomaly_mode import annotate_node_creation
+    from candle._C._autograd_engine import annotate_node_creation
     from candle._dispatch.dispatcher import current_dispatch_keyset, redispatch
     from candle._C._autograd_node import Node
 
@@ -121,7 +121,7 @@ def _autograd_binary(name, backward_impl, *, save_inputs=True):
 def _autograd_binary_args(name, backward_impl, *, save_inputs=True):
     """Wrapper factory for binary ops with extra positional/keyword args."""
     from candle.autograd.grad_mode import GradMode
-    from candle.autograd.anomaly_mode import annotate_node_creation
+    from candle._C._autograd_engine import annotate_node_creation
     from candle._dispatch.dispatcher import current_dispatch_keyset, redispatch
     from candle._C._autograd_node import Node
 
@@ -157,7 +157,7 @@ def _autograd_binary_args(name, backward_impl, *, save_inputs=True):
 def _autograd_unary_args(name, backward_impl, *, cpu_only=False, save_input=True):
     """Wrapper factory for unary ops with extra positional/keyword args."""
     from candle.autograd.grad_mode import GradMode
-    from candle.autograd.anomaly_mode import annotate_node_creation
+    from candle._C._autograd_engine import annotate_node_creation
     from candle._dispatch.dispatcher import current_dispatch_keyset, redispatch
     from candle._C._autograd_node import Node
 
@@ -213,7 +213,7 @@ def _autograd_norm(name, backward_impl):
     Also tracks weight and bias as Node inputs so their gradients propagate.
     """
     from candle.autograd.grad_mode import GradMode
-    from candle.autograd.anomaly_mode import annotate_node_creation
+    from candle._C._autograd_engine import annotate_node_creation
     from candle._dispatch.dispatcher import current_dispatch_keyset, redispatch
     from candle._C._autograd_node import Node
 

--- a/src/candle/autograd/anomaly_mode.py
+++ b/src/candle/autograd/anomaly_mode.py
@@ -1,17 +1,15 @@
 import contextlib
-import sys
-import traceback
 import warnings
-import weakref
 
 from .._C._autograd_engine import (  # pylint: disable=import-error,no-name-in-module
-    current_anomaly_parent,
+    annotate_node_creation,
     is_anomaly_check_nan_enabled,
     is_anomaly_enabled,
     pop_anomaly_config,
     pop_evaluating_node,
     push_anomaly_config,
     push_evaluating_node,
+    report_anomaly,
 )
 
 
@@ -57,50 +55,3 @@ def evaluating_node(node):
         yield
     finally:
         pop_evaluating_node()
-
-
-def annotate_node_creation(node):
-    if not is_anomaly_enabled():
-        return
-    parent = current_anomaly_parent()
-    node._anomaly_parent = None if parent is None else weakref.ref(parent)
-    node._anomaly_trace = "".join(traceback.format_stack()[:-2])
-
-
-def _warn_or_stderr(message):
-    try:
-        warnings.warn(message, UserWarning)
-    except Warning as exc:
-        print(f"{type(exc).__name__}: {exc}", file=sys.stderr)
-
-
-def _node_trace_message(node, *, previous):
-    trace = getattr(node, "_anomaly_trace", None)
-    node_name = node.name()
-    if previous:
-        prefix = f"\nPrevious calculation was induced by {node_name}. "
-        if trace:
-            return prefix + "Traceback of forward call that induced the previous calculation:\n" + trace
-        return prefix + (
-            "No forward pass information available. Enable detect anomaly during forward pass for more information."
-        )
-    prefix = f"Error detected in {node_name}. "
-    if trace:
-        return prefix + "Traceback of forward call that caused the error:\n" + trace
-    return prefix + (
-        "No forward pass information available. Enable detect anomaly during forward pass for more information."
-    )
-
-
-def report_anomaly(node):
-    if not is_anomaly_enabled():
-        return
-    seen = set()
-    current = node
-    previous = False
-    while current is not None and id(current) not in seen:
-        seen.add(id(current))
-        _warn_or_stderr(_node_trace_message(current, previous=previous))
-        parent_ref = getattr(current, "_anomaly_parent", None)
-        current = None if parent_ref is None else parent_ref()
-        previous = True

--- a/src/candle/library.py
+++ b/src/candle/library.py
@@ -338,7 +338,7 @@ class CustomOpHandle:
         def autograd_wrapper(*args, **kwargs):
             from .autograd.function import FunctionCtx
             from .autograd.node import Node
-            from .autograd.anomaly_mode import annotate_node_creation
+            from ._C._autograd_engine import annotate_node_creation  # pylint: disable=import-error,no-name-in-module
             from .autograd.grad_mode import is_grad_enabled
             from ._dispatch.dispatcher import redispatch, current_dispatch_keyset
             from ._tensor import Tensor

--- a/tests/cpu/test_autograd_function.py
+++ b/tests/cpu/test_autograd_function.py
@@ -3,7 +3,7 @@ import importlib.machinery
 import pytest
 import numpy as np
 import candle as torch
-from candle._C import _autograd_function
+from candle._C import _autograd_engine, _autograd_function
 from candle.autograd import Function, function
 from candle.autograd.engine import backward, grad
 
@@ -24,6 +24,15 @@ def test_function_meta_lives_in_compiled_c_boundary():
 
 def test_once_differentiable_lives_in_compiled_c_boundary():
     assert function.once_differentiable.__module__ == "candle._C._autograd_function"
+
+
+def test_anomaly_helpers_live_in_compiled_c_boundary():
+    import candle.autograd.anomaly_mode as anomaly_mode
+
+    assert anomaly_mode.annotate_node_creation.__module__ == "candle._C._autograd_engine"
+    assert anomaly_mode.report_anomaly.__module__ == "candle._C._autograd_engine"
+    assert anomaly_mode.annotate_node_creation is _autograd_engine.annotate_node_creation
+    assert anomaly_mode.report_anomaly is _autograd_engine.report_anomaly
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Move anomaly trace annotation and reporting helpers into `candle._C._autograd_engine`
- Keep `candle.autograd.anomaly_mode` focused on public context-manager surface and re-export compiled helpers
- Update autograd Cython/custom-op call sites to use the compiled anomaly helpers directly

## Test plan
- [x] `conda run -n candle311 python setup.py build_ext --inplace`
- [x] `conda run -n candle311 python -m pytest tests/cpu/test_autograd_function.py tests/cpu/test_autograd_inplace.py tests/contract/test_autograd_engine_topo.py tests/contract/test_autograd_contract.py -q --tb=short`
- [x] `conda run -n candle311 python -m pytest tests/cpu/ tests/contract/ -q --tb=short`
- [x] `conda run -n candle311 pylint src/candle/ --rcfile=.github/pylint.conf`
- [x] `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
