### PR TITLE
fix(autograd): align gammainc backward error parity

### DIFF
--- a/src/candle/_backends/autograd.py
+++ b/src/candle/_backends/autograd.py
@@ -5770,7 +5770,8 @@ def _special_multigammaln_backward(grad, _a, saved_a, keyset, args, kwargs):
 def _special_gammainc_backward(grad, a, b, saved_a, saved_b, keyset):
     """Backward for gammainc(a, x): grad_x = x^(a-1)*exp(-x)/gamma(a)."""
     with _grad_context(keyset):
-        grad_a = None  # grad w.r.t. a is complex (involves integral), skip
+        if getattr(a, "requires_grad", False):
+            raise NotImplementedError("the derivative for 'igamma: input' is not implemented.")
         if getattr(b, "requires_grad", False):
             ones = saved_a._ones_like()
             a_minus_1 = redispatch("sub", keyset, saved_a, ones)
@@ -5782,15 +5783,15 @@ def _special_gammainc_backward(grad, a, b, saved_a, saved_b, keyset):
             grad_b = redispatch("mul", keyset, grad, deriv)
         else:
             grad_b = None
-    grad_a = reduce_grad(grad_a, a.shape) if grad_a is not None else None
     grad_b = reduce_grad(grad_b, b.shape) if grad_b is not None else None
-    return grad_a, grad_b
+    return None, grad_b
 
 
 def _special_gammaincc_backward(grad, a, b, saved_a, saved_b, keyset):
     """Backward for gammaincc(a, x): negative of gammainc grad_x."""
     with _grad_context(keyset):
-        grad_a = None
+        if getattr(a, "requires_grad", False):
+            raise NotImplementedError("the derivative for 'igammac: input' is not implemented.")
         if getattr(b, "requires_grad", False):
             ones = saved_a._ones_like()
             a_minus_1 = redispatch("sub", keyset, saved_a, ones)
@@ -5803,9 +5804,8 @@ def _special_gammaincc_backward(grad, a, b, saved_a, saved_b, keyset):
             grad_b = redispatch("mul", keyset, grad, deriv)
         else:
             grad_b = None
-    grad_a = reduce_grad(grad_a, a.shape) if grad_a is not None else None
     grad_b = reduce_grad(grad_b, b.shape) if grad_b is not None else None
-    return grad_a, grad_b
+    return None, grad_b
 
 
 # Special polygamma needs a custom wrapper since n is first arg, x is second

--- a/tests/contract/test_autograd_contract.py
+++ b/tests/contract/test_autograd_contract.py
@@ -31,3 +31,31 @@ def test_special_zeta_backward_error_matches_torch():
         pt.special.zeta(x, q).sum().backward()
 
     assert_torch_error(mt, th)
+
+
+def test_special_gammainc_backward_error_matches_torch():
+    def mt():
+        x = torch.tensor([2.0], requires_grad=True)
+        y = torch.tensor([1.0])
+        torch.special.gammainc(x, y).sum().backward()
+
+    def th():
+        x = pt.tensor([2.0], requires_grad=True)
+        y = pt.tensor([1.0])
+        pt.special.gammainc(x, y).sum().backward()
+
+    assert_torch_error(mt, th)
+
+
+def test_special_gammaincc_backward_error_matches_torch():
+    def mt():
+        x = torch.tensor([2.0], requires_grad=True)
+        y = torch.tensor([1.0])
+        torch.special.gammaincc(x, y).sum().backward()
+
+    def th():
+        x = pt.tensor([2.0], requires_grad=True)
+        y = pt.tensor([1.0])
+        pt.special.gammaincc(x, y).sum().backward()
+
+    assert_torch_error(mt, th)


### PR DESCRIPTION
## Summary
- align `torch.special.gammainc` backward error behavior with PyTorch when differentiating the input parameter
- align `torch.special.gammaincc` backward error behavior with PyTorch for the same unsupported derivative
- add contract tests that pin the `NotImplementedError` type/message parity

## Test plan
- [x] `env PYTHONPATH=src conda run --no-capture-output -n candle311 python -m pytest tests/contract/test_autograd_contract.py -k "gammainc_backward_error_matches_torch or gammaincc_backward_error_matches_torch" -v --tb=short`
- [x] `env PYTHONPATH=src conda run --no-capture-output -n candle311 python -m pytest tests/contract/test_autograd_contract.py -v --tb=short`
- [x] `env PYTHONPATH=src conda run --no-capture-output -n candle311 python -m pytest tests/cpu/test_special.py -k "gammainc or gammaincc" -v --tb=short`
- [x] `env PYTHONPATH=src conda run --no-capture-output -n candle311 python -m pytest tests/cpu/test_autograd.py -k test_autograd_diag_and_special_binary_batch_routes_compiled_backward -v --tb=short`
- [x] `conda run -n candle311 pylint src/candle/_backends/autograd.py --rcfile=.github/pylint.conf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)