### PR TITLE
fix(autograd): align zeta backward error parity

### DIFF
--- a/src/candle/_generated/_functions_cy.pyx
+++ b/src/candle/_generated/_functions_cy.pyx
@@ -30,7 +30,7 @@ _current_dispatch_keyset = None
 
 
 def _cy_not_implemented(name):
-    raise NotImplementedError(name)
+    raise NotImplementedError(f"the derivative for '{name}' is not implemented.")
 
 
 cdef inline void _ensure_refs():

--- a/src/candle/_generated/functions.py
+++ b/src/candle/_generated/functions.py
@@ -17,6 +17,10 @@ from .._dispatch.dispatcher import redispatch
 from ..autograd.utils import reduce_grad
 
 
+def _raise_not_implemented(name):
+    raise NotImplementedError(f"the derivative for '{name}' is not implemented.")
+
+
 def _inverse_permutation(dims):
     inv = [0] * len(dims)
     for i, d in enumerate(dims):

--- a/tests/contract/test_autograd_contract.py
+++ b/tests/contract/test_autograd_contract.py
@@ -17,3 +17,17 @@ def test_inplace_view_version_error_message():
         y.sum().backward()
 
     assert_torch_error(mt, th)
+
+
+def test_special_zeta_backward_error_matches_torch():
+    def mt():
+        x = torch.tensor([2.5], requires_grad=True)
+        q = torch.tensor([3.0])
+        torch.special.zeta(x, q).sum().backward()
+
+    def th():
+        x = pt.tensor([2.5], requires_grad=True)
+        q = pt.tensor([3.0])
+        pt.special.zeta(x, q).sum().backward()
+
+    assert_torch_error(mt, th)

--- a/tools/autograd/formula_transpiler.py
+++ b/tools/autograd/formula_transpiler.py
@@ -607,7 +607,7 @@ def _split_ternary(expr: str):
 
 
 def _raise_not_implemented(name):
-    raise NotImplementedError(name)
+    raise NotImplementedError(f"the derivative for '{name}' is not implemented.")
 
 
 __all__ = ['transpile', 'TranspileError']

--- a/tools/autograd/gen_functions.py
+++ b/tools/autograd/gen_functions.py
@@ -44,6 +44,10 @@ from .._dispatch.dispatcher import redispatch
 from ..autograd.utils import reduce_grad
 
 
+def _raise_not_implemented(name):
+    raise NotImplementedError(f"the derivative for '{name}' is not implemented.")
+
+
 def _inverse_permutation(dims):
     inv = [0] * len(dims)
     for i, d in enumerate(dims):
@@ -1660,7 +1664,7 @@ _current_dispatch_keyset = None
 
 
 def _cy_not_implemented(name):
-    raise NotImplementedError(name)
+    raise NotImplementedError(f"the derivative for '{name}' is not implemented.")
 
 
 cdef inline void _ensure_refs():


### PR DESCRIPTION
## Summary
- align Candle `special.zeta` backward `NotImplementedError` type/message with PyTorch
- restore the missing runtime `_raise_not_implemented` helper in preserved generated Python backward nodes
- sync the generator templates and checked-in generated Cython helper so codegen roundtrips stay consistent

## Test plan
- [x] `env PYTHONPATH=src conda run --no-capture-output -n candle311 python -m pytest tests/contract/test_autograd_contract.py -k special_zeta -v --tb=short`
- [x] `env PYTHONPATH=src conda run --no-capture-output -n candle311 python -m pytest tests/contract/test_codegen_roundtrip.py -v --tb=short`
- [x] `env PYTHONPATH=src conda run --no-capture-output -n candle311 python -m pytest tests/cpu/ tests/contract/ -v --tb=short`
- [x] `conda run --no-capture-output -n candle311 pylint tools/autograd/ --rcfile=.github/pylint.conf`
- [x] `env PYTHONPATH=src conda run --no-capture-output -n candle311 pylint src/candle/ --rcfile=.github/pylint.conf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)