### PR TITLE
fix(autograd): align unique_consecutive backward errors

### DIFF
--- a/src/candle/_functional.py
+++ b/src/candle/_functional.py
@@ -1563,7 +1563,20 @@ def unique(a, sorted=True, return_inverse=False, return_counts=False, dim=None):
 
 
 def unique_consecutive(a, return_inverse=False, return_counts=False, dim=None):
-    return dispatch("unique_consecutive", a.device.type, a, return_inverse, return_counts, dim)
+    out = dispatch("unique_consecutive", a.device.type, a, return_inverse, return_counts, dim)
+    if GradMode.enabled and getattr(a, "requires_grad", False):
+        from .autograd.anomaly_mode import annotate_node_creation
+        from .autograd.node import Node
+
+        def _backward(_grad):
+            raise NotImplementedError("the derivative for 'unique_consecutive' is not implemented.")
+
+        node = Node(_backward, (a,), name="UniqueConsecutiveBackward0")
+        annotate_node_creation(node)
+        result = out[0] if isinstance(out, tuple) else out
+        result.grad_fn = node
+        result.requires_grad = True
+    return out
 
 
 def searchsorted(sorted_seq, values, out_int32=False, right=False, side=None, sorter=None):

--- a/tests/contract/test_autograd_contract.py
+++ b/tests/contract/test_autograd_contract.py
@@ -71,3 +71,15 @@ def test_unique_backward_error_matches_torch():
         pt.unique(x).sum().backward()
 
     assert_torch_error(mt, th)
+
+
+def test_unique_consecutive_backward_error_matches_torch():
+    def mt():
+        x = torch.tensor([1.0, 1.0, 2.0], requires_grad=True)
+        torch.unique_consecutive(x).sum().backward()
+
+    def th():
+        x = pt.tensor([1.0, 1.0, 2.0], requires_grad=True)
+        pt.unique_consecutive(x).sum().backward()
+
+    assert_torch_error(mt, th)


### PR DESCRIPTION
## Summary
- Preserve the autograd edge for `unique_consecutive` outputs when the input requires grad.
- Match PyTorch's unsupported backward behavior by raising the same `NotImplementedError` message.
- Add a contract test covering `unique_consecutive` backward error parity.

## Test plan
- [x] `env PYTHONPATH="/home/jenkins/lvyufeng/candle/.claude/worktrees/autograd-batch-s-chunk-backward/src" conda run --no-capture-output -n candle311 python -m pytest tests/contract/test_autograd_contract.py -k unique_consecutive_backward_error_matches_torch -v --tb=short`
- [x] `env PYTHONPATH="/home/jenkins/lvyufeng/candle/.claude/worktrees/autograd-batch-s-chunk-backward/src" conda run --no-capture-output -n candle311 python -m pytest tests/contract/test_autograd_contract.py -v --tb=short`
- [x] `env PYTHONPATH="/home/jenkins/lvyufeng/candle/.claude/worktrees/autograd-batch-s-chunk-backward/src" conda run --no-capture-output -n candle311 python -m pytest tests/contract/test_autograd_audit_inventory.py -v --tb=short`
- [x] `env PYTHONPATH="/home/jenkins/lvyufeng/candle/.claude/worktrees/autograd-batch-s-chunk-backward/src" conda run --no-capture-output -n candle311 pylint src/candle/_functional.py src/candle/_backends/autograd.py --rcfile=.github/pylint.conf`
- [x] `git diff --check`
- [x] `env PYTHONPATH="/home/jenkins/lvyufeng/candle/.claude/worktrees/autograd-batch-s-chunk-backward/src" conda run --no-capture-output -n candle311 python -m pytest tests/cpu/ tests/contract/ -q --tb=short`

🤖 Generated with [Claude Code](https://claude.com/claude-code)