### PR TITLE
fix(autograd): align nextafter backward errors

### DIFF
--- a/src/candle/__init__.py
+++ b/src/candle/__init__.py
@@ -165,7 +165,7 @@ from ._functional import add_, mul_, relu_, zero_, clamp_, copy_
 from ._functional import min, max, amin, amax, fmin, fmax, where
 from ._functional import atan, atan2, asin, acos, lerp, addcmul, addcdiv
 from ._functional import reshape, transpose, view_as_real, view_as_complex
-from ._functional import logaddexp, logaddexp2, hypot, remainder, fmod
+from ._functional import logaddexp, logaddexp2, hypot, remainder, fmod, nextafter
 from ._functional import squeeze, unsqueeze, permute
 from ._functional import var, var_mean, norm, prod
 from ._functional import reciprocal, addmm, einsum
@@ -823,6 +823,7 @@ __all__ = [
     "hypot",
     "remainder",
     "fmod",
+    "nextafter",
     "sum",
     "std",
     "reshape",

--- a/src/candle/_backends/cpu/__init__.py
+++ b/src/candle/_backends/cpu/__init__.py
@@ -180,6 +180,7 @@ from .ops import (
     hypot,
     remainder,
     fmod,
+    nextafter,
     flip,
     roll,
     rot90,
@@ -373,6 +374,7 @@ registry.register("logaddexp2", "cpu", logaddexp2, meta=meta_infer.infer_binary)
 registry.register("hypot", "cpu", hypot, meta=meta_infer.infer_binary)
 registry.register("remainder", "cpu", remainder, meta=meta_infer.infer_binary)
 registry.register("fmod", "cpu", fmod, meta=meta_infer.infer_binary)
+registry.register("nextafter", "cpu", nextafter, meta=meta_infer.infer_binary)
 registry.register("flip", "cpu", flip, meta=meta_infer.infer_flip)
 registry.register("roll", "cpu", roll, meta=meta_infer.infer_roll)
 registry.register("rot90", "cpu", rot90, meta=meta_infer.infer_rot90)

--- a/src/candle/_backends/cpu/ops.py
+++ b/src/candle/_backends/cpu/ops.py
@@ -1850,6 +1850,13 @@ def fmod(a, b):
     return _from_numpy(np.fmod(a_np, b_np), ref.dtype, ref.device)
 
 
+def nextafter(a, b):
+    a_np = _to_numpy(a) if isinstance(a, Tensor) else a
+    b_np = _to_numpy(b) if isinstance(b, Tensor) else b
+    ref = a if isinstance(a, Tensor) else b
+    return _from_numpy(np.nextafter(a_np, b_np), ref.dtype, ref.device)
+
+
 def _normalize_index_key(key):
     if isinstance(key, Tensor):
         arr = _to_numpy(key)

--- a/src/candle/_dispatch/schemas.py
+++ b/src/candle/_dispatch/schemas.py
@@ -419,7 +419,7 @@ def register_schemas():
     registry.register_schema("dropout", "dropout(Tensor input, float p=0.5, bool training=True) -> Tensor")
     registry.register_schema("leaky_relu", "leaky_relu(Tensor input, float negative_slope=0.01) -> Tensor")
     registry.register_schema("elu", "elu(Tensor input, float alpha=1.0) -> Tensor")
-    _register_binary_ops(("pow", "sub", "div", "true_divide", "min", "max", "fmin", "fmax", "atan2", "logaddexp", "logaddexp2", "hypot", "remainder", "fmod"), other_type="Any")
+    _register_binary_ops(("pow", "sub", "div", "true_divide", "min", "max", "fmin", "fmax", "atan2", "logaddexp", "logaddexp2", "hypot", "remainder", "fmod", "nextafter"), other_type="Any")
     registry.register_schema("lerp", "lerp(Tensor input, Tensor other, Any weight) -> Tensor")
     registry.register_schema("addcmul", "addcmul(Tensor input, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor")
     registry.register_schema("addcdiv", "addcdiv(Tensor input, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor")

--- a/src/candle/_functional.py
+++ b/src/candle/_functional.py
@@ -539,6 +539,10 @@ def fmod(a, b):
     return dispatch("fmod", a.device.type, a, b)
 
 
+def nextafter(a, b):
+    return dispatch("nextafter", a.device.type, a, b)
+
+
 def div(a, b, *, rounding_mode=None):
     r = _handle_torch_function(div, (a, b), {'rounding_mode': rounding_mode})
     if r is not NotImplemented:

--- a/src/candle/_generated/registration.py
+++ b/src/candle/_generated/registration.py
@@ -115,6 +115,8 @@ def register_generated_autograd_kernels():
     register_autograd_post_kernels('floor', _VT.floor_autograd_post)
     register_autograd_kernels('fmod', default=_VT.fmod_autograd, cpu=_VT.fmod_autograd, cuda=_VT.fmod_autograd, npu=_VT.fmod_autograd, meta=_VT.fmod_autograd)
     register_autograd_post_kernels('fmod', _VT.fmod_autograd_post)
+    register_autograd_kernels('nextafter', default=_VT.nextafter_autograd, cpu=_VT.nextafter_autograd, cuda=_VT.nextafter_autograd, npu=_VT.nextafter_autograd, meta=_VT.nextafter_autograd)
+    register_autograd_post_kernels('nextafter', _VT.nextafter_autograd_post)
     register_autograd_kernels('frac', default=_VT.frac_autograd, cpu=_VT.frac_autograd, cuda=_VT.frac_autograd, npu=_VT.frac_autograd, meta=_VT.frac_autograd)
     register_autograd_post_kernels('frac', _VT.frac_autograd_post)
     register_autograd_kernels('gather', default=_VT.gather_autograd, cpu=_VT.gather_autograd, cuda=_VT.gather_autograd, npu=_VT.gather_autograd, meta=_VT.gather_autograd)

--- a/tests/contract/test_autograd_audit_inventory.py
+++ b/tests/contract/test_autograd_audit_inventory.py
@@ -226,8 +226,8 @@ def _not_implemented_entries():
 
 def test_autograd_registration_inventory_counts():
     text = _read(_SRC / "_generated" / "registration.py")
-    assert len(re.findall(r"register_autograd_kernels\(", text)) == 303
-    assert len(re.findall(r"register_autograd_post_kernels\(", text)) == 303
+    assert len(re.findall(r"register_autograd_kernels\(", text)) == 304
+    assert len(re.findall(r"register_autograd_post_kernels\(", text)) == 304
     assert re.findall(r"_VT_PY\.", text) == []
     assert "_VT = _VT_CY if _VT_CY is not None else _VT_PY" in text
 

--- a/tests/contract/test_autograd_contract.py
+++ b/tests/contract/test_autograd_contract.py
@@ -83,3 +83,17 @@ def test_unique_consecutive_backward_error_matches_torch():
         pt.unique_consecutive(x).sum().backward()
 
     assert_torch_error(mt, th)
+
+
+def test_nextafter_backward_error_matches_torch():
+    def mt():
+        x = torch.tensor([1.0], requires_grad=True)
+        y = torch.tensor([2.0])
+        torch.nextafter(x, y).sum().backward()
+
+    def th():
+        x = pt.tensor([1.0], requires_grad=True)
+        y = pt.tensor([2.0])
+        pt.nextafter(x, y).sum().backward()
+
+    assert_torch_error(mt, th)


### PR DESCRIPTION
## Summary
- expose `nextafter` on Candle's Python surface and CPU dispatch path
- register generated autograd handling for `nextafter` so backward matches PyTorch's not-implemented behavior
- add a contract test and update the autograd inventory count for the new registration

## Test plan
- [x] `env PYTHONPATH="/home/jenkins/lvyufeng/candle/.claude/worktrees/autograd-batch-s-chunk-backward/src" conda run --no-capture-output -n candle311 python -m pytest tests/contract/test_autograd_contract.py -k nextafter_backward_error_matches_torch -v --tb=short`
- [x] `env PYTHONPATH="/home/jenkins/lvyufeng/candle/.claude/worktrees/autograd-batch-s-chunk-backward/src" conda run --no-capture-output -n candle311 python -m pytest tests/contract/test_autograd_contract.py -v --tb=short`
- [x] `env PYTHONPATH="/home/jenkins/lvyufeng/candle/.claude/worktrees/autograd-batch-s-chunk-backward/src" conda run --no-capture-output -n candle311 python -m pytest tests/contract/test_autograd_audit_inventory.py -v --tb=short`
- [x] `env PYTHONPATH="/home/jenkins/lvyufeng/candle/.claude/worktrees/autograd-batch-s-chunk-backward/src" conda run --no-capture-output -n candle311 python -m pytest tests/contract/test_codegen_roundtrip.py -v --tb=short`
- [x] `env PYTHONPATH="/home/jenkins/lvyufeng/candle/.claude/worktrees/autograd-batch-s-chunk-backward/src" conda run --no-capture-output -n candle311 pylint src/candle/_functional.py src/candle/__init__.py src/candle/_dispatch/schemas.py src/candle/_backends/cpu/__init__.py src/candle/_backends/cpu/ops.py --rcfile=.github/pylint.conf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)