### PR TITLE
refactor(autograd): move profiler shims into Cython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,10 @@ if _system in ("Linux", "Darwin"):
             ["src/candle/_C/_autograd_ops.pyx"],
         ),
         Extension(
+            "candle._C._autograd_profiler",
+            ["src/candle/_C/_autograd_profiler.pyx"],
+        ),
+        Extension(
             "candle._C._autograd_utils",
             ["src/candle/_C/_autograd_utils.pyx"],
         ),

--- a/src/candle/_C/_autograd_profiler.pyx
+++ b/src/candle/_C/_autograd_profiler.pyx
@@ -1,0 +1,22 @@
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""Cython-owned autograd profiler compatibility shims."""
+
+from contextlib import contextmanager
+
+
+def emit_itt(*args, **kwargs):  # noqa: ARG001
+    return None
+
+
+def emit_nvtx(*args, **kwargs):  # noqa: ARG001
+    return None
+
+
+@contextmanager
+def profile(*args, **kwargs):  # noqa: ARG001
+    yield None
+
+
+@contextmanager
+def record_function(*args, **kwargs):  # noqa: ARG001
+    yield None

--- a/src/candle/autograd/profiler.py
+++ b/src/candle/autograd/profiler.py
@@ -1,19 +1,6 @@
-from contextlib import contextmanager
-
-
-def emit_itt(*args, **kwargs):  # noqa: ARG001
-    return None
-
-
-def emit_nvtx(*args, **kwargs):  # noqa: ARG001
-    return None
-
-
-@contextmanager
-def profile(*args, **kwargs):  # noqa: ARG001
-    yield None
-
-
-@contextmanager
-def record_function(*args, **kwargs):  # noqa: ARG001
-    yield None
+from .._C._autograd_profiler import (  # pylint: disable=import-error,no-name-in-module
+    emit_itt,
+    emit_nvtx,
+    profile,
+    record_function,
+)

--- a/tests/cpu/test_profiler.py
+++ b/tests/cpu/test_profiler.py
@@ -1,3 +1,12 @@
+def test_autograd_profiler_shims_live_in_compiled_c_boundary():
+    import candle.autograd.profiler as autograd_profiler
+
+    assert autograd_profiler.emit_itt.__module__ == "candle._C._autograd_profiler"
+    assert autograd_profiler.emit_nvtx.__module__ == "candle._C._autograd_profiler"
+    assert autograd_profiler.profile.__module__ == "candle._C._autograd_profiler"
+    assert autograd_profiler.record_function.__module__ == "candle._C._autograd_profiler"
+
+
 import inspect
 import os
 import json


### PR DESCRIPTION
## Summary
- Move autograd profiler compatibility shims into new compiled `_C._autograd_profiler`
- Keep `candle.autograd.profiler` as a thin public re-export
- Add a boundary regression test that keeps the autograd profiler shim surface on the compiled side

## Test plan
- [x] `conda run -n candle311 python setup.py build_ext --inplace`
- [x] `conda run -n candle311 python -m pytest tests/cpu/test_profiler.py -q --tb=short`
- [x] `conda run -n candle311 python -m pytest tests/cpu/test_profiler.py tests/cpu/test_autograd_function.py tests/contract/test_autograd_contract.py -q --tb=short`
- [x] `conda run -n candle311 python -m pytest tests/cpu/ tests/contract/ -q --tb=short`
- [x] `conda run -n candle311 pylint src/candle/ --rcfile=.github/pylint.conf`
- [x] `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
