### PR TITLE
fix(_C): tensor_flatten/tensor_unflatten set _view_meta op for view-tracking 1B-A

### DIFF
--- a/docs/superpowers/plans/2026-05-05-view-tracking-1b-six-ops.md
+++ b/docs/superpowers/plans/2026-05-05-view-tracking-1b-six-ops.md
@@ -1,0 +1,843 @@
+# View-Tracking 1B-A: Conditional-View Forward for `contiguous`/`flatten`/`unflatten`
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `contiguous` / `flatten` / `unflatten` return a real view (or the input itself for `contiguous`) when the input is already contiguous, instead of always copying — matching PyTorch's conditional-view semantics. No autograd or codegen changes.
+
+**Architecture:** A small forward-path fix in three backends. CPU and NPU `contiguous` add a `if a.is_contiguous(): return a` short-circuit. CPU `flatten`/`unflatten` and MPS `flatten`/`unflatten` GPU paths route through `view_backend._make_view` for contiguous inputs, falling back to existing copy paths otherwise. NPU `flatten_op`/`unflatten_op` already delegate to `view_backend.reshape` and need no change. After this plan, the engine rebase block landed in PR #372 still has no live consumers — that's 1B-B's job.
+
+**Tech Stack:** Python (numpy for CPU), Metal/Cython for MPS, ctypes for NPU. View infrastructure: `src/candle/_backends/common/view.py:_make_view` and `_get_base` and `_contiguous_stride`.
+
+---
+
+## Spec reference
+
+Spec: `docs/superpowers/specs/2026-05-04-view-tracking-1b-six-ops-design.md`. Read it before starting any task.
+
+## Pre-task setup
+
+You are working inside the existing worktree at `/home/jenkins/lvyufeng/candle/.worktrees/view-tracking-1b` on branch `view-tracking-1b`. The worktree was set up by an earlier session and is already rebased onto `upstream/main`. Do NOT create a new worktree.
+
+Verify before starting:
+
+```bash
+cd /home/jenkins/lvyufeng/candle/.worktrees/view-tracking-1b
+git rev-parse --abbrev-ref HEAD   # should print: view-tracking-1b
+git status --short                # should print nothing (clean tree)
+```
+
+## File map
+
+| File | Responsibility | Action |
+|---|---|---|
+| `tests/cpu/test_view_fastpath.py` | Pin conditional-view forward semantics for the 3 ops | Create |
+| `src/candle/_backends/cpu/ops.py` | CPU forward kernels for `contiguous`, `flatten`, `unflatten` | Modify lines 1351-1364 (`contiguous`), 3058-3074 (`flatten`, `unflatten`) |
+| `src/candle/_backends/mps/ops/shape.py` | MPS GPU+CPU paths for `flatten`, `unflatten` | Modify lines 1099-1135 |
+| `src/candle/_backends/npu/ops/shape.py` | NPU `contiguous` adds fast-path | Modify lines 1428-1444 |
+
+Out of scope: any change to `_generated/`, any `view_func`/`rev_view_func` wiring, any CUDA backend file (no `_backends/cuda/ops/shape.py` for these ops).
+
+## Conventions used by this codebase
+
+- Tests live in `tests/cpu/` and import `candle as torch` (not real PyTorch).
+- Storage-share assertion idiom is `a.storage() is b.storage()` — NOT `a.storage().data_ptr() == b.storage().data_ptr()`.
+- `_make_view(base, shape, stride, offset, op_name, source=a)` — `source=a` lets it inherit `creation_kind` from the input view metadata.
+- `_get_base(a)` returns `a._base if a._base is not None else a` — always use it before passing to `_make_view`, so view-of-view chains collapse to the storage root.
+- All Python view ops in `_backends/common/view.py` already use `_get_base` + `_make_view`; the new code in this plan follows that pattern verbatim.
+- Pylint must pass on `src/candle/`. The conda env is `candle`. The pyobjc imports for MPS need `# pylint: disable=import-error`.
+
+---
+
+## Task 1: Red tests for the conditional-view fast-path
+
+**Files:**
+- Create: `tests/cpu/test_view_fastpath.py`
+
+This task is TDD-style: write failing tests first to pin the desired behavior. The tests will fail today because CPU `contiguous`/`flatten`/`unflatten` always copy.
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `tests/cpu/test_view_fastpath.py` with this exact content:
+
+```python
+"""Pin conditional-view forward semantics for contiguous/flatten/unflatten.
+
+After Sub-batch 1B-A:
+- contiguous(a) returns `a` itself when a is already contiguous in default
+  format. Non-contiguous input still copies.
+- flatten(a, ...) and unflatten(a, ...) return a real view (storage shared,
+  _base set, _view_meta["op"] populated) when a is contiguous. Non-contiguous
+  input still copies.
+
+Tests stay on CPU — MPS and NPU regression coverage rides on the cpu/contract
+gate plus the existing per-backend test suites.
+"""
+import numpy as np
+import candle as torch
+
+
+# ---------------------------------------------------------------------------
+# contiguous
+# ---------------------------------------------------------------------------
+
+def test_contiguous_returns_self_when_already_contiguous():
+    t = torch.randn(3, 4)
+    assert t.is_contiguous()
+    u = t.contiguous()
+    assert u is t
+
+
+def test_contiguous_copies_when_input_is_non_contiguous():
+    t = torch.randn(4, 4).t()
+    assert not t.is_contiguous()
+    u = t.contiguous()
+    assert u is not t
+    assert u.storage() is not t.storage()
+    assert u.is_contiguous()
+
+
+# ---------------------------------------------------------------------------
+# flatten
+# ---------------------------------------------------------------------------
+
+def test_flatten_shares_storage_when_input_is_contiguous():
+    t = torch.randn(3, 4)
+    u = t.flatten()
+    assert u.storage() is t.storage()
+    assert u._base is not None
+    assert u._view_meta is not None
+    assert u._view_meta["op"] == "flatten"
+    assert u._view_func is None
+    assert u._rev_view_func is None
+
+
+def test_flatten_view_mutation_propagates_to_input():
+    t = torch.randn(3, 4)
+    u = t.flatten()
+    u[0] = 99.0
+    np.testing.assert_array_equal(t.flatten().numpy()[0], 99.0)
+
+
+def test_flatten_copies_when_input_is_non_contiguous():
+    t = torch.randn(4, 4).t()
+    assert not t.is_contiguous()
+    u = t.flatten()
+    assert u.storage() is not t.storage()
+
+
+# ---------------------------------------------------------------------------
+# unflatten
+# ---------------------------------------------------------------------------
+
+def test_unflatten_shares_storage_when_input_is_contiguous():
+    t = torch.randn(2, 6)
+    u = t.unflatten(1, (2, 3))
+    assert u.storage() is t.storage()
+    assert u._base is not None
+    assert u._view_meta is not None
+    assert u._view_meta["op"] == "unflatten"
+    assert u._view_func is None
+    assert u._rev_view_func is None
+
+
+def test_unflatten_view_mutation_propagates_to_input():
+    t = torch.randn(2, 6)
+    u = t.unflatten(1, (2, 3))
+    u[0, 0, 0] = 99.0
+    np.testing.assert_array_equal(t.numpy()[0, 0], 99.0)
+
+
+def test_unflatten_copies_when_input_is_non_contiguous():
+    t = torch.randn(4, 4).t()
+    assert not t.is_contiguous()
+    u = t.unflatten(0, (2, 2))
+    assert u.storage() is not t.storage()
+
+
+# ---------------------------------------------------------------------------
+# Backward through the fast-path is unchanged: hand-added *Backward0 classes
+# in src/candle/_generated/functions.py still drive grad propagation in 1B-A.
+# These tests guard against regressions in that wiring.
+# ---------------------------------------------------------------------------
+
+def test_flatten_backward_is_identity_after_fast_path():
+    t = torch.randn(3, 4, requires_grad=True)
+    u = t.flatten()
+    u.sum().backward()
+    np.testing.assert_array_equal(t.grad.numpy(), np.ones((3, 4), dtype=np.float32))
+
+
+def test_unflatten_backward_is_identity_after_fast_path():
+    t = torch.randn(2, 6, requires_grad=True)
+    u = t.unflatten(1, (2, 3))
+    u.sum().backward()
+    np.testing.assert_array_equal(t.grad.numpy(), np.ones((2, 6), dtype=np.float32))
+
+
+def test_contiguous_backward_is_identity_when_already_contiguous():
+    t = torch.randn(3, 4, requires_grad=True)
+    u = t.contiguous()
+    assert u is t
+    u.sum().backward()
+    np.testing.assert_array_equal(t.grad.numpy(), np.ones((3, 4), dtype=np.float32))
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/cpu/test_view_fastpath.py -v --tb=short
+```
+
+Expected before any source changes: most assertions in the storage-sharing tests fail. Specifically:
+- `test_contiguous_returns_self_when_already_contiguous` fails because today CPU `contiguous(a)` always returns a fresh `_from_numpy(...)` tensor (line 1364).
+- `test_flatten_shares_storage_when_input_is_contiguous` fails (`u.storage() is not t.storage()`).
+- `test_unflatten_shares_storage_when_input_is_contiguous` fails (same reason).
+- The backward-identity tests should pass already (the existing `*Backward0` classes are independent of forward path).
+- The "copies when non-contiguous" tests should pass already.
+
+If the failing tests do NOT include the three storage-share tests, stop and investigate — something about the codebase has shifted and the spec assumptions are stale.
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add tests/cpu/test_view_fastpath.py
+git commit -m "$(cat <<'EOF'
+test(cpu): pin conditional-view fast-path for contiguous/flatten/unflatten
+
+Failing tests for Sub-batch 1B-A. They assert:
+- contiguous(a) returns a itself when a is already contiguous
+- flatten/unflatten share storage and set _base/_view_meta when contiguous
+- non-contiguous input still copies for all three ops
+- backward through the fast path is still identity
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: CPU `contiguous` fast-path
+
+**Files:**
+- Modify: `src/candle/_backends/cpu/ops.py:1351-1364`
+
+- [ ] **Step 1: Edit `contiguous` to short-circuit on contiguous input**
+
+Replace the current body of `contiguous` (lines 1351-1364):
+
+```python
+def contiguous(a, memory_format=None):
+    if a.device.type != "cpu":
+        raise ValueError("CPU contiguous expects CPU tensors")
+    if getattr(memory_format, "_name", None) == "channels_last":
+        if len(a.shape) != 4:
+            raise RuntimeError("required rank 4 tensor to use channels_last format")
+        if _is_channels_last_stride(a.shape, a.stride):
+            return a
+        arr = np.ascontiguousarray(np.transpose(_to_numpy(a), (0, 2, 3, 1)))
+        storage = typed_storage_from_numpy(arr.reshape(-1), a.dtype, device=a.device)
+        stride = _channels_last_stride(a.shape)
+        return cy_make_tensor_from_storage(storage, a.shape, stride, 0, False)
+    arr = np.ascontiguousarray(_to_numpy(a))
+    return _from_numpy(arr, a.dtype, a.device)
+```
+
+with:
+
+```python
+def contiguous(a, memory_format=None):
+    if a.device.type != "cpu":
+        raise ValueError("CPU contiguous expects CPU tensors")
+    if getattr(memory_format, "_name", None) == "channels_last":
+        if len(a.shape) != 4:
+            raise RuntimeError("required rank 4 tensor to use channels_last format")
+        if _is_channels_last_stride(a.shape, a.stride):
+            return a
+        arr = np.ascontiguousarray(np.transpose(_to_numpy(a), (0, 2, 3, 1)))
+        storage = typed_storage_from_numpy(arr.reshape(-1), a.dtype, device=a.device)
+        stride = _channels_last_stride(a.shape)
+        return cy_make_tensor_from_storage(storage, a.shape, stride, 0, False)
+    if a.is_contiguous():
+        return a
+    arr = np.ascontiguousarray(_to_numpy(a))
+    return _from_numpy(arr, a.dtype, a.device)
+```
+
+The single new line is `if a.is_contiguous(): return a` immediately before the existing `np.ascontiguousarray` copy. The channels_last branch is unchanged.
+
+- [ ] **Step 2: Run the contiguous tests**
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/cpu/test_view_fastpath.py -v --tb=short -k contiguous
+```
+
+Expected:
+- `test_contiguous_returns_self_when_already_contiguous` PASSES.
+- `test_contiguous_copies_when_input_is_non_contiguous` PASSES (was passing before too).
+- `test_contiguous_backward_is_identity_when_already_contiguous` PASSES.
+
+- [ ] **Step 3: Run the existing memory_format suite for regression**
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/cpu/ -v --tb=short -k "memory_format or channels_last"
+```
+
+Expected: all green. The channels_last branch was untouched — if these regress, the edit was wrong.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/candle/_backends/cpu/ops.py
+git commit -m "$(cat <<'EOF'
+fix(cpu): contiguous returns input when already contiguous
+
+Match PyTorch's t.contiguous() returning self for already-contiguous inputs
+in default memory format. Previously always allocated via np.ascontiguousarray.
+channels_last branch unchanged.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: CPU `flatten` and `unflatten` view fast-path
+
+**Files:**
+- Modify: `src/candle/_backends/cpu/ops.py:3058-3074`
+
+- [ ] **Step 1: Edit `flatten` and `unflatten`**
+
+Replace lines 3058-3074:
+
+```python
+def flatten(a, start_dim=0, end_dim=-1):
+    arr = _to_numpy(a)
+    ndim = arr.ndim
+    start = start_dim if start_dim >= 0 else start_dim + ndim
+    end = end_dim if end_dim >= 0 else end_dim + ndim
+    new_shape = arr.shape[:start] + (-1,) + arr.shape[end + 1:]
+    out = arr.reshape(new_shape)
+    return _from_numpy(np.ascontiguousarray(out), a.dtype, a.device)
+
+
+def unflatten(a, dim, sizes):
+    arr = _to_numpy(a)
+    ndim = arr.ndim
+    d = dim if dim >= 0 else dim + ndim
+    new_shape = arr.shape[:d] + tuple(sizes) + arr.shape[d + 1:]
+    out = arr.reshape(new_shape)
+    return _from_numpy(np.ascontiguousarray(out), a.dtype, a.device)
+```
+
+with:
+
+```python
+def flatten(a, start_dim=0, end_dim=-1):
+    ndim = len(a.shape)
+    start = start_dim if start_dim >= 0 else start_dim + ndim
+    end = end_dim if end_dim >= 0 else end_dim + ndim
+    flat_size = 1
+    for i in range(start, end + 1):
+        flat_size *= a.shape[i]
+    new_shape = a.shape[:start] + (flat_size,) + a.shape[end + 1:]
+    if a.is_contiguous():
+        from ..._backends.common import view as view_backend
+        base = view_backend._get_base(a)
+        new_stride = view_backend._contiguous_stride(new_shape)
+        return view_backend._make_view(
+            base, new_shape, new_stride, a.offset, "flatten", source=a
+        )
+    arr = _to_numpy(a)
+    out = arr.reshape(new_shape)
+    return _from_numpy(np.ascontiguousarray(out), a.dtype, a.device)
+
+
+def unflatten(a, dim, sizes):
+    ndim = len(a.shape)
+    d = dim if dim >= 0 else dim + ndim
+    new_shape = a.shape[:d] + tuple(sizes) + a.shape[d + 1:]
+    if a.is_contiguous():
+        from ..._backends.common import view as view_backend
+        base = view_backend._get_base(a)
+        new_stride = view_backend._contiguous_stride(new_shape)
+        return view_backend._make_view(
+            base, new_shape, new_stride, a.offset, "unflatten", source=a
+        )
+    arr = _to_numpy(a)
+    out = arr.reshape(new_shape)
+    return _from_numpy(np.ascontiguousarray(out), a.dtype, a.device)
+```
+
+Key differences from the original:
+- Compute `new_shape` from `a.shape` (already a tuple of ints) instead of `arr.shape` — avoids materializing the numpy array on the fast-path.
+- `flatten` resolves `-1` itself by computing `flat_size = prod(a.shape[start:end+1])` — the same logic the NPU `flatten_op` uses.
+- Fast-path branch goes through `view_backend._make_view` with the standard `_get_base` lookup. `op` argument is the literal string `"flatten"` or `"unflatten"`. `source=a` propagates `creation_kind` from `a._view_meta` if `a` is itself a view.
+- `view_func` and `rev_view_func` are deliberately NOT passed — they default to `None`. Sub-batch 1B-B will populate them.
+- Non-contiguous fallback is the original two-line copy path.
+
+- [ ] **Step 2: Run flatten/unflatten tests**
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/cpu/test_view_fastpath.py -v --tb=short
+```
+
+Expected: all 11 tests in `test_view_fastpath.py` PASS.
+
+- [ ] **Step 3: Run the broader cpu tensor-view suite**
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/cpu/test_tensor_view.py tests/cpu/test_view_dispatch.py \
+                   tests/cpu/test_view_tracking_infrastructure.py -v --tb=short
+```
+
+Expected: all green. These pin existing view semantics that should be unaffected.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/candle/_backends/cpu/ops.py
+git commit -m "$(cat <<'EOF'
+fix(cpu): flatten/unflatten return a view when input is contiguous
+
+Match PyTorch's conditional-view semantics. When the input is already
+contiguous, build a real view via view_backend._make_view instead of
+copying through np.ascontiguousarray. Non-contiguous input still copies.
+
+view_func/rev_view_func default to None — autograd routing stays on the
+hand-added FlattenBackward0/UnflattenBackward0 classes for now.
+Sub-batch 1B-B will wire those callables.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: MPS `flatten` and `unflatten` view fast-path
+
+**Files:**
+- Modify: `src/candle/_backends/mps/ops/shape.py:1099-1135`
+
+This task can only be physically run on a host with MPS hardware. CI test-mps runs on macos-14 (M1). Local validation: see CLAUDE.md for the macOS Apple Silicon checklist. If the implementer is on a Linux host (no MPS), they may write the change and rely on test-mps in CI as the safety net — but they MUST visually compare the new MPS code against the CPU implementation in Task 3 to ensure the same semantic invariant.
+
+- [ ] **Step 1: Edit `flatten` and `unflatten` in MPS shape.py**
+
+Replace lines 1099-1135:
+
+```python
+def flatten(a, start_dim=0, end_dim=-1):
+    ndim = len(a.shape)
+    start = start_dim if start_dim >= 0 else start_dim + ndim
+    end = end_dim if end_dim >= 0 else end_dim + ndim
+    new_shape = a.shape[:start] + (-1,) + a.shape[end + 1:]
+    # Compute actual -1 size
+    known = 1
+    for i, s in enumerate(new_shape):
+        if s != -1:
+            known *= s
+    total = 1
+    for s in a.shape:
+        total *= s
+    new_shape = tuple(s if s != -1 else total // known for s in new_shape)
+    if _can_use_gpu(a) and a.is_contiguous():
+        from ...._C import _compute_strides
+        return _from_metal_buffer(_metal_buf(a), new_shape, _compute_strides(new_shape), a.dtype, a.device)
+    # Non-contiguous GPU: make contiguous and retry
+    if _can_use_gpu(a):
+        return flatten(a.contiguous(), start_dim=start_dim, end_dim=end_dim)
+    arr = _to_numpy(a)
+    out = arr.reshape(new_shape)
+    return _from_numpy(np.ascontiguousarray(out), a.dtype, a.device)
+
+def unflatten(a, dim, sizes):
+    ndim = len(a.shape)
+    d = dim if dim >= 0 else dim + ndim
+    new_shape = a.shape[:d] + tuple(sizes) + a.shape[d + 1:]
+    if _can_use_gpu(a) and a.is_contiguous():
+        from ...._C import _compute_strides
+        return _from_metal_buffer(_metal_buf(a), new_shape, _compute_strides(new_shape), a.dtype, a.device)
+    # Non-contiguous GPU: make contiguous and retry
+    if _can_use_gpu(a):
+        return unflatten(a.contiguous(), dim, sizes)
+    arr = _to_numpy(a)
+    out = arr.reshape(new_shape)
+    return _from_numpy(np.ascontiguousarray(out), a.dtype, a.device)
+```
+
+with:
+
+```python
+def flatten(a, start_dim=0, end_dim=-1):
+    ndim = len(a.shape)
+    start = start_dim if start_dim >= 0 else start_dim + ndim
+    end = end_dim if end_dim >= 0 else end_dim + ndim
+    flat_size = 1
+    for i in range(start, end + 1):
+        flat_size *= a.shape[i]
+    new_shape = a.shape[:start] + (flat_size,) + a.shape[end + 1:]
+    if a.is_contiguous():
+        from ...common import view as view_backend
+        base = view_backend._get_base(a)
+        new_stride = view_backend._contiguous_stride(new_shape)
+        return view_backend._make_view(
+            base, new_shape, new_stride, a.offset, "flatten", source=a
+        )
+    # Non-contiguous GPU: make contiguous and retry
+    if _can_use_gpu(a):
+        return flatten(a.contiguous(), start_dim=start_dim, end_dim=end_dim)
+    arr = _to_numpy(a)
+    out = arr.reshape(new_shape)
+    return _from_numpy(np.ascontiguousarray(out), a.dtype, a.device)
+
+def unflatten(a, dim, sizes):
+    ndim = len(a.shape)
+    d = dim if dim >= 0 else dim + ndim
+    new_shape = a.shape[:d] + tuple(sizes) + a.shape[d + 1:]
+    if a.is_contiguous():
+        from ...common import view as view_backend
+        base = view_backend._get_base(a)
+        new_stride = view_backend._contiguous_stride(new_shape)
+        return view_backend._make_view(
+            base, new_shape, new_stride, a.offset, "unflatten", source=a
+        )
+    # Non-contiguous GPU: make contiguous and retry
+    if _can_use_gpu(a):
+        return unflatten(a.contiguous(), dim, sizes)
+    arr = _to_numpy(a)
+    out = arr.reshape(new_shape)
+    return _from_numpy(np.ascontiguousarray(out), a.dtype, a.device)
+```
+
+Key differences from the original:
+- The `_can_use_gpu(a) and a.is_contiguous()` branch becomes simply `a.is_contiguous()` and uses `_make_view` instead of `_from_metal_buffer(_metal_buf(a), ...)`. This produces a same-storage tensor with `_base`, `_view_meta`, etc. — what 1B-B can later wire to view_func.
+- The `_compute_strides` import (`from ...._C import _compute_strides`) is replaced with `view_backend._contiguous_stride` for parity with CPU. Both compute the same thing for a contiguous shape; using `view_backend._contiguous_stride` keeps all backends going through the same helper.
+- `flatten` resolves `-1` up front via `flat_size = prod(a.shape[start:end+1])` (matches CPU and NPU `flatten_op`). The numpy-based `-1` resolution is gone; that's fine because non-contiguous fallback already operates on `new_shape` with no `-1` left.
+- The non-contiguous-GPU branch (`_can_use_gpu(a)` retry) and the CPU fallback path stay unchanged.
+- `view_func` / `rev_view_func` not passed (default `None`) — same as CPU.
+
+- [ ] **Step 2: Audit MPS for `_base is None` callers**
+
+Before running the suite, grep for any MPS code that branches on `_base`:
+
+```bash
+grep -rn "_base is None\|_base is not None" src/candle/_backends/mps/
+```
+
+Expected: only references in shared helpers — no MPS-specific code that would break if a flatten/unflatten output has `_base != None`. If you find new branching that wasn't audited in the spec, stop and surface the finding before continuing.
+
+- [ ] **Step 3: Rebuild Cython if needed**
+
+The `_C/_compute_strides` symbol is no longer imported by `flatten`/`unflatten`. No Cython rebuild required (pure Python edit). To be safe:
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python setup.py build_ext --inplace 2>&1 | tail -20
+```
+
+Expected: `build_ext` succeeds (or is a no-op since nothing in `_C` changed). If the build fails, the failure is unrelated to this edit — investigate separately.
+
+- [ ] **Step 4: Run MPS tests if hardware is available**
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/mps/ -v --tb=short -k "flatten or unflatten or contiguous"
+```
+
+If running on a Linux host without MPS hardware, the suite auto-skips per `tests/conftest.py`. Note that you skipped it — do NOT mark this task complete with full confidence; the macOS CI run will be the gate.
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/mps/ -v --tb=short
+```
+
+Expected when MPS is available: all green. The change preserves storage sharing on the contiguous GPU path (already shared via `_metal_buf`), but now the output also carries view metadata.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/candle/_backends/mps/ops/shape.py
+git commit -m "$(cat <<'EOF'
+fix(mps): flatten/unflatten return a registered view when input is contiguous
+
+Replace the GPU contiguous fast-path that produced a same-storage tensor
+via _from_metal_buffer (no _base, no _view_meta) with view_backend._make_view.
+Output now has _base, _view_meta, and inherits creation_kind from the input
+when it is a view. Non-contiguous fallback unchanged.
+
+view_func/rev_view_func default to None — autograd routing stays on the
+hand-added FlattenBackward0/UnflattenBackward0 classes for now.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: NPU `contiguous` fast-path
+
+**Files:**
+- Modify: `src/candle/_backends/npu/ops/shape.py:1428-1444`
+
+This task can only be physically run on a host with NPU hardware. The `view-tracking-1b` worktree's host has NPU available (per CLAUDE.md). If the implementer is on a host without NPU, write the change and rely on the existing NPU test suite as the gate.
+
+NPU `flatten_op` (line 1409) and `unflatten_op` (line 1974) already delegate to `view_backend.reshape`, which itself routes to `_make_view` for contiguous inputs. They need NO change in this plan — verified by reading `src/candle/_backends/common/view.py:reshape`.
+
+- [ ] **Step 1: Edit NPU `contiguous`**
+
+Replace lines 1428-1444:
+
+```python
+def contiguous(a):
+    runtime = npu_runtime.get_runtime((a.device.index or 0))
+    if a.device.type != "npu":
+        raise ValueError("NPU contiguous expects NPU tensors")
+
+    a_storage = _unwrap_storage(a)
+    out_size = _numel(a.shape) * _dtype_itemsize(a.dtype)
+    out_ptr = npu_runtime._alloc_device(out_size, runtime=runtime)
+    npu_runtime.memcpy_d2d(
+        out_ptr,
+        out_size,
+        a_storage.data_ptr(),
+        runtime=runtime,
+    )
+
+    storage = npu_typed_storage_from_ptr(out_ptr, _numel(a.shape), a.dtype, device=a.device)
+    return _wrap_tensor(storage, a.shape, npu_runtime._contiguous_stride(a.shape))
+```
+
+with:
+
+```python
+def contiguous(a):
+    if a.device.type != "npu":
+        raise ValueError("NPU contiguous expects NPU tensors")
+    if a.is_contiguous():
+        return a
+    runtime = npu_runtime.get_runtime((a.device.index or 0))
+
+    a_storage = _unwrap_storage(a)
+    out_size = _numel(a.shape) * _dtype_itemsize(a.dtype)
+    out_ptr = npu_runtime._alloc_device(out_size, runtime=runtime)
+    npu_runtime.memcpy_d2d(
+        out_ptr,
+        out_size,
+        a_storage.data_ptr(),
+        runtime=runtime,
+    )
+
+    storage = npu_typed_storage_from_ptr(out_ptr, _numel(a.shape), a.dtype, device=a.device)
+    return _wrap_tensor(storage, a.shape, npu_runtime._contiguous_stride(a.shape))
+```
+
+The diff is two lines: hoist the device check above the `runtime` lookup so we don't pay for runtime resolution on the fast-path, and add `if a.is_contiguous(): return a`. Everything else is unchanged.
+
+Note: NPU has no `memory_format` parameter — there's no channels_last branch to preserve.
+
+- [ ] **Step 2: Run NPU tests if hardware is available**
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/npu/ -v --tb=short -k "contiguous or flatten or unflatten"
+```
+
+Expected when NPU is available: all green. Most tests don't exercise the fast-path explicitly, but several call `.contiguous()` on already-contiguous tensors and should now skip the memcpy.
+
+If NPU hardware is unavailable on this host, the suite auto-skips. Note that.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/candle/_backends/npu/ops/shape.py
+git commit -m "$(cat <<'EOF'
+fix(npu): contiguous returns input when already contiguous
+
+Match PyTorch's t.contiguous() returning self for already-contiguous inputs.
+Previously always allocated and ran memcpy_d2d.
+
+NPU flatten_op/unflatten_op already delegate to view_backend.reshape, which
+handles the conditional-view semantics correctly — no change needed there.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Pylint and full gate
+
+**Files:** none (validation only)
+
+- [ ] **Step 1: Run pylint on src/candle**
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  pylint src/candle/ --rcfile=.github/pylint.conf 2>&1 | tail -40
+```
+
+Expected: pylint passes (`Your code has been rated at 10.00/10` or no new violations vs. `view-tracking-1b` baseline). If new violations appear, fix them before continuing. Common false positives:
+- `import-outside-toplevel` on the `from ..._backends.common import view as view_backend` lines — already used by `movedim`, `narrow`, etc. in the same file, so the rule should already be disabled. If it fires, add `# pylint: disable=import-outside-toplevel` on the line.
+
+- [ ] **Step 2: Run the cpu + contract gate**
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/cpu/ tests/contract/ -v --tb=short 2>&1 | tail -40
+```
+
+Expected: same pass/fail/skip count as the `view-tracking-1b` baseline (PR #372 shipped with 3013 passed, 30 skipped, 1 failed — the 1 failure is the codegen-roundtrip drift on 110 unrelated legacy ops). Compare against:
+
+```bash
+git stash && \
+  conda run -n candle python -m pytest tests/cpu/ tests/contract/ --tb=no -q 2>&1 | tail -3 && \
+  git stash pop
+```
+
+If the new diff introduces additional failures, investigate and fix before proceeding.
+
+- [ ] **Step 3: Run NPU suite if hardware is available**
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/npu/ -v --tb=short 2>&1 | tail -40
+```
+
+If NPU is unavailable, the suite auto-skips. Note skipped tests in the PR description.
+
+- [ ] **Step 4: Final commit, if any pylint fixes were needed**
+
+If you had to add a pylint suppression or formatting fix in Step 1:
+
+```bash
+git add -A
+git commit -m "style: silence pylint false-positive on view_backend import"
+```
+
+If no pylint fixes were needed, skip this step.
+
+---
+
+## Task 7: Push and open PR
+
+**Files:** none.
+
+- [ ] **Step 1: Verify the commit log is clean**
+
+```bash
+git log --oneline view-tracking-1b ^upstream/main
+```
+
+Expected output (5–7 commits):
+- `docs(specs): add view-tracking 1B six-ops conditional-view design`
+- `docs(specs): tighten 1B-A contiguous semantics — return self, not _make_view`
+- `test(cpu): pin conditional-view fast-path for contiguous/flatten/unflatten`
+- `fix(cpu): contiguous returns input when already contiguous`
+- `fix(cpu): flatten/unflatten return a view when input is contiguous`
+- `fix(mps): flatten/unflatten return a registered view when input is contiguous`
+- `fix(npu): contiguous returns input when already contiguous`
+- (optional) `style: silence pylint false-positive on view_backend import`
+
+If commits are missing or out of order, address that before pushing.
+
+- [ ] **Step 2: Rebase onto upstream/main**
+
+```bash
+git fetch upstream main
+git rebase upstream/main
+```
+
+Expected: clean rebase. If conflicts arise, resolve them before continuing.
+
+- [ ] **Step 3: Push to origin**
+
+```bash
+git push -u origin view-tracking-1b
+```
+
+Expected: push succeeds. If `gh` CLI behaves oddly, recall that the real CLI lives at `~/anaconda3/envs/candle311/bin/gh` (v2.91.0).
+
+- [ ] **Step 4: Create the PR**
+
+```bash
+~/anaconda3/envs/candle311/bin/gh pr create \
+  --repo candle-org/candle \
+  --head lvyufeng:view-tracking-1b \
+  --base main \
+  --title "fix(backends): contiguous/flatten/unflatten conditional-view forward (1B-A of view-tracking)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Sub-batch 1B-A of view-tracking. Wires three of the six PyTorch `VIEW_FUNCTIONS` ops onto candle's view infrastructure by fixing their forward path:
+
+- `contiguous(a)` returns `a` itself when already contiguous in default format. Was: always allocated a fresh copy.
+- `flatten(a, ...)` and `unflatten(a, ...)` return a registered view (`_make_view`) when the input is contiguous. Was: always allocated a copy via `np.ascontiguousarray`.
+- For non-contiguous input, all three ops still allocate and copy as before.
+
+Backends touched: cpu, mps, npu. CUDA has no separate impl. NPU `flatten_op`/`unflatten_op` already delegate to `view_backend.reshape`, which handles conditional-view correctly — no change there.
+
+## What is NOT in this PR
+
+- No `view_func` / `rev_view_func` wiring. They stay `None` on every output. The infrastructure landed in PR #372 still has no live consumers.
+- No removal of hand-added `ContiguousBackward0` / `FlattenBackward0` / `UnflattenBackward0` classes. Autograd still flows through them.
+- No autograd-routing changes for `narrow`, `squeeze`, `movedim` (their forward is already correct — they're 1B-B work).
+
+Sub-batch 1B-B will land both pieces in a separate PR once 1B-A is merged.
+
+## Spec
+
+`docs/superpowers/specs/2026-05-04-view-tracking-1b-six-ops-design.md`
+
+## Test plan
+
+- [x] `tests/cpu/test_view_fastpath.py` — new file, 11 tests covering identity-on-fast-path, storage-sharing, mutation propagation, copy fallback, backward identity.
+- [x] `pytest tests/cpu/ tests/contract/` — same baseline as `view-tracking-1b` after PR #372.
+- [ ] `pytest tests/mps/` — runs in CI (macos-14).
+- [ ] `pytest tests/npu/` — local NPU host.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: gh prints the PR URL. Save the URL for follow-up.
+
+- [ ] **Step 5: Surface the PR URL to the user**
+
+Print the URL and the change summary so the user can review.
+
+---
+
+## Spec coverage check (run after writing the plan)
+
+Cross-walk the spec → tasks:
+
+| Spec section | Implemented in |
+|---|---|
+| `contiguous` returns `a` when contiguous (CPU) | Task 2 |
+| `contiguous` returns `a` when contiguous (MPS) | already correct, spec line 122–124 |
+| `contiguous` returns `a` when contiguous (NPU) | Task 5 |
+| `flatten` view via `_make_view` when contiguous (CPU) | Task 3 |
+| `flatten` view via `_make_view` when contiguous (MPS) | Task 4 |
+| `flatten` view (NPU) | already correct via `view_backend.reshape`, spec line 136 |
+| `unflatten` view (CPU) | Task 3 |
+| `unflatten` view (MPS) | Task 4 |
+| `unflatten` view (NPU) | already correct, spec line 137 |
+| view_func / rev_view_func stay None | Tasks 3 and 4 explicitly omit them |
+| Test file `tests/cpu/test_view_fastpath.py` | Task 1 |
+| Pylint + cpu/contract gate | Task 6 |
+| MPS regression coverage | Task 6 (CI) |
+| NPU regression coverage | Task 6 (local) |
+| Open PR | Task 7 |
+
+No spec gaps. `contiguous` MPS and `flatten`/`unflatten` NPU are explicitly no-ops per spec — no task is needed for those, by design.

--- a/docs/superpowers/specs/2026-05-04-view-tracking-1b-six-ops-design.md
+++ b/docs/superpowers/specs/2026-05-04-view-tracking-1b-six-ops-design.md
@@ -1,0 +1,224 @@
+# Sub-batch 1B Design: Wire 6 shape/view ops onto view-tracking infrastructure
+
+**Date:** 2026-05-04
+**Status:** Draft (1B-A scope; 1B-B opens after 1B-A merges)
+**Predecessor:** PR #372 (view-tracking infrastructure 1A — `_view_func`/`_rev_view_func` cdef attrs, `_make_view` parameters, engine grad rebase, codegen `view_funcs.py`).
+**Successor scope:** 1B-B will wire all 6 ops onto `view_func`/`rev_view_func` and delete the hand-added Backward classes.
+
+## Goal
+
+Land six PyTorch `VIEW_FUNCTIONS` / `RETURNS_VIEWS_OF_INPUT` ops — `contiguous`, `flatten`, `squeeze`, `narrow`, `movedim`, `unflatten` — onto Candle's view-tracking infrastructure so backward flows through view rebase rather than hand-added identity Backward classes.
+
+The work is split into two PRs to keep blast radius small:
+
+* **1B-A (this spec, this PR):** make the **forward** path of the three currently-copying ops (`contiguous`, `flatten`, `unflatten`) match PyTorch's conditional-view semantics. No autograd or codegen changes.
+* **1B-B (separate spec, separate PR):** wire all 6 ops into `view_func` / `rev_view_func`, drop their hand-added `*Backward0` classes from `_generated/`.
+
+This document specifies **1B-A only**. 1B-B will get its own design doc when 1B-A is merged.
+
+## Context
+
+PR #372 added the infrastructure: a view tensor can carry an op-specific `_view_func` (replay forward) and `_rev_view_func` (rebase a gradient onto its base), and the autograd engine walks the rebase chain inside `_accumulate_tensor_grad`. That PR did not flip any ops to use it — the field defaults to `None`, the engine rebase block is dead code today, and the 6 view ops still rely on hand-added identity Backward classes (`ContiguousBackward0`, `FlattenBackward0`, `SqueezeBackward0`, `NarrowBackward0`, `MovedimBackward0`, `UnflattenBackward0` in `src/candle/_generated/functions.py`).
+
+A direct audit of the 6 ops shows two distinct gaps from PyTorch:
+
+| Op          | Currently in candle (forward)                   | PyTorch (forward)                                | Gap                              |
+|-------------|--------------------------------------------------|---------------------------------------------------|----------------------------------|
+| `narrow`    | view via `_make_view`                            | view (slice metadata only)                       | none (forward) — only autograd wiring left |
+| `squeeze`   | view via `_make_view`                            | conditional view (in `VIEW_FUNCTIONS`)            | none (forward) — only autograd wiring left |
+| `movedim`   | view via `_make_view`                            | view (permute-style stride remap)                | none (forward) — only autograd wiring left |
+| `contiguous`| **always copies**                                | **conditional view** (returns self if already contiguous in requested format) | forward path differs |
+| `flatten`   | **always copies**                                | **conditional view** (view if stride-collapsible over `[start_dim, end_dim]`, else copy) | forward path differs |
+| `unflatten` | **always copies**                                | **conditional view** (delegates to `view`/`reshape` semantics; view if stride-compatible) | forward path differs |
+
+So the 6 ops divide naturally:
+
+* 3 ops (`narrow`, `squeeze`, `movedim`) already produce a real view in candle. Forward is correct. They are "forward-clean, autograd-pending."
+* 3 ops (`contiguous`, `flatten`, `unflatten`) still always allocate a fresh storage and copy. Forward is wrong vs torch. They need a forward fix before any view-tracking wiring will work — you cannot rebase a gradient onto a view that isn't actually a view.
+
+**1B-A fixes the forward path of the second group.** It does not touch autograd. After 1B-A all 6 ops produce real views when the input is contiguous (or otherwise view-compatible), but their Backward classes still run unchanged.
+
+## Why split 1B into 1B-A + 1B-B
+
+The two stages have different blast radii and different validation needs:
+
+* **1B-A** changes 6 backend kernel functions (`contiguous`/`flatten`/`unflatten` × cpu/mps/npu). It changes runtime behavior for any caller that mutates the output of `contiguous`/`flatten`/`unflatten` — these are observable semantics and need their own regression coverage.
+* **1B-B** changes generator output (`_generated/functions.py`, `_generated/variable_type.py`, `_generated/registration.py`) and adds `view_func`/`rev_view_func` callables on view ops. It changes autograd behavior — gradients reach the base via rebase instead of via hand-added Backward.
+
+Mixing both into one PR would mean a 6-op forward semantic change *and* an autograd-routing change land in the same diff. Separating them makes each PR's scope auditable on its own and lets a regression bisect onto whichever change introduced it.
+
+## Scope of 1B-A
+
+**In scope:**
+
+* Backend forward path for `contiguous`, `flatten`, `unflatten` on CPU, MPS, and NPU.
+* Make each return a real view (via `_make_view`) when the input's existing layout already satisfies the op's contract. Otherwise keep the copy path.
+* New test file `tests/cpu/test_view_fastpath.py` covering view-share semantics and the still-copy fallback.
+
+**Out of scope (deferred to 1B-B):**
+
+* Setting `view_func` / `rev_view_func` on any op output. They stay `None` after 1B-A. The infrastructure exists (PR #372) but is not exercised yet.
+* Removing the hand-added `ContiguousBackward0` / `FlattenBackward0` / `SqueezeBackward0` / `NarrowBackward0` / `MovedimBackward0` / `UnflattenBackward0` classes. They keep running.
+* Autograd-routing changes for `narrow`, `squeeze`, `movedim` (their forward is already correct).
+* CUDA backend — no separate `contiguous`/`flatten`/`unflatten` impl exists in `_backends/cuda/`.
+
+## Conditional-view semantics
+
+Each of the three ops gets a **view fast-path** under specific conditions; otherwise it falls back to the existing copy path.
+
+### `contiguous(a, memory_format=None)`
+
+* `memory_format` is `None` or `contiguous_format` (default):
+  * If `a.is_contiguous()`: return a view with the same shape/stride/offset (essentially `a`, but constructed through `_make_view` so it carries view metadata). This matches PyTorch's `t.contiguous()` returning `self` when already contiguous.
+* `memory_format` is `channels_last`:
+  * Already handled correctly: existing path returns `a` when `_is_channels_last_stride(...)` matches. No change needed.
+* Otherwise: keep the existing copy path (`np.ascontiguousarray` on CPU, `aclnnInplaceCopy`-equivalent on NPU, `_dispatch_unary_gpu(a, "identity")` on MPS).
+
+The functional contract is "guaranteed contiguous output." The view fast-path satisfies that contract because the input is already contiguous.
+
+> **Open question — return `a` directly vs. `_make_view`.**
+> Today, when the input is already contiguous, the cpu and mps `contiguous` paths return `a` itself (no metadata wrap). Going through `_make_view` produces a *new* tensor that shares storage. PyTorch's `t.contiguous()` returns `self` (same Python object) for already-contiguous inputs. To match torch's identity behavior we should **return `a` directly** in the fast-path — not wrap through `_make_view`. The wrap-through-`_make_view` form would only be needed if 1B-B's `view_func`/`rev_view_func` wiring requires distinct view metadata, in which case 1B-B can revisit. For 1B-A the right call is **return `a`**.
+
+### `flatten(a, start_dim=0, end_dim=-1)`
+
+PyTorch's flatten returns a view when the strides over `[start_dim, end_dim]` already collapse to a single contiguous run. Concretely, that holds when:
+
+* `start_dim == end_dim` (no-op flatten): just return `a`.
+* The input is contiguous (full-tensor stride pattern matches `_contiguous_stride(shape)`): the flattened range is trivially collapsible. Return a view with shape `a.shape[:start] + (prod(a.shape[start:end+1]),) + a.shape[end+1:]` and stride `_contiguous_stride(new_shape)`.
+* Sub-range stride-collapsible (general case): there exists a single stride `s` such that `a.stride[start_dim] = s * prod(a.shape[start_dim+1:end_dim+1])`, `a.stride[start_dim+1] = s * prod(a.shape[start_dim+2:end_dim+1])`, …, `a.stride[end_dim] = s`. PyTorch handles this with its general view-feasibility check. **For 1B-A we conservatively support only the "input is contiguous" path** — that covers the dominant case (post-Linear / post-conv tensors are contiguous) and avoids reproducing PyTorch's stride-feasibility math now. The general case can land later.
+
+When the input is not contiguous (and `start_dim != end_dim`): keep the existing copy path.
+
+### `unflatten(a, dim, sizes)`
+
+PyTorch's unflatten delegates to `view` / `reshape` semantics. Conditional view holds when:
+
+* The split dim's stride is compatible with the new shape — i.e., `a.is_contiguous()` is sufficient (most common case), or more narrowly when `a.stride[dim]` factors cleanly across `sizes`.
+* For 1B-A we conservatively support only the "input is contiguous" path. Output shape is `a.shape[:d] + tuple(sizes) + a.shape[d+1:]`. Output stride is `_contiguous_stride(new_shape)`.
+
+When the input is not contiguous: keep the existing copy path.
+
+### Common pattern across the 3 ops
+
+```python
+if a.is_contiguous():
+    base = _get_base(a)
+    return _make_view(base, new_shape, new_stride, a.offset, op_name, source=a)
+# else: existing copy path stays unchanged
+```
+
+with `op_name` set to `"contiguous"`, `"flatten"`, or `"unflatten"`. `view_func` and `rev_view_func` are not passed (default `None`) — 1B-A leaves the autograd path unchanged. Note: for `contiguous` specifically, the open-question above proposes returning `a` directly instead of going through `_make_view`. That decision is locked in as **return `a`** for 1B-A.
+
+## Per-backend changes
+
+**CPU** — `src/candle/_backends/cpu/ops.py`:
+
+* `contiguous` (line 1351): for the default-memory-format branch, after the existing `if getattr(memory_format, "_name", None) == "channels_last":` block, when `memory_format is None` or `contiguous_format`: if `a.is_contiguous()`, `return a`. Otherwise keep `np.ascontiguousarray(_to_numpy(a))` copy.
+* `flatten` (line 3058): if `a.is_contiguous()`, build view via `_make_view` (import `view_backend` like `movedim` does at line 3082). Otherwise keep `np.ascontiguousarray` copy.
+* `unflatten` (line 3068): same pattern as `flatten`. If `a.is_contiguous()`, view; else copy.
+
+**MPS** — `src/candle/_backends/mps/ops/shape.py`:
+
+* `contiguous` (line 23): the existing `if a.is_contiguous(): return a` already short-circuits. **Confirmed correct as-is.** No change needed for the contiguous fast-path. The change for MPS is only that this op now produces tensors that 1B-B can later wire to `view_func` — but no wiring happens here.
+* `flatten` (line 1099): the existing GPU path constructs a fresh storage tensor via `_from_metal_buffer(_metal_buf(a), new_shape, ...)` — that's a same-storage tensor but it's *not* registered as a view (no `_make_view`, no `_base`). Replace the `_can_use_gpu(a) and a.is_contiguous()` branch to go through `view_backend._make_view(...)` instead. Non-contiguous GPU and CPU-fallback paths stay unchanged.
+* `unflatten` (line 1123): same pattern as `flatten`.
+
+**NPU** — `src/candle/_backends/npu/ops/shape.py`:
+
+* `contiguous` (line 1428): currently always memcpy_d2d. Add a fast-path: if `a.is_contiguous()`, `return a`. Otherwise keep the existing memcpy path. (NPU has no memory_format parameter — only the default-format case applies.)
+* `flatten_op` (line 1409): currently always returns `view_backend.reshape(a, new_shape)`. The current behavior already produces a view when the input is contiguous (because `view_backend.reshape` calls `_make_view` for contiguous inputs and `a.contiguous()`-then-view for non-contiguous ones). **Verify by reading `view_backend.reshape`** that this already meets the conditional-view contract; if so, no NPU change is needed for `flatten_op`. If not, add explicit conditional-view branching.
+* `unflatten_op` (line 1974): same as `flatten_op` — already delegates to `view_backend.reshape`. Verify and adjust similarly.
+
+**CUDA**: no `_backends/cuda/ops/shape.py` for these ops. No change.
+
+## What changes in observable behavior
+
+After 1B-A, calling `contiguous` / `flatten` / `unflatten` on a contiguous input returns a tensor that **shares storage** with the input. Concretely:
+
+* `out.storage().data_ptr() == a.storage().data_ptr()` (was: a fresh allocation).
+* `out._base is a` (was: `None`).
+* Mutating `out` mutates `a`, and vice versa, on the contiguous fast-path. PyTorch behaves the same way.
+
+Code that called `contiguous()` *to defensively detach storage* relied on undocumented behavior — torch never guaranteed that. Anything that wants a real copy should call `.clone()`. We expect very little candle code to depend on the old detach side-effect, but the regression test suite will surface it.
+
+## Test plan
+
+New file: `tests/cpu/test_view_fastpath.py`. Tests cover:
+
+1. **Storage sharing on contiguous fast-path:**
+   * `t = torch.randn(3, 4); u = t.contiguous(); assert u.storage().data_ptr() == t.storage().data_ptr()`
+   * `t = torch.randn(3, 4); u = t.flatten(); assert u.storage().data_ptr() == t.storage().data_ptr()`
+   * `t = torch.randn(2, 6); u = t.unflatten(1, (2, 3)); assert u.storage().data_ptr() == t.storage().data_ptr()`
+
+2. **Mutation propagates through the fast-path view:**
+   * `u = t.flatten(); u[0] = 99.0; assert t.flatten()[0].item() == 99.0`
+   * Same for `unflatten` and (where applicable) `contiguous` of an already-contiguous input.
+
+3. **Copy fallback still produces an independent allocation when input is non-contiguous:**
+   * `t = torch.randn(4, 4).t()` (non-contiguous) `; u = t.contiguous(); assert u.storage().data_ptr() != t.storage().data_ptr()`
+   * Same for non-contiguous `flatten`.
+
+4. **`_base` and `_view_meta` are populated on the fast-path:**
+   * `u._base is t` (or its existing base).
+   * `u._view_meta["op"] in {"contiguous","flatten","unflatten"}`.
+   * `u._view_func is None and u._rev_view_func is None` (1B-A doesn't wire those).
+
+5. **Backward through fast-path still works** (this is the safety net for "we didn't break the existing autograd path"):
+   * `t = torch.randn(3, 4, requires_grad=True); u = t.flatten(); u.sum().backward(); assert torch.allclose(t.grad, torch.ones_like(t))`
+   * Same for `contiguous` and `unflatten`. (The existing `*Backward0` classes still run and do identity-grad — the result must be unchanged.)
+
+6. **`memory_format=channels_last` for `contiguous` is unchanged:**
+   * Existing tests in `tests/cpu/test_*memory_format*` already cover this. No new test needed; the change must not regress them.
+
+## Files touched
+
+* `src/candle/_backends/cpu/ops.py` — modify `contiguous`, `flatten`, `unflatten`.
+* `src/candle/_backends/mps/ops/shape.py` — modify `flatten`, `unflatten` GPU paths. `contiguous` already correct.
+* `src/candle/_backends/npu/ops/shape.py` — modify `contiguous`. Verify (and possibly noop) `flatten_op` and `unflatten_op` already delegate correctly through `view_backend.reshape`.
+* `tests/cpu/test_view_fastpath.py` — new file.
+* `docs/superpowers/specs/2026-05-04-view-tracking-1b-six-ops-design.md` — this spec.
+
+Estimated diff: ~80–120 lines source change + ~150 lines new test.
+
+## Verification
+
+Per `CLAUDE.md` Rule 4, `src/candle/` changes require pylint + cpu/contract tests + local backend tests:
+
+```bash
+# Pylint
+pylint src/candle/ --rcfile=.github/pylint.conf
+
+# CPU + contract
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/cpu/ tests/contract/ -v --tb=short
+
+# Local backend (this host has NPU; MPS host runs the MPS suite separately)
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/npu/ -v --tb=short
+```
+
+Targeted suites to surface 1B-A breakage early:
+
+```bash
+python -m pytest tests/cpu/test_view_fastpath.py -v --tb=short
+python -m pytest tests/cpu/test_view_tracking_infrastructure.py -v --tb=short
+python -m pytest tests/cpu/ -v -k "contiguous or flatten or unflatten" --tb=short
+```
+
+## Risks
+
+* **Hidden mutation-aliasing:** existing candle code may have called `contiguous()` expecting the result to be storage-detached. Regression coverage above will catch the most common cases; rest gets caught by the cpu/contract gate.
+* **MPS GPU path divergence:** `flatten`/`unflatten` on MPS GPU currently produce a same-storage tensor via `_from_metal_buffer` but without `_make_view` metadata. Switching to `_make_view` changes how downstream ops see this tensor (it now has `_base` and view meta). Risk surface: any MPS op that branches on `_base`. Audit `mps/ops/` for `_base is None` checks before merging.
+* **NPU `flatten_op`/`unflatten_op` already-correct assumption:** spec says "verify and possibly no-op." If the verify step finds `view_backend.reshape` *doesn't* actually preserve view-share for the contiguous case, the NPU branch needs explicit conditional-view code, not a no-op.
+
+## Out of scope (1B-B)
+
+Captured here only so the next spec author knows what's pending:
+
+* `_view_func` / `_rev_view_func` callables registered for: `contiguous`, `flatten`, `squeeze`, `narrow`, `movedim`, `unflatten`.
+* Removal of `ContiguousBackward0`, `FlattenBackward0`, `SqueezeBackward0`, `NarrowBackward0`, `MovedimBackward0`, `UnflattenBackward0` from `src/candle/_generated/functions.py`.
+* Removal of `*_autograd` wrappers in `src/candle/_generated/variable_type.py` for these 6 ops.
+* `_VT_PY` → standard registration entries in `src/candle/_generated/registration.py` for these 6 ops.
+* Engine rebase block in `_accumulate_tensor_grad` becomes live for these 6 ops (was dead code in PR #372).
+
+1B-B will get its own design doc the day 1B-A is merged.

--- a/docs/superpowers/specs/2026-05-04-view-tracking-1b-six-ops-design.md
+++ b/docs/superpowers/specs/2026-05-04-view-tracking-1b-six-ops-design.md
@@ -11,7 +11,7 @@ Land six PyTorch `VIEW_FUNCTIONS` / `RETURNS_VIEWS_OF_INPUT` ops — `contiguous
 
 The work is split into two PRs to keep blast radius small:
 
-* **1B-A (this spec, this PR):** make the **forward** path of the three currently-copying ops (`contiguous`, `flatten`, `unflatten`) match PyTorch's conditional-view semantics. No autograd or codegen changes.
+* **1B-A (this spec, this PR):** make the **forward** path of the three currently-copying ops (`contiguous`, `flatten`, `unflatten`) match PyTorch's conditional semantics. `contiguous` returns `self` when already contiguous; `flatten`/`unflatten` return real views when view-compatible. No autograd or codegen changes.
 * **1B-B (separate spec, separate PR):** wire all 6 ops into `view_func` / `rev_view_func`, drop their hand-added `*Backward0` classes from `_generated/`.
 
 This document specifies **1B-A only**. 1B-B will get its own design doc when 1B-A is merged.
@@ -36,7 +36,11 @@ So the 6 ops divide naturally:
 * 3 ops (`narrow`, `squeeze`, `movedim`) already produce a real view in candle. Forward is correct. They are "forward-clean, autograd-pending."
 * 3 ops (`contiguous`, `flatten`, `unflatten`) still always allocate a fresh storage and copy. Forward is wrong vs torch. They need a forward fix before any view-tracking wiring will work — you cannot rebase a gradient onto a view that isn't actually a view.
 
-**1B-A fixes the forward path of the second group.** It does not touch autograd. After 1B-A all 6 ops produce real views when the input is contiguous (or otherwise view-compatible), but their Backward classes still run unchanged.
+**1B-A fixes the forward path of the second group.** It does not touch autograd. After 1B-A:
+
+* `contiguous(a)` returns `a` itself when `a` is already contiguous (matching torch's identity behavior); otherwise the existing copy path runs.
+* `flatten(a, ...)` and `unflatten(a, ...)` return real views (via `_make_view`) when `a` is contiguous; otherwise the existing copy path runs.
+* All 6 ops' Backward classes still run unchanged — autograd routing is 1B-B's job.
 
 ## Why split 1B into 1B-A + 1B-B
 
@@ -52,8 +56,9 @@ Mixing both into one PR would mean a 6-op forward semantic change *and* an autog
 **In scope:**
 
 * Backend forward path for `contiguous`, `flatten`, `unflatten` on CPU, MPS, and NPU.
-* Make each return a real view (via `_make_view`) when the input's existing layout already satisfies the op's contract. Otherwise keep the copy path.
-* New test file `tests/cpu/test_view_fastpath.py` covering view-share semantics and the still-copy fallback.
+* `contiguous`: when input is already contiguous in the requested format, return the input itself (`return a`).
+* `flatten` / `unflatten`: when input is contiguous, return a real view via `_make_view`. Otherwise keep the copy path.
+* New test file `tests/cpu/test_view_fastpath.py` covering the three behaviors above.
 
 **Out of scope (deferred to 1B-B):**
 
@@ -69,15 +74,14 @@ Each of the three ops gets a **view fast-path** under specific conditions; other
 ### `contiguous(a, memory_format=None)`
 
 * `memory_format` is `None` or `contiguous_format` (default):
-  * If `a.is_contiguous()`: return a view with the same shape/stride/offset (essentially `a`, but constructed through `_make_view` so it carries view metadata). This matches PyTorch's `t.contiguous()` returning `self` when already contiguous.
+  * If `a.is_contiguous()`: **return `a` directly** (matching torch's `t.contiguous()` returning `self` for already-contiguous inputs — same Python identity, no `_make_view` wrap).
 * `memory_format` is `channels_last`:
   * Already handled correctly: existing path returns `a` when `_is_channels_last_stride(...)` matches. No change needed.
 * Otherwise: keep the existing copy path (`np.ascontiguousarray` on CPU, `aclnnInplaceCopy`-equivalent on NPU, `_dispatch_unary_gpu(a, "identity")` on MPS).
 
 The functional contract is "guaranteed contiguous output." The view fast-path satisfies that contract because the input is already contiguous.
 
-> **Open question — return `a` directly vs. `_make_view`.**
-> Today, when the input is already contiguous, the cpu and mps `contiguous` paths return `a` itself (no metadata wrap). Going through `_make_view` produces a *new* tensor that shares storage. PyTorch's `t.contiguous()` returns `self` (same Python object) for already-contiguous inputs. To match torch's identity behavior we should **return `a` directly** in the fast-path — not wrap through `_make_view`. The wrap-through-`_make_view` form would only be needed if 1B-B's `view_func`/`rev_view_func` wiring requires distinct view metadata, in which case 1B-B can revisit. For 1B-A the right call is **return `a`**.
+Note that today the cpu `contiguous` path **does not** short-circuit to `return a` even when the input is already contiguous in default format — it always allocates via `np.ascontiguousarray`. That's the bug 1B-A fixes for cpu. The mps `contiguous` already returns `a` on the fast-path (line 23) and is correct as-is.
 
 ### `flatten(a, start_dim=0, end_dim=-1)`
 
@@ -100,14 +104,18 @@ When the input is not contiguous: keep the existing copy path.
 
 ### Common pattern across the 3 ops
 
+For `flatten` and `unflatten`:
+
 ```python
 if a.is_contiguous():
     base = _get_base(a)
-    return _make_view(base, new_shape, new_stride, a.offset, op_name, source=a)
+    return _make_view(base, new_shape, _contiguous_stride(new_shape), a.offset, op_name, source=a)
 # else: existing copy path stays unchanged
 ```
 
-with `op_name` set to `"contiguous"`, `"flatten"`, or `"unflatten"`. `view_func` and `rev_view_func` are not passed (default `None`) — 1B-A leaves the autograd path unchanged. Note: for `contiguous` specifically, the open-question above proposes returning `a` directly instead of going through `_make_view`. That decision is locked in as **return `a`** for 1B-A.
+with `op_name` set to `"flatten"` or `"unflatten"`. `view_func` and `rev_view_func` are not passed (default `None`) — 1B-A leaves the autograd path unchanged.
+
+For `contiguous` the fast-path is simpler — `return a` directly (no `_make_view` wrap). Output is the same Python object as the input, matching torch's `t.contiguous() is t` identity when already contiguous.
 
 ## Per-backend changes
 
@@ -133,41 +141,46 @@ with `op_name` set to `"contiguous"`, `"flatten"`, or `"unflatten"`. `view_func`
 
 ## What changes in observable behavior
 
-After 1B-A, calling `contiguous` / `flatten` / `unflatten` on a contiguous input returns a tensor that **shares storage** with the input. Concretely:
+After 1B-A:
 
-* `out.storage().data_ptr() == a.storage().data_ptr()` (was: a fresh allocation).
-* `out._base is a` (was: `None`).
-* Mutating `out` mutates `a`, and vice versa, on the contiguous fast-path. PyTorch behaves the same way.
+* `contiguous(a)` when `a` is already contiguous returns `a` itself (`out is a`). Was: a fresh copy with new storage.
+* `flatten(a, ...)` / `unflatten(a, ...)` when `a` is contiguous return a view: `out.storage().data_ptr() == a.storage().data_ptr()`, `out._base is _get_base(a)`. Was: a fresh copy.
+* For non-contiguous input, all three ops still allocate and copy as before.
+* Mutating the fast-path output mutates the input's storage, and vice versa. PyTorch behaves the same way.
 
-Code that called `contiguous()` *to defensively detach storage* relied on undocumented behavior — torch never guaranteed that. Anything that wants a real copy should call `.clone()`. We expect very little candle code to depend on the old detach side-effect, but the regression test suite will surface it.
+Code that called `contiguous()` / `flatten()` / `unflatten()` *to defensively detach storage* relied on undocumented behavior — torch never guaranteed that. Anything that wants a real copy should call `.clone()`. We expect very little candle code to depend on the old detach side-effect, but the regression test suite will surface it.
 
 ## Test plan
 
 New file: `tests/cpu/test_view_fastpath.py`. Tests cover:
 
-1. **Storage sharing on contiguous fast-path:**
-   * `t = torch.randn(3, 4); u = t.contiguous(); assert u.storage().data_ptr() == t.storage().data_ptr()`
+1. **`contiguous` returns self on the fast-path:**
+   * `t = torch.randn(3, 4); u = t.contiguous(); assert u is t`
+   * `t = torch.randn(3, 4).t(); u = t.contiguous(); assert u is not t and u.storage().data_ptr() != t.storage().data_ptr()` (non-contiguous still copies)
+
+2. **`flatten` / `unflatten` storage sharing on contiguous fast-path:**
    * `t = torch.randn(3, 4); u = t.flatten(); assert u.storage().data_ptr() == t.storage().data_ptr()`
    * `t = torch.randn(2, 6); u = t.unflatten(1, (2, 3)); assert u.storage().data_ptr() == t.storage().data_ptr()`
 
-2. **Mutation propagates through the fast-path view:**
-   * `u = t.flatten(); u[0] = 99.0; assert t.flatten()[0].item() == 99.0`
-   * Same for `unflatten` and (where applicable) `contiguous` of an already-contiguous input.
+3. **Mutation propagates through the fast-path view:**
+   * `t = torch.randn(3, 4); u = t.flatten(); u[0] = 99.0; assert t.view(-1)[0].item() == 99.0`
+   * Same for `unflatten`.
 
-3. **Copy fallback still produces an independent allocation when input is non-contiguous:**
-   * `t = torch.randn(4, 4).t()` (non-contiguous) `; u = t.contiguous(); assert u.storage().data_ptr() != t.storage().data_ptr()`
-   * Same for non-contiguous `flatten`.
+4. **Copy fallback still produces an independent allocation when input is non-contiguous:**
+   * `t = torch.randn(4, 4).t()` (non-contiguous) `; u = t.flatten(); assert u.storage().data_ptr() != t.storage().data_ptr()`
+   * Same for `unflatten`.
 
-4. **`_base` and `_view_meta` are populated on the fast-path:**
-   * `u._base is t` (or its existing base).
-   * `u._view_meta["op"] in {"contiguous","flatten","unflatten"}`.
+5. **`_base` and `_view_meta` are populated on the `flatten`/`unflatten` fast-path:**
+   * `u._base is _get_base(t)` (resolves via `_make_view`'s `_get_base` call).
+   * `u._view_meta["op"] in {"flatten", "unflatten"}`.
    * `u._view_func is None and u._rev_view_func is None` (1B-A doesn't wire those).
+   * For `contiguous` fast-path: `u is t`, so `u._view_meta` reflects `t`'s pre-existing meta (no new view created) — there's no new view metadata to assert here.
 
-5. **Backward through fast-path still works** (this is the safety net for "we didn't break the existing autograd path"):
+6. **Backward through fast-path still works** (this is the safety net for "we didn't break the existing autograd path"):
    * `t = torch.randn(3, 4, requires_grad=True); u = t.flatten(); u.sum().backward(); assert torch.allclose(t.grad, torch.ones_like(t))`
-   * Same for `contiguous` and `unflatten`. (The existing `*Backward0` classes still run and do identity-grad — the result must be unchanged.)
+   * Same for `unflatten`. For `contiguous` on already-contiguous input the existing tests already cover this since the function is now a true no-op.
 
-6. **`memory_format=channels_last` for `contiguous` is unchanged:**
+7. **`memory_format=channels_last` for `contiguous` is unchanged:**
    * Existing tests in `tests/cpu/test_*memory_format*` already cover this. No new test needed; the change must not regress them.
 
 ## Files touched

--- a/src/candle/_C/_tensor_api.pyx
+++ b/src/candle/_C/_tensor_api.pyx
@@ -808,9 +808,17 @@ def tensor_flatten(self, start_dim=0, end_dim=-1):
     cdef Py_ssize_t i
     cdef Py_ssize_t flattened = 1
     cdef tuple new_shape
+    cdef object result
+    cdef object meta
 
     if ndim == 0:
-        return self.reshape((1,))
+        result = self.reshape((1,))
+        meta = getattr(result, "_view_meta", None)
+        if meta is not None:
+            meta = dict(meta)
+            meta["op"] = "flatten"
+            result._view_meta = meta
+        return result
     if start_dim < 0:
         start_dim += ndim
     if end_dim < 0:
@@ -825,7 +833,13 @@ def tensor_flatten(self, start_dim=0, end_dim=-1):
     for i in range(start_dim, end_dim + 1):
         flattened *= self.shape[i]
     new_shape = self.shape[:start_dim] + (flattened,) + self.shape[end_dim + 1:]
-    return self.reshape(new_shape)
+    result = self.reshape(new_shape)
+    meta = getattr(result, "_view_meta", None)
+    if meta is not None:
+        meta = dict(meta)
+        meta["op"] = "flatten"
+        result._view_meta = meta
+    return result
 
 
 def tensor_t(self):
@@ -1550,9 +1564,22 @@ def tensor_div_(self, other):
 
 def tensor_unflatten(self, dim, sizes):
     cdef Py_ssize_t ndim = len(self.shape)
+    cdef tuple new_shape
+    cdef object result
+    cdef object meta
     if dim < 0:
         dim += ndim
-    return self.view(self.shape[:dim] + tuple(sizes) + self.shape[dim + 1:])
+    new_shape = self.shape[:dim] + tuple(sizes) + self.shape[dim + 1:]
+    # Use reshape (not view) so non-contiguous input falls back to a copy
+    # instead of raising. PyTorch's unflatten has the same conditional-view
+    # semantics.
+    result = self.reshape(new_shape)
+    meta = getattr(result, "_view_meta", None)
+    if meta is not None:
+        meta = dict(meta)
+        meta["op"] = "unflatten"
+        result._view_meta = meta
+    return result
 
 
 def tensor_bitwise_and_(self, other):

--- a/tests/cpu/test_view_fastpath.py
+++ b/tests/cpu/test_view_fastpath.py
@@ -1,0 +1,120 @@
+"""Pin conditional-view forward semantics for contiguous/flatten/unflatten.
+
+After Sub-batch 1B-A:
+- contiguous(a) returns `a` itself when a is already contiguous in default
+  format. Non-contiguous input still copies.
+- flatten(a, ...) and unflatten(a, ...) return a real view (storage shared,
+  _base set, _view_meta["op"] populated) when a is contiguous. Non-contiguous
+  input still copies.
+
+Tests stay on CPU — MPS and NPU regression coverage rides on the cpu/contract
+gate plus the existing per-backend test suites.
+"""
+import numpy as np
+import candle as torch
+
+
+# ---------------------------------------------------------------------------
+# contiguous
+# ---------------------------------------------------------------------------
+
+def test_contiguous_returns_self_when_already_contiguous():
+    t = torch.randn(3, 4)
+    assert t.is_contiguous()
+    u = t.contiguous()
+    assert u is t
+
+
+def test_contiguous_copies_when_input_is_non_contiguous():
+    t = torch.randn(4, 4).t()
+    assert not t.is_contiguous()
+    u = t.contiguous()
+    assert u is not t
+    assert u.storage() is not t.storage()
+    assert u.is_contiguous()
+
+
+# ---------------------------------------------------------------------------
+# flatten
+# ---------------------------------------------------------------------------
+
+def test_flatten_shares_storage_when_input_is_contiguous():
+    t = torch.randn(3, 4)
+    u = t.flatten()
+    assert u.storage() is t.storage()
+    assert u._base is not None
+    assert u._view_meta is not None
+    assert u._view_meta["op"] == "flatten"
+    assert u._view_func is None
+    assert u._rev_view_func is None
+
+
+def test_flatten_view_mutation_propagates_to_input():
+    t = torch.randn(3, 4)
+    u = t.flatten()
+    u[0] = 99.0
+    np.testing.assert_array_equal(t.flatten().numpy()[0], 99.0)
+
+
+def test_flatten_copies_when_input_is_non_contiguous():
+    t = torch.randn(4, 4).t()
+    assert not t.is_contiguous()
+    u = t.flatten()
+    assert u.storage() is not t.storage()
+
+
+# ---------------------------------------------------------------------------
+# unflatten
+# ---------------------------------------------------------------------------
+
+def test_unflatten_shares_storage_when_input_is_contiguous():
+    t = torch.randn(2, 6)
+    u = t.unflatten(1, (2, 3))
+    assert u.storage() is t.storage()
+    assert u._base is not None
+    assert u._view_meta is not None
+    assert u._view_meta["op"] == "unflatten"
+    assert u._view_func is None
+    assert u._rev_view_func is None
+
+
+def test_unflatten_view_mutation_propagates_to_input():
+    t = torch.randn(2, 6)
+    u = t.unflatten(1, (2, 3))
+    u[0, 0, 0] = 99.0
+    np.testing.assert_array_equal(t.numpy()[0, 0], 99.0)
+
+
+def test_unflatten_copies_when_input_is_non_contiguous():
+    t = torch.randn(4, 4).t()
+    assert not t.is_contiguous()
+    u = t.unflatten(0, (2, 2))
+    assert u.storage() is not t.storage()
+
+
+# ---------------------------------------------------------------------------
+# Backward through the fast-path is unchanged: hand-added *Backward0 classes
+# in src/candle/_generated/functions.py still drive grad propagation in 1B-A.
+# These tests guard against regressions in that wiring.
+# ---------------------------------------------------------------------------
+
+def test_flatten_backward_is_identity_after_fast_path():
+    t = torch.randn(3, 4, requires_grad=True)
+    u = t.flatten()
+    u.sum().backward()
+    np.testing.assert_array_equal(t.grad.numpy(), np.ones((3, 4), dtype=np.float32))
+
+
+def test_unflatten_backward_is_identity_after_fast_path():
+    t = torch.randn(2, 6, requires_grad=True)
+    u = t.unflatten(1, (2, 3))
+    u.sum().backward()
+    np.testing.assert_array_equal(t.grad.numpy(), np.ones((2, 6), dtype=np.float32))
+
+
+def test_contiguous_backward_is_identity_when_already_contiguous():
+    t = torch.randn(3, 4, requires_grad=True)
+    u = t.contiguous()
+    assert u is t
+    u.sum().backward()
+    np.testing.assert_array_equal(t.grad.numpy(), np.ones((3, 4), dtype=np.float32))


### PR DESCRIPTION
## Summary

Sub-batch **1B-A** of the view-tracking work (predecessor: PR #372). Fixes `_view_meta["op"]` for `flatten`/`unflatten` so subsequent 1B-B autograd wiring can route gradients through the right view callback.

PyTorch's \`flatten\`/\`unflatten\` are conditional-view ops in \`VIEW_FUNCTIONS\`: when the input is contiguous they return a real view sharing storage with the input, otherwise they fall back to a copy. Candle was already producing a view in the contiguous case (via \`reshape\`), but the \`_view_meta[\"op\"]\` was set to \`\"reshape\"\` rather than \`\"flatten\"\`/\`\"unflatten\"\`, which would mis-route the eventual \`view_func\`/\`rev_view_func\` lookup in 1B-B.

This PR fixes only the forward path. No autograd or codegen changes — the hand-added \`FlattenBackward0\` / \`UnflattenBackward0\` continue to run unchanged. 1B-B will wire \`view_func\`/\`rev_view_func\` and remove the hand-added Backward classes.

## Changes

* \`src/candle/_C/_tensor_api.pyx\`:
  * \`tensor_flatten\`: after \`self.reshape(new_shape)\`, override \`result._view_meta[\"op\"] = \"flatten\"\` (with \`dict()\` copy to avoid sharing dict identity).
  * \`tensor_unflatten\`: switched routing from \`self.view\` to \`self.reshape\` so non-contiguous input falls back to a copy (matching torch) instead of raising; override \`result._view_meta[\"op\"] = \"unflatten\"\`.
* \`tests/cpu/test_view_fastpath.py\`: 11 new tests pinning conditional-view semantics (storage sharing, mutation propagation, copy fallback, \`_view_meta\` op string, backward identity).
* \`docs/superpowers/specs/2026-05-04-view-tracking-1b-six-ops-design.md\`: 1B-A design doc.
* \`docs/superpowers/plans/2026-05-05-view-tracking-1b-six-ops.md\`: 1B-A implementation plan.

\`tensor_contiguous\` (line 790) was already correct — it returns \`self\` when \`is_contiguous(memory_format=...)\`. No change needed there.

The 6 backend kernel files in \`_backends/{cpu,mps,npu}/\` are NOT on the call path for these methods — \`Tensor.flatten\`/\`unflatten\`/\`contiguous\` route through the \`_C/_TensorBase.pyx\` install table → \`_tensor_api.tensor_*\`. So a single Cython source change covers all backends uniformly.

## Test plan

- [x] \`pytest tests/cpu/test_view_fastpath.py -v\` — 11/11 pass
- [x] \`pytest tests/cpu/test_view_tracking_infrastructure.py tests/cpu/test_tensor_view.py -v\` — 355/355 pass
- [x] \`pytest tests/cpu/ tests/contract/\` — 3031/3031 pass (1 pre-existing failure: \`test_codegen_roundtrip\` is the documented codegen drift, unrelated; verified to also fail at \`cdb2ce8\` baseline before this change)
- [x] \`pylint src/candle/ --rcfile=.github/pylint.conf\` — 10.00/10
- [ ] NPU regression — local NPU runtime unavailable (\`libunified_dlog.so\` missing); CI will validate
- [ ] MPS regression — no Apple Silicon host on this machine; CI will validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)