### PR TITLE
Align linalg autograd backward parity

### DIFF
--- a/src/candle/_backends/autograd.py
+++ b/src/candle/_backends/autograd.py
@@ -6451,7 +6451,32 @@ def _autograd_linalg_svd(name):
                 a_np = saved_a._numpy_view().astype(_np.float64)
                 U_np, S_np, Vh_np = _np.linalg.svd(a_np, full_matrices=False)
                 grad_np = grad._numpy_view().astype(_np.float64)
-                grad_a_np = U_np @ (_np.eye(S_np.shape[-1]) * grad_np[..., :S_np.shape[-1], :S_np.shape[-1]].diagonal(axis1=-2, axis2=-1)[..., None]) @ Vh_np if grad_np.ndim >= 2 else _np.zeros_like(a_np)
+
+                k = S_np.shape[-1]
+                eye_k = _np.eye(k, dtype=_np.float64)
+                if grad_np.shape == S_np.shape:
+                    grad_a_np = U_np @ (eye_k * grad_np[..., None, :]) @ Vh_np
+                elif grad_np.shape == U_np.shape:
+                    ut_grad_u = U_np.swapaxes(-2, -1) @ grad_np
+                    skew_u = ut_grad_u - ut_grad_u.swapaxes(-2, -1)
+                    denom = S_np[..., :, None] ** 2 - S_np[..., None, :] ** 2
+                    f = _np.divide(1.0, denom, out=_np.zeros_like(denom), where=~eye_k.astype(bool))
+                    middle = -(f * skew_u) * S_np[..., None, :]
+                    grad_a_np = U_np @ middle @ Vh_np
+                    if a_np.shape[-2] > k:
+                        proj = eye_k
+                        left_eye = _np.eye(a_np.shape[-2], dtype=_np.float64)
+                        grad_a_np = grad_a_np + (left_eye - U_np @ U_np.swapaxes(-2, -1)) @ grad_np @ (proj / S_np[..., None, :]) @ Vh_np
+                elif grad_np.shape == Vh_np.shape:
+                    grad_v = grad_np.swapaxes(-2, -1)
+                    vt_grad_v = Vh_np @ grad_v
+                    skew_v = vt_grad_v - vt_grad_v.swapaxes(-2, -1)
+                    denom = S_np[..., :, None] ** 2 - S_np[..., None, :] ** 2
+                    f = _np.divide(1.0, denom, out=_np.zeros_like(denom), where=~eye_k.astype(bool))
+                    middle = -S_np[..., :, None] * (f * skew_v)
+                    grad_a_np = U_np @ middle @ Vh_np
+                else:
+                    grad_a_np = _np.zeros_like(a_np)
                 from .._C import typed_storage_from_numpy
                 from .._C._tensor_impl import cy_make_tensor_from_storage  # pylint: disable=import-error,no-name-in-module
                 from .._dtype import to_numpy_dtype
@@ -6669,16 +6694,35 @@ def _autograd_linalg_lu_factor(name):
             node_holder = {}
 
             def _backward(grad):
-                saved_a = node_holder["node"].saved_tensors()[0]
-                backward_keyset = _backward_dispatch_keyset(raw_keyset, active_keyset)
+                saved = node_holder["node"].saved_tensors()
+                saved_a, saved_lu, saved_pivots = saved[0], saved[1], saved[2]
+                _backward_dispatch_keyset(raw_keyset, active_keyset)
                 import numpy as _np
-                a_np = saved_a._numpy_view().astype(_np.float64)
+                a_np = saved_a._numpy_view()
+                lu_np = saved_lu._numpy_view().astype(_np.float64)
+                pivots_np = saved_pivots._numpy_view()
                 grad_np = grad._numpy_view().astype(_np.float64)
-                grad_a_np = grad_np.copy() if grad_np.shape == a_np.shape else _np.zeros_like(a_np)
+
+                if not pivot or a_np.ndim != 2 or a_np.shape[0] != a_np.shape[1]:
+                    raise RuntimeError("linalg.lu_factor backward is only implemented for pivoted square 2-D inputs")
+
+                n = a_np.shape[0]
+                lower_grad = _np.tril(grad_np, -1)
+                upper_grad = _np.triu(grad_np)
+                lower = _np.tril(lu_np, -1) + _np.eye(n, dtype=_np.float64)
+                upper = _np.triu(lu_np)
+
+                middle = _np.tril(lower.T @ lower_grad, -1) + _np.triu(upper_grad @ upper.T)
+                grad_pa = _np.linalg.solve(lower.T, middle) @ _np.linalg.inv(upper.T)
+                permutation = _np.eye(n, dtype=_np.float64)
+                for i, pivot_index in enumerate(pivots_np.astype(_np.int64)):
+                    permutation[[i, pivot_index]] = permutation[[pivot_index, i]]
+                grad_a_np = permutation.T @ grad_pa
+
                 from .._C import typed_storage_from_numpy
                 from .._C._tensor_impl import cy_make_tensor_from_storage  # pylint: disable=import-error,no-name-in-module
                 from .._dtype import to_numpy_dtype
-                grad_a_np = grad_a_np.astype(to_numpy_dtype(saved_a.dtype))
+                grad_a_np = _np.ascontiguousarray(grad_a_np.astype(to_numpy_dtype(saved_a.dtype)))
                 storage = typed_storage_from_numpy(grad_a_np, saved_a.dtype, device=saved_a.device)
                 stride = tuple(_np.array(grad_a_np.strides) // grad_a_np.itemsize)
                 return (cy_make_tensor_from_storage(storage, grad_a_np.shape, stride, 0, False),)
@@ -6686,10 +6730,12 @@ def _autograd_linalg_lu_factor(name):
             node = Node(_backward, (a,), name=f"{name.capitalize()}Backward0")
             annotate_node_creation(node)
             node_holder["node"] = weakref.proxy(node)
-            node.save_for_backward(a)
             if isinstance(out, tuple):
+                node.save_for_backward(a, out[0], out[1])
                 out[0].grad_fn = node
                 out[0].requires_grad = True
+            else:
+                node.save_for_backward(a)
         return out
 
     return wrapper

--- a/tests/contract/test_autograd_audit_inventory.py
+++ b/tests/contract/test_autograd_audit_inventory.py
@@ -55,43 +55,25 @@ CREATION_RANDOM_OPS = {
 
 INPLACE_OR_MUTATION_OPS = {
     "abs_",
-    "add_",
     "bitwise_and_",
     "bitwise_or_",
     "bitwise_xor_",
     "ceil_",
-    "clamp_",
-    "copy_",
     "cos_",
-    "div_",
     "erfinv_",
     "exp_",
     "floor_",
-    "index_add_",
-    "index_copy_",
-    "index_fill_",
-    "index_put_",
     "log10_",
     "log2_",
     "log_",
-    "masked_fill_",
-    "masked_scatter_",
-    "max_",
-    "min_",
-    "mul_",
     "neg_",
     "pow_",
     "randint_",
     "reciprocal_",
-    "relu_",
     "round_",
-    "scatter_",
-    "scatter_add_",
-    "setitem",
     "sigmoid_",
     "sin_",
     "sqrt_",
-    "sub_",
     "tan_",
     "tanh_",
     "trunc_",
@@ -112,43 +94,27 @@ COMPARISON_INDEX_OPS = {
     "isposinf",
     "isreal",
     "searchsorted",
-    "unique",
 }
 
 SHAPE_VIEW_COPY_OPS = {
     "as_strided_copy",
-    "dsplit",
     "expand_copy",
     "flatten",
-    "hsplit",
     "movedim",
     "narrow",
     "slice_copy",
-    "split",
     "squeeze",
-    "to",
-    "unbind",
     "unflatten",
-    "vsplit",
 }
 
 MANUAL_REVIEW_SCHEMA_OPS = {
-    "aminmax",
     "bitwise_and",
     "bitwise_left_shift",
     "bitwise_not",
     "bitwise_or",
     "bitwise_right_shift",
     "bitwise_xor",
-    "dropout",
-    "einsum",
-    "linalg_eigh",
-    "linalg_lu_factor",
-    "linalg_multi_dot",
-    "linalg_svd",
     "logical_xor",
-    "max_unpool1d",
-    "rrelu",
 }
 
 LIKELY_NONDIFFERENTIABLE_NOT_IMPLEMENTED = {
@@ -208,8 +174,14 @@ def _schema_ops():
 
 
 def _autograd_registered_ops():
-    text = _read(_SRC / "_generated" / "registration.py")
-    return set(re.findall(r"register_autograd_kernels\('([^']+)'", text))
+    generated = _read(_SRC / "_generated" / "registration.py")
+    manual = _read(_SRC / "_backends" / "autograd.py")
+    return (
+        set(re.findall(r"register_autograd_kernels\('([^']+)'", generated))
+        | set(re.findall(r'\("([A-Za-z0-9_]+)",\s*lambda:', manual))
+        | set(re.findall(r'\("([A-Za-z0-9_]+)",\s*lambda\s*:', manual))
+        | set(re.findall(r'\("([A-Za-z0-9_]+)",\s*_[A-Za-z0-9_]+\)', manual))
+    )
 
 
 def _not_implemented_entries():
@@ -244,7 +216,7 @@ def test_schema_ops_without_autograd_registration_are_categorized():
     actual_missing = _schema_ops() - _autograd_registered_ops()
     assert sorted(actual_missing - expected_missing) == []
     assert sorted(expected_missing - actual_missing) == []
-    assert len(actual_missing) == 121
+    assert len(actual_missing) == 87
 
 
 def test_derivatives_not_implemented_inventory_is_classified():

--- a/tests/cpu/test_autograd.py
+++ b/tests/cpu/test_autograd.py
@@ -1016,6 +1016,40 @@ def test_autograd_fft_residual_batch_routes_compiled_backward():
     assert type(ihfft_out.grad_fn).__name__ == "Fft_ihfftBackward0"
 
 
+def _assert_linalg_svd_grad_matches_pytorch(input_data, loss_selector, atol=1e-5, rtol=1e-5):
+    import torch as real_torch
+
+    candle_a = torch.tensor(input_data)
+    candle_a.requires_grad = True
+    candle_out = torch.linalg.svd(candle_a, full_matrices=False)
+    loss_selector(candle_out).sum().backward()
+
+    torch_a = real_torch.tensor(input_data, dtype=real_torch.float64, requires_grad=True)
+    torch_out = real_torch.linalg.svd(torch_a, full_matrices=False)
+    loss_selector(torch_out).sum().backward()
+
+    np.testing.assert_allclose(
+        np.asarray(candle_a.grad.tolist()),
+        torch_a.grad.detach().numpy(),
+        atol=atol,
+        rtol=rtol,
+    )
+
+
+def test_linalg_svd_u_backward_matches_pytorch():
+    _assert_linalg_svd_grad_matches_pytorch(
+        [[3.0, 1.0], [0.5, 2.0], [1.0, -0.25]],
+        lambda svd_out: svd_out[0],
+    )
+
+
+def test_linalg_svd_vh_backward_matches_pytorch():
+    _assert_linalg_svd_grad_matches_pytorch(
+        [[3.0, 1.0], [0.5, 2.0], [1.0, -0.25]],
+        lambda svd_out: svd_out[2],
+    )
+
+
 def test_autograd_linalg_batch_routes_compiled_backward():
     a = torch.eye(3) * 2.0
     a.requires_grad = True

--- a/tests/cpu/test_autograd_ops.py
+++ b/tests/cpu/test_autograd_ops.py
@@ -721,5 +721,23 @@ class TestTopkBackward:
         _check_grad(x, [0.0, 1.0, 0.0, 1.0])
 
 
+class TestLinalgLuFactorBackward:
+    def test_lu_output_backward_matches_torch_for_2x2_pivoted_factorization(self):
+        import torch as real_torch
+
+        data = [[0.5, 3.0], [2.0, 1.0]]
+        upstream = [[1.5, -2.0], [0.25, 0.75]]
+
+        ref = real_torch.tensor(data, dtype=real_torch.float32, requires_grad=True)
+        ref_lu, _ = real_torch.linalg.lu_factor(ref)
+        (ref_lu * real_torch.tensor(upstream, dtype=real_torch.float32)).sum().backward()
+
+        x = _tensor(data)
+        lu, _ = torch.linalg.lu_factor(x)
+        (lu * torch.tensor(upstream, dtype=torch.float32)).sum().backward()
+
+        _check_grad(x, ref.grad.detach().numpy(), atol=1e-5, rtol=1e-5)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Add PyTorch parity coverage for reduced `torch.linalg.svd` U/Vh backward and pivoted square `torch.linalg.lu_factor` backward.
- Implement analytic backward paths for those linalg outputs in the autograd backend.
- Update the autograd audit inventory to count manual autograd registrations alongside generated registrations.

## Test plan
- [x] `PYTHONPATH=/home/jenkins/lvyufeng/candle/.claude/worktrees/autograd-linalg-batch/src conda run --no-capture-output -n candle311 python -m pytest tests/cpu/ tests/contract/ -v --tb=short`
- [x] `PYTHONPATH=/home/jenkins/lvyufeng/candle/.claude/worktrees/autograd-linalg-batch/src conda run --no-capture-output -n candle311 pylint src/candle/ --rcfile=.github/pylint.conf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)