### PR TITLE
refactor(autograd): move default JVP rules into Cython

### DIFF
--- a/src/candle/_C/_forward_ad.pyx
+++ b/src/candle/_C/_forward_ad.pyx
@@ -139,3 +139,71 @@ def unpack_dual(tensor, *, level=None):
     if level < 0:
         return unpacked_dual_type(tensor, None)
     return unpacked_dual_type(tensor, get_tangent(tensor, level))
+
+
+def _tangent_or_zero(tangent, like):
+    if tangent is None:
+        from candle._functional import zeros_like
+        return zeros_like(like)
+    return tangent
+
+
+def _unary_tangent(x, _tangents):
+    return _tangent_or_zero(_tangents[0], x)
+
+
+def _sum_jvp(x, *, _tangents, **kwargs):
+    tangent = _tangent_or_zero(_tangents[0], x)
+    dim = kwargs.get("dim")
+    keepdim = kwargs.get("keepdim", False)
+    if dim is None:
+        return tangent.sum()
+    return tangent.sum(dim=dim, keepdim=keepdim)
+
+
+def _mean_jvp(x, *, _tangents, **kwargs):
+    tangent = _tangent_or_zero(_tangents[0], x)
+    dim = kwargs.get("dim")
+    keepdim = kwargs.get("keepdim", False)
+    if dim is None:
+        return tangent.mean()
+    return tangent.mean(dim=dim, keepdim=keepdim)
+
+
+def _view_jvp(x, shape, *, _tangents):
+    tangent = _tangent_or_zero(_tangents[0], x)
+    return tangent.view(shape)
+
+
+def _reshape_jvp(x, shape, *, _tangents):
+    tangent = _tangent_or_zero(_tangents[0], x)
+    return tangent.reshape(shape)
+
+
+def _register_default_jvps():
+    register_jvp(
+        "add",
+        lambda x, y, *, _tangents: _tangent_or_zero(_tangents[0], x)
+        + _tangent_or_zero(_tangents[1], y),
+    )
+    register_jvp(
+        "mul",
+        lambda x, y, *, _tangents: _tangent_or_zero(_tangents[0], x) * y
+        + x * _tangent_or_zero(_tangents[1], y),
+    )
+    register_jvp("sum", _sum_jvp)
+    register_jvp("neg", lambda x, *, _tangents: -_unary_tangent(x, _tangents))
+    register_jvp("exp", lambda x, *, _tangents: _unary_tangent(x, _tangents) * x.exp())
+    register_jvp("sin", lambda x, *, _tangents: _unary_tangent(x, _tangents) * x.cos())
+    register_jvp("cos", lambda x, *, _tangents: -_unary_tangent(x, _tangents) * x.sin())
+    register_jvp(
+        "tanh",
+        lambda x, *, _tangents: _unary_tangent(x, _tangents)
+        * (x._ones_like() - x.tanh() * x.tanh()),
+    )
+    register_jvp("mean", _mean_jvp)
+    register_jvp("view", _view_jvp)
+    register_jvp("reshape", _reshape_jvp)
+
+
+_register_default_jvps()

--- a/src/candle/autograd/forward_ad.py
+++ b/src/candle/autograd/forward_ad.py
@@ -27,45 +27,6 @@ class UnpackedDualTensor(_UnpackedDualTensor):
     pass
 
 
-def _tangent_or_zero(tangent, like):
-    if tangent is None:
-        from .._functional import zeros_like
-        return zeros_like(like)
-    return tangent
-
-
-def _unary_tangent(x, _tangents):
-    return _tangent_or_zero(_tangents[0], x)
-
-
-def _sum_jvp(x, *, _tangents, **kwargs):
-    tangent = _tangent_or_zero(_tangents[0], x)
-    dim = kwargs.get("dim")
-    keepdim = kwargs.get("keepdim", False)
-    if dim is None:
-        return tangent.sum()
-    return tangent.sum(dim=dim, keepdim=keepdim)
-
-
-def _mean_jvp(x, *, _tangents, **kwargs):
-    tangent = _tangent_or_zero(_tangents[0], x)
-    dim = kwargs.get("dim")
-    keepdim = kwargs.get("keepdim", False)
-    if dim is None:
-        return tangent.mean()
-    return tangent.mean(dim=dim, keepdim=keepdim)
-
-
-def _view_jvp(x, shape, *, _tangents):
-    tangent = _tangent_or_zero(_tangents[0], x)
-    return tangent.view(shape)
-
-
-def _reshape_jvp(x, shape, *, _tangents):
-    tangent = _tangent_or_zero(_tangents[0], x)
-    return tangent.reshape(shape)
-
-
 set_unpacked_dual_type(UnpackedDualTensor)
 
 
@@ -81,28 +42,3 @@ __all__ = [
     "temporarily_disable",
     "get_tangent",
 ]
-
-
-register_jvp(
-    "add",
-    lambda x, y, *, _tangents: _tangent_or_zero(_tangents[0], x)
-    + _tangent_or_zero(_tangents[1], y),
-)
-register_jvp(
-    "mul",
-    lambda x, y, *, _tangents: _tangent_or_zero(_tangents[0], x) * y
-    + x * _tangent_or_zero(_tangents[1], y),
-)
-register_jvp("sum", _sum_jvp)
-register_jvp("neg", lambda x, *, _tangents: -_unary_tangent(x, _tangents))
-register_jvp("exp", lambda x, *, _tangents: _unary_tangent(x, _tangents) * x.exp())
-register_jvp("sin", lambda x, *, _tangents: _unary_tangent(x, _tangents) * x.cos())
-register_jvp("cos", lambda x, *, _tangents: -_unary_tangent(x, _tangents) * x.sin())
-register_jvp(
-    "tanh",
-    lambda x, *, _tangents: _unary_tangent(x, _tangents)
-    * (x._ones_like() - x.tanh() * x.tanh()),
-)
-register_jvp("mean", _mean_jvp)
-register_jvp("view", _view_jvp)
-register_jvp("reshape", _reshape_jvp)

--- a/tests/cpu/test_forward_ad_contract.py
+++ b/tests/cpu/test_forward_ad_contract.py
@@ -6,6 +6,16 @@ from candle.autograd import forward_ad
 
 
 @pytest.mark.parametrize(
+    "op_name",
+    ["add", "mul", "sum", "mean", "view", "reshape", "neg", "exp", "sin", "cos", "tanh"],
+)
+def test_forward_ad_default_jvp_rules_live_in_compiled_c_boundary(op_name):
+    rule = forward_ad.get_jvp(op_name)
+    assert rule is not None
+    assert rule.__module__ == "candle._C._forward_ad"
+
+
+@pytest.mark.parametrize(
     ("op_name", "expected_fn"),
     [
         ("neg", lambda x, tx: -tx),


### PR DESCRIPTION
## Summary

Forward-mode AD level stack, registry, dual helpers, and `make_dual` / `unpack_dual` were already compiled in `_C._forward_ad`, but the eleven default JVP callables (`add`, `mul`, `sum`, `mean`, `view`, `reshape`, `neg`, `exp`, `sin`, `cos`, `tanh`) were still constructed in the Python public shell `candle.autograd.forward_ad`.

Moving them into the same compiled boundary keeps the runtime mechanism in `_C`, leaves the Python module as a thin re-export plus the `UnpackedDualTensor` namedtuple subclass, and matches the established torch alignment direction (Python = public shell, runtime/mechanism = compiled `_C`).

## Changes

- `_C/_forward_ad.pyx`: own `_tangent_or_zero`, `_unary_tangent`, and the `_sum_jvp` / `_mean_jvp` / `_view_jvp` / `_reshape_jvp` rule callables; register all eleven default JVPs at module import via `_register_default_jvps()`.
- `autograd/forward_ad.py`: drop the helper functions and the eleven Python-side `register_jvp(...)` calls; keep only `UnpackedDualTensor`, `set_unpacked_dual_type`, the re-exports, and `__all__`.
- `tests/cpu/test_forward_ad_contract.py`: assert that every default JVP rule's `__module__` is `candle._C._forward_ad`, locking the ownership boundary.

No semantic change: the registered callables are the same expressions that lived in Python before; the contract tests for `add`, `mul`, the unary set, `mean`, `view`, and `reshape` continue to pass unchanged. Only the runtime owner moves.

## Test plan

- [x] `pytest tests/cpu/test_forward_ad.py tests/cpu/test_forward_ad_contract.py -q` → 35 passed
- [x] `pytest tests/cpu/test_autograd_api.py tests/cpu/test_autograd_function.py tests/cpu/test_custom_op.py tests/contract/test_autograd_create_graph.py -q` → 75 passed
- [x] `pytest tests/cpu/ tests/contract/ -q` → 2996 passed, 30 skipped
- [x] `pylint src/candle/ --rcfile=.github/pylint.conf` → 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)