### PR TITLE
fix(autograd): reject backward on non-grad outputs

### DIFF
--- a/src/candle/_C/_autograd_engine.pyx
+++ b/src/candle/_C/_autograd_engine.pyx
@@ -607,6 +607,8 @@ def _run_backward(
 
 
 def backward(tensor, grad=None, retain_graph=False, create_graph=False, inputs=None):
+    if not tensor.requires_grad and tensor.grad_fn is None:
+        raise RuntimeError("element 0 of tensors does not require grad and does not have a grad_fn")
     if grad is None:
         if tensor.numel() != 1:
             raise RuntimeError("grad can be implicitly created only for scalar outputs")

--- a/tests/contract/test_autograd_contract.py
+++ b/tests/contract/test_autograd_contract.py
@@ -111,6 +111,38 @@ def test_aminmax_backward_error_matches_torch():
     assert_torch_error(mt, th)
 
 
+def test_non_scalar_no_grad_backward_error_matches_torch():
+    def mt():
+        torch.tensor([1.0, 2.0]).backward()
+
+    def th():
+        pt.tensor([1.0, 2.0]).backward()
+
+    assert_torch_error(mt, th)
+
+
+def test_logical_xor_backward_error_matches_torch():
+    def mt():
+        x = torch.tensor([0.0, 1.0], requires_grad=True)
+        torch.logical_xor(x, torch.tensor([1.0, 1.0])).sum().backward()
+
+    def th():
+        x = pt.tensor([0.0, 1.0], requires_grad=True)
+        pt.logical_xor(x, pt.tensor([1.0, 1.0])).sum().backward()
+
+    assert_torch_error(mt, th)
+
+
+def test_bitwise_not_backward_error_matches_torch():
+    def mt():
+        torch.bitwise_not(torch.tensor([1, 3])).sum().backward()
+
+    def th():
+        pt.bitwise_not(pt.tensor([1, 3])).sum().backward()
+
+    assert_torch_error(mt, th)
+
+
 def test_top_level_rrelu_backward_matches_torch():
     x = torch.tensor([-2.0, 1.0], requires_grad=True)
     out = torch.rrelu(x, lower=0.1, upper=0.1, training=False)

--- a/tests/cpu/test_autograd_api.py
+++ b/tests/cpu/test_autograd_api.py
@@ -28,9 +28,10 @@ def test_retain_graph_allows_double_backward():
 
 def test_retain_grad_populates_non_leaf_grad():
     t = torch.ones((2,))
-    y = t.sum()
+    t.requires_grad = True
+    y = t * 2.0
     y.retain_grad()
-    y.backward()
+    y.sum().backward()
     assert y.grad is not None
 
 


### PR DESCRIPTION
## Summary
- Match PyTorch by raising when `backward()` is called on tensors without `requires_grad` or `grad_fn`.
- Add parity coverage for no-grad tensors, logical outputs, and bitwise integer outputs.
- Correct the retain-grad API test to use a true non-leaf requiring-grad tensor.

## Test plan
- [x] `python -m pytest tests/contract/test_autograd_contract.py::test_non_scalar_no_grad_backward_error_matches_torch tests/contract/test_autograd_contract.py::test_logical_xor_backward_error_matches_torch tests/contract/test_autograd_contract.py::test_bitwise_not_backward_error_matches_torch -v --tb=short`
- [x] `python -m pytest tests/contract/test_autograd_contract.py tests/cpu/test_autograd_api.py tests/contract/test_autograd_audit_inventory.py -v --tb=short`
- [x] `python -m pytest tests/cpu/ tests/contract/ -v --tb=short`
- [x] `pylint src/candle/ --rcfile=.github/pylint.conf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)