### PR TITLE
fix(autograd): align remaining not implemented parity

### DIFF
--- a/src/candle/_generated/_functions_cy.pyx
+++ b/src/candle/_generated/_functions_cy.pyx
@@ -6566,7 +6566,7 @@ class SpecialZetaBackward0(_Node):
         other = self.saved_tensors[self._saved_other_idx] if self._saved_other_idx is not None else None
         self_ = self.saved_tensors[self._saved_self_idx] if self._saved_self_idx is not None else None
         with _grad_context(keyset):
-            grad_self = _cy_not_implemented("SpecialZetaBackward0: self")
+            grad_self = _cy_not_implemented("SpecialZetaBackward0: self") if getattr(self.inputs[0], 'requires_grad', False) else None
             grad_other = _cy_not_implemented("SpecialZetaBackward0: other")
         return (grad_self, grad_other,)
 
@@ -6609,7 +6609,7 @@ class SpecialZetaOtherScalarBackward0(_Node):
         keyset = _backward_dispatch_keyset(self._raw_keyset)
         other = self._other
         with _grad_context(keyset):
-            grad_self = _cy_not_implemented("SpecialZetaOtherScalarBackward0: self")
+            grad_self = _cy_not_implemented("SpecialZetaOtherScalarBackward0: self") if getattr(self.inputs[0], 'requires_grad', False) else None
         return (grad_self,)
 
 class LogNormalBackward0(_Node):

--- a/src/candle/_generated/functions.py
+++ b/src/candle/_generated/functions.py
@@ -6482,7 +6482,7 @@ class SpecialZetaBackward0(Node):
         other = _saved[self._saved_other_idx]
         self_ = _saved[self._saved_self_idx]
         with _grad_context(keyset):
-            grad_self = _raise_not_implemented("zeta")
+            grad_self = _raise_not_implemented("zeta") if getattr(self.inputs[0], 'requires_grad', False) else None
             grad_other = redispatch("mul", keyset, redispatch("mul", keyset, grad, redispatch("neg", keyset, self_)), redispatch("special_zeta", keyset, redispatch("add", keyset, self_, 1.), other))
         return (grad_self, grad_other,)
 

--- a/tests/contract/test_autograd_audit_inventory.py
+++ b/tests/contract/test_autograd_audit_inventory.py
@@ -148,11 +148,13 @@ INTERNAL_NOT_IMPLEMENTED = {
     "native_layer_norm_backward",
 }
 
-MANUAL_REVIEW_NOT_IMPLEMENTED = {
+PYTORCH_ERROR_PARITY_NOT_IMPLEMENTED = {
     "igamma",
     "igammac",
     "special_zeta",
 }
+
+MANUAL_REVIEW_NOT_IMPLEMENTED = set()
 
 
 def _read(path):
@@ -228,6 +230,7 @@ def test_derivatives_not_implemented_inventory_is_classified():
     expected_ops = (
         LIKELY_NONDIFFERENTIABLE_NOT_IMPLEMENTED
         | INTERNAL_NOT_IMPLEMENTED
+        | PYTORCH_ERROR_PARITY_NOT_IMPLEMENTED
         | MANUAL_REVIEW_NOT_IMPLEMENTED
     )
     counts_by_op = {name: 0 for name in actual_ops}

--- a/tests/contract/test_autograd_contract.py
+++ b/tests/contract/test_autograd_contract.py
@@ -165,6 +165,57 @@ def test_bitwise_binary_backward_error_matches_torch(op_name, left, right):
     assert_torch_error(mt, th)
 
 
+def test_special_zeta_other_backward_matches_torch():
+    x = torch.tensor([2.5])
+    q = torch.tensor([3.0], requires_grad=True)
+    torch.special.zeta(x, q).sum().backward()
+
+    expected_x = pt.tensor([2.5])
+    expected_q = pt.tensor([3.0], requires_grad=True)
+    pt.special.zeta(expected_x, expected_q).sum().backward()
+
+    actual_grad = pt.tensor(q.grad.detach().numpy())
+    assert pt.allclose(actual_grad, expected_q.grad.detach(), atol=1e-6, rtol=1e-6)
+
+
+def test_nextafter_other_backward_error_matches_torch():
+    def mt():
+        x = torch.tensor([1.0])
+        y = torch.tensor([2.0], requires_grad=True)
+        torch.nextafter(x, y).sum().backward()
+
+    def th():
+        x = pt.tensor([1.0])
+        y = pt.tensor([2.0], requires_grad=True)
+        pt.nextafter(x, y).sum().backward()
+
+    assert_torch_error(mt, th)
+
+
+def test_unique_dim_backward_error_matches_torch():
+    def mt():
+        x = torch.tensor([[1.0, 2.0], [1.0, 2.0]], requires_grad=True)
+        torch.unique(x, dim=0).sum().backward()
+
+    def th():
+        x = pt.tensor([[1.0, 2.0], [1.0, 2.0]], requires_grad=True)
+        pt.unique(x, dim=0).sum().backward()
+
+    assert_torch_error(mt, th)
+
+
+def test_unique_consecutive_dim_backward_error_matches_torch():
+    def mt():
+        x = torch.tensor([[1.0, 2.0], [1.0, 2.0]], requires_grad=True)
+        torch.unique_consecutive(x, dim=0).sum().backward()
+
+    def th():
+        x = pt.tensor([[1.0, 2.0], [1.0, 2.0]], requires_grad=True)
+        pt.unique_consecutive(x, dim=0).sum().backward()
+
+    assert_torch_error(mt, th)
+
+
 def test_top_level_rrelu_backward_matches_torch():
     x = torch.tensor([-2.0, 1.0], requires_grad=True)
     out = torch.rrelu(x, lower=0.1, upper=0.1, training=False)

--- a/tools/autograd/gen_functions.py
+++ b/tools/autograd/gen_functions.py
@@ -1588,7 +1588,11 @@ def _gen_one_node(info: DifferentiabilityInfo) -> str:
             var_name = deriv.var_names[0]
             grad_var = f"grad_{var_name}"
             grad_vars[var_name] = grad_var
-            lines.append(f"            {grad_var} = {formula}")
+            if _should_guard_not_implemented_formula(formula, var_name, info):
+                needed = _grad_needed_expr(var_name, info)
+                lines.append(f"            {grad_var} = {formula} if {needed} else None")
+            else:
+                lines.append(f"            {grad_var} = {formula}")
         else:
             # Multi-output: tuple unpacking (e.g. conv backward returns all grads at once)
             grad_var_names = [f"grad_{v}" for v in deriv.var_names]
@@ -1616,6 +1620,25 @@ def _gen_one_node(info: DifferentiabilityInfo) -> str:
         lines.append(f"        return ({', '.join(ret_parts)},)")
 
     return "\n".join(lines)
+
+
+def _is_not_implemented_formula(formula: str) -> bool:
+    return "_raise_not_implemented(" in formula or "_cy_not_implemented(" in formula
+
+
+def _should_guard_not_implemented_formula(formula: str, var_name: str, info: DifferentiabilityInfo) -> bool:
+    return (
+        info.op_name == "special_zeta"
+        and var_name == "self"
+        and _is_not_implemented_formula(formula)
+    )
+
+
+def _grad_needed_expr(var_name: str, info: DifferentiabilityInfo) -> str:
+    for idx, arg in enumerate(info.differentiable_inputs):
+        if arg.name == var_name:
+            return f"getattr(self.inputs[{idx}], 'requires_grad', False)"
+    return "True"
 
 
 def _rewrite_keyword_refs(formula: str, arg_names: set[str]) -> str:
@@ -2089,9 +2112,17 @@ def _gen_one_node_pyx(info: DifferentiabilityInfo) -> str:
             grad_vars[var_name] = grad_var
             local_names.add(grad_var)
             if safe_formula:
-                lines.append(f"            {grad_var} = {formula}")
+                if _should_guard_not_implemented_formula(formula, var_name, info):
+                    needed = _grad_needed_expr(var_name, info)
+                    lines.append(f"            {grad_var} = {formula} if {needed} else None")
+                else:
+                    lines.append(f"            {grad_var} = {formula}")
             else:
-                lines.append(f"            {grad_var} = _cy_not_implemented(\"{cls_name}: {var_name}\")")
+                if _should_guard_not_implemented_formula(formula, var_name, info):
+                    needed = _grad_needed_expr(var_name, info)
+                    lines.append(f"            {grad_var} = _cy_not_implemented(\"{cls_name}: {var_name}\") if {needed} else None")
+                else:
+                    lines.append(f"            {grad_var} = _cy_not_implemented(\"{cls_name}: {var_name}\")")
         else:
             grad_var_names = [f"grad_{v}" for v in deriv.var_names]
             for v, gv in zip(deriv.var_names, grad_var_names):


### PR DESCRIPTION
## Summary
- recategorize remaining manual-review not-implemented derivatives as explicit PyTorch error-parity cases
- add contract coverage for zeta other-input gradient parity plus nextafter/unique dim error parity
- guard the unsupported zeta self derivative so supported other-input gradients can run

## Test plan
- [x] conda run -n candle311 python setup.py build_ext --inplace -j4
- [x] conda run -n candle311 python -m pytest tests/contract/test_autograd_contract.py -v --tb=short
- [x] conda run -n candle311 python -m pytest tests/contract/test_autograd_audit_inventory.py -v --tb=short
- [x] conda run -n candle311 python -m pytest tests/contract/test_codegen_roundtrip.py -v --tb=short
- [x] conda run -n candle311 python -m pytest tests/cpu/ tests/contract/ --tb=short -q
- [x] conda run -n candle311 pylint tools/autograd/ --rcfile=.github/pylint.conf
- [x] conda run -n candle311 pylint src/candle/ --rcfile=.github/pylint.conf

🤖 Generated with [Claude Code](https://claude.com/claude-code)