### PR TITLE
refactor(autograd): unify custom-op autograd runtime in Cython

### DIFF
--- a/src/candle/_C/_autograd_function.pyx
+++ b/src/candle/_C/_autograd_function.pyx
@@ -212,6 +212,118 @@ def _function_apply(cls, args, kwargs):
     return output
 
 
+def _apply_custom_op_autograd(backward_fn, args, output, *, setup_context=None, name=None):
+    import weakref
+
+    from candle._tensor import Tensor
+    from candle._C._autograd_node import Node, InputMetadata
+    from candle._C._autograd_engine import annotate_node_creation
+
+    cdef FunctionCtx ctx = FunctionCtx()
+    ctx._needs_input_grad = tuple(
+        isinstance(a, Tensor) and a.requires_grad for a in args
+    )
+
+    if setup_context is not None:
+        setup_context(ctx, args, output)
+
+    cdef set dirty = ctx._dirty
+    cdef object dirty_obj
+    cdef set seen_dirty_ids
+    cdef object dirty_id
+    if dirty:
+        seen_dirty_ids = set()
+        for dirty_obj in args:
+            if isinstance(dirty_obj, Tensor) and id(dirty_obj) in dirty:
+                dirty_id = id(dirty_obj)
+                if dirty_id in seen_dirty_ids:
+                    continue
+                dirty_obj._bump_version()
+                seen_dirty_ids.add(dirty_id)
+
+    cdef list input_tensors = [a for a in args if isinstance(a, Tensor) and a.requires_grad]
+    cdef bint materialize = ctx._materialize_grads
+    cdef set non_diff = ctx._non_differentiable
+    cdef object o
+    cdef object node
+    cdef object node_holder
+    cdef object first_saved_list = None
+    cdef tuple outputs
+    cdef list differentiable_outputs = []
+    cdef int diff_index
+    cdef object node_name = name or f"{getattr(backward_fn, '__name__', 'CustomOp')}Backward"
+
+    if isinstance(output, Tensor):
+        def _backward(grad):
+            if materialize and grad is None:
+                from candle._functional import zeros_like
+                grad = zeros_like(output)
+            return backward_fn(ctx, grad)
+
+        node = Node(_backward, input_tensors, name=node_name)
+        annotate_node_creation(node)
+        node._input_metadata = [InputMetadata(t) for t in input_tensors]
+
+        if ctx._to_save is not None:
+            node.save_for_backward(*ctx._to_save)
+            ctx._saved_tensors = node._saved_tensors_list
+
+        _mark_output(output, non_diff, node, Tensor, 0)
+        return output
+
+    if isinstance(output, tuple):
+        outputs = output
+        for o in outputs:
+            if isinstance(o, Tensor) and id(o) not in non_diff:
+                differentiable_outputs.append(o)
+
+        for diff_index, o in enumerate(differentiable_outputs):
+            node_holder = {}
+
+            def _backward(grad, _output=o, _diff_index=diff_index, _diff_outputs=tuple(differentiable_outputs), _node_holder=node_holder):
+                cdef list backward_grads
+                cdef int i
+                cdef object _node
+                if materialize and grad is None:
+                    from candle._functional import zeros_like
+                    grad = zeros_like(_output)
+                backward_grads = []
+                for i, _out in enumerate(_diff_outputs):
+                    if i == _diff_index:
+                        backward_grads.append(grad)
+                    elif materialize:
+                        from candle._functional import zeros_like
+                        backward_grads.append(zeros_like(_out))
+                    else:
+                        backward_grads.append(None)
+                if ctx._to_save is not None:
+                    _node = _node_holder["node"]
+                    ctx._saved_tensors = _node._saved_tensors_list
+                return backward_fn(ctx, *backward_grads)
+
+            node = Node(_backward, input_tensors, name=node_name)
+            annotate_node_creation(node)
+            node._input_metadata = [InputMetadata(t) for t in input_tensors]
+
+            if ctx._to_save is not None:
+                node.save_for_backward(*ctx._to_save)
+                if first_saved_list is None:
+                    first_saved_list = node._saved_tensors_list
+
+            node_holder["node"] = weakref.proxy(node)
+            _mark_output(o, non_diff, node, Tensor, diff_index)
+
+        for o in outputs:
+            if not (isinstance(o, Tensor) and id(o) not in non_diff):
+                _mark_output(o, non_diff, None, Tensor, 0)
+
+        if first_saved_list is not None:
+            ctx._saved_tensors = first_saved_list
+        return output
+
+    return output
+
+
 cdef void _mark_output(object o, set non_diff, object node, object Tensor, int output_nr=0):
     """Mark a single output tensor with grad_fn / non-differentiable."""
     cdef object view_meta

--- a/src/candle/autograd/function.py
+++ b/src/candle/autograd/function.py
@@ -1,6 +1,7 @@
 from .._C._autograd_function import (  # pylint: disable=import-error,no-name-in-module
     FunctionCtx,
     FunctionMeta,
+    _apply_custom_op_autograd,
     _function_apply,
     once_differentiable,
 )

--- a/src/candle/library.py
+++ b/src/candle/library.py
@@ -336,20 +336,16 @@ class CustomOpHandle:
         qualname = self._qualname
 
         def autograd_wrapper(*args, **kwargs):
-            from .autograd.function import FunctionCtx
-            from .autograd.node import Node
-            from ._C._autograd_engine import annotate_node_creation  # pylint: disable=import-error,no-name-in-module
+            from .autograd.function import _apply_custom_op_autograd
             from .autograd.grad_mode import is_grad_enabled
             from ._dispatch.dispatcher import redispatch, current_dispatch_keyset
             from ._tensor import Tensor
 
-            # Check if any input requires grad
             needs_grad = any(
                 isinstance(a, Tensor) and a.requires_grad
                 for a in args
             ) and is_grad_enabled()
 
-            # Strip autograd keys and redispatch
             keyset = current_dispatch_keyset()
             inner_keyset = keyset.without(_AUTOGRAD_KEYS)
             output = redispatch(qualname, inner_keyset, *args, **kwargs)
@@ -357,41 +353,13 @@ class CustomOpHandle:
             if not needs_grad:
                 return output
 
-            # Build autograd graph
-            ctx = FunctionCtx()
-            input_tensors = [a for a in args if isinstance(a, Tensor) and a.requires_grad]
-            ctx._needs_input_grad = tuple(
-                isinstance(a, Tensor) and a.requires_grad for a in args
+            return _apply_custom_op_autograd(
+                backward_fn,
+                args,
+                output,
+                setup_context=setup_context,
+                name=f"{backward_fn.__name__}Backward",
             )
-
-            if setup_context is not None:
-                setup_context(ctx, args, output)
-
-            materialize = ctx._materialize_grads
-
-            def _backward(grad):
-                if materialize and grad is None:
-                    from ._functional import zeros_like
-                    grad = zeros_like(output)
-                return backward_fn(ctx, grad)
-
-            node = Node(_backward, input_tensors, name=f"{backward_fn.__name__}Backward")
-            annotate_node_creation(node)
-
-            if ctx._to_save is not None:
-                node.save_for_backward(*ctx._to_save)
-                ctx._saved_tensors = node._saved_tensors_list
-
-            if isinstance(output, Tensor):
-                output.grad_fn = node
-                output.requires_grad = True
-            elif isinstance(output, tuple):
-                for o in output:
-                    if isinstance(o, Tensor):
-                        o.grad_fn = node
-                        o.requires_grad = True
-
-            return output
 
         # Register the autograd wrapper for all autograd dispatch keys
         for key in (DispatchKey.Autograd, DispatchKey.AutogradCPU,

--- a/tests/cpu/test_custom_op.py
+++ b/tests/cpu/test_custom_op.py
@@ -245,3 +245,74 @@ class TestRegisterAutograd:
         x = torch.tensor([3.0])  # no requires_grad
         y = no_grad_op(x)
         assert y.grad_fn is None
+
+    def test_autograd_multi_output_uses_distinct_output_slots(self):
+        @custom_op("testns::split_pair", mutates_args=(), device_types="cpu")
+        def split_pair(x: Tensor):
+            return x.clone(), x.clone()
+
+        def bwd(ctx, grad_a, grad_b):
+            if grad_a is None:
+                grad_a = torch.zeros_like(ctx.saved_tensors[0])
+            if grad_b is None:
+                grad_b = torch.zeros_like(ctx.saved_tensors[0])
+            return (grad_a + grad_b,)
+
+        def setup(ctx, inputs, output):
+            (x,) = inputs
+            ctx.save_for_backward(x)
+
+        split_pair.register_autograd(bwd, setup_context=setup)
+
+        x = torch.tensor([3.0], requires_grad=True)
+        a, b = split_pair(x)
+
+        assert a.output_nr == 0
+        assert b.output_nr == 1
+
+        backward(b.sum())
+        assert _allclose(x.grad, [1.0])
+
+    def test_autograd_mark_non_differentiable_clears_grad_fn(self):
+        @custom_op("testns::nondiff", mutates_args=(), device_types="cpu")
+        def nondiff(x: Tensor):
+            return x.clone()
+
+        def setup(ctx, inputs, output):
+            ctx.mark_non_differentiable(output)
+
+        def bwd(ctx, grad_output):
+            raise AssertionError("backward should not run for non-differentiable output")
+
+        nondiff.register_autograd(bwd, setup_context=setup)
+
+        x = torch.tensor([2.0], requires_grad=True)
+        y = nondiff(x)
+
+        assert y.grad_fn is None
+        assert y.requires_grad is False
+
+    def test_autograd_set_materialize_grads_false_preserves_none_for_missing_output_grad(self):
+        seen = {}
+
+        @custom_op("testns::pair_materialize", mutates_args=(), device_types="cpu")
+        def pair_materialize(x: Tensor):
+            return x.clone(), x.clone()
+
+        def setup(ctx, inputs, output):
+            ctx.set_materialize_grads(False)
+
+        def bwd(ctx, grad_a, grad_b):
+            seen["grad_a_is_none"] = grad_a is None
+            seen["grad_b_is_none"] = grad_b is None
+            grad_a = torch.zeros((1,)) if grad_a is None else grad_a
+            grad_b = torch.zeros((1,)) if grad_b is None else grad_b
+            return (grad_a + grad_b,)
+
+        pair_materialize.register_autograd(bwd, setup_context=setup)
+
+        x = torch.tensor([4.0], requires_grad=True)
+        a, b = pair_materialize(x)
+        backward(a.sum())
+
+        assert seen == {"grad_a_is_none": False, "grad_b_is_none": True}


### PR DESCRIPTION
## Summary
- Move the custom-op autograd Node/ctx/output-slot builder from the Python `CustomOpHandle.register_autograd()` wrapper into a new compiled helper `_apply_custom_op_autograd` in `_C/_autograd_function.pyx`.
- The compiled helper reuses the same `FunctionCtx`, `_mark_output`, multi-output slot routing, `materialize_grads` rules, and `save_for_backward` lifecycle that `Function.apply()` already uses, so custom-op autograd and standard `autograd.Function` no longer maintain divergent runtimes.
- Reduce `library.py:register_autograd()` to a thin dispatcher shell that strips autograd keys, redispatches, then calls the compiled helper.

This brings three torch contracts that the Python glue silently dropped:
- multi-output custom ops now expose distinct `_output_nr` per output and only inject grad into the matching backward slot
- `ctx.mark_non_differentiable(out)` clears `grad_fn` and `requires_grad` on that output
- `ctx.set_materialize_grads(False)` on multi-output custom ops preserves `None` for outputs without an incoming grad instead of collapsing the backward call to a single-arg form

## Test plan
- [x] `python setup.py build_ext --inplace` rebuilds `_autograd_function`
- [x] `pytest tests/cpu/test_custom_op.py` — 23 passed (includes 3 new red→green regressions and previously dropped `test_no_grad_skips_autograd`)
- [x] `pytest tests/cpu/test_autograd_function.py tests/cpu/test_autograd_api.py tests/contract/test_autograd_create_graph.py` — 52 passed
- [x] `pytest tests/cpu/ tests/contract/` — 2984 passed, 30 skipped
- [x] `pylint src/candle/ --rcfile=.github/pylint.conf` — 10.00/10
