### PR TITLE
fix(autograd): align functional forward-mode errors

### DIFF
--- a/src/candle/autograd/functional.py
+++ b/src/candle/autograd/functional.py
@@ -339,7 +339,7 @@ def jacobian(
             )
         if not vectorize:
             raise NotImplementedError(
-                "Computing Jacobian using forward-AD or forward-over-reverse Hessian is "
+                "Computing Jacobian using forward-AD or forward-over-reverse Hessian is"
                 "only implemented for `vectorize=True`."
             )
         vectorize = False

--- a/tests/contract/test_autograd_functional.py
+++ b/tests/contract/test_autograd_functional.py
@@ -308,3 +308,64 @@ def test_autograd_functional_jacobian_empty_output_error_matches_torch():
 
     assert_torch_error(mt, th)
 
+
+def test_autograd_functional_jacobian_forward_mode_without_vectorize_error_matches_torch():
+    def mt():
+        x = torch.tensor([1.0, 2.0], requires_grad=True)
+        torch.autograd.functional.jacobian(lambda value: value * value, x, strategy="forward-mode")
+
+    def th():
+        x = pt.tensor([1.0, 2.0], requires_grad=True)
+        pt.autograd.functional.jacobian(lambda value: value * value, x, strategy="forward-mode")
+
+    assert_torch_error(mt, th)
+
+
+def test_autograd_functional_jacobian_forward_mode_create_graph_error_matches_torch():
+    def mt():
+        x = torch.tensor([1.0, 2.0], requires_grad=True)
+        torch.autograd.functional.jacobian(
+            lambda value: value * value, x, vectorize=True, strategy="forward-mode", create_graph=True,
+        )
+
+    def th():
+        x = pt.tensor([1.0, 2.0], requires_grad=True)
+        pt.autograd.functional.jacobian(
+            lambda value: value * value, x, vectorize=True, strategy="forward-mode", create_graph=True,
+        )
+
+    assert_torch_error(mt, th)
+
+
+def test_autograd_functional_jacobian_forward_mode_strict_error_matches_torch():
+    def mt():
+        x = torch.tensor([1.0, 2.0], requires_grad=True)
+        torch.autograd.functional.jacobian(
+            lambda value: value * value, x, vectorize=True, strategy="forward-mode", strict=True,
+        )
+
+    def th():
+        x = pt.tensor([1.0, 2.0], requires_grad=True)
+        pt.autograd.functional.jacobian(
+            lambda value: value * value, x, vectorize=True, strategy="forward-mode", strict=True,
+        )
+
+    assert_torch_error(mt, th)
+
+
+def test_autograd_functional_hessian_forward_mode_without_vectorize_error_matches_torch():
+    def mt():
+        x = torch.tensor([1.0, 2.0], requires_grad=True)
+        torch.autograd.functional.hessian(
+            lambda value: (value * value).sum(), x, outer_jacobian_strategy="forward-mode",
+        )
+
+    def th():
+        x = pt.tensor([1.0, 2.0], requires_grad=True)
+        pt.autograd.functional.hessian(
+            lambda value: (value * value).sum(), x, outer_jacobian_strategy="forward-mode",
+        )
+
+    assert_torch_error(mt, th)
+
+


### PR DESCRIPTION
## Summary
- align unsupported forward-mode jacobian/hessian error messages with PyTorch
- add contract coverage for forward-mode without vectorize and forward-mode create_graph/strict boundary cases
- keep existing forward-mode vectorized success-path parity intact

## Test plan
- [x] conda run -n candle311 python setup.py build_ext --inplace -j4
- [x] conda run -n candle311 python -m pytest tests/contract/test_autograd_functional.py -v --tb=short
- [x] conda run -n candle311 python -m pytest tests/contract/test_autograd_audit_inventory.py -v --tb=short
- [x] conda run -n candle311 python -m pytest tests/contract/test_codegen_roundtrip.py -v --tb=short
- [x] conda run -n candle311 python -m pytest tests/cpu/ tests/contract/ --tb=short -q
- [x] conda run -n candle311 pylint src/candle/ --rcfile=.github/pylint.conf

🤖 Generated with [Claude Code](https://claude.com/claude-code)