### PR TITLE
fix(autograd): align inverse hyperbolic inplace tensor methods

### DIFF
--- a/src/candle/_C/_TensorBase.pyx
+++ b/src/candle/_C/_TensorBase.pyx
@@ -660,6 +660,9 @@ def _install_tensor_api(TensorBase):
     TensorBase.cos_ = _tensor_api_mod.tensor_cos_
     TensorBase.tan_ = _tensor_api_mod.tensor_tan_
     TensorBase.tanh_ = _tensor_api_mod.tensor_tanh_
+    TensorBase.acosh_ = _tensor_api_mod.tensor_acosh_
+    TensorBase.asinh_ = _tensor_api_mod.tensor_asinh_
+    TensorBase.atanh_ = _tensor_api_mod.tensor_atanh_
     TensorBase.sigmoid_ = _tensor_api_mod.tensor_sigmoid_
     TensorBase.floor_ = _tensor_api_mod.tensor_floor_
     TensorBase.ceil_ = _tensor_api_mod.tensor_ceil_

--- a/src/candle/_C/_tensor_api.pyx
+++ b/src/candle/_C/_tensor_api.pyx
@@ -1169,6 +1169,24 @@ def tensor_tanh_(self):
     return _dispatch_fn("tanh_", self.device.type, self)
 
 
+def tensor_acosh_(self):
+    _ensure_dispatch_ref()
+    self._check_inplace()
+    return _dispatch_fn("acosh_", self.device.type, self)
+
+
+def tensor_asinh_(self):
+    _ensure_dispatch_ref()
+    self._check_inplace()
+    return _dispatch_fn("asinh_", self.device.type, self)
+
+
+def tensor_atanh_(self):
+    _ensure_dispatch_ref()
+    self._check_inplace()
+    return _dispatch_fn("atanh_", self.device.type, self)
+
+
 def tensor_sigmoid_(self):
     _ensure_dispatch_ref()
     self._check_inplace()

--- a/src/candle/_tensor.py
+++ b/src/candle/_tensor.py
@@ -1023,15 +1023,6 @@ class Tensor(torch._C.TensorBase):
 
         return Resize.apply(self, tensor.size())
 
-    def acosh_(self):
-        return torch.acosh_(self)
-
-    def asinh_(self):
-        return torch.asinh_(self)
-
-    def atanh_(self):
-        return torch.atanh_(self)
-
     def unique(self, sorted=True, return_inverse=False, return_counts=False, dim=None):
         r"""Returns the unique elements of the input tensor.
 

--- a/src/candle/_tensor.py
+++ b/src/candle/_tensor.py
@@ -1023,6 +1023,15 @@ class Tensor(torch._C.TensorBase):
 
         return Resize.apply(self, tensor.size())
 
+    def acosh_(self):
+        return torch.acosh_(self)
+
+    def asinh_(self):
+        return torch.asinh_(self)
+
+    def atanh_(self):
+        return torch.atanh_(self)
+
     def unique(self, sorted=True, return_inverse=False, return_counts=False, dim=None):
         r"""Returns the unique elements of the input tensor.
 

--- a/tests/contract/test_autograd_contract.py
+++ b/tests/contract/test_autograd_contract.py
@@ -97,3 +97,39 @@ def test_nextafter_backward_error_matches_torch():
         pt.nextafter(x, y).sum().backward()
 
     assert_torch_error(mt, th)
+
+
+def test_tensor_acosh_inplace_leaf_error_matches_torch():
+    def mt():
+        x = torch.tensor([2.0], requires_grad=True)
+        x.acosh_()
+
+    def th():
+        x = pt.tensor([2.0], requires_grad=True)
+        x.acosh_()
+
+    assert_torch_error(mt, th)
+
+
+def test_tensor_asinh_inplace_leaf_error_matches_torch():
+    def mt():
+        x = torch.tensor([2.0], requires_grad=True)
+        x.asinh_()
+
+    def th():
+        x = pt.tensor([2.0], requires_grad=True)
+        x.asinh_()
+
+    assert_torch_error(mt, th)
+
+
+def test_tensor_atanh_inplace_leaf_error_matches_torch():
+    def mt():
+        x = torch.tensor([0.2], requires_grad=True)
+        x.atanh_()
+
+    def th():
+        x = pt.tensor([0.2], requires_grad=True)
+        x.atanh_()
+
+    assert_torch_error(mt, th)


### PR DESCRIPTION
## Summary
- expose `Tensor.acosh_`, `Tensor.asinh_`, and `Tensor.atanh_` through the Cython Tensor API
- route those methods to the existing top-level in-place implementations so leaf requires-grad errors match PyTorch
- add contract coverage for the three Tensor in-place leaf error paths

## Test plan
- [x] `env PYTHONPATH="/home/jenkins/lvyufeng/candle/.claude/worktrees/autograd-batch-s-chunk-backward/src" conda run --no-capture-output -n candle311 python -m pytest tests/contract/test_autograd_contract.py -k "tensor_acosh_inplace_leaf_error_matches_torch or tensor_asinh_inplace_leaf_error_matches_torch or tensor_atanh_inplace_leaf_error_matches_torch" -v --tb=short`
- [x] `env PYTHONPATH="/home/jenkins/lvyufeng/candle/.claude/worktrees/autograd-batch-s-chunk-backward/src" conda run --no-capture-output -n candle311 python -m pytest tests/contract/test_autograd_contract.py -v --tb=short`
- [x] `env PYTHONPATH="/home/jenkins/lvyufeng/candle/.claude/worktrees/autograd-batch-s-chunk-backward/src" conda run --no-capture-output -n candle311 python -m pytest tests/contract/test_autograd_audit_inventory.py -v --tb=short`
- [x] `env PYTHONPATH="/home/jenkins/lvyufeng/candle/.claude/worktrees/autograd-batch-s-chunk-backward/src" conda run --no-capture-output -n candle311 python -m pytest tests/cpu/test_autograd_ops.py -q --tb=short`
- [x] `env PYTHONPATH="/home/jenkins/lvyufeng/candle/.claude/worktrees/autograd-batch-s-chunk-backward/src" conda run --no-capture-output -n candle311 pylint src/candle/_tensor.py --rcfile=.github/pylint.conf`
- [x] `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)