### PR TITLE
fix(autograd): align manual parity gaps

### DIFF
--- a/src/candle/_backends/autograd.py
+++ b/src/candle/_backends/autograd.py
@@ -5265,13 +5265,11 @@ def _autograd_aminmax(name):
             node_holder_min = {}
             node_holder_max = {}
 
-            def _backward_min(grad):
-                backward_keyset = _backward_dispatch_keyset(raw_keyset, active_keyset)
-                return _aminmax_min_backward(grad, a, min_val, backward_keyset, dim, keepdim)
+            def _backward_min(_grad):
+                raise RuntimeError("derivative for aten::aminmax is not implemented")
 
-            def _backward_max(grad):
-                backward_keyset = _backward_dispatch_keyset(raw_keyset, active_keyset)
-                return _aminmax_max_backward(grad, a, max_val, backward_keyset, dim, keepdim)
+            def _backward_max(_grad):
+                raise RuntimeError("derivative for aten::aminmax is not implemented")
 
             node_min = Node(_backward_min, (a,), name="MinBackward0")
             annotate_node_creation(node_min)
@@ -6522,6 +6520,32 @@ def _autograd_linalg_eigh(name):
     return wrapper
 
 
+def _autograd_max_unpool1d(name):
+    def wrapper(input_tensor, indices, kernel_size, stride=None, padding=0, output_size=None):
+        active_keyset = current_dispatch_keyset()
+        raw_keyset = _strip_autograd_keys(active_keyset)
+        out = redispatch(name, raw_keyset, input_tensor, indices, kernel_size, stride, padding, output_size)
+        if GradMode.enabled and getattr(input_tensor, "requires_grad", False):
+            def _backward(grad):
+                backward_keyset = _backward_dispatch_keyset(raw_keyset, active_keyset)
+                with _grad_context(backward_keyset):
+                    from .._creation import arange
+                    plane_count = indices.numel() // indices.shape[-1]
+                    output_length = grad.shape[-1]
+                    offsets = arange(0, plane_count, dtype=indices.dtype, device=indices.device).reshape(indices.shape[:-1] + (1,))
+                    flat_indices = redispatch("add", backward_keyset, indices, offsets * output_length).reshape((-1,))
+                    grad_input = redispatch("gather", backward_keyset, grad.reshape((-1,)), 0, flat_indices)
+                    return (grad_input.reshape(input_tensor.shape),)
+
+            node = Node(_backward, (input_tensor,), name="MaxUnpool1DBackward0")
+            annotate_node_creation(node)
+            out.grad_fn = node
+            out.requires_grad = True
+        return out
+
+    return wrapper
+
+
 def _autograd_linalg_multi_dot(name):
     """Autograd wrapper for linalg_multi_dot: chain of matmul backwards."""
     def wrapper(tensors):
@@ -6542,16 +6566,20 @@ def _autograd_linalg_multi_dot(name):
                         if not getattr(tensors[i], "requires_grad", False):
                             grads.append(None)
                             continue
-                        # grad_i = (product of tensors before i)^T @ grad @ (product of tensors after i)^T
-                        left = grad
-                        for j in range(i - 1, -1, -1):
-                            t_j = redispatch("transpose", backward_keyset, saved[j], -2, -1)
-                            left = redispatch("matmul", backward_keyset, t_j, left)
-                        right = left
-                        for j in range(i + 1, n):
-                            t_j = redispatch("transpose", backward_keyset, saved[j], -2, -1)
-                            right = redispatch("matmul", backward_keyset, right, t_j)
-                        grads.append(right)
+                        grad_i = grad
+                        if i > 0:
+                            left = saved[0]
+                            for j in range(1, i):
+                                left = redispatch("matmul", backward_keyset, left, saved[j])
+                            left_t = redispatch("transpose", backward_keyset, left, -2, -1)
+                            grad_i = redispatch("matmul", backward_keyset, left_t, grad_i)
+                        if i + 1 < n:
+                            right = saved[i + 1]
+                            for j in range(i + 2, n):
+                                right = redispatch("matmul", backward_keyset, right, saved[j])
+                            right_t = redispatch("transpose", backward_keyset, right, -2, -1)
+                            grad_i = redispatch("matmul", backward_keyset, grad_i, right_t)
+                        grads.append(grad_i)
                     return tuple(grads)
 
             node = Node(_backward, tuple(tensors), name=f"{name.capitalize()}Backward0")
@@ -7183,6 +7211,7 @@ for _entry in (
     ("as_strided_scatter", lambda: _autograd_binary_args("as_strided_scatter", _as_strided_scatter_backward, save_inputs=False), False),
     ("setitem", lambda: _autograd_setitem("setitem"), False),
     ("dropout", _autograd_dropout),
+    ("max_unpool1d", lambda: _autograd_max_unpool1d("max_unpool1d")),
     # Multi-output ops
     ("unique", lambda: _autograd_unique()),
     ("split", lambda: _autograd_multi_output("split", _split_backward, save_input=False)),

--- a/tests/contract/test_autograd_contract.py
+++ b/tests/contract/test_autograd_contract.py
@@ -99,6 +99,18 @@ def test_nextafter_backward_error_matches_torch():
     assert_torch_error(mt, th)
 
 
+def test_aminmax_backward_error_matches_torch():
+    def mt():
+        x = torch.tensor([1.0, 3.0, 2.0], requires_grad=True)
+        torch.aminmax(x)[0].backward()
+
+    def th():
+        x = pt.tensor([1.0, 3.0, 2.0], requires_grad=True)
+        pt.aminmax(x)[0].backward()
+
+    assert_torch_error(mt, th)
+
+
 def test_top_level_rrelu_backward_matches_torch():
     x = torch.tensor([-2.0, 1.0], requires_grad=True)
     out = torch.rrelu(x, lower=0.1, upper=0.1, training=False)

--- a/tests/cpu/test_autograd.py
+++ b/tests/cpu/test_autograd.py
@@ -1127,6 +1127,55 @@ def test_linalg_svd_singular_values_backward_matches_svdvals():
     assert np.allclose(x.grad.numpy(), expected_x.grad.numpy(), atol=1e-6, rtol=1e-6)
 
 
+def test_linalg_multi_dot_three_matrix_backward_matches_torch():
+    a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    b = torch.tensor([[2.0, 0.0], [0.0, 2.0]])
+    c = torch.tensor([[1.0], [2.0]])
+    a.requires_grad = True
+    b.requires_grad = True
+    c.requires_grad = True
+    out = torch.linalg.multi_dot([a, b, c])
+    out.sum().backward()
+
+    import torch as torch_ref
+
+    a_ref = torch_ref.tensor([[1.0, 2.0], [3.0, 4.0]], requires_grad=True)
+    b_ref = torch_ref.tensor([[2.0, 0.0], [0.0, 2.0]], requires_grad=True)
+    c_ref = torch_ref.tensor([[1.0], [2.0]], requires_grad=True)
+    ref_out = torch_ref.linalg.multi_dot([a_ref, b_ref, c_ref])
+    ref_out.sum().backward()
+
+    assert np.allclose(a.grad.numpy(), a_ref.grad.numpy(), atol=1e-6, rtol=1e-6)
+    assert np.allclose(b.grad.numpy(), b_ref.grad.numpy(), atol=1e-6, rtol=1e-6)
+    assert np.allclose(c.grad.numpy(), c_ref.grad.numpy(), atol=1e-6, rtol=1e-6)
+
+
+def test_max_unpool1d_backward_matches_torch():
+    x = torch.tensor([[[1.0, 2.0], [3.0, 4.0]]])
+    x.requires_grad = True
+    indices = torch.tensor([[[0, 1], [0, 1]]], dtype=torch.int64)
+    out = F.max_unpool1d(x, indices, kernel_size=2, stride=2, output_size=(1, 2, 4))
+    weights = torch.tensor([[[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]]])
+    (out * weights).sum().backward()
+
+    import torch as torch_ref
+
+    x_ref = torch_ref.tensor([[[1.0, 2.0], [3.0, 4.0]]], requires_grad=True)
+    indices_ref = torch_ref.tensor([[[0, 1], [0, 1]]])
+    ref_out = torch_ref.nn.functional.max_unpool1d(
+        x_ref,
+        indices_ref,
+        kernel_size=2,
+        stride=2,
+        output_size=(1, 2, 4),
+    )
+    weights_ref = torch_ref.tensor([[[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]]])
+    (ref_out * weights_ref).sum().backward()
+
+    assert x.grad is not None
+    assert np.allclose(x.grad.numpy(), x_ref.grad.numpy(), atol=1e-6, rtol=1e-6)
+
+
 def test_autograd_normalization_batch_routes_compiled_backward():
     x = torch.tensor([[1.0, 2.0, 3.0, 4.0], [2.0, 3.0, 4.0, 5.0]])
     x.requires_grad = True


### PR DESCRIPTION
## Summary
- Match PyTorch's unimplemented backward behavior for `torch.aminmax`.
- Fix `torch.linalg.multi_dot` gradients for a three-matrix chain.
- Add `max_unpool1d` backward propagation with per-plane index offsets.

## Test plan
- [x] `python -m pytest tests/contract/test_autograd_contract.py::test_aminmax_backward_error_matches_torch tests/cpu/test_autograd.py::test_linalg_multi_dot_three_matrix_backward_matches_torch tests/cpu/test_autograd.py::test_max_unpool1d_backward_matches_torch -v --tb=short`
- [x] `python -m pytest tests/cpu/test_autograd.py tests/contract/test_autograd_contract.py tests/contract/test_autograd_audit_inventory.py -v --tb=short`
- [x] `python -m pytest tests/cpu/ tests/contract/ -v --tb=short`
- [x] `pylint src/candle/ --rcfile=.github/pylint.conf`

Note: `git fetch upstream main` failed twice locally with `OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 110`; local `upstream/main` was already at #408 (`0bdf4fb`) and is an ancestor of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)