### PR TITLE
refactor(autograd): move version_counter and profiler_util shells into Cython

### DIFF
--- a/src/candle/_C/_autograd_profiler.pyx
+++ b/src/candle/_C/_autograd_profiler.pyx
@@ -20,3 +20,28 @@ def profile(*args, **kwargs):  # noqa: ARG001
 @contextmanager
 def record_function(*args, **kwargs):  # noqa: ARG001
     yield None
+
+
+# ---------------------------------------------------------------------------
+# torch.autograd.profiler_util compatibility stubs
+# ---------------------------------------------------------------------------
+# These mirror torch.autograd.profiler_util's public surface for code that
+# imports the names without doing real profiling.  Candle does not link
+# kineto / itt / nvtx, so the implementations are intentionally minimal.
+
+
+class EventList(list):
+    """torch.autograd.profiler_util.EventList compatibility stub."""
+
+
+class FunctionEvent:
+    """torch.autograd.profiler_util.FunctionEvent compatibility stub."""
+
+
+class FunctionEventAvg:
+    """torch.autograd.profiler_util.FunctionEventAvg compatibility stub."""
+
+
+def _format_time(*args, **kwargs):  # noqa: ARG001
+    """torch.autograd.profiler_util._format_time compatibility stub."""
+    return "0.0us"

--- a/src/candle/_C/_tensor_impl.pyx
+++ b/src/candle/_C/_tensor_impl.pyx
@@ -736,3 +736,19 @@ cdef class _VersionCounterProxy:
 
     cpdef void bump(self):
         self._impl._version_value += 1
+
+
+# -------------------------------------------------------------------
+# Standalone VersionCounter — used in contexts that do not have a
+# TensorImpl as a base.  Mirrors torch's Variable._version field shape.
+# -------------------------------------------------------------------
+
+class VersionCounter:
+    """Standalone version counter (used when TensorImpl is not the base)."""
+    __slots__ = ("value",)
+
+    def __init__(self, value=0):
+        self.value = int(value)
+
+    def bump(self):
+        self.value += 1

--- a/src/candle/autograd/profiler_util.py
+++ b/src/candle/autograd/profiler_util.py
@@ -1,14 +1,18 @@
-class EventList(list):
-    pass
+"""Public shell for ``candle.autograd.profiler_util``.
+
+Mirrors torch.autograd.profiler_util's public surface; the runtime owner is
+``candle._C._autograd_profiler`` (which already hosts the profiler context
+managers).  This module is only a thin re-export so that
+``candle.autograd.profiler_util.{EventList, FunctionEvent, FunctionEventAvg,
+_format_time}`` keep working.
+"""
+
+from .._C._autograd_profiler import (  # pylint: disable=import-error,no-name-in-module
+    EventList,
+    FunctionEvent,
+    FunctionEventAvg,
+    _format_time,
+)
 
 
-class FunctionEvent:
-    pass
-
-
-class FunctionEventAvg:
-    pass
-
-
-def _format_time(*args, **kwargs):  # noqa: ARG001
-    return "0.0us"
+__all__ = ["EventList", "FunctionEvent", "FunctionEventAvg", "_format_time"]

--- a/src/candle/autograd/version_counter.py
+++ b/src/candle/autograd/version_counter.py
@@ -1,17 +1,12 @@
-"""Version counter for tensor mutation tracking.
+"""Public shell for the standalone autograd ``VersionCounter``.
 
-This module provides ``VersionCounter`` for contexts that do not use
-``TensorImpl`` as a base. The ``_VersionCounterProxy`` used by
-``TensorImpl`` is provided by the compiled ``_tensor_impl`` extension.
+Mirrors torch.autograd's exposure of ``VersionCounter``; the runtime owner
+is ``candle._C._tensor_impl`` (which already hosts ``_VersionCounterProxy``
+for tensors backed by ``TensorImpl``).  This module is only a thin re-export
+so that ``candle.autograd.version_counter.VersionCounter`` keeps working.
 """
 
+from .._C._tensor_impl import VersionCounter  # pylint: disable=import-error,no-name-in-module
 
-class VersionCounter:
-    """Standalone version counter (used when TensorImpl is not the base)."""
-    __slots__ = ("value",)
 
-    def __init__(self, value=0):
-        self.value = int(value)
-
-    def bump(self):
-        self.value += 1
+__all__ = ["VersionCounter"]

--- a/tests/cpu/test_autograd_shells.py
+++ b/tests/cpu/test_autograd_shells.py
@@ -1,0 +1,51 @@
+"""Compiled-boundary ownership tests for autograd public-shell stubs.
+
+These modules — ``candle.autograd.version_counter`` and
+``candle.autograd.profiler_util`` — only host torch-compatible compatibility
+shims.  Per the repo-wide rule (Python public surface mirrors torch 1:1,
+runtime/mechanism stays in compiled ``_C``), even the stubs must be owned
+by a compiled extension, with the Python files acting as thin re-export
+shells.
+"""
+
+import importlib.machinery
+
+
+def test_version_counter_lives_in_compiled_c_boundary():
+    """VersionCounter (standalone, non-TensorImpl path) should be owned by
+    the compiled ``candle._C._tensor_impl`` extension that already hosts
+    ``_VersionCounterProxy``."""
+    from candle._C import _tensor_impl
+    from candle.autograd import version_counter as version_counter_shell
+
+    assert isinstance(_tensor_impl.__loader__, importlib.machinery.ExtensionFileLoader)
+
+    assert version_counter_shell.VersionCounter.__module__ == "candle._C._tensor_impl"
+    assert version_counter_shell.VersionCounter is _tensor_impl.VersionCounter
+
+
+def test_profiler_util_shims_live_in_compiled_c_boundary():
+    """The torch-compatible profiler_util stubs must be owned by the
+    compiled ``candle._C._autograd_profiler`` extension, not defined in
+    the Python public shell."""
+    from candle._C import _autograd_profiler
+    from candle.autograd import profiler_util as profiler_util_shell
+
+    assert isinstance(_autograd_profiler.__loader__, importlib.machinery.ExtensionFileLoader)
+
+    assert profiler_util_shell.EventList.__module__ == "candle._C._autograd_profiler"
+    assert profiler_util_shell.FunctionEvent.__module__ == "candle._C._autograd_profiler"
+    assert profiler_util_shell.FunctionEventAvg.__module__ == "candle._C._autograd_profiler"
+    assert profiler_util_shell._format_time.__module__ == "candle._C._autograd_profiler"
+
+
+def test_profiler_util_shims_are_reexports():
+    """The Python shell candle.autograd.profiler_util must hand back the
+    same compiled objects as ``candle._C._autograd_profiler``."""
+    from candle._C import _autograd_profiler
+    from candle.autograd import profiler_util as profiler_util_shell
+
+    assert profiler_util_shell.EventList is _autograd_profiler.EventList
+    assert profiler_util_shell.FunctionEvent is _autograd_profiler.FunctionEvent
+    assert profiler_util_shell.FunctionEventAvg is _autograd_profiler.FunctionEventAvg
+    assert profiler_util_shell._format_time is _autograd_profiler._format_time


### PR DESCRIPTION
## Summary

Two small autograd public-shell stubs were still owned by Python:

- `candle/autograd/version_counter.py` defined the standalone `VersionCounter` class used in contexts that do not have a `TensorImpl` as a base.
- `candle/autograd/profiler_util.py` defined the torch-compatible profiler stubs `EventList` / `FunctionEvent` / `FunctionEventAvg` / `_format_time`.

These had no internal callers but still contained Python-side class / function definitions, making them an outlier vs the repo-wide rule that runtime/mechanism — even compatibility shims — should live in compiled `_C`.

## Changes

- Add `VersionCounter` to `candle/_C/_tensor_impl.pyx` alongside the existing `_VersionCounterProxy`; semantics unchanged.
- Add `EventList`, `FunctionEvent`, `FunctionEventAvg`, `_format_time` to `candle/_C/_autograd_profiler.pyx` alongside the existing profiler context managers; semantics unchanged.
- Reduce `candle/autograd/version_counter.py` and `candle/autograd/profiler_util.py` to thin re-export shells.
- Add a new `tests/cpu/test_autograd_shells.py` with compiled-boundary ownership tests asserting `__module__ == \"candle._C._tensor_impl\"` / `\"candle._C._autograd_profiler\"` plus identity re-export checks.

## Test plan

- [x] TDD red boundary tests fail before the migration.
- [x] Focused autograd + version-counter regression suite (autograd_api / autograd_function / autograd_inplace / forward_ad / forward_ad_contract / gradient_checkpoint / autograd_shells / autograd_create_graph + functionalize / version_counter contract tests): **176 passed, 3 skipped**.
- [x] Full required gate: \`pytest tests/cpu/ tests/contract/\` — **3006 passed, 30 skipped**.
- [x] \`pylint src/candle/ --rcfile=.github/pylint.conf\` — **10.00/10**.

## Out of scope

- multi-output `Function.apply` / custom-op single-node topology refactor.
- `src/candle/_backends/autograd.py` legacy Python autograd wrapper migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)