### PR TITLE
refactor(autograd): remove dead zero_ inplace + view factory shadowed by generator

### DIFF
--- a/src/candle/_backends/autograd.py
+++ b/src/candle/_backends/autograd.py
@@ -80,30 +80,6 @@ def _autograd_unary(name, backward_impl, *, cpu_only=False, save_input=True):
     return wrapper
 
 
-def _autograd_view(name, backward_impl):
-    def wrapper(a, *args):
-        active_keyset = current_dispatch_keyset()
-        raw_keyset = _strip_autograd_keys(active_keyset)
-        out = redispatch(name, raw_keyset, a, *args)
-        if GradMode.enabled and a.requires_grad:
-            node_holder = {}
-
-            def _backward(grad):
-                saved_a = node_holder["node"].saved_tensors()[0]
-                backward_keyset = _backward_dispatch_keyset(raw_keyset, active_keyset)
-                return backward_impl(grad, a, saved_a, args, backward_keyset)
-
-            node = Node(_backward, (a,), name=f"{name.capitalize()}Backward0")
-            annotate_node_creation(node)
-            node_holder["node"] = weakref.proxy(node)
-            node.save_for_backward(a)
-            out.grad_fn = node
-            out.requires_grad = True
-        return out
-
-    return wrapper
-
-
 def _autograd_inplace(name, backward_impl, *, cpu_only=False, save_input=True):
     def wrapper(a, *args):
         active_keyset = current_dispatch_keyset()
@@ -315,12 +291,6 @@ def _inplace_relu_backward(grad, _a, saved_a, _args, keyset):
         mask = redispatch("sign", keyset, redispatch("relu", keyset, saved_a))
         grad_input = redispatch("mul", keyset, grad, mask)
         return (grad_input,)
-
-
-def _inplace_zero_backward(_grad, _a, _saved_a, _args, _keyset):
-    return (None,)
-
-
 
 
 def _contiguous_backward(grad, _a, _saved_a, _keyset):
@@ -7169,7 +7139,6 @@ for _entry in (
     ("add_", lambda: _autograd_inplace("add_", _inplace_binary_backward, save_input=True)),
     ("mul_", lambda: _autograd_inplace("mul_", _inplace_binary_backward, save_input=True)),
     ("relu_", lambda: _autograd_inplace("relu_", _inplace_relu_backward, save_input=True)),
-    ("zero_", lambda: _autograd_inplace("zero_", _inplace_zero_backward, save_input=False)),
     ("sub_", lambda: _autograd_inplace("sub_", _inplace_sub_backward, save_input=False)),
     ("div_", lambda: _autograd_inplace("div_", _inplace_div_backward, save_input=True)),
     ("clamp_", lambda: _autograd_inplace("clamp_", _inplace_clamp_backward, save_input=True)),

--- a/tests/contract/test_codegen_mps_coverage.py
+++ b/tests/contract/test_codegen_mps_coverage.py
@@ -1,0 +1,41 @@
+"""Generator-side contract: PrivateUse3 (mps autograd) is a fallthrough key.
+
+torch's autograd path on MPS does NOT use a per-op AutogradMPS kernel.  Candle
+mirrors that design via ``DispatchKey.PrivateUse3``: the dispatch core
+registers it as a global fallthrough placeholder (see
+``src/candle/_dispatch/registry.py::_register_global_fallthroughs``).  Any
+``register_autograd_kernels(name, mps=...)`` call that writes to PrivateUse3
+turns the placeholder into an active kernel and breaks fallthrough behaviour
+(seen empirically: ``div`` autograd silently returns ``None`` because the
+PrivateUse3 entry short-circuits the AutogradCPU path).
+
+This test pins generator output: the autograd codegen must NOT emit ``mps=``
+arguments for ``register_autograd_kernels``; instead MPS device autograd is
+served by the ``default`` (DispatchKey.Autograd) kernel through fallthrough.
+"""
+from tools.autograd.load_derivatives import load_derivatives
+from tools.autograd.gen_registration import gen_registration
+
+
+def test_gen_registration_does_not_register_mps_autograd():
+    """The generator must NOT write a `mps=` argument for any op.
+
+    Reasoning: ``DispatchKey.PrivateUse3`` (the mps autograd alias) is
+    registered as a fallthrough placeholder. Adding a real kernel there breaks
+    autograd dispatch on MPS — the mps device's autograd path is served by
+    the ``default`` (DispatchKey.Autograd) kernel via fallthrough.
+    """
+    infos = load_derivatives('tools/autograd/derivatives.yaml')
+    src = gen_registration(infos)
+    offenders = []
+    for line in src.splitlines():
+        line = line.strip()
+        if not line.startswith("register_autograd_kernels("):
+            continue
+        if "mps=" in line:
+            offenders.append(line)
+    assert not offenders, (
+        f"Generator emitted {len(offenders)} register_autograd_kernels(...) "
+        "calls with `mps=`. PrivateUse3 must remain a fallthrough placeholder. "
+        f"First offender: {offenders[0]}"
+    )

--- a/tests/cpu/test_autograd_zero_inplace_routing.py
+++ b/tests/cpu/test_autograd_zero_inplace_routing.py
@@ -1,0 +1,110 @@
+"""Boundary tests: in-place autograd routing for zero_ and dead-factory cleanup.
+
+These tests pin three facts after migrating ``zero_`` autograd ownership to
+the generator-driven path and removing the unused ``_autograd_view`` helper:
+
+1. ``zero_``'s autograd kernel is registered at every ACTIVE supported autograd
+   dispatch key (Autograd / AutogradCPU / AutogradCUDA / AutogradNPU /
+   AutogradMeta) and that kernel comes from the generated module
+   ``candle._generated.variable_type``.
+
+   Note: ``DispatchKey.PrivateUse3`` (the mps autograd alias) is intentionally
+   excluded — it's a global fallthrough placeholder; mps autograd flows through
+   the ``default`` (DispatchKey.Autograd) kernel rather than via a per-op mps
+   registration. See ``tests/contract/test_codegen_mps_coverage.py``.
+
+2. The dead helper ``_autograd_view`` no longer exists in
+   ``candle._backends.autograd`` (it had zero callers after the migration to
+   derivatives.yaml).
+
+3. ``zero_`` is no longer registered through the manual ``_autograd_inplace``
+   factory — its generator-supplied registration is the single source of truth.
+"""
+import candle  # noqa: F401  (initializes registry)
+
+from candle._dispatch.keys import DispatchKey
+from candle._dispatch.registry import registry
+
+
+_AUTOGRAD_KEYS_FOR_ZERO_ = (
+    DispatchKey.Autograd,
+    DispatchKey.AutogradCPU,
+    DispatchKey.AutogradCUDA,
+    DispatchKey.AutogradNPU,
+    DispatchKey.AutogradMeta,
+)
+
+
+def _entry(name):
+    return registry._entry(name)  # pylint: disable=protected-access
+
+
+def test_zero_inplace_autograd_kernel_lives_at_every_active_autograd_key():
+    entry = _entry("zero_")
+    for key in _AUTOGRAD_KEYS_FOR_ZERO_:
+        assert key in entry.kernels, (
+            f"zero_ missing autograd kernel for {key.name!r}; "
+            f"present: {sorted(k.name for k in entry.kernels)}"
+        )
+
+
+def test_zero_inplace_autograd_kernel_comes_from_generated_module():
+    entry = _entry("zero_")
+    expected_modules = {
+        "candle._generated.variable_type",
+        "candle._generated._variable_type_cy",
+    }
+    for key in _AUTOGRAD_KEYS_FOR_ZERO_:
+        fn = entry.kernels.get(key)
+        assert fn is not None, f"zero_ has no kernel at {key.name}"
+        mod = getattr(fn, "__module__", "")
+        assert mod in expected_modules, (
+            f"zero_'s autograd kernel at {key.name} is owned by {mod!r}; "
+            f"should come from {expected_modules}"
+        )
+
+
+def test_zero_inplace_does_not_register_at_mps_fallthrough_key():
+    """PrivateUse3 (mps autograd alias) must remain a fallthrough placeholder.
+
+    Even though ``zero_`` is fully covered by the generator, no kernel must be
+    written to PrivateUse3 — that key is reserved as a global fallthrough so
+    that mps autograd dispatch falls through to the ``default``
+    DispatchKey.Autograd kernel.
+    """
+    entry = _entry("zero_")
+    assert DispatchKey.PrivateUse3 not in entry.kernels, (
+        "zero_ has a kernel registered at PrivateUse3 (mps autograd alias); "
+        "that key must remain a fallthrough placeholder."
+    )
+
+
+def test_autograd_view_factory_is_removed():
+    from candle._backends import autograd as backends_autograd
+    assert not hasattr(backends_autograd, "_autograd_view"), (
+        "_autograd_view factory has zero callers and should be removed"
+    )
+
+
+def test_autograd_inplace_no_longer_registers_zero_():
+    """The Python ``_autograd_inplace('zero_', ...)`` registration is dead
+    code (overridden by the generator) and should be removed.
+    """
+    from pathlib import Path
+    src = Path("src/candle/_backends/autograd.py").read_text(encoding="utf-8")
+    assert '_autograd_inplace("zero_"' not in src, (
+        "src/candle/_backends/autograd.py still registers zero_ via the dead "
+        "_autograd_inplace factory; that registration is overridden by the "
+        "generator and should be deleted."
+    )
+
+
+def test_inplace_zero_backward_helper_is_removed():
+    """The ``_inplace_zero_backward`` helper has no callers after the
+    ``_autograd_inplace('zero_', ...)`` line is deleted; it must be removed
+    too so dead code does not accumulate.
+    """
+    from candle._backends import autograd as backends_autograd
+    assert not hasattr(backends_autograd, "_inplace_zero_backward"), (
+        "_inplace_zero_backward has no callers and must be removed"
+    )


### PR DESCRIPTION
## Summary

- ``_backends.autograd`` registered \`zero_\` autograd through ``_autograd_inplace(...)`` and then ``_generated.registration`` re-registered \`zero_\` (default/cpu/cuda/npu/meta) with the derivatives.yaml-driven ``zero__autograd`` wrapper. Because the generated pass runs after the manual loop, the Python factory's registrations were always overridden — the manual code was dead. Removed.
- ``_autograd_view`` had zero callers in the entire codebase. Removed.
- ``_inplace_zero_backward`` was only used by the dead ``zero_`` registration. Removed.

The generator-supplied wrappers (``zero__autograd`` + ``ZeroBackward0``) remain the single source of truth for \`zero_\` autograd.

## Boundary tests added

- \`zero_\` autograd kernel is registered at every active autograd dispatch key (Autograd / AutogradCPU / AutogradCUDA / AutogradNPU / AutogradMeta) and each one comes from \`candle._generated.variable_type\`.
- \`DispatchKey.PrivateUse3\` (mps autograd alias) is intentionally absent — it is a global fallthrough placeholder, mps autograd flows through the \`default\` (DispatchKey.Autograd) kernel via fallthrough, and writing a real kernel there empirically breaks autograd dispatch on MPS (verified by trying to add it).
- \`gen_registration\` must NOT emit \`mps=\` for any op (contract test).
- \`_autograd_view\` and \`_inplace_zero_backward\` are gone from \`_backends.autograd\`.
- \`_autograd_inplace("zero_", ...)\` is gone from the registration loop.

## Test plan

- [x] \`pytest tests/cpu/test_autograd_zero_inplace_routing.py tests/contract/test_codegen_mps_coverage.py\` — 7 passed
- [x] \`pytest tests/cpu/test_autograd_inplace.py tests/cpu/test_autograd_api.py tests/cpu/test_autograd_function.py tests/contract/test_autograd_create_graph.py tests/contract/test_codegen_canonical_aliases.py tests/contract/test_codegen_overload_names.py tests/contract/test_gen_registration_filter.py tests/cpu/test_declarative_autograd.py\` — 143 passed
- [x] \`pytest tests/cpu/ tests/contract/\` — 3013 passed, 30 skipped
- [x] \`pylint src/candle/ --rcfile=.github/pylint.conf\` — 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)