### PR TITLE
Recategorize resolved autograd audit gaps

### DIFF
--- a/tests/contract/test_autograd_audit_inventory.py
+++ b/tests/contract/test_autograd_audit_inventory.py
@@ -107,7 +107,7 @@ SHAPE_VIEW_COPY_OPS = {
     "unflatten",
 }
 
-MANUAL_REVIEW_SCHEMA_OPS = {
+NONDIFFERENTIABLE_OUTPUT_OPS = {
     "bitwise_and",
     "bitwise_left_shift",
     "bitwise_not",
@@ -116,6 +116,8 @@ MANUAL_REVIEW_SCHEMA_OPS = {
     "bitwise_xor",
     "logical_xor",
 }
+
+MANUAL_REVIEW_SCHEMA_OPS = set()
 
 LIKELY_NONDIFFERENTIABLE_NOT_IMPLEMENTED = {
     "_unique",
@@ -211,6 +213,7 @@ def test_schema_ops_without_autograd_registration_are_categorized():
         | INPLACE_OR_MUTATION_OPS
         | COMPARISON_INDEX_OPS
         | SHAPE_VIEW_COPY_OPS
+        | NONDIFFERENTIABLE_OUTPUT_OPS
         | MANUAL_REVIEW_SCHEMA_OPS
     )
     actual_missing = _schema_ops() - _autograd_registered_ops()

--- a/tests/contract/test_autograd_contract.py
+++ b/tests/contract/test_autograd_contract.py
@@ -1,3 +1,5 @@
+import pytest
+
 import candle as torch
 import torch as pt
 from .helpers import assert_torch_error
@@ -139,6 +141,26 @@ def test_bitwise_not_backward_error_matches_torch():
 
     def th():
         pt.bitwise_not(pt.tensor([1, 3])).sum().backward()
+
+    assert_torch_error(mt, th)
+
+
+@pytest.mark.parametrize(
+    ("op_name", "left", "right"),
+    [
+        ("bitwise_and", [1, 2], [3, 1]),
+        ("bitwise_or", [1, 2], [3, 1]),
+        ("bitwise_xor", [1, 2], [3, 1]),
+        ("bitwise_left_shift", [1, 2], [1, 2]),
+        ("bitwise_right_shift", [4, 8], [1, 2]),
+    ],
+)
+def test_bitwise_binary_backward_error_matches_torch(op_name, left, right):
+    def mt():
+        getattr(torch, op_name)(torch.tensor(left), torch.tensor(right)).sum().backward()
+
+    def th():
+        getattr(pt, op_name)(pt.tensor(left), pt.tensor(right)).sum().backward()
 
     assert_torch_error(mt, th)
 

--- a/tests/cpu/test_autograd_ops.py
+++ b/tests/cpu/test_autograd_ops.py
@@ -739,5 +739,19 @@ class TestLinalgLuFactorBackward:
         _check_grad(x, ref.grad.detach().numpy(), atol=1e-5, rtol=1e-5)
 
 
+class TestChunkBackward:
+    def test_first_chunk_dim1(self):
+        x = _tensor([[1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12]])
+        first, _second, _third = torch.chunk(x, 3, dim=1)
+        first.sum().backward()
+        _check_grad(x, [[1, 1, 0, 0, 0, 0], [1, 1, 0, 0, 0, 0]])
+
+    def test_later_chunk_uneven_dim0(self):
+        x = _tensor([[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]])
+        _first, _second, third = torch.chunk(x, 3, dim=0)
+        third.sum().backward()
+        _check_grad(x, [[0, 0], [0, 0], [0, 0], [0, 0], [1, 1]])
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Add PyTorch error-parity coverage for non-differentiable bitwise binary outputs.
- Add runtime coverage for `torch.chunk` backward through selected outputs.
- Move resolved bitwise/logical schema ops out of manual-review inventory into a non-differentiable output category.

## Test plan
- [x] `PYTHONPATH=/home/jenkins/lvyufeng/candle/.claude/worktrees/autograd-next-batch/src conda run --no-capture-output -n candle311 python -m pytest tests/contract/test_autograd_audit_inventory.py tests/contract/test_autograd_contract.py tests/cpu/test_autograd_ops.py -v --tb=short`

🤖 Generated with [Claude Code](https://claude.com/claude-code)