### PR TITLE
refactor(autograd): move checkpoint node runtime into Cython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,10 @@ if _system in ("Linux", "Darwin"):
             ["src/candle/_C/_autograd_graph.pyx"],
         ),
         Extension(
+            "candle._C._autograd_checkpoint",
+            ["src/candle/_C/_autograd_checkpoint.pyx"],
+        ),
+        Extension(
             "candle._C._autograd_engine",
             ["src/candle/_C/_autograd_engine.pyx"],
         ),

--- a/src/candle/_C/_autograd_checkpoint.pyx
+++ b/src/candle/_C/_autograd_checkpoint.pyx
@@ -1,0 +1,28 @@
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""Cython-owned checkpoint autograd runtime helpers."""
+
+from candle._C._autograd_node import Node  # pylint: disable=import-error,no-name-in-module
+
+_RELEASED_SAVED_TENSORS_ERROR = (
+    "Trying to backward through the graph a second time (or directly access saved tensors after they have already been freed). "
+    "Saved intermediate values of the graph are freed when you call .backward() or autograd.grad(). "
+    "Specify retain_graph=True if you need to backward through the graph a second time or if you need to access saved tensors after calling backward."
+)
+
+
+class _CheckpointNode(Node):
+    def __init__(self, backward, inputs, recompute_saved_result):
+        super().__init__(backward, inputs)
+        self._recompute_saved_result = recompute_saved_result
+        self._checkpoint_released = False
+
+    def release_saved_tensors(self):
+        super().release_saved_tensors()
+        self._checkpoint_released = True
+
+    def __getattr__(self, name):
+        if name == "_saved_result":
+            if self._checkpoint_released:
+                raise RuntimeError(_RELEASED_SAVED_TENSORS_ERROR)
+            return self._recompute_saved_result()
+        return super().__getattr__(name)

--- a/src/candle/utils/checkpoint.py
+++ b/src/candle/utils/checkpoint.py
@@ -7,7 +7,7 @@ import warnings
 
 from ..autograd.grad_mode import no_grad, enable_grad
 from ..autograd.engine import _run_backward
-from ..autograd.node import Node
+from .._C._autograd_checkpoint import _CheckpointNode  # pylint: disable=import-error,no-name-in-module
 from . import checkpoint_state
 
 
@@ -45,28 +45,6 @@ _allowed_determinism_checks_to_fns = {
 
 class CheckpointPolicy(str, Enum):
     DEFAULT = "DEFAULT"
-
-
-class _CheckpointNode(Node):
-    def __init__(self, backward, inputs, recompute_saved_result):
-        super().__init__(backward, inputs)
-        self._recompute_saved_result = recompute_saved_result
-        self._checkpoint_released = False
-
-    def release_saved_tensors(self):
-        super().release_saved_tensors()
-        self._checkpoint_released = True
-
-    def __getattr__(self, name):
-        if name == "_saved_result":
-            if self._checkpoint_released:
-                raise RuntimeError(
-                    "Trying to backward through the graph a second time (or directly access saved tensors after they have already been freed). "
-                    "Saved intermediate values of the graph are freed when you call .backward() or autograd.grad(). "
-                    "Specify retain_graph=True if you need to backward through the graph a second time or if you need to access saved tensors after calling backward."
-                )
-            return self._recompute_saved_result()
-        return super().__getattr__(name)
 
 
 class _CheckpointEarlyStop:

--- a/tests/cpu/test_gradient_checkpoint.py
+++ b/tests/cpu/test_gradient_checkpoint.py
@@ -7,7 +7,12 @@ import numpy as np
 import candle as torch
 import candle.nn as nn
 import candle.nn.functional as F
+import candle.utils.checkpoint as checkpoint_mod
 from candle.utils.checkpoint import checkpoint, checkpoint_sequential
+
+
+def test_checkpoint_node_lives_in_compiled_c_boundary():
+    assert checkpoint_mod._CheckpointNode.__module__ == "candle._C._autograd_checkpoint"
 
 
 def _make_mlp():


### PR DESCRIPTION
## Summary

`candle.utils.checkpoint` still owned its autograd runtime node in Python: `_CheckpointNode` carried the saved-result recomputation hook and the post-backward release guard even though core `Node`, the autograd engine, custom-op autograd runtime, forward AD state, and other mechanism pieces already live under compiled `_C`.

This PR moves `_CheckpointNode` into a dedicated compiled module, `candle._C._autograd_checkpoint`, and leaves `candle.utils.checkpoint` as the public API shell. The checkpoint API and semantics stay the same; only the runtime owner changes.

## Changes

- Add `src/candle/_C/_autograd_checkpoint.pyx` with compiled-owned `_CheckpointNode`.
- Register the new Cython extension in `setup.py`.
- Remove the Python `_CheckpointNode` implementation from `src/candle/utils/checkpoint.py` and import the compiled owner instead.
- Add a contract-style test asserting `_CheckpointNode.__module__ == "candle._C._autograd_checkpoint"`.

## Notes

- Checkpoint functional behavior is covered by `tests/cpu/test_gradient_checkpoint.py`.
- Saved-result lifetime/release behavior is also covered through the existing autograd saved-tensor regression surface in the full CPU + contract suite.

## Test plan

- [x] `pytest tests/cpu/test_gradient_checkpoint.py -q` → 7 passed
- [x] `pytest tests/cpu/test_gradient_checkpoint.py tests/cpu/test_autograd_api.py tests/cpu/test_autograd_function.py tests/cpu/test_custom_op.py tests/contract/test_autograd_create_graph.py tests/contract/test_autograd_graph_node.py -q --tb=short` → 93 passed
- [x] `pytest tests/cpu/ tests/contract/ -q --tb=short` → 2986 passed, 30 skipped
- [x] `pylint src/candle/ --rcfile=.github/pylint.conf` → 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)