### PR TITLE
fix(autograd): align svd and rrelu parity

### DIFF
--- a/src/candle/__init__.py
+++ b/src/candle/__init__.py
@@ -180,6 +180,7 @@ from ._functional import baddbmm, trace, cummin, logsumexp, renorm
 from ._functional import bitwise_and, bitwise_or, bitwise_xor, bitwise_not
 from ._functional import unflatten, broadcast_to, movedim, moveaxis, diagonal
 from ._functional import unique, unique_consecutive, searchsorted, kthvalue, median
+from .nn.functional import rrelu
 # Category A: Export existing functions
 from ._functional import eq, ne, lt, le, gt, ge
 from ._functional import select, expand, masked_fill, unfold

--- a/src/candle/_backends/autograd.py
+++ b/src/candle/_backends/autograd.py
@@ -6446,14 +6446,13 @@ def _autograd_linalg_svd(name):
             def _backward(grad):
                 saved_a = node_holder["node"].saved_tensors()[0]
                 backward_keyset = _backward_dispatch_keyset(raw_keyset, active_keyset)
+                if grad.shape == out[1].shape:
+                    return _linalg_svdvals_backward(grad, saved_a, saved_a, backward_keyset)
+
                 import numpy as _np
-                # SVD backward via numpy for correctness
                 a_np = saved_a._numpy_view().astype(_np.float64)
                 U_np, S_np, Vh_np = _np.linalg.svd(a_np, full_matrices=False)
                 grad_np = grad._numpy_view().astype(_np.float64)
-
-                # Gradient w.r.t. S only (simplified)
-                # grad_A = U @ diag(grad_S) @ Vh
                 grad_a_np = U_np @ (_np.eye(S_np.shape[-1]) * grad_np[..., :S_np.shape[-1], :S_np.shape[-1]].diagonal(axis1=-2, axis2=-1)[..., None]) @ Vh_np if grad_np.ndim >= 2 else _np.zeros_like(a_np)
                 from .._C import typed_storage_from_numpy
                 from .._C._tensor_impl import cy_make_tensor_from_storage  # pylint: disable=import-error,no-name-in-module

--- a/tests/contract/test_autograd_contract.py
+++ b/tests/contract/test_autograd_contract.py
@@ -99,6 +99,21 @@ def test_nextafter_backward_error_matches_torch():
     assert_torch_error(mt, th)
 
 
+def test_top_level_rrelu_backward_matches_torch():
+    x = torch.tensor([-2.0, 1.0], requires_grad=True)
+    out = torch.rrelu(x, lower=0.1, upper=0.1, training=False)
+    out.sum().backward()
+
+    expected_x = pt.tensor([-2.0, 1.0], requires_grad=True)
+    expected = pt.rrelu(expected_x, lower=0.1, upper=0.1, training=False)
+    expected.sum().backward()
+
+    actual_out = pt.tensor(out.detach().numpy())
+    actual_grad = pt.tensor(x.grad.detach().numpy())
+    assert pt.allclose(actual_out, expected.detach(), atol=1e-6, rtol=1e-6)
+    assert pt.allclose(actual_grad, expected_x.grad.detach(), atol=1e-6, rtol=1e-6)
+
+
 def test_tensor_acosh_inplace_leaf_error_matches_torch():
     def mt():
         x = torch.tensor([2.0], requires_grad=True)

--- a/tests/cpu/test_autograd.py
+++ b/tests/cpu/test_autograd.py
@@ -1111,6 +1111,22 @@ def test_autograd_linalg_batch_routes_compiled_backward():
     )
 
 
+def test_linalg_svd_singular_values_backward_matches_svdvals():
+    x = torch.tensor([[3.0, 1.0], [1.0, 3.0]])
+    x.requires_grad = True
+    _u, s, _vh = torch.linalg.svd(x)
+
+    expected_x = torch.tensor([[3.0, 1.0], [1.0, 3.0]])
+    expected_x.requires_grad = True
+    expected = torch.linalg.svdvals(expected_x)
+
+    s.sum().backward()
+    expected.sum().backward()
+
+    assert x.grad is not None
+    assert np.allclose(x.grad.numpy(), expected_x.grad.numpy(), atol=1e-6, rtol=1e-6)
+
+
 def test_autograd_normalization_batch_routes_compiled_backward():
     x = torch.tensor([[1.0, 2.0, 3.0, 4.0], [2.0, 3.0, 4.0, 5.0]])
     x.requires_grad = True


### PR DESCRIPTION
## Summary
- Route `torch.linalg.svd(...)[1]` singular-value gradients through the existing `svdvals` backward path.
- Expose the existing `rrelu` implementation at the `torch.rrelu` top level.
- Add regression coverage for both PyTorch parity gaps.

## Test plan
- [x] `python -m pytest tests/cpu/test_autograd.py::test_linalg_svd_singular_values_backward_matches_svdvals -v --tb=short`
- [x] `python -m pytest tests/contract/test_autograd_contract.py::test_top_level_rrelu_backward_matches_torch -v --tb=short`
- [x] `python -m pytest tests/contract/test_autograd_audit_inventory.py -v --tb=short`
- [x] `python -m pytest tests/cpu/test_autograd.py tests/contract/test_autograd_contract.py -v --tb=short`
- [x] `python -m pytest tests/cpu/ tests/contract/ -v --tb=short`
- [x] `pylint src/candle/ --rcfile=.github/pylint.conf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)