### PR TITLE
fix autograd grad leaf semantics

### DIFF
--- a/src/candle/_C/_autograd_engine.pyx
+++ b/src/candle/_C/_autograd_engine.pyx
@@ -200,12 +200,12 @@ cdef class _GraphTask:
             return nullcontext()
         return no_grad()
 
-    def _accumulate_tensor_grad(self, tensor, grad):
+    def _accumulate_tensor_grad(self, tensor, grad, mark_create_graph=True, apply_hooks=True):
         cdef bint should_touch_leaf
         cdef object acc_node
         cdef bint should_accumulate_into_grad
         cdef object prev
-        cdef bint preserve_reference
+        cdef object stored_grad
 
         should_touch_leaf = (
             self.inputs is None or tensor.grad_fn is not None or id(tensor) in self.input_ids
@@ -213,11 +213,12 @@ cdef class _GraphTask:
         if not should_touch_leaf:
             return grad
 
-        grad = _apply_hooks(tensor, grad)
+        if apply_hooks:
+            grad = _apply_hooks(tensor, grad)
         acc_node = getattr(tensor, "_accumulate_grad_node", None)
         if acc_node is not None:
             grad = acc_node.apply_prehooks(grad)
-        if self.create_graph and grad is not None:
+        if mark_create_graph and self.create_graph and grad is not None:
             grad.requires_grad = True
         should_accumulate_into_grad = (
             self.accumulate_grad and (
@@ -229,7 +230,12 @@ cdef class _GraphTask:
         if should_accumulate_into_grad:
             if tensor.grad_fn is None or getattr(tensor, "_retain_grad", False):
                 if tensor.grad is None:
-                    tensor.grad = grad
+                    if tensor.grad_fn is None:
+                        stored_grad = grad.clone()
+                        stored_grad.requires_grad = False
+                        tensor.grad = stored_grad
+                    else:
+                        tensor.grad = grad
                 else:
                     preserve_reference = not self.create_graph
                     if getattr(tensor.grad, "is_sparse", False) and not getattr(grad, "is_sparse", False):
@@ -421,6 +427,7 @@ def _run_backward(
     accumulate_grad,
     inputs=None,
     allow_unused=False,
+    materialize_grads=False,
 ):
     cdef _GraphTask task = _GraphTask(
         _build_dependencies(outputs, inputs),
@@ -442,7 +449,12 @@ def _run_backward(
                 continue
             grad = _apply_hooks(out, grad)
             if out.grad_fn is None:
-                task._accumulate_tensor_grad(out, grad)
+                task._accumulate_tensor_grad(
+                    out,
+                    grad,
+                    mark_create_graph=False,
+                    apply_hooks=False,
+                )
             else:
                 task._accumulate_node_grad(out.grad_fn, grad)
         task.run()
@@ -454,10 +466,16 @@ def _run_backward(
     results = []
     for inp in inputs:
         grad_val = task.grads_map.get(inp)
-        if grad_val is None and not allow_unused:
-            raise RuntimeError(
-                "One of the differentiated Tensors appears to not have been used in the graph."
-            )
+        if grad_val is None:
+            if materialize_grads:
+                from candle._functional import zeros_like
+                grad_val = zeros_like(inp)
+                if create_graph:
+                    grad_val.requires_grad = True
+            elif not allow_unused:
+                raise RuntimeError(
+                    "One of the differentiated Tensors appears to not have been used in the graph."
+                )
         results.append(grad_val)
     return tuple(results)
 
@@ -480,19 +498,36 @@ def backward(tensor, grad=None, retain_graph=False, create_graph=False, inputs=N
     )
 
 
-def grad(outputs, inputs, grad_outputs=None, retain_graph=None, create_graph=False, allow_unused=False):
+def grad(
+    outputs,
+    inputs,
+    grad_outputs=None,
+    retain_graph=None,
+    create_graph=False,
+    allow_unused=None,
+    materialize_grads=False,
+):
     cdef object outs
     cdef object ins
+    materialize_grads = bool(materialize_grads)
+    if materialize_grads:
+        if allow_unused is False:
+            raise ValueError(
+                "Expected allow_unused to be True or not passed when "
+                "materialize_grads=True, but got: allow_unused=False."
+            )
+        allow_unused = True
+    elif allow_unused is None:
+        allow_unused = False
     if retain_graph is None:
         retain_graph = create_graph
     outs = outputs if isinstance(outputs, (tuple, list)) else (outputs,)
     ins = inputs if isinstance(inputs, (tuple, list)) else (inputs,)
-    if all(out.grad_fn is None and not out.requires_grad for out in outs):
-        if allow_unused:
-            return tuple(None for _ in ins)
-        raise RuntimeError(
-            "element 0 of tensors does not require grad and does not have a grad_fn"
-        )
+    for i, out in enumerate(outs):
+        if out.grad_fn is None and not out.requires_grad:
+            raise RuntimeError(
+                f"element {i} of tensors does not require grad and does not have a grad_fn"
+            )
     if grad_outputs is None:
         grad_outputs = []
         for out in outs:
@@ -504,6 +539,14 @@ def grad(outputs, inputs, grad_outputs=None, retain_graph=None, create_graph=Fal
         grad_outputs = grad_outputs if isinstance(grad_outputs, (tuple, list)) else (grad_outputs,)
         if len(grad_outputs) != len(outs):
             raise RuntimeError("grad_outputs must be the same length as outputs")
+    if (
+        len(outs) == 1
+        and len(ins) == 1
+        and outs[0] is ins[0]
+        and outs[0].grad_fn is None
+        and grad_outputs[0] is not None
+    ):
+        return (_apply_hooks(outs[0], grad_outputs[0]),)
     return _run_backward(
         outs,
         grad_outputs,
@@ -512,4 +555,5 @@ def grad(outputs, inputs, grad_outputs=None, retain_graph=None, create_graph=Fal
         accumulate_grad=False,
         inputs=ins,
         allow_unused=allow_unused,
+        materialize_grads=materialize_grads,
     )

--- a/tests/cpu/test_autograd_api.py
+++ b/tests/cpu/test_autograd_api.py
@@ -51,13 +51,26 @@ def test_detach_inplace():
 def test_register_hook_receives_grad():
     t = torch.ones((2,))
     t.requires_grad_(True)
-    seen = {}
+    seen = []
+
     def hook(grad):
-        seen["grad"] = grad.numpy().tolist()
+        seen.append(grad.numpy().tolist())
         return grad
+
     t.register_hook(hook)
     t.sum().backward()
-    assert seen["grad"] == [1.0, 1.0]
+    assert seen == [[1.0, 1.0]]
+
+
+def test_backward_leaf_output_copies_input_grad_tensor():
+    x = torch.tensor([2.0], requires_grad=True)
+    grad = torch.tensor([3.0], requires_grad=True)
+
+    x.backward(grad)
+
+    assert x.grad.tolist() == [3.0]
+    assert x.grad is not grad
+    assert x.grad.requires_grad is False
 
 
 def test_autograd_grad_basic():
@@ -68,11 +81,100 @@ def test_autograd_grad_basic():
     assert gx.numpy().tolist() == [2.0, 2.0]
 
 
+def test_autograd_grad_leaf_identity_applies_hooks_once():
+    x = torch.tensor([2.0], requires_grad=True)
+    grad = torch.tensor([3.0])
+    seen = []
+
+    def hook(g):
+        seen.append(g.tolist())
+        return g
+
+    x.register_hook(hook)
+
+    (gx,) = torch.autograd.grad(x, (x,), grad_outputs=grad)
+
+    assert gx.tolist() == [3.0]
+    assert seen == [[3.0]]
+
+
+def test_autograd_grad_leaf_identity_create_graph_keeps_grad_flag():
+    x = torch.tensor([2.0], requires_grad=True)
+    grad = torch.tensor([3.0])
+
+    (gx,) = torch.autograd.grad(x, (x,), grad_outputs=grad, create_graph=True)
+
+    assert gx.tolist() == [3.0]
+    assert gx.requires_grad is False
+
+
 def test_autograd_grad_allow_unused():
     x = torch.ones((2,))
     x.requires_grad_(True)
-    y = torch.ones((1,))
+    unused = torch.ones((2,))
+    unused.requires_grad_(True)
+    y = x.sum()
     with pytest.raises(RuntimeError):
-        torch.autograd.grad(y, (x,))
-    gx = torch.autograd.grad(y, (x,), allow_unused=True)[0]
+        torch.autograd.grad(y, (unused,))
+
+    x = torch.ones((2,))
+    x.requires_grad_(True)
+    unused = torch.ones((2,))
+    unused.requires_grad_(True)
+    y = x.sum()
+    gx = torch.autograd.grad(y, (unused,), allow_unused=True)[0]
     assert gx is None
+
+
+def test_autograd_grad_allow_unused_still_rejects_outputs_without_grad():
+    x = torch.ones((2,))
+    x.requires_grad_(True)
+    y = torch.ones((1,))
+
+    with pytest.raises(RuntimeError, match="does not require grad"):
+        torch.autograd.grad(y, (x,), allow_unused=True)
+
+
+def test_autograd_grad_rejects_mixed_outputs_without_grad():
+    x = torch.ones((1,))
+    x.requires_grad_(True)
+    y = x.sum()
+    z = torch.ones((1,))
+
+    with pytest.raises(RuntimeError, match="element 1 of tensors does not require grad"):
+        torch.autograd.grad((y, z), (x,), grad_outputs=(torch.ones_like(y), torch.ones_like(z)))
+
+
+def test_autograd_grad_materialize_grads_returns_zeros_for_unused_input():
+    a = torch.tensor([2.0], requires_grad=True)
+    b = torch.tensor([5.0], requires_grad=True)
+    out = (a * a).sum()
+
+    grad_a, grad_b = torch.autograd.grad(out, (a, b), materialize_grads=True)
+
+    assert grad_a is not None
+    assert grad_a.tolist() == [4.0]
+    assert grad_b is not None
+    assert grad_b.tolist() == [0.0]
+    assert grad_b.requires_grad is False
+
+
+def test_autograd_grad_materialize_grads_create_graph_requires_grad():
+    a = torch.tensor([2.0], requires_grad=True)
+    b = torch.tensor([5.0], requires_grad=True)
+    out = (a * a).sum()
+
+    grad_a, grad_b = torch.autograd.grad(out, (a, b), create_graph=True, materialize_grads=True)
+
+    assert grad_a.requires_grad is True
+    assert grad_b.tolist() == [0.0]
+    assert grad_b.requires_grad is True
+
+
+def test_autograd_grad_materialize_grads_rejects_allow_unused_false():
+    a = torch.tensor([2.0], requires_grad=True)
+    b = torch.tensor([5.0], requires_grad=True)
+    out = (a * a).sum()
+
+    with pytest.raises(ValueError, match="allow_unused"):
+        torch.autograd.grad(out, (a, b), materialize_grads=True, allow_unused=False)


### PR DESCRIPTION
## Summary
- align `autograd.grad` with torch for `materialize_grads`, `allow_unused`, and no-grad output validation
- fix leaf hook/identity-gradient handling so leaf-output hooks fire once and simple leaf `autograd.grad` skips unnecessary engine setup
- make leaf `backward(grad)` store a copied `.grad` tensor instead of aliasing the caller-provided gradient

## Test plan
- [x] `PYTHONPATH="$PWD/src" conda run -n candle311 python -m pytest tests/cpu/test_autograd_api.py tests/contract/test_autograd_engine_topo.py tests/contract/test_autograd_create_graph.py tests/cpu/test_autograd_function.py -q --tb=short`
- [x] `PYTHONPATH="$PWD/src" conda run -n candle311 python -m pytest tests/cpu/ tests/contract/ -q --tb=short`
- [x] `PYTHONPATH="$PWD/src" conda run -n candle311 pylint src/candle/ --rcfile=.github/pylint.conf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
