### PR TITLE
fix(autograd): close remaining public backward gaps

### DIFF
--- a/src/candle/_C/_autograd_engine.pyx
+++ b/src/candle/_C/_autograd_engine.pyx
@@ -310,7 +310,7 @@ cdef class _GraphTask:
         acc_node = getattr(tensor, "_accumulate_grad_node", None)
         if acc_node is not None:
             grad = acc_node.apply_prehooks(grad)
-        if mark_create_graph and self.create_graph and grad is not None:
+        if mark_create_graph and self.create_graph and grad is not None and getattr(grad, "grad_fn", None) is not None:
             grad.requires_grad = True
         # PyTorch-aligned view-rebase: if the tensor is a view that carries a
         # _rev_view_func, transform grad via _rev_view_func before forwarding

--- a/src/candle/_backends/autograd.py
+++ b/src/candle/_backends/autograd.py
@@ -575,13 +575,16 @@ def _layer_norm_backward(grad, _a, saved_a, keyset, args, kwargs, backward_data=
             n *= saved_a.shape[d]
         n_t = _scalar_tensor_like(saved_a, float(n))
 
-        mean_dl_dxhat = redispatch("div", keyset, redispatch("sum", keyset, dl_dxhat, dim=axis_dims, keepdim=True), n_t)
-        mean_dl_dxhat_xhat = redispatch("div", keyset, redispatch("sum", keyset, redispatch("mul", keyset, dl_dxhat, x_hat), dim=axis_dims, keepdim=True), n_t)
-
-        grad_input = redispatch("mul", keyset, inv_std,
+        dl_dxhat_sum = redispatch("sum", keyset, dl_dxhat, dim=axis_dims, keepdim=True)
+        dl_dxhat_xhat_sum = redispatch("sum", keyset, redispatch("mul", keyset, dl_dxhat, x_hat), dim=axis_dims, keepdim=True)
+        scaled = redispatch("add", keyset,
             redispatch("add", keyset,
-                redispatch("add", keyset, dl_dxhat, redispatch("neg", keyset, mean_dl_dxhat)),
-                redispatch("neg", keyset, redispatch("mul", keyset, x_hat, mean_dl_dxhat_xhat))))
+                redispatch("mul", keyset, n_t, dl_dxhat),
+                redispatch("neg", keyset, dl_dxhat_sum)),
+            redispatch("neg", keyset, redispatch("mul", keyset, x_hat, dl_dxhat_xhat_sum)))
+        grad_input = redispatch("mul", keyset, redispatch("div", keyset, inv_std, n_t), scaled)
+        grad_input = redispatch("add", keyset, grad_input, redispatch("neg", keyset,
+            redispatch("div", keyset, redispatch("sum", keyset, grad_input, dim=axis_dims, keepdim=True), n_t)))
 
         # Compute weight and bias gradients
         grad_weight = None
@@ -6703,35 +6706,70 @@ def _autograd_linalg_lu_factor(name):
                 pivots_np = saved_pivots._numpy_view()
                 grad_np = grad._numpy_view().astype(_np.float64)
 
-                if not pivot or a_np.ndim < 2 or a_np.shape[-1] != a_np.shape[-2]:
-                    raise RuntimeError("linalg.lu_factor backward is only implemented for pivoted square inputs")
+                if not pivot or a_np.ndim < 2:
+                    raise RuntimeError("linalg.lu_factor backward is only implemented for pivoted inputs")
 
-                n = a_np.shape[-1]
-                lower_grad = _np.tril(grad_np, -1)
-                upper_grad = _np.triu(grad_np)
-                eye_n = _np.eye(n, dtype=_np.float64)
-                lower = _np.tril(lu_np, -1) + eye_n
-                upper = _np.triu(lu_np)
-
-                lower_t = _np.swapaxes(lower, -2, -1)
-                upper_t = _np.swapaxes(upper, -2, -1)
-                middle = _np.tril(lower_t @ lower_grad, -1) + _np.triu(upper_grad @ upper_t)
-                grad_pa = _np.linalg.solve(lower_t, middle) @ _np.linalg.inv(upper_t)
+                m, n = a_np.shape[-2], a_np.shape[-1]
+                k = min(m, n)
+                eye_k = _np.eye(k, dtype=_np.float64)
 
                 pivots_int = pivots_np.astype(_np.int64)
+                eye_m = _np.eye(m, dtype=_np.float64)
                 if a_np.ndim == 2:
-                    permutation = _np.eye(n, dtype=_np.float64)
+                    permutation = eye_m.copy()
                     for i, pivot_index in enumerate(pivots_int):
                         permutation[[i, pivot_index]] = permutation[[pivot_index, i]]
                 else:
                     batch_shape = a_np.shape[:-2]
-                    permutation = _np.broadcast_to(eye_n, batch_shape + (n, n)).copy()
-                    flat_perm = permutation.reshape(-1, n, n)
-                    flat_pivots = pivots_int.reshape(-1, n)
+                    permutation = _np.broadcast_to(eye_m, batch_shape + (m, m)).copy()
+                    flat_perm = permutation.reshape(-1, m, m)
+                    flat_pivots = pivots_int.reshape(-1, k)
                     for b in range(flat_perm.shape[0]):
                         for i, pivot_index in enumerate(flat_pivots[b]):
                             flat_perm[b, [i, int(pivot_index)]] = flat_perm[b, [int(pivot_index), i]]
-                    permutation = flat_perm.reshape(batch_shape + (n, n))
+                    permutation = flat_perm.reshape(batch_shape + (m, m))
+
+                if m == n:
+                    lower_grad = _np.tril(grad_np, -1)
+                    upper_grad = _np.triu(grad_np)
+                    lower = _np.tril(lu_np, -1) + eye_k
+                    upper = _np.triu(lu_np)
+
+                    lower_t = _np.swapaxes(lower, -2, -1)
+                    upper_t = _np.swapaxes(upper, -2, -1)
+                    middle = _np.tril(lower_t @ lower_grad, -1) + _np.triu(upper_grad @ upper_t)
+                    grad_pa = _np.linalg.solve(lower_t, middle) @ _np.linalg.inv(upper_t)
+                else:
+                    lower = _np.tril(lu_np[..., :, :k], -1)
+                    diag_idx = _np.arange(k)
+                    lower[..., diag_idx, diag_idx] = 1.0
+                    upper = _np.triu(lu_np[..., :k, :])
+                    lower_grad = grad_np[..., :, :k]
+                    upper_grad = grad_np[..., :k, :]
+                    lower_t = _np.swapaxes(lower, -2, -1)
+                    upper_t = _np.swapaxes(upper, -2, -1)
+                    lower_1 = lower[..., :k, :]
+                    lower_1_t = _np.swapaxes(lower_1, -2, -1)
+                    upper_1 = upper[..., :, :k]
+                    upper_1_t = _np.swapaxes(upper_1, -2, -1)
+
+                    if m < n:
+                        upper_1_grad = upper_grad[..., :, :k]
+                        upper_2_grad = upper_grad[..., :, k:]
+                        tmp = lower_t @ lower_grad - _np.triu(upper_grad) @ upper_t
+                        left_part = _np.tril(tmp, -1) @ _np.linalg.inv(upper_1_t)
+                        left_part = left_part + _np.triu(upper_1_grad)
+                        a_grad = _np.concatenate((left_part, upper_2_grad), axis=-1)
+                        grad_pa = _np.linalg.solve(lower_t, a_grad)
+                    else:
+                        lower_1_grad = lower_grad[..., :k, :]
+                        lower_2_grad = lower_grad[..., k:, :]
+                        tmp = upper_grad @ upper_t - lower_t @ _np.tril(lower_grad, -1)
+                        top_part = _np.linalg.solve(lower_1_t, _np.triu(tmp))
+                        top_part = top_part + _np.tril(lower_1_grad, -1)
+                        a_grad = _np.concatenate((top_part, lower_2_grad), axis=-2)
+                        grad_pa = a_grad @ _np.linalg.inv(upper_t)
+
                 grad_a_np = _np.swapaxes(permutation, -2, -1) @ grad_pa
 
                 from .._C import typed_storage_from_numpy

--- a/src/candle/_generated/_functions_cy.pyx
+++ b/src/candle/_generated/_functions_cy.pyx
@@ -401,10 +401,12 @@ def _norm_grad_core(dl_dxhat, x_hat, inv_std, axes, n, keyset):
     mean_dl_xhat = _redispatch("div", keyset,
         _redispatch("sum", keyset, _redispatch("mul", keyset, dl_dxhat, x_hat),
                    dim=axes, keepdim=True), n_t)
-    return _redispatch("mul", keyset, inv_std,
+    grad_input = _redispatch("mul", keyset, inv_std,
         _redispatch("add", keyset,
             _redispatch("add", keyset, dl_dxhat, _redispatch("neg", keyset, mean_dl)),
             _redispatch("neg", keyset, _redispatch("mul", keyset, x_hat, mean_dl_xhat))))
+    return _redispatch("add", keyset, grad_input, _redispatch("neg", keyset,
+        _redispatch("div", keyset, _redispatch("sum", keyset, grad_input, dim=axes, keepdim=True), n_t)))
 
 
 def _layer_norm_grad_input(grad, input_, normalized_shape, weight, eps, keyset):
@@ -1319,7 +1321,7 @@ def _dist_backward_all(grad, self_, other, p, keyset):
 
 def _cdist_backward_all(grad, self_, other, p, keyset):
     from .._backends.autograd import _cdist_backward
-    return _cdist_backward(grad, self_, other, self_, other, keyset, (p,))
+    return _cdist_backward(grad, self_, other, p, keyset)
 
 
 def _as_strided_scatter_backward_all(grad, self_, src, size, stride, storage_offset, keyset):

--- a/src/candle/_generated/functions.py
+++ b/src/candle/_generated/functions.py
@@ -422,10 +422,12 @@ def _norm_grad_core(dl_dxhat, x_hat, inv_std, axes, n, keyset):
     mean_dl_xhat = redispatch("div", keyset,
         redispatch("sum", keyset, redispatch("mul", keyset, dl_dxhat, x_hat),
                    dim=axes, keepdim=True), n_t)
-    return redispatch("mul", keyset, inv_std,
+    grad_input = redispatch("mul", keyset, inv_std,
         redispatch("add", keyset,
             redispatch("add", keyset, dl_dxhat, redispatch("neg", keyset, mean_dl)),
             redispatch("neg", keyset, redispatch("mul", keyset, x_hat, mean_dl_xhat))))
+    return redispatch("add", keyset, grad_input, redispatch("neg", keyset,
+        redispatch("div", keyset, redispatch("sum", keyset, grad_input, dim=axes, keepdim=True), n_t)))
 
 
 def _layer_norm_grad_input(grad, input_, normalized_shape, weight, eps, keyset):
@@ -1361,7 +1363,7 @@ def _dist_backward_all(grad, self_, other, p, keyset):
 
 def _cdist_backward_all(grad, self_, other, p, keyset):
     from .._backends.autograd import _cdist_backward
-    return _cdist_backward(grad, self_, other, self_, other, keyset, (p,))
+    return _cdist_backward(grad, self_, other, p, keyset)
 
 
 def _as_strided_scatter_backward_all(grad, self_, src, size, stride, storage_offset, keyset):

--- a/src/candle/nn/functional.py
+++ b/src/candle/nn/functional.py
@@ -2006,8 +2006,8 @@ def pdist(input, p=2.0):
     from ..autograd.anomaly_mode import annotate_node_creation
     from ..autograd.grad_mode import GradMode
     from ..autograd.node import Node
-    from .._C._autograd_engine import is_create_graph_enabled  # pylint: disable=no-name-in-module
-    from .._C._autograd_ops import (  # pylint: disable=no-name-in-module
+    from .._C._autograd_engine import is_create_graph_enabled  # pylint: disable=import-error,no-name-in-module
+    from .._C._autograd_ops import (  # pylint: disable=import-error,no-name-in-module
         _backward_dispatch_keyset,
         _grad_context,
         _strip_autograd_keys,

--- a/src/candle/nn/functional.py
+++ b/src/candle/nn/functional.py
@@ -1997,8 +1997,64 @@ def pdist(input, p=2.0):
             results.append(d.unsqueeze(0))
     if not results:
         from .._creation import zeros
-        return zeros(0, device=input.device)
-    return dispatch("cat", None, results, 0)
+        out = zeros(0, device=input.device)
+    else:
+        out = dispatch("cat", None, results, 0)
+    if p != 2.0 or not getattr(input, "requires_grad", False):
+        return out
+
+    from ..autograd.anomaly_mode import annotate_node_creation
+    from ..autograd.grad_mode import GradMode
+    from ..autograd.node import Node
+    from .._C._autograd_engine import is_create_graph_enabled  # pylint: disable=no-name-in-module
+    from .._C._autograd_ops import (  # pylint: disable=no-name-in-module
+        _backward_dispatch_keyset,
+        _grad_context,
+        _strip_autograd_keys,
+    )
+    from .._dispatch.dispatcher import current_dispatch_keyset, redispatch
+
+    if not GradMode.enabled:
+        return out
+    active_keyset = current_dispatch_keyset()
+    raw_keyset = _strip_autograd_keys(active_keyset)
+    node_holder = {}
+
+    def _backward(grad):
+        saved_input = node_holder["node"].saved_tensors()[0]
+        keyset = _backward_dispatch_keyset(raw_keyset, active_keyset)
+        with _grad_context(keyset):
+            zero = _tensor(0.0, dtype=saved_input.dtype, device=saved_input.device)
+            rows = [redispatch("mul", keyset, saved_input[i], zero) for i in range(saved_input.shape[0])]
+            pair_idx = 0
+            for i in range(saved_input.shape[0]):
+                for j in range(i + 1, saved_input.shape[0]):
+                    diff = redispatch("add", keyset, saved_input[i], redispatch("neg", keyset, saved_input[j]))
+                    dist = redispatch("norm", keyset, diff, 2.0, None, False)
+                    safe_dist = redispatch("add", keyset, dist, _tensor(1e-30, dtype=saved_input.dtype, device=saved_input.device))
+                    direction = redispatch("div", keyset, diff, safe_dist)
+                    grad_pair = redispatch("mul", keyset, grad[pair_idx], direction)
+                    rows[i] = redispatch("add", keyset, rows[i], grad_pair)
+                    rows[j] = redispatch("add", keyset, rows[j], redispatch("neg", keyset, grad_pair))
+                    pair_idx += 1
+            grad_input = redispatch("stack", keyset, rows, 0)
+        if is_create_graph_enabled():
+            def _raise_pdist_backward(_grad):
+                raise NotImplementedError("the derivative for '_pdist_backward' is not implemented.")
+            grad_node = Node(_raise_pdist_backward, (), name="PdistBackwardBackward0")
+            annotate_node_creation(grad_node)
+            grad_input.grad_fn = grad_node
+            grad_input.requires_grad = True
+        return (grad_input,)
+
+    node = Node(_backward, (input,), name="PdistForwardBackward0")
+    annotate_node_creation(node)
+    node_holder["node"] = node
+    node.save_for_backward(input)
+    out.grad_fn = node
+    out.requires_grad = True
+    return out
+
 
 
 

--- a/tests/cpu/test_autograd_ops.py
+++ b/tests/cpu/test_autograd_ops.py
@@ -4,6 +4,8 @@ import math
 import numpy as np
 import pytest
 
+import torch as real_torch
+
 import candle as torch
 import candle.nn.functional as F
 
@@ -18,6 +20,25 @@ def _check_grad(x, expected, *, atol=1e-5, rtol=1e-5):
     actual = x.grad.numpy()
     np.testing.assert_allclose(actual, np.array(expected, dtype=actual.dtype),
                                atol=atol, rtol=rtol)
+
+
+def _assert_torch_error(mt_fn, th_fn):
+    try:
+        th_fn()
+    except Exception as th_exc:  # pylint: disable=broad-exception-caught
+        expected = th_exc
+    else:
+        expected = None
+
+    try:
+        mt_fn()
+    except Exception as mt_exc:  # pylint: disable=broad-exception-caught
+        actual = mt_exc
+    else:
+        actual = None
+
+    assert type(actual) is type(expected)
+    assert str(actual) == str(expected)
 
 
 def _tensor(vals, requires_grad=True):
@@ -723,8 +744,6 @@ class TestTopkBackward:
 
 class TestLinalgLuFactorBackward:
     def test_lu_output_backward_matches_torch_for_2x2_pivoted_factorization(self):
-        import torch as real_torch
-
         data = [[0.5, 3.0], [2.0, 1.0]]
         upstream = [[1.5, -2.0], [0.25, 0.75]]
 
@@ -739,8 +758,6 @@ class TestLinalgLuFactorBackward:
         _check_grad(x, ref.grad.detach().numpy(), atol=1e-5, rtol=1e-5)
 
     def test_lu_output_backward_matches_torch_for_batched_3d_input(self):
-        import torch as real_torch
-
         data = [
             [[2.0, 1.0], [1.0, 3.0]],
             [[0.5, 3.0], [2.0, 1.0]],
@@ -749,6 +766,34 @@ class TestLinalgLuFactorBackward:
             [[1.0, -0.5], [0.25, 0.75]],
             [[1.5, -2.0], [0.25, 0.75]],
         ]
+
+        ref = real_torch.tensor(data, dtype=real_torch.float32, requires_grad=True)
+        ref_lu, _ = real_torch.linalg.lu_factor(ref)
+        (ref_lu * real_torch.tensor(upstream, dtype=real_torch.float32)).sum().backward()
+
+        x = _tensor(data)
+        lu, _ = torch.linalg.lu_factor(x)
+        (lu * torch.tensor(upstream, dtype=torch.float32)).sum().backward()
+
+        _check_grad(x, ref.grad.detach().numpy(), atol=1e-5, rtol=1e-5)
+
+    def test_lu_output_backward_matches_torch_for_tall_rectangular_input(self):
+        data = [[2.0, 1.0, 0.5], [1.0, 3.0, 1.5], [4.0, 2.0, 2.5], [1.5, 0.5, 3.5]]
+        upstream = [[1.0, -0.5, 0.25], [0.75, 1.25, -1.0], [0.5, -0.25, 1.5], [1.0, 0.0, -0.75]]
+
+        ref = real_torch.tensor(data, dtype=real_torch.float32, requires_grad=True)
+        ref_lu, _ = real_torch.linalg.lu_factor(ref)
+        (ref_lu * real_torch.tensor(upstream, dtype=real_torch.float32)).sum().backward()
+
+        x = _tensor(data)
+        lu, _ = torch.linalg.lu_factor(x)
+        (lu * torch.tensor(upstream, dtype=torch.float32)).sum().backward()
+
+        _check_grad(x, ref.grad.detach().numpy(), atol=1e-5, rtol=1e-5)
+
+    def test_lu_output_backward_matches_torch_for_wide_rectangular_input(self):
+        data = [[2.0, 1.0, 0.5, 1.5], [1.0, 3.0, 1.5, 0.5], [4.0, 2.0, 2.5, 3.5]]
+        upstream = [[1.0, -0.5, 0.25, 0.75], [0.75, 1.25, -1.0, 0.5], [0.5, -0.25, 1.5, -0.75]]
 
         ref = real_torch.tensor(data, dtype=real_torch.float32, requires_grad=True)
         ref_lu, _ = real_torch.linalg.lu_factor(ref)
@@ -779,6 +824,100 @@ class TestLinalgEighBatchedBackward:
         vectors.sum().backward()
 
         _check_grad(x, ref.grad.detach().numpy(), atol=1e-5, rtol=1e-5)
+
+
+class TestRemainingAutogradParity:
+    def test_cdist_backward_matches_torch(self):
+        x_data = [[1.0, 0.0, 0.5], [0.0, 1.0, 1.5], [1.0, 1.0, 0.25], [2.0, 0.5, 1.0]]
+        y_data = [[0.5, 1.0, 0.0], [1.5, 0.0, 1.0], [0.0, 0.5, 2.0], [2.0, 1.0, 0.5], [1.0, 2.0, 1.5]]
+        upstream = np.arange(20, dtype=np.float32).reshape(4, 5) / 10.0 + 0.25
+
+        ref_x = real_torch.tensor(x_data, dtype=real_torch.float32, requires_grad=True)
+        ref_y = real_torch.tensor(y_data, dtype=real_torch.float32, requires_grad=True)
+        (real_torch.cdist(ref_x, ref_y) * real_torch.tensor(upstream, dtype=real_torch.float32)).sum().backward()
+
+        x = _tensor(x_data)
+        y = _tensor(y_data)
+        (torch.cdist(x, y) * torch.tensor(upstream, dtype=torch.float32)).sum().backward()
+
+        _check_grad(x, ref_x.grad.detach().numpy(), atol=1e-5, rtol=1e-5)
+        _check_grad(y, ref_y.grad.detach().numpy(), atol=1e-5, rtol=1e-5)
+
+    def test_layer_norm_second_backward_matches_torch(self):
+        x_data = [[1.0, 2.0, 3.0, 4.0], [4.0, 5.0, 6.0, 7.0]]
+        weight_data = [0.5, 0.7, 0.9, 1.1]
+        bias_data = [0.1, 0.2, 0.3, 0.4]
+
+        ref_x = real_torch.tensor(x_data, dtype=real_torch.float32, requires_grad=True)
+        ref_weight = real_torch.tensor(weight_data, dtype=real_torch.float32, requires_grad=True)
+        ref_bias = real_torch.tensor(bias_data, dtype=real_torch.float32, requires_grad=True)
+        ref_out = real_torch.nn.functional.layer_norm(ref_x, [4], ref_weight, ref_bias)
+        ref_grad_x = real_torch.autograd.grad(ref_out.sum(), ref_x, create_graph=True)[0]
+        ref_grad_x.sum().backward()
+
+        x = _tensor(x_data)
+        weight = _tensor(weight_data)
+        bias = _tensor(bias_data)
+        out = F.layer_norm(x, [4], weight, bias)
+        grad_x = torch.autograd.grad(out.sum(), x, create_graph=True)[0]
+        grad_x.sum().backward()
+
+        _check_grad(x, ref_x.grad.detach().numpy(), atol=1e-5, rtol=1e-5)
+        _check_grad(weight, ref_weight.grad.detach().numpy(), atol=1e-5, rtol=1e-5)
+        assert bias.grad is None
+        assert ref_bias.grad is None
+
+    def test_pdist_second_backward_error_matches_torch(self):
+        def mt():
+            x = torch.tensor(
+                [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [1.0, 1.0, 0.5]],
+                dtype=torch.float32,
+                requires_grad=True,
+            )
+            grad_x = torch.autograd.grad(F.pdist(x).sum(), x, create_graph=True)[0]
+            grad_x.sum().backward()
+
+        def th():
+            x = real_torch.tensor(
+                [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [1.0, 1.0, 0.5]],
+                dtype=real_torch.float32,
+                requires_grad=True,
+            )
+            grad_x = real_torch.autograd.grad(real_torch.nn.functional.pdist(x).sum(), x, create_graph=True)[0]
+            grad_x.sum().backward()
+
+        _assert_torch_error(mt, th)
+
+    def test_embedding_bag_second_backward_error_matches_torch(self):
+        def mt():
+            weight = torch.tensor(
+                (np.arange(40, dtype=np.float32).reshape(10, 4) / 40.0),
+                requires_grad=True,
+            )
+            grad_weight = torch.autograd.grad(
+                F.embedding_bag(torch.tensor([1, 2, 4, 5, 4, 3, 2, 9]), weight, torch.tensor([0, 4])).sum(),
+                weight,
+                create_graph=True,
+            )[0]
+            grad_weight.sum().backward()
+
+        def th():
+            weight = real_torch.tensor(
+                (np.arange(40, dtype=np.float32).reshape(10, 4) / 40.0),
+                requires_grad=True,
+            )
+            grad_weight = real_torch.autograd.grad(
+                real_torch.nn.functional.embedding_bag(
+                    real_torch.tensor([1, 2, 4, 5, 4, 3, 2, 9]),
+                    weight,
+                    real_torch.tensor([0, 4]),
+                ).sum(),
+                weight,
+                create_graph=True,
+            )[0]
+            grad_weight.sum().backward()
+
+        _assert_torch_error(mt, th)
 
 
 class TestChunkBackward:

--- a/tools/autograd/gen_functions.py
+++ b/tools/autograd/gen_functions.py
@@ -396,10 +396,12 @@ def _norm_grad_core(dl_dxhat, x_hat, inv_std, axes, n, keyset):
     mean_dl_xhat = redispatch("div", keyset,
         redispatch("sum", keyset, redispatch("mul", keyset, dl_dxhat, x_hat),
                    dim=axes, keepdim=True), n_t)
-    return redispatch("mul", keyset, inv_std,
+    grad_input = redispatch("mul", keyset, inv_std,
         redispatch("add", keyset,
             redispatch("add", keyset, dl_dxhat, redispatch("neg", keyset, mean_dl)),
             redispatch("neg", keyset, redispatch("mul", keyset, x_hat, mean_dl_xhat))))
+    return redispatch("add", keyset, grad_input, redispatch("neg", keyset,
+        redispatch("div", keyset, redispatch("sum", keyset, grad_input, dim=axes, keepdim=True), n_t)))
 
 
 def _layer_norm_grad_input(grad, input_, normalized_shape, weight, eps, keyset):
@@ -1314,7 +1316,7 @@ def _dist_backward_all(grad, self_, other, p, keyset):
 
 def _cdist_backward_all(grad, self_, other, p, keyset):
     from .._backends.autograd import _cdist_backward
-    return _cdist_backward(grad, self_, other, self_, other, keyset, (p,))
+    return _cdist_backward(grad, self_, other, p, keyset)
 
 
 def _as_strided_scatter_backward_all(grad, self_, src, size, stride, storage_offset, keyset):


### PR DESCRIPTION
## Summary
- Align rectangular `torch.linalg.lu_factor` backward for tall/wide 2-D inputs while preserving square and batched-square behavior.
- Fix `torch.cdist` backward helper routing so first-order grads match PyTorch for both inputs.
- Align higher-order public autograd parity for `layer_norm`, `pdist`, and `embedding_bag`: `layer_norm` second-order input grads now match PyTorch; `pdist`/`embedding_bag` second-order behavior now raises the same errors PyTorch raises.

## Test plan
- [x] RED confirmed before implementation for the six focused failures:
  - tall/wide rectangular `lu_factor` backward
  - `cdist` first backward
  - `layer_norm` second backward input grad
  - `pdist` second-backward error parity
  - `embedding_bag` second-backward error parity
- [x] `python -m pytest tests/cpu/test_autograd_ops.py -k "rectangular or cdist_backward or layer_norm_second or pdist_second or embedding_bag_second" -v --tb=short` → 6 passed
- [x] `python -m pytest tests/cpu/test_autograd_ops.py -v --tb=short` → 86 passed
- [x] `python -m pytest tests/cpu/test_tensor_view.py -k "pdist" -v --tb=short` → 14 passed
- [x] `python -m pytest tests/contract/test_autograd_audit_inventory.py -v --tb=short` → 5 passed
- [x] `python -m pytest tests/contract/test_codegen_roundtrip.py -v --tb=short` → 1 passed
- [x] `python -m pytest tests/cpu/ tests/contract/ --tb=short -q` → 3159 passed, 30 skipped
- [x] `pylint src/candle/ --rcfile=.github/pylint.conf` → 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)