### PR TITLE
refactor(autograd): move anomaly_mode shell into Cython

### DIFF
--- a/src/candle/_C/_autograd_engine.pyx
+++ b/src/candle/_C/_autograd_engine.pyx
@@ -2,7 +2,7 @@
 """Cython-owned autograd backward engine and hot-path state helpers."""
 
 from collections import deque
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 import sys
 import threading
 import traceback
@@ -14,6 +14,21 @@ from candle.autograd.grad_mode import no_grad
 
 cdef object _GRAPH_STATE = threading.local()
 cdef object _ANOMALY_STATE = threading.local()
+
+
+_ANOMALY_ENABLE_WARNING = (
+    "Anomaly Detection has been enabled. This mode will increase the runtime "
+    "and should only be enabled for debugging."
+)
+
+
+class _AnomalyConfig:
+    """Internal anomaly-mode config record pushed onto the anomaly state stack."""
+    __slots__ = ("enabled", "check_nan")
+
+    def __init__(self, enabled, check_nan):
+        self.enabled = bool(enabled)
+        self.check_nan = bool(check_nan)
 
 
 cdef list _graph_task_stack():
@@ -84,6 +99,39 @@ def pop_evaluating_node():
     if not stack:
         return None
     return stack.pop()
+
+
+@contextmanager
+def detect_anomaly(check_nan=True):
+    """Enable autograd anomaly detection for the duration of the context."""
+    warnings.warn(_ANOMALY_ENABLE_WARNING, UserWarning)
+    push_anomaly_config(_AnomalyConfig(True, check_nan))
+    try:
+        yield
+    finally:
+        pop_anomaly_config()
+
+
+@contextmanager
+def set_detect_anomaly(mode, check_nan=True):
+    """Set autograd anomaly detection mode for the duration of the context."""
+    if mode:
+        warnings.warn(_ANOMALY_ENABLE_WARNING, UserWarning)
+    push_anomaly_config(_AnomalyConfig(mode, check_nan))
+    try:
+        yield
+    finally:
+        pop_anomaly_config()
+
+
+@contextmanager
+def evaluating_node(node):
+    """Mark ``node`` as the currently evaluating backward node for anomaly tracking."""
+    push_evaluating_node(node)
+    try:
+        yield
+    finally:
+        pop_evaluating_node()
 
 
 def annotate_node_creation(node):

--- a/src/candle/autograd/anomaly_mode.py
+++ b/src/candle/autograd/anomaly_mode.py
@@ -1,8 +1,15 @@
-import contextlib
-import warnings
+"""Public shell for autograd anomaly mode.
+
+The runtime owner is ``candle._C._autograd_engine``; this module is only a
+thin re-export of the user-facing context managers and helpers so existing
+``candle.autograd.anomaly_mode.detect_anomaly`` etc. callers keep working.
+"""
 
 from .._C._autograd_engine import (  # pylint: disable=import-error,no-name-in-module
+    _AnomalyConfig,
     annotate_node_creation,
+    detect_anomaly,
+    evaluating_node,
     is_anomaly_check_nan_enabled,
     is_anomaly_enabled,
     pop_anomaly_config,
@@ -10,48 +17,21 @@ from .._C._autograd_engine import (  # pylint: disable=import-error,no-name-in-m
     push_anomaly_config,
     push_evaluating_node,
     report_anomaly,
+    set_detect_anomaly,
 )
 
 
-_ENABLE_WARNING = (
-    "Anomaly Detection has been enabled. This mode will increase the runtime "
-    "and should only be enabled for debugging."
-)
-
-
-class _AnomalyConfig:
-    __slots__ = ("enabled", "check_nan")
-
-    def __init__(self, enabled, check_nan):
-        self.enabled = bool(enabled)
-        self.check_nan = bool(check_nan)
-
-
-@contextlib.contextmanager
-def detect_anomaly(check_nan=True):
-    warnings.warn(_ENABLE_WARNING, UserWarning)
-    push_anomaly_config(_AnomalyConfig(True, check_nan))
-    try:
-        yield
-    finally:
-        pop_anomaly_config()
-
-
-@contextlib.contextmanager
-def set_detect_anomaly(mode, check_nan=True):
-    if mode:
-        warnings.warn(_ENABLE_WARNING, UserWarning)
-    push_anomaly_config(_AnomalyConfig(mode, check_nan))
-    try:
-        yield
-    finally:
-        pop_anomaly_config()
-
-
-@contextlib.contextmanager
-def evaluating_node(node):
-    push_evaluating_node(node)
-    try:
-        yield
-    finally:
-        pop_evaluating_node()
+__all__ = [
+    "_AnomalyConfig",
+    "annotate_node_creation",
+    "detect_anomaly",
+    "evaluating_node",
+    "is_anomaly_check_nan_enabled",
+    "is_anomaly_enabled",
+    "pop_anomaly_config",
+    "pop_evaluating_node",
+    "push_anomaly_config",
+    "push_evaluating_node",
+    "report_anomaly",
+    "set_detect_anomaly",
+]

--- a/tests/cpu/test_autograd_function.py
+++ b/tests/cpu/test_autograd_function.py
@@ -35,6 +35,32 @@ def test_anomaly_helpers_live_in_compiled_c_boundary():
     assert anomaly_mode.report_anomaly is _autograd_engine.report_anomaly
 
 
+def test_anomaly_mode_shell_lives_in_compiled_c_boundary():
+    """The anomaly_mode public API (config + contextmanagers) should be owned
+    by the compiled boundary, not defined in the Python public shell."""
+    import candle.autograd.anomaly_mode as anomaly_mode
+
+    # _AnomalyConfig is the runtime-internal config object pushed onto the
+    # anomaly state stack; its definition belongs in the compiled module.
+    assert anomaly_mode._AnomalyConfig.__module__ == "candle._C._autograd_engine"
+
+    # The user-facing context managers must come from the compiled module too.
+    assert anomaly_mode.detect_anomaly.__module__ == "candle._C._autograd_engine"
+    assert anomaly_mode.set_detect_anomaly.__module__ == "candle._C._autograd_engine"
+    assert anomaly_mode.evaluating_node.__module__ == "candle._C._autograd_engine"
+
+
+def test_anomaly_mode_context_managers_are_reexports():
+    """anomaly_mode.detect_anomaly et al. must be the same object exposed by
+    candle._C._autograd_engine — i.e. a re-export, not a Python-defined wrapper."""
+    import candle.autograd.anomaly_mode as anomaly_mode
+
+    assert anomaly_mode.detect_anomaly is _autograd_engine.detect_anomaly
+    assert anomaly_mode.set_detect_anomaly is _autograd_engine.set_detect_anomaly
+    assert anomaly_mode.evaluating_node is _autograd_engine.evaluating_node
+    assert anomaly_mode._AnomalyConfig is _autograd_engine._AnomalyConfig
+
+
 # ---------------------------------------------------------------------------
 # 1. Old-style Function (ctx as first param)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The anomaly state stack and helpers (`push/pop_anomaly_config`, `push/pop_evaluating_node`, `annotate_node_creation`, `report_anomaly`) were already compiled-owned in `candle._C._autograd_engine`, but the user-facing context managers and the `_AnomalyConfig` record were still defined in the Python public shell `candle/autograd/anomaly_mode.py`. This batch keeps the repository-wide rule consistent: Python public surface mirrors torch 1:1, runtime/mechanism stays in compiled `_C`.

## Changes

- `_AnomalyConfig`, `detect_anomaly`, `set_detect_anomaly`, `evaluating_node` now live inside `candle/_C/_autograd_engine.pyx`, owning the warning message and stack push/pop logic.
- `candle/autograd/anomaly_mode.py` becomes a thin re-export shell.
- Add compiled-boundary ownership tests asserting `__module__ == "candle._C._autograd_engine"` for `_AnomalyConfig`, `detect_anomaly`, `set_detect_anomaly`, `evaluating_node`, plus identity re-export checks.

## Test plan

- [x] TDD red boundary tests fail before the migration.
- [x] Focused autograd suite (autograd_api / autograd_function / autograd_inplace / forward_ad / forward_ad_contract / gradient_checkpoint / autograd_create_graph) — 116 passed, 1 skipped.
- [x] Full required gate: \`pytest tests/cpu/ tests/contract/\` — 3002 passed, 30 skipped.
- [x] \`pylint src/candle/ --rcfile=.github/pylint.conf\` — rated 10.00/10.

## Out of scope

- multi-output `Function.apply` / custom-op single-node topology refactor.
- `src/candle/_backends/autograd.py` legacy Python autograd wrapper migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)