### PR TITLE
fix(compat): align CPU creation/validation APIs with PyTorch

### DIFF
--- a/src/candle/_C/_creation_ops.pyx
+++ b/src/candle/_C/_creation_ops.pyx
@@ -3,6 +3,8 @@ import numpy as np
 
 from candle._dtype import float32, int64
 from candle._dtype import bool as bool_dtype
+
+cdef bint _frombuffer_writable_warned = False
 cdef object _get_default_dtype():
     from candle import get_default_dtype
     return get_default_dtype()
@@ -257,6 +259,25 @@ def frombuffer(buffer, *, dtype, count=-1, offset=0, requires_grad=False):
         view = memoryview(buffer)
     except TypeError as exc:
         raise ValueError("object does not implement Python buffer protocol.") from exc
+
+    try:
+        readonly = bool(view.readonly)
+    except AttributeError:
+        readonly = False
+    global _frombuffer_writable_warned
+    if readonly:
+        from candle import is_warn_always_enabled
+        if is_warn_always_enabled() or not _frombuffer_writable_warned:
+            import warnings
+            warnings.warn(
+                "The given buffer is not writable, and PyTorch does not support non-writable tensors. "
+                "This means you can write to the underlying (supposedly non-writable) buffer using the tensor. "
+                "You may want to copy the buffer to protect its data or make it writable before converting it to a tensor. "
+                "This type of warning will be suppressed for the rest of this program.",
+                UserWarning,
+                stacklevel=2,
+            )
+            _frombuffer_writable_warned = True
 
     byte_len = int(view.nbytes)
     itemsize = int(np.dtype(np_dtype).itemsize)

--- a/src/candle/_C/_creation_ops.pyx
+++ b/src/candle/_C/_creation_ops.pyx
@@ -86,6 +86,51 @@ cdef bint _device_matches(object tensor, object target_device):
     return tensor.device.index == target.index
 
 
+cdef _validate_layout(object layout_arg):
+    if layout_arg is None:
+        return
+    from candle import strided
+    if layout_arg is not strided:
+        raise TypeError(
+            f"candle currently only supports torch.strided layout, got {layout_arg!r}"
+        )
+
+
+cdef _check_no_internal_overlap(object out):
+    cdef object shape = tuple(out.shape)
+    cdef object stride = tuple(out.stride())
+    for size_i, stride_i in zip(shape, stride):
+        if size_i > 1 and stride_i == 0:
+            raise RuntimeError(
+                "unsupported operation: more than one element of the written-to tensor "
+                "refers to a single memory location. Please clone() the tensor before "
+                "performing the operation."
+            )
+
+
+cdef object _finalize_out(object value, object out):
+    if out is None:
+        return value
+    _check_no_internal_overlap(out)
+    if tuple(out.shape) != tuple(value.shape):
+        if int(out.numel()) != 0 and int(out.numel()) == int(value.numel()):
+            out.copy_(value.reshape(tuple(out.shape)))
+            return out
+        if int(out.numel()) != 0:
+            import warnings
+            warnings.warn(
+                "The out tensor will be resized to match the shape of the result. "
+                "This behavior is deprecated, and in a future PyTorch release outputs will not "
+                "be resized unless they have zero elements.",
+                UserWarning,
+                stacklevel=2,
+            )
+        out.cy_set_data_runtime_truth_from(value)
+        return out
+    out.copy_(value)
+    return out
+
+
 def tensor(data, *, dtype=None, device=None, requires_grad=False):
     from candle._functional import tensor as tensor_dispatch
 
@@ -96,146 +141,244 @@ def tensor(data, *, dtype=None, device=None, requires_grad=False):
     return tensor_dispatch(data, dtype=dtype, device=device, requires_grad=requires_grad)
 
 
-def zeros(*shape, dtype=None, device=None, memory_format=None, requires_grad=False):
+def _resolve_size_kwarg(tuple shape, object size):
+    if size is None:
+        return shape
+    if len(shape) != 0:
+        raise TypeError("received an invalid combination of arguments")
+    return (size,)
+
+
+def zeros(*shape, dtype=None, device=None, memory_format=None, layout=None, out=None, requires_grad=False, size=None):
     from candle._functional import zeros as zeros_dispatch
 
+    shape = _resolve_size_kwarg(shape, size)
+    _validate_layout(layout)
     if dtype is None:
-        dtype = _get_default_dtype()
-    return _apply_requires_grad(
-        zeros_dispatch(*shape, dtype=dtype, device=device, memory_format=memory_format),
-        requires_grad,
-    )
+        dtype = _get_default_dtype() if out is None else out.dtype
+    value = zeros_dispatch(*shape, dtype=dtype, device=device, memory_format=memory_format)
+    if out is not None:
+        return _apply_requires_grad(_finalize_out(value, out), requires_grad)
+    return _apply_requires_grad(value, requires_grad)
 
 
-def ones(*shape, dtype=None, device=None, memory_format=None, requires_grad=False):
+def ones(*shape, dtype=None, device=None, memory_format=None, layout=None, out=None, requires_grad=False, size=None):
     from candle._functional import ones as ones_dispatch
 
+    shape = _resolve_size_kwarg(shape, size)
+    _validate_layout(layout)
     if dtype is None:
-        dtype = _get_default_dtype()
-    return _apply_requires_grad(
-        ones_dispatch(*shape, dtype=dtype, device=device, memory_format=memory_format),
-        requires_grad,
-    )
+        dtype = _get_default_dtype() if out is None else out.dtype
+    value = ones_dispatch(*shape, dtype=dtype, device=device, memory_format=memory_format)
+    if out is not None:
+        return _apply_requires_grad(_finalize_out(value, out), requires_grad)
+    return _apply_requires_grad(value, requires_grad)
 
 
-def empty(*shape, dtype=None, device=None, memory_format=None, requires_grad=False):
+def empty(*shape, dtype=None, device=None, memory_format=None, layout=None, out=None, requires_grad=False, size=None):
     from candle._functional import empty as empty_dispatch
 
+    shape = _resolve_size_kwarg(shape, size)
+    _validate_layout(layout)
+    if dtype is None:
+        dtype = _get_default_dtype() if out is None else out.dtype
+    value = empty_dispatch(*shape, dtype=dtype, device=device, memory_format=memory_format)
+    if out is not None:
+        return _apply_requires_grad(_finalize_out(value, out), requires_grad)
+    return _apply_requires_grad(value, requires_grad)
+
+
+def empty_strided(size, stride, *, dtype=None, device=None, layout=None, requires_grad=False, pin_memory=False):
+    cdef tuple size_t
+    cdef tuple stride_t
+    cdef Py_ssize_t required = 0
+    cdef Py_ssize_t max_index = 0
+    cdef Py_ssize_t dim
+    cdef Py_ssize_t step
+    cdef object base
+
+    _validate_layout(layout)
     if dtype is None:
         dtype = _get_default_dtype()
-    return _apply_requires_grad(
-        empty_dispatch(*shape, dtype=dtype, device=device, memory_format=memory_format),
-        requires_grad,
-    )
+    if pin_memory:
+        raise RuntimeError("Need to provide pin_memory allocator to use pin memory.")
+    size_t = tuple(int(s) for s in size)
+    stride_t = tuple(int(s) for s in stride)
+    if len(size_t) != len(stride_t):
+        raise RuntimeError("mismatch in length of strides and shape")
+    if size_t and all(dim > 0 for dim in size_t):
+        for dim, step in zip(size_t, stride_t):
+            max_index += (dim - 1) * step
+        required = max_index + 1
+    base = empty((required,), dtype=dtype, device=device, requires_grad=requires_grad)
+    return base.as_strided(size_t, stride_t)
 
 
-def arange(start, end=None, step=1, dtype=None, device=None, requires_grad=False):
+def _format_range_endpoint(object value):
+    if value == float("inf"):
+        return "inf"
+    if value == float("-inf"):
+        return "-inf"
+    if value != value:
+        return "nan"
+    return str(value)
+
+
+def _validate_arange_args(object start, object end, object step):
+    cdef object actual_start = 0 if end is None else start
+    cdef object actual_end = start if end is None else end
+    import math
+
+    if step == 0:
+        raise RuntimeError("step must be nonzero")
+    if isinstance(actual_start, (int, float)) and isinstance(actual_end, (int, float)) and isinstance(step, (int, float)):
+        if not math.isfinite(float(actual_start)) or not math.isfinite(float(actual_end)):
+            raise RuntimeError(
+                f"unsupported range: {_format_range_endpoint(actual_start)} -> {_format_range_endpoint(actual_end)}"
+            )
+        if math.isfinite(float(step)) and step != 0:
+            span = (float(actual_end) - float(actual_start)) / float(step)
+            if span > 9223372036854775807:
+                raise RuntimeError("overflow when unpacking long")
+
+
+def arange(start, end=None, step=1, dtype=None, device=None, layout=None, out=None, requires_grad=False):
     from candle._functional import arange as arange_dispatch
 
     cdef list args
 
+    _validate_arange_args(start, end, step)
+    _validate_layout(layout)
     if dtype is None:
-        args = [start] + ([end] if end is not None else []) + [step]
-        if all(isinstance(a, int) for a in args):
-            dtype = int64
+        if out is not None:
+            dtype = out.dtype
         else:
-            dtype = _get_default_dtype()
-    return _apply_requires_grad(
-        arange_dispatch(start, end=end, step=step, dtype=dtype, device=device),
-        requires_grad,
-    )
+            args = [start] + ([end] if end is not None else []) + [step]
+            if all(isinstance(a, int) for a in args):
+                dtype = int64
+            else:
+                dtype = _get_default_dtype()
+    value = arange_dispatch(start, end=end, step=step, dtype=dtype, device=device)
+    if out is not None:
+        return _apply_requires_grad(_finalize_out(value, out), requires_grad)
+    return _apply_requires_grad(value, requires_grad)
 
 
-def linspace(start, end, steps, dtype=None, device=None, requires_grad=False):
+def linspace(start, end, steps, dtype=None, device=None, layout=None, out=None, requires_grad=False):
     from candle._functional import linspace as linspace_dispatch
 
+    _validate_layout(layout)
+    if int(steps) < 0:
+        raise RuntimeError(f"number of steps must be non-negative, but got steps={int(steps)}")
     if dtype is None:
-        dtype = _get_default_dtype()
-    return _apply_requires_grad(
-        linspace_dispatch(start, end, steps, dtype=dtype, device=device),
-        requires_grad,
-    )
+        dtype = _get_default_dtype() if out is None else out.dtype
+    value = linspace_dispatch(start, end, steps, dtype=dtype, device=device)
+    if out is not None:
+        return _apply_requires_grad(_finalize_out(value, out), requires_grad)
+    return _apply_requires_grad(value, requires_grad)
 
 
-def full(*args, dtype=None, device=None, requires_grad=False, memory_format=None):
+def full(*args, dtype=None, device=None, requires_grad=False, memory_format=None, layout=None, out=None):
     from candle._functional import full as full_dispatch
 
+    _validate_layout(layout)
     if dtype is None:
-        dtype = _get_default_dtype()
-    return _apply_requires_grad(
-        full_dispatch(*args, dtype=dtype, device=device, memory_format=memory_format),
-        requires_grad,
-    )
+        dtype = _get_default_dtype() if out is None else out.dtype
+    value = full_dispatch(*args, dtype=dtype, device=device, memory_format=memory_format)
+    if out is not None:
+        return _apply_requires_grad(_finalize_out(value, out), requires_grad)
+    return _apply_requires_grad(value, requires_grad)
 
 
-def logspace(start, end, steps, dtype=None, device=None, requires_grad=False):
+def logspace(start, end, steps, base=10.0, dtype=None, device=None, layout=None, out=None, requires_grad=False):
     from candle._functional import logspace as logspace_dispatch
 
+    _validate_layout(layout)
+    if int(steps) < 0:
+        raise RuntimeError(f"number of steps must be non-negative, but got steps={int(steps)}")
     if dtype is None:
-        dtype = _get_default_dtype()
-    return _apply_requires_grad(
-        logspace_dispatch(start, end, steps, dtype=dtype, device=device),
-        requires_grad,
-    )
+        dtype = _get_default_dtype() if out is None else out.dtype
+    if base != 10.0:
+        # Fallback: compute via linspace + base ** x to support arbitrary base.
+        from candle._functional import linspace as linspace_dispatch
+        exponents = linspace_dispatch(start, end, steps, dtype=dtype, device=device)
+        value = base ** exponents
+    else:
+        value = logspace_dispatch(start, end, steps, dtype=dtype, device=device)
+    if out is not None:
+        return _apply_requires_grad(_finalize_out(value, out), requires_grad)
+    return _apply_requires_grad(value, requires_grad)
 
 
-def eye(n, m=None, dtype=None, device=None, out=None, requires_grad=False):
+def eye(n, m=None, dtype=None, device=None, layout=None, out=None, requires_grad=False):
     from candle._functional import eye as eye_dispatch
 
+    _validate_layout(layout)
     if dtype is None:
-        dtype = _get_default_dtype()
-    return _apply_requires_grad(
-        eye_dispatch(n, m, dtype=dtype, device=device, out=out),
-        requires_grad,
-    )
+        dtype = _get_default_dtype() if out is None else out.dtype
+    value = eye_dispatch(n, m, dtype=dtype, device=device, out=None)
+    if out is not None:
+        return _apply_requires_grad(_finalize_out(value, out), requires_grad)
+    return _apply_requires_grad(value, requires_grad)
 
 
-def range(start, end, step=1, dtype=None, device=None):
+def range(start, end, step=1, dtype=None, device=None, out=None):
     from candle._functional import range as range_dispatch
 
     if dtype is None:
-        dtype = _get_default_dtype()
-    return range_dispatch(start, end, step=step, dtype=dtype, device=device)
+        dtype = _get_default_dtype() if out is None else out.dtype
+    value = range_dispatch(start, end, step=step, dtype=dtype, device=device)
+    return _finalize_out(value, out)
 
 
-def randn(*shape, dtype=None, device=None, memory_format=None, generator=None, requires_grad=False):
+def randn(*shape, dtype=None, device=None, memory_format=None, generator=None, layout=None, out=None, requires_grad=False):
     from candle._functional import randn as randn_dispatch
 
+    _validate_layout(layout)
     if dtype is None:
-        dtype = _get_default_dtype()
-    return _apply_requires_grad(
-        randn_dispatch(*shape, dtype=dtype, device=device, memory_format=memory_format, generator=generator),
-        requires_grad,
-    )
+        dtype = _get_default_dtype() if out is None else out.dtype
+    value = randn_dispatch(*shape, dtype=dtype, device=device, memory_format=memory_format, generator=generator)
+    if out is not None:
+        return _apply_requires_grad(_finalize_out(value, out), requires_grad)
+    return _apply_requires_grad(value, requires_grad)
 
 
-def rand(*shape, dtype=None, device=None, memory_format=None, generator=None, requires_grad=False):
+def rand(*shape, dtype=None, device=None, memory_format=None, generator=None, layout=None, out=None, requires_grad=False):
     from candle._functional import rand as rand_dispatch
 
+    _validate_layout(layout)
     if dtype is None:
-        dtype = _get_default_dtype()
-    return _apply_requires_grad(
-        rand_dispatch(*shape, dtype=dtype, device=device, memory_format=memory_format, generator=generator),
-        requires_grad,
-    )
+        dtype = _get_default_dtype() if out is None else out.dtype
+    value = rand_dispatch(*shape, dtype=dtype, device=device, memory_format=memory_format, generator=generator)
+    if out is not None:
+        return _apply_requires_grad(_finalize_out(value, out), requires_grad)
+    return _apply_requires_grad(value, requires_grad)
 
 
-def randint(low, high=None, size=None, *, dtype=None, device=None, generator=None, memory_format=None):
+def randint(low, high=None, size=None, *, dtype=None, device=None, generator=None, memory_format=None, layout=None, out=None):
     from candle._functional import randint as randint_dispatch
 
+    _validate_layout(layout)
     if size is None and isinstance(high, (tuple, list)):
         size = high
         high = None
-    return randint_dispatch(
+    if dtype is None and out is not None:
+        dtype = out.dtype
+    value = randint_dispatch(
         low, high=high, size=size, dtype=dtype, device=device,
         generator=generator, memory_format=memory_format,
     )
+    return _finalize_out(value, out)
 
 
-def randperm(n, *, dtype=None, device=None, generator=None):
+def randperm(n, *, dtype=None, device=None, generator=None, layout=None, out=None):
     from candle._functional import randperm as randperm_dispatch
 
-    return randperm_dispatch(n, dtype=dtype, device=device, generator=generator)
+    _validate_layout(layout)
+    if dtype is None and out is not None:
+        dtype = out.dtype
+    value = randperm_dispatch(n, dtype=dtype, device=device, generator=generator)
+    return _finalize_out(value, out)
 
 
 def from_numpy(ndarray):
@@ -377,6 +520,8 @@ def asarray(obj, *, dtype=None, device=None, copy=None, requires_grad=False):
                 raise ValueError(f"can't alias tensor from device '{tensor_obj.device}' to '{dev}'.")
             if wrong_dtype:
                 raise ValueError(f"can't alias tensor with dtype '{tensor_obj.dtype}' into dtype '{dtype}'.")
+        if tensor_obj.requires_grad != bool(requires_grad):
+            tensor_obj.requires_grad_(bool(requires_grad))
         return _apply_requires_grad(tensor_obj, requires_grad)
 
     if force_alias:

--- a/src/candle/_C/_functional_ops.pyx
+++ b/src/candle/_C/_functional_ops.pyx
@@ -1556,6 +1556,26 @@ def chunk(a, chunks, dim=0):
     return split(a, chunk_size, d)
 
 
+def _split_sizes_from_indices(dim_size, indices):
+    cdef list sizes = []
+    cdef object raw_index
+    cdef object index
+    cdef object start = 0
+
+    for raw_index in indices:
+        index = int(raw_index)
+        if index < 0:
+            index += dim_size
+        if index < 0:
+            index = 0
+        elif index > dim_size:
+            index = dim_size
+        sizes.append(index - start if index >= start else 0)
+        start = index
+    sizes.append(dim_size - start if dim_size >= start else 0)
+    return sizes
+
+
 def vsplit(a, split_size_or_sections):
     cdef object sizes
     cdef object sections
@@ -1569,15 +1589,25 @@ def vsplit(a, split_size_or_sections):
     if not _is_base_tensor(a):
         return _dispatch_fn("vsplit", a.device.type, a, split_size_or_sections)
 
+    if a.dim() < 2:
+        raise RuntimeError(
+            f"torch.vsplit requires a tensor with at least 2 dimension, but got a tensor with {a.dim()} dimensions!"
+        )
     if isinstance(split_size_or_sections, int):
         sections = split_size_or_sections
         if sections <= 0:
-            raise ValueError("sections must be > 0")
+            raise RuntimeError("torch.vsplit sections must be > 0")
         dim_size = a.shape[0]
         size, extra = divmod(dim_size, sections)
+        if extra != 0:
+            raise RuntimeError(
+                f"torch.vsplit attempted to split along dimension 0, "
+                f"but the size of the dimension {dim_size} is not divisible by the split_size {sections}!"
+            )
         sizes = [size + 1] * extra + [size] * (sections - extra)
         return split(a, tuple(sizes), 0)
-    return split(a, split_size_or_sections, 0)
+    sizes = _split_sizes_from_indices(a.shape[0], split_size_or_sections)
+    return split(a, tuple(sizes), 0)
 
 
 def hsplit(a, split_size_or_sections):
@@ -1594,16 +1624,26 @@ def hsplit(a, split_size_or_sections):
     if not _is_base_tensor(a):
         return _dispatch_fn("hsplit", a.device.type, a, split_size_or_sections)
 
+    if a.dim() < 1:
+        raise RuntimeError(
+            f"torch.hsplit requires a tensor with at least 1 dimension, but got a tensor with {a.dim()} dimensions!"
+        )
     dim = 0 if a.dim() == 1 else 1
     if isinstance(split_size_or_sections, int):
         sections = split_size_or_sections
         if sections <= 0:
-            raise ValueError("sections must be > 0")
+            raise RuntimeError("torch.hsplit sections must be > 0")
         dim_size = a.shape[dim]
         size, extra = divmod(dim_size, sections)
+        if extra != 0:
+            raise RuntimeError(
+                f"torch.hsplit attempted to split along dimension {dim}, "
+                f"but the size of the dimension {dim_size} is not divisible by the split_size {sections}!"
+            )
         sizes = [size + 1] * extra + [size] * (sections - extra)
         return split(a, tuple(sizes), dim)
-    return split(a, split_size_or_sections, dim)
+    sizes = _split_sizes_from_indices(a.shape[dim], split_size_or_sections)
+    return split(a, tuple(sizes), dim)
 
 
 def dsplit(a, split_size_or_sections):
@@ -1620,17 +1660,25 @@ def dsplit(a, split_size_or_sections):
         return _dispatch_fn("dsplit", a.device.type, a, split_size_or_sections)
 
     if a.dim() < 3:
-        raise ValueError("dsplit expects input with at least 3 dimensions")
+        raise RuntimeError(
+            f"torch.dsplit requires a tensor with at least 3 dimension, but got a tensor with {a.dim()} dimensions!"
+        )
 
     if isinstance(split_size_or_sections, int):
         sections = split_size_or_sections
         if sections <= 0:
-            raise ValueError("sections must be > 0")
+            raise RuntimeError("torch.dsplit sections must be > 0")
         dim_size = a.shape[2]
         size, extra = divmod(dim_size, sections)
+        if extra != 0:
+            raise RuntimeError(
+                f"torch.dsplit attempted to split along dimension 2, "
+                f"but the size of the dimension {dim_size} is not divisible by the split_size {sections}!"
+            )
         sizes = [size + 1] * extra + [size] * (sections - extra)
         return split(a, tuple(sizes), 2)
-    return split(a, split_size_or_sections, 2)
+    sizes = _split_sizes_from_indices(a.shape[2], split_size_or_sections)
+    return split(a, tuple(sizes), 2)
 
 
 def view(*args, **kwargs):

--- a/src/candle/_C/_tensor_api.pyx
+++ b/src/candle/_C/_tensor_api.pyx
@@ -161,6 +161,28 @@ cdef inline void _ensure_grad_mode_ref():
         _is_grad_enabled_fn = is_grad_enabled
 
 
+cdef inline void _validate_as_strided_args(tuple size, tuple stride, Py_ssize_t storage_offset):
+    cdef Py_ssize_t dim
+    cdef Py_ssize_t step
+
+    if len(size) != len(stride):
+        raise RuntimeError(
+            f"mismatch in length of strides and shape: {len(stride)} != {len(size)}"
+        )
+    if storage_offset < 0:
+        raise RuntimeError(f"Tensor: invalid storage offset {storage_offset}")
+    for dim in size:
+        if dim < 0:
+            raise RuntimeError(
+                f"Storage size calculation overflowed with sizes={list(size)} and strides={list(stride)}"
+            )
+    for step in stride:
+        if step < 0:
+            raise RuntimeError(
+                f"as_strided: Negative strides are not supported at the moment, got strides: {list(stride)}"
+            )
+
+
 cdef inline void _ensure_functional_refs():
     global _add_fn, _mul_fn, _matmul_fn, _relu_fn, _neg_fn
     global _reshape_dispatch_fn, _transpose_dispatch_fn, _view_dispatch_fn
@@ -873,8 +895,11 @@ def tensor_t(self):
 
 def tensor_as_strided(self, size, stride, storage_offset=None):
     cdef object offset = storage_offset if storage_offset is not None else self.offset
+    size = tuple(int(s) for s in size)
+    stride = tuple(int(s) for s in stride)
+    _validate_as_strided_args(size, stride, int(offset))
     _ensure_view_factory_ref()
-    return _cy_make_view_tensor_fn(self, self._storage, tuple(size), tuple(stride), offset)
+    return _cy_make_view_tensor_fn(self, self._storage, size, stride, offset)
 
 
 def tensor_size(self, dim=None):
@@ -1396,9 +1421,17 @@ def tensor_unsqueeze_(self, dim):
 
 
 def tensor_as_strided_(self, size, stride, storage_offset=None):
+    cdef object offset
+    cdef tuple size_t
+    cdef tuple stride_t
+
     _ensure_dispatch_ref()
     self._check_inplace()
-    return _dispatch_fn("as_strided_", self.device.type, self, size, stride, storage_offset)
+    offset = storage_offset if storage_offset is not None else self.offset
+    size_t = tuple(int(s) for s in size)
+    stride_t = tuple(int(s) for s in stride)
+    _validate_as_strided_args(size_t, stride_t, int(offset))
+    return _dispatch_fn("as_strided_", self.device.type, self, size_t, stride_t, storage_offset)
 
 
 def tensor_swapdims_(self, dim0, dim1):
@@ -2183,13 +2216,22 @@ def tensor_hsplit(self, split_size_or_sections):
     if self.requires_grad:
         return _dispatch_fn("hsplit", self.device.type, self, split_size_or_sections)
 
+    if self.dim() < 1:
+        raise RuntimeError(
+            f"torch.hsplit requires a tensor with at least 1 dimension, but got a tensor with {self.dim()} dimensions!"
+        )
     dim = 0 if self.dim() == 1 else 1
     if isinstance(split_size_or_sections, int):
         sections = split_size_or_sections
         if sections <= 0:
-            raise ValueError("sections must be > 0")
+            raise RuntimeError("torch.hsplit sections must be > 0")
         dim_size = self.shape[dim]
         size, extra = divmod(dim_size, sections)
+        if extra != 0:
+            raise RuntimeError(
+                f"torch.hsplit attempted to split along dimension {dim}, "
+                f"but the size of the dimension {dim_size} is not divisible by the split_size {sections}!"
+            )
         sizes = [size + 1] * extra + [size] * (sections - extra)
         return tensor_split_method(self, tuple(sizes), dim)
     return tensor_split_method(self, split_size_or_sections, dim)
@@ -2207,14 +2249,21 @@ def tensor_dsplit(self, split_size_or_sections):
         return _dispatch_fn("dsplit", self.device.type, self, split_size_or_sections)
 
     if self.dim() < 3:
-        raise ValueError("dsplit expects input with at least 3 dimensions")
+        raise RuntimeError(
+            f"torch.dsplit requires a tensor with at least 3 dimension, but got a tensor with {self.dim()} dimensions!"
+        )
 
     if isinstance(split_size_or_sections, int):
         sections = split_size_or_sections
         if sections <= 0:
-            raise ValueError("sections must be > 0")
+            raise RuntimeError("torch.dsplit sections must be > 0")
         dim_size = self.shape[2]
         size, extra = divmod(dim_size, sections)
+        if extra != 0:
+            raise RuntimeError(
+                f"torch.dsplit attempted to split along dimension 2, "
+                f"but the size of the dimension {dim_size} is not divisible by the split_size {sections}!"
+            )
         sizes = [size + 1] * extra + [size] * (sections - extra)
         return tensor_split_method(self, tuple(sizes), 2)
     return tensor_split_method(self, split_size_or_sections, 2)
@@ -3147,13 +3196,29 @@ def tensor_atan_method(self):
 
 
 def tensor_as_strided_copy_method(self, size, stride, storage_offset=None):
+    cdef object offset
+    cdef tuple size_t
+    cdef tuple stride_t
+
     _ensure_dispatch_ref()
-    return _dispatch_fn("as_strided_copy", self.device.type, self, size, stride, storage_offset)
+    size_t = tuple(int(s) for s in size)
+    stride_t = tuple(int(s) for s in stride)
+    offset = storage_offset if storage_offset is not None else self.offset
+    _validate_as_strided_args(size_t, stride_t, int(offset))
+    return _dispatch_fn("as_strided_copy", self.device.type, self, size_t, stride_t, storage_offset)
 
 
 def tensor_as_strided_scatter_method(self, src, size, stride, storage_offset=None):
+    cdef object offset
+    cdef tuple size_t
+    cdef tuple stride_t
+
     _ensure_dispatch_ref()
-    return _dispatch_fn("as_strided_scatter", self.device.type, self, src, size, stride, storage_offset)
+    size_t = tuple(int(s) for s in size)
+    stride_t = tuple(int(s) for s in stride)
+    offset = storage_offset if storage_offset is not None else self.offset
+    _validate_as_strided_args(size_t, stride_t, int(offset))
+    return _dispatch_fn("as_strided_scatter", self.device.type, self, src, size_t, stride_t, storage_offset)
 
 
 def tensor_multinomial_method(self, num_samples, replacement=False, *, generator=None):

--- a/src/candle/_C/_tensor_impl.pyx
+++ b/src/candle/_C/_tensor_impl.pyx
@@ -294,7 +294,11 @@ cdef class TensorImpl:
 
     @property
     def layout(self):
-        return getattr(self, "_layout", "strided")
+        existing = getattr(self, "_layout", None)
+        if existing is not None:
+            return existing
+        from candle import strided
+        return strided
 
     @layout.setter
     def layout(self, value):

--- a/src/candle/__init__.py
+++ b/src/candle/__init__.py
@@ -104,6 +104,18 @@ def get_default_dtype():
     return _DEFAULT_DTYPE
 
 
+_WARN_ALWAYS = False
+
+def set_warn_always(enabled):
+    """Force WARN_ONCE-style warnings to fire every time when True."""
+    global _WARN_ALWAYS
+    _WARN_ALWAYS = _builtins.bool(enabled)
+
+
+def is_warn_always_enabled():
+    return _WARN_ALWAYS
+
+
 # Vitals (minimal compatibility)
 def vitals_enabled():
     return os.environ.get("TORCH_VITAL", "").upper() == "ON"

--- a/src/candle/__init__.py
+++ b/src/candle/__init__.py
@@ -16,6 +16,7 @@ from ._dtype import (
     # info classes
     finfo, iinfo,
 )
+chalf = complex32
 from ._dtype import float as float  # noqa: F811
 from ._dtype import int as int  # noqa: F811
 from ._dtype import DType as dtype  # torch.dtype compatibility
@@ -158,7 +159,7 @@ BoolTensor = Tensor
 ComplexFloatTensor = Tensor
 ComplexDoubleTensor = Tensor
 Size = tuple
-from ._creation import tensor, zeros, ones, empty, arange, linspace, full, logspace, eye, range, randn, rand, randint, randperm, from_numpy, frombuffer, as_tensor, asarray, normal
+from ._creation import tensor, zeros, ones, empty, empty_strided, arange, linspace, full, logspace, eye, range, randn, rand, randint, randperm, from_numpy, frombuffer, as_tensor, asarray, normal
 from ._functional import zeros_like
 from ._functional import ones_like, empty_like, full_like, randn_like, rand_like, randint_like
 from .storage import UntypedStorage, TypedStorage
@@ -208,6 +209,7 @@ from ._functional import nansum, nanmean, det, dist, matrix_power, argwhere
 # Category C1: Pure-Python functions
 from ._functional import meshgrid, atleast_1d, atleast_2d, atleast_3d
 from ._functional import broadcast_tensors, broadcast_shapes
+from ._functional import vander
 from ._functional import complex, polar
 # Category C2: Dispatch-based functions
 from ._functional import diff, bincount, cdist, aminmax
@@ -219,7 +221,7 @@ from ._functional import is_tensor, is_floating_point, is_complex, numel, square
 from ._functional import clone, detach, contiguous
 from ._functional import index_add, index_copy, index_fill, scatter_add
 from ._functional import tensor_split, split_with_sizes
-from ._functional import hann_window, hamming_window, bartlett_window, blackman_window
+from ._functional import hann_window, hamming_window, bartlett_window, blackman_window, kaiser_window
 # Aliases matching torch top-level names
 absolute = abs
 arccos = acos
@@ -1040,29 +1042,6 @@ __all__ = [
     "sparse_bsr",
     "sparse_bsc",
 ]
-
-
-strided = "strided"
-
-
-def sparse_coo(*args, **kwargs):  # noqa: ARG001
-    raise NotImplementedError("sparse_coo is not implemented in candle")
-
-
-def sparse_csr(*args, **kwargs):  # noqa: ARG001
-    raise NotImplementedError("sparse_csr is not implemented in candle")
-
-
-def sparse_csc(*args, **kwargs):  # noqa: ARG001
-    raise NotImplementedError("sparse_csc is not implemented in candle")
-
-
-def sparse_bsr(*args, **kwargs):  # noqa: ARG001
-    raise NotImplementedError("sparse_bsr is not implemented in candle")
-
-
-def sparse_bsc(*args, **kwargs):  # noqa: ARG001
-    raise NotImplementedError("sparse_bsc is not implemented in candle")
 
 
 def sparse_coo_tensor(indices, values, size=None, *, dtype=None, device=None, requires_grad=False):

--- a/src/candle/_backends/cpu/ops.py
+++ b/src/candle/_backends/cpu/ops.py
@@ -16,6 +16,13 @@ from ..._dtype import float64 as float64_dtype
 from ..._dtype import int64 as int64_dtype
 from ..._dtype import from_numpy_dtype
 from ..._dtype import to_numpy_dtype
+
+
+def _f32_to_bf16_bits(arr):
+    u32 = arr.astype(np.float32, copy=False).view(np.uint32)
+    rounding_bias = (u32 >> 16) & 1
+    u32 = u32 + 0x7FFF + rounding_bias
+    return (u32 >> 16).astype(np.uint16)
 from ..._C import typed_storage_from_numpy
 from ..._C import _StrideTuple
 from ..._tensor import Tensor
@@ -563,7 +570,13 @@ def stack(tensors, dim=0):
 
 def cat(tensors, dim=0):
     arrays = [_to_numpy(t) for t in tensors]
-    return _from_numpy(np.concatenate(arrays, axis=dim), tensors[0].dtype, tensors[0].device)
+    try:
+        out = np.concatenate(arrays, axis=dim)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"Sizes of tensors must match except in dimension {dim}."
+        ) from exc
+    return _from_numpy(out, tensors[0].dtype, tensors[0].device)
 
 
 def concatenate(tensors, dim=0):
@@ -571,16 +584,24 @@ def concatenate(tensors, dim=0):
 
 
 def hstack(tensors):
+    if tensors[0].dim() == 0:
+        expanded = [t.reshape((1,)) for t in tensors]
+        return cat(expanded, dim=0)
     if tensors[0].dim() == 1:
         return cat(tensors, dim=0)
     return cat(tensors, dim=1)
 
 
 def vstack(tensors):
-    if tensors[0].dim() == 1:
-        expanded = [t.reshape((1, t.shape[0])) for t in tensors]
-        return cat(expanded, dim=0)
-    return cat(tensors, dim=0)
+    expanded = []
+    for t in tensors:
+        if t.dim() == 0:
+            expanded.append(t.reshape((1, 1)))
+        elif t.dim() == 1:
+            expanded.append(t.reshape((1, t.shape[0])))
+        else:
+            expanded.append(t)
+    return cat(expanded, dim=0)
 
 
 def row_stack(tensors):
@@ -591,21 +612,33 @@ def dstack(tensors):
     arrays = [_to_numpy(t) for t in tensors]
     expanded = []
     for arr in arrays:
-        if arr.ndim == 1:
+        if arr.ndim == 0:
+            expanded.append(arr.reshape(1, 1, 1))
+        elif arr.ndim == 1:
             expanded.append(arr.reshape(1, arr.shape[0], 1))
         elif arr.ndim == 2:
             expanded.append(arr.reshape(arr.shape[0], arr.shape[1], 1))
         else:
             expanded.append(arr)
-    out = np.concatenate(expanded, axis=2)
+    try:
+        out = np.concatenate(expanded, axis=2)
+    except ValueError as exc:
+        raise RuntimeError(
+            "Sizes of tensors must match except in dimension 2."
+        ) from exc
     return _from_numpy(out, tensors[0].dtype, tensors[0].device)
 
 
 def column_stack(tensors):
-    if tensors[0].dim() == 1:
-        expanded = [t.reshape((t.shape[0], 1)) for t in tensors]
-        return cat(expanded, dim=1)
-    return cat(tensors, dim=1)
+    expanded = []
+    for t in tensors:
+        if t.dim() == 0:
+            expanded.append(t.reshape((1, 1)))
+        elif t.dim() == 1:
+            expanded.append(t.reshape((t.shape[0], 1)))
+        else:
+            expanded.append(t)
+    return cat(expanded, dim=1)
 
 
 def _check_indices_layout(layout):
@@ -3052,12 +3085,79 @@ def random_(a, from_=0, to=None, generator=None):
     from ..._random import _get_cpu_rng
     rng = generator._rng if (generator is not None and hasattr(generator, '_rng') and generator._rng is not None) else _get_cpu_rng()
     arr = _to_numpy(a)
-    if to is None:
-        if np.issubdtype(arr.dtype, np.floating):
-            to = 2**24 if arr.dtype == np.float32 else 2**53
+    dtype_name = str(a.dtype).split(".")[-1]
+
+    if dtype_name == "bool":
+        min_val = 0
+        max_val = 1
+        default_high = 2
+    elif getattr(a.dtype, "is_floating_point", False):
+        min_val = -(2**63)
+        max_val = 2**63 - 1
+        if dtype_name == "float64":
+            default_high = 2**53
+        elif dtype_name == "float16":
+            default_high = 2**11
+        elif dtype_name == "bfloat16":
+            default_high = 2**8
         else:
-            to = int(np.iinfo(arr.dtype).max) + 1
-    arr[...] = rng.randint(int(from_), int(to), size=arr.shape).astype(arr.dtype)
+            default_high = 2**24
+    elif np.issubdtype(arr.dtype, np.integer):
+        info = np.iinfo(arr.dtype)
+        min_val = int(info.min)
+        max_val = int(info.max)
+        default_high = max_val + 1
+    else:
+        min_val = -(2**63)
+        max_val = 2**63 - 1
+        default_high = 2**24
+
+    from_int = int(from_)
+    single_arg_upper_bound = False
+    if to is None:
+        if from_int > 0:
+            low = 0
+            high = from_int
+            single_arg_upper_bound = True
+        else:
+            low = from_int
+            high = default_high
+    else:
+        low = from_int
+        high = int(to)
+
+    fp_limit = None
+    if dtype_name == "float64":
+        fp_limit = 2**53
+    elif dtype_name == "float32":
+        fp_limit = 2**24
+    elif dtype_name == "float16":
+        fp_limit = 2**11
+    elif dtype_name == "bfloat16":
+        fp_limit = 2**8
+
+    if high <= low:
+        raise RuntimeError(
+            f"random_ expects 'from' to be less than 'to', but got from={low} >= to={high}"
+        )
+    if low < min_val or low > max_val:
+        raise RuntimeError("from is out of bounds")
+    if high - 1 < min_val or high - 1 > max_val:
+        raise RuntimeError("to - 1 is out of bounds")
+    if fp_limit is not None and not single_arg_upper_bound:
+        import warnings
+        if low < -fp_limit:
+            warnings.warn("from is out of bounds", UserWarning, stacklevel=2)
+            low = -fp_limit
+        if high - 1 > fp_limit:
+            warnings.warn("to - 1 is out of bounds", UserWarning, stacklevel=2)
+            high = fp_limit + 1
+
+    samples = rng.randint(low, high, size=arr.shape)
+    if dtype_name == "bfloat16":
+        arr[...] = _f32_to_bf16_bits(samples.astype(np.float32))
+    else:
+        arr[...] = samples.astype(arr.dtype)
     return a
 
 

--- a/src/candle/_creation.py
+++ b/src/candle/_creation.py
@@ -3,6 +3,7 @@ from ._C._creation_ops import (  # pylint: disable=no-name-in-module
     as_tensor,
     asarray,
     empty,
+    empty_strided,
     eye,
     from_numpy,
     frombuffer,

--- a/src/candle/_functional.py
+++ b/src/candle/_functional.py
@@ -790,7 +790,16 @@ def concat(tensors, dim=0, out=None):
     return cat(tensors, dim=dim, out=out)
 
 
+def _check_stack_tensors_arg(name, tensors):
+    from ._tensor import Tensor
+    if isinstance(tensors, Tensor):
+        raise TypeError(
+            f"{name}(): argument 'tensors' (position 1) must be tuple of Tensors, not Tensor"
+        )
+
+
 def hstack(tensors, out=None):
+    _check_stack_tensors_arg("hstack", tensors)
     result = dispatch("hstack", tensors[0].device.type, tensors)
     if out is not None:
         out._storage = result.storage()
@@ -804,6 +813,7 @@ def hstack(tensors, out=None):
 
 
 def vstack(tensors, out=None):
+    _check_stack_tensors_arg("vstack", tensors)
     result = dispatch("vstack", tensors[0].device.type, tensors)
     if out is not None:
         out._storage = result.storage()
@@ -817,6 +827,7 @@ def vstack(tensors, out=None):
 
 
 def column_stack(tensors, out=None):
+    _check_stack_tensors_arg("column_stack", tensors)
     result = dispatch("column_stack", tensors[0].device.type, tensors)
     if out is not None:
         out._storage = result.storage()
@@ -836,10 +847,12 @@ def concatenate(tensors, dim=0, axis=None):
 
 
 def row_stack(tensors):
+    _check_stack_tensors_arg("row_stack", tensors)
     return dispatch("row_stack", tensors[0].device.type, tensors)
 
 
 def dstack(tensors):
+    _check_stack_tensors_arg("dstack", tensors)
     return dispatch("dstack", tensors[0].device.type, tensors)
 
 
@@ -1767,24 +1780,103 @@ def broadcast_tensors(*tensors):
     return [t.expand(*target) for t in tensors]
 
 
-def complex(real, imag):
+def vander(x, N=None, increasing=False):
     import numpy as _np
+    if x.dim() != 1:
+        raise RuntimeError("x must be a one-dimensional tensor.")
+    if N is not None and N < 0:
+        raise RuntimeError("N must be non-negative.")
+    arr = x.numpy()
+    result = _np.vander(arr, N, increasing=increasing)
+    from ._creation import from_numpy
+    return from_numpy(result).to(device=x.device)
+
+
+def _complex_result_dtype(real_dtype):
+    from ._dtype import float16, float32, float64, complex32, complex64, complex128
+    if real_dtype == float16:
+        return complex32
+    if real_dtype == float32:
+        return complex64
+    if real_dtype == float64:
+        return complex128
+    return None
+
+
+def _torch_scalar_type_name(dtype):
+    names = {
+        "bool": "Bool",
+        "uint8": "Byte",
+        "int8": "Char",
+        "int16": "Short",
+        "int32": "Int",
+        "int64": "Long",
+        "float16": "Half",
+        "float32": "Float",
+        "float64": "Double",
+        "bfloat16": "BFloat16",
+        "complex32": "ComplexHalf",
+        "complex64": "ComplexFloat",
+        "complex128": "ComplexDouble",
+    }
+    return names.get(getattr(dtype, "name", str(dtype)), str(dtype))
+
+
+def _validate_complex_inputs(real, imag, out):
+    result_dtype = _complex_result_dtype(real.dtype)
+    if result_dtype is None or _complex_result_dtype(imag.dtype) is None:
+        raise RuntimeError(
+            "Expected both inputs to be Half, Float or Double tensors but got "
+            f"{_torch_scalar_type_name(real.dtype)} and {_torch_scalar_type_name(imag.dtype)}"
+        )
+    if real.dtype != imag.dtype:
+        raise RuntimeError(
+            f"Expected object of scalar type {_torch_scalar_type_name(real.dtype)} but got scalar type "
+            f"{_torch_scalar_type_name(imag.dtype)} for second argument"
+        )
+    if out is not None and out.dtype != result_dtype:
+        raise RuntimeError(
+            f"Expected object of scalar type {_torch_scalar_type_name(result_dtype)} but got scalar type "
+            f"{_torch_scalar_type_name(out.dtype)} for argument 'out'"
+        )
+    return result_dtype
+
+
+def complex(real, imag, *, out=None):
+    import numpy as _np
+    result_dtype = _validate_complex_inputs(real, imag, out)
     r = real.numpy() if hasattr(real, 'numpy') else _np.asarray(real)
     i = imag.numpy() if hasattr(imag, 'numpy') else _np.asarray(imag)
-    c = r.astype(_np.float64) + 1j * i.astype(_np.float64)
-    from ._dtype import complex128 as _cdouble
+    np_dtype = _np.float32 if result_dtype.name in ("complex32", "complex64") else _np.float64
+    c = r.astype(np_dtype) + 1j * i.astype(np_dtype)
     dev = _as_device(real.device if hasattr(real, 'device') else None)
-    return dispatch("tensor", dev, c.tolist(), dtype=_cdouble)
+    value = dispatch("tensor", dev, c.tolist(), dtype=result_dtype)
+    if out is not None:
+        if tuple(out.shape) != tuple(value.shape):
+            out.cy_set_data_runtime_truth_from(value)
+            return out
+        out.copy_(value)
+        return out
+    return value
 
 
-def polar(abs, angle):
+def polar(abs, angle, *, out=None):
     import numpy as _np
+    result_dtype = _validate_complex_inputs(abs, angle, out)
     a = abs.numpy() if hasattr(abs, 'numpy') else _np.asarray(abs)
     ang = angle.numpy() if hasattr(angle, 'numpy') else _np.asarray(angle)
-    c = a * _np.exp(1j * ang)
-    from ._dtype import complex128 as _cdouble
+    np_dtype = _np.float32 if result_dtype.name in ("complex32", "complex64") else _np.float64
+    c = a.astype(np_dtype) * _np.exp(1j * ang.astype(np_dtype))
     dev = _as_device(abs.device if hasattr(abs, 'device') else None)
-    return dispatch("tensor", dev, c.tolist(), dtype=_cdouble)
+    value = dispatch("tensor", dev, c.tolist(), dtype=result_dtype)
+    if out is not None:
+        if tuple(out.shape) != tuple(value.shape):
+            out.cy_set_data_runtime_truth_from(value)
+            return out
+        out.copy_(value)
+        return out
+    return value
+
 
 
 # ---------------------------------------------------------------------------
@@ -1937,6 +2029,31 @@ def tensor_split(a, indices_or_sections, dim=0):
 
 def split_with_sizes(a, split_sizes, dim=0):
     return split(a, split_sizes, dim)
+
+
+def kaiser_window(window_length, periodic=True, beta=12.0, *, dtype=None, device=None, requires_grad=False, layout=None):
+    import numpy as _np
+    from ._creation import tensor as _tensor
+    if layout is not None:
+        from . import strided
+        if layout is not strided:
+            raise TypeError("layout must be torch.strided")
+    if dtype is None:
+        from . import get_default_dtype
+        dtype = get_default_dtype()
+    if not dtype.is_floating_point:
+        raise RuntimeError("kaiser_window expects floating point dtype")
+    if window_length <= 0:
+        out = _tensor([], dtype=dtype, device=device)
+    else:
+        length = window_length + 1 if periodic and window_length > 1 else window_length
+        arr = _np.kaiser(length, beta)
+        if periodic and window_length > 1:
+            arr = arr[:-1]
+        out = _tensor(arr.tolist(), dtype=dtype, device=device)
+    if requires_grad:
+        out.requires_grad_(True)
+    return out
 
 
 def hann_window(window_length, periodic=True, *, dtype=None, device=None):

--- a/src/candle/testing/_internal/common_device_type.py
+++ b/src/candle/testing/_internal/common_device_type.py
@@ -208,7 +208,13 @@ def instantiate_device_type_tests(test_class, scope, except_for=None, only_for=N
                     def make_test(f, d, dtype):
                         @functools.wraps(f)
                         def test_fn(self):
-                            return f(self, device=d, dtype=dtype)
+                            sig = inspect.signature(f)
+                            kwargs = {}
+                            if "device" in sig.parameters:
+                                kwargs["device"] = d
+                            if "dtype" in sig.parameters:
+                                kwargs["dtype"] = dtype
+                            return f(self, **kwargs)
                         return test_fn
 
                     setattr(device_class, test_name, make_test(fn, device, dt))

--- a/src/candle/testing/_internal/common_device_type.py
+++ b/src/candle/testing/_internal/common_device_type.py
@@ -220,9 +220,12 @@ def instantiate_device_type_tests(test_class, scope, except_for=None, only_for=N
                     @functools.wraps(f)
                     def test_fn(self):
                         sig = inspect.signature(f)
+                        kwargs = {}
+                        if "device" in sig.parameters:
+                            kwargs["device"] = d
                         if "dtype" in sig.parameters:
-                            return f(self, device=d, dtype=torch.float32)
-                        return f(self, device=d)
+                            kwargs["dtype"] = torch.float32
+                        return f(self, **kwargs)
                     return test_fn
 
                 setattr(device_class, test_name, make_test_no_dtype(fn, device))

--- a/src/candle/testing/_internal/common_dtype.py
+++ b/src/candle/testing/_internal/common_dtype.py
@@ -46,13 +46,16 @@ def get_all_complex_dtypes():
 
 
 def get_all_dtypes(include_half=True, include_bfloat16=True,
-                   include_complex=True, include_bool=True):
+                   include_complex=True, include_bool=True,
+                   include_complex32=False):
     dtypes = get_all_int_dtypes() + get_all_fp_dtypes(
         include_half=include_half, include_bfloat16=include_bfloat16
     )
     if include_bool:
         dtypes.append(torch.bool)
     if include_complex:
+        if include_complex32:
+            dtypes.append(torch.complex32)
         dtypes += get_all_complex_dtypes()
     return dtypes
 

--- a/src/candle/testing/_internal/common_utils.py
+++ b/src/candle/testing/_internal/common_utils.py
@@ -109,20 +109,42 @@ class TestCase(unittest.TestCase):
             rtol=self.rel_tol,
         )
 
-    def assertEqual(self, x, y, msg=None, *, atol=None, rtol=None, equal_nan=False):
+    def assertEqual(self, x, y, msg=None, *, atol=None, rtol=None, equal_nan=False, exact_dtype=None):
         if isinstance(x, np.ndarray) and isinstance(y, torch.Tensor):
             x = torch.from_numpy(np.ascontiguousarray(x))
         elif isinstance(x, torch.Tensor) and isinstance(y, np.ndarray):
             y = torch.from_numpy(np.ascontiguousarray(y))
+        elif isinstance(x, torch.Tensor) and isinstance(y, (tuple, list)):
+            y = torch.tensor(y, dtype=x.dtype, device=x.device)
+        elif isinstance(x, (tuple, list)) and isinstance(y, torch.Tensor):
+            x = torch.tensor(x, dtype=y.dtype, device=y.device)
+        elif isinstance(x, torch.Tensor) and x.dim() == 0 and isinstance(y, (int, float, complex, bool)):
+            y = torch.tensor(y, dtype=x.dtype, device=x.device)
+        elif isinstance(y, torch.Tensor) and y.dim() == 0 and isinstance(x, (int, float, complex, bool)):
+            x = torch.tensor(x, dtype=y.dtype, device=y.device)
         if isinstance(x, torch.Tensor) and isinstance(y, torch.Tensor):
             _atol = atol if atol is not None else self.precision
             _rtol = rtol if rtol is not None else self.rel_tol
-            torch.testing.assert_close(x, y, atol=_atol, rtol=_rtol, msg=msg)
-        else:
-            if equal_nan and isinstance(x, float) and isinstance(y, float):
-                if math.isnan(x) and math.isnan(y):
-                    return
-            super().assertEqual(x, y, msg=msg)
+            check_dtype = True if exact_dtype is None else bool(exact_dtype)
+            torch.testing.assert_close(x, y, atol=_atol, rtol=_rtol, msg=msg, check_dtype=check_dtype)
+            return
+        if isinstance(x, (tuple, list)) and isinstance(y, (tuple, list)):
+            super().assertEqual(len(x), len(y), msg=msg)
+            for actual, expected in zip(x, y):
+                self.assertEqual(
+                    actual,
+                    expected,
+                    msg=msg,
+                    atol=atol,
+                    rtol=rtol,
+                    equal_nan=equal_nan,
+                    exact_dtype=exact_dtype,
+                )
+            return
+        if equal_nan and isinstance(x, float) and isinstance(y, float):
+            if math.isnan(x) and math.isnan(y):
+                return
+        super().assertEqual(x, y, msg=msg)
 
     @contextlib.contextmanager
     def assertWarnsOnceRegex(self, expected_warning, expected_regex=""):

--- a/src/candle/testing/_internal/common_utils.py
+++ b/src/candle/testing/_internal/common_utils.py
@@ -38,8 +38,12 @@ TEST_NPU = (
     else False
 )
 
-# Map CUDA tests to NPU when appropriate
-TEST_CUDA = TEST_CUDA or TEST_NPU
+# ---------------------------------------------------------------------------
+# NOTE: Do NOT alias TEST_CUDA to include TEST_NPU. Downstream code in
+# common_device_type._get_available_devices treats them as distinct device
+# types; aliasing here would cause NPU-only machines to generate CUDA test
+# variants and skip NPU ones.
+# ---------------------------------------------------------------------------
 
 TEST_MULTIGPU = False
 if TEST_CUDA and hasattr(torch, "cuda") and hasattr(torch.cuda, "device_count"):
@@ -106,6 +110,10 @@ class TestCase(unittest.TestCase):
         )
 
     def assertEqual(self, x, y, msg=None, *, atol=None, rtol=None, equal_nan=False):
+        if isinstance(x, np.ndarray) and isinstance(y, torch.Tensor):
+            x = torch.from_numpy(np.ascontiguousarray(x))
+        elif isinstance(x, torch.Tensor) and isinstance(y, np.ndarray):
+            y = torch.from_numpy(np.ascontiguousarray(y))
         if isinstance(x, torch.Tensor) and isinstance(y, torch.Tensor):
             _atol = atol if atol is not None else self.precision
             _rtol = rtol if rtol is not None else self.rel_tol
@@ -116,13 +124,40 @@ class TestCase(unittest.TestCase):
                     return
             super().assertEqual(x, y, msg=msg)
 
+    @contextlib.contextmanager
+    def assertWarnsOnceRegex(self, expected_warning, expected_regex=""):
+        """Context manager that always asserts a matching warning is raised.
+
+        Forces TORCH_WARN_ONCE-style warnings to fire on every call
+        (via set_warn_always_context) so tests can rely on observing them.
+        """
+        import re
+        pattern = re.compile(expected_regex)
+        with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter("always")
+            with set_warn_always_context():
+                yield
+            if len(ws) == 0:
+                self.fail("no warning caught")
+            assert any(isinstance(w.message, expected_warning) for w in ws), (
+                f"no {expected_warning.__name__} warning seen; got: {[type(w.message).__name__ for w in ws]}"
+            )
+            assert any(
+                re.search(pattern, str(w.message))
+                for w in ws
+                if isinstance(w.message, expected_warning)
+            ), (
+                f"no warning matching {pattern.pattern!r}; got: "
+                f"{[str(w.message) for w in ws if isinstance(w.message, expected_warning)]}"
+            )
+
 
 # ---------------------------------------------------------------------------
 # Skip / expected-failure decorators
 # ---------------------------------------------------------------------------
 def skipIfNoCuda(fn):
     """Skip a test if no CUDA/NPU device is available."""
-    return unittest.skipIf(not TEST_CUDA, "No CUDA/NPU device")(fn)
+    return unittest.skipIf(not (TEST_CUDA or TEST_NPU), "No CUDA/NPU device")(fn)
 
 
 def skipIfNoMPS(fn):
@@ -195,10 +230,17 @@ def disable_gc():
 
 @contextlib.contextmanager
 def set_warn_always_context():
-    """Context manager that forces warnings to be shown."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("always")
-        yield
+    """Context manager that forces TORCH_WARN_ONCE-style warnings to fire every time."""
+    prev = torch.is_warn_always_enabled() if hasattr(torch, "is_warn_always_enabled") else False
+    if hasattr(torch, "set_warn_always"):
+        torch.set_warn_always(True)
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("always")
+            yield
+    finally:
+        if hasattr(torch, "set_warn_always"):
+            torch.set_warn_always(prev)
 
 
 def gradcheck(*args, **kwargs):  # noqa: ARG001

--- a/tests/cpu/test_creation.py
+++ b/tests/cpu/test_creation.py
@@ -41,10 +41,34 @@ def test_arange_cpu():
     assert x.numpy().tolist() == [0, 1, 2, 3, 4]
 
 
+def test_arange_rejects_non_finite_ranges_cpu():
+    with pytest.raises(RuntimeError, match="unsupported range"):
+        torch.arange(-5, float("nan"))
+    with pytest.raises(RuntimeError, match="unsupported range"):
+        torch.arange(0, float("inf"))
+    with pytest.raises(RuntimeError, match="unsupported range"):
+        torch.arange(float("nan"))
+
+
+def test_arange_rejects_zero_step_cpu():
+    with pytest.raises(RuntimeError, match="step must be nonzero"):
+        torch.arange(0, 1, 0)
+
+
 def test_linspace_cpu():
     x = torch.linspace(0.0, 1.0, 5)
     assert x.shape == (5,)
     assert x.numpy().tolist() == [0.0, 0.25, 0.5, 0.75, 1.0]
+
+
+def test_linspace_rejects_negative_steps_cpu():
+    with pytest.raises(RuntimeError, match="number of steps must be non-negative"):
+        torch.linspace(0.0, 1.0, -1)
+
+
+def test_logspace_rejects_negative_steps_cpu():
+    with pytest.raises(RuntimeError, match="number of steps must be non-negative"):
+        torch.logspace(0.0, 1.0, -1)
 
 
 def test_full_cpu():
@@ -91,3 +115,264 @@ def test_rand_creation_requires_grad_rejects_integer_dtype_cpu():
 def test_randn_creation_requires_grad_rejects_bool_dtype_cpu():
     with pytest.raises(RuntimeError, match="Only Tensors of floating point and complex dtype can require gradients"):
         torch.randn((2, 3), dtype=torch.bool, requires_grad=True)
+
+
+# ---------------------------------------------------------------------------
+# layout= and out= kwargs (PyTorch parity)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("factory", [torch.zeros, torch.ones, torch.empty])
+def test_factory_accepts_size_kwarg_cpu(factory):
+    out = factory(size=(1, 3), dtype=torch.float32)
+    assert out.shape == (1, 3)
+
+
+@pytest.mark.parametrize("factory", [torch.zeros, torch.ones, torch.empty])
+def test_factory_rejects_size_kwarg_with_positional_shape_cpu(factory):
+    with pytest.raises(TypeError, match="received an invalid combination"):
+        factory((1, 3), size=(1, 3), dtype=torch.float32)
+
+
+@pytest.mark.parametrize("factory", [torch.zeros, torch.ones, torch.empty])
+def test_factory_accepts_layout_strided_cpu(factory):
+    t = factory((2, 3), dtype=torch.float32, layout=torch.strided)
+    assert t.shape == (2, 3)
+    assert t.layout is torch.strided
+
+
+@pytest.mark.parametrize("factory", [torch.zeros, torch.ones, torch.empty])
+def test_factory_rejects_non_strided_layout_cpu(factory):
+    with pytest.raises(TypeError, match="layout"):
+        factory((2, 3), layout="not-a-layout")
+
+
+def test_linspace_out_aliases_output_storage_cpu():
+    out = torch.empty((4,), dtype=torch.float32)
+    res = torch.linspace(0.0, 1.0, 4, out=out)
+    assert res.data_ptr() == out.data_ptr()
+    assert res.shape == (4,)
+    np.testing.assert_allclose(res.numpy(), [0.0, 1 / 3, 2 / 3, 1.0])
+
+
+def test_logspace_out_aliases_output_storage_cpu():
+    out = torch.empty((4,), dtype=torch.float32)
+    res = torch.logspace(0.0, 1.0, 4, out=out)
+    assert res.data_ptr() == out.data_ptr()
+    assert res.shape == (4,)
+
+
+def test_linspace_out_rejects_memory_overlap_cpu():
+    x = torch.rand((1,)).expand((10,))
+    with pytest.raises(RuntimeError, match="unsupported operation"):
+        torch.linspace(1, 10, 10, out=x)
+
+
+def test_logspace_out_rejects_memory_overlap_cpu():
+    x = torch.rand((1,)).expand((10,))
+    with pytest.raises(RuntimeError, match="unsupported operation"):
+        torch.logspace(1, 10, 10, out=x)
+
+
+def test_ones_out_resizes_empty_output_cpu():
+    out = torch.empty((0,), dtype=torch.float32)
+    res = torch.ones((2, 3), out=out)
+    assert res is out
+    assert out.shape == (2, 3)
+    np.testing.assert_allclose(out.numpy(), np.ones((2, 3), dtype=np.float32))
+
+
+def test_linspace_out_resizes_empty_output_cpu():
+    out = torch.empty((0,), dtype=torch.float32)
+    res = torch.linspace(0.0, 1.0, 4, out=out)
+    assert res is out
+    assert out.shape == (4,)
+    np.testing.assert_allclose(out.numpy(), [0.0, 1 / 3, 2 / 3, 1.0])
+
+
+def test_arange_out_warns_when_resizing_non_empty_output_cpu():
+    out = torch.zeros(size=(1, 3), dtype=torch.float32)
+    with pytest.warns(UserWarning, match="The out tensor will be resized"):
+        res = torch.arange(0, 4, out=out)
+    assert res is out
+    assert out.shape == (4,)
+    np.testing.assert_allclose(out.numpy(), [0.0, 1.0, 2.0, 3.0])
+
+
+def test_arange_out_writes_non_contiguous_view_cpu():
+    x = torch.zeros((2, 3), dtype=torch.float32)
+    out = x.narrow(1, 1, 2)
+    res = torch.arange(0, 4, out=out)
+    assert res is out
+    assert out.shape == (2, 2)
+    np.testing.assert_allclose(x.numpy(), [[0.0, 0.0, 1.0], [0.0, 2.0, 3.0]])
+
+
+def test_linspace_out_writes_non_contiguous_view_cpu():
+    x = torch.zeros((2, 3), dtype=torch.float32)
+    out = x.narrow(1, 1, 2)
+    res = torch.linspace(0, 3, 4, out=out)
+    assert res is out
+    assert out.shape == (2, 2)
+    np.testing.assert_allclose(x.numpy(), [[0.0, 0.0, 1.0], [0.0, 2.0, 3.0]])
+
+
+def test_logspace_out_writes_non_contiguous_view_cpu():
+    x = torch.zeros((2, 3), dtype=torch.float32)
+    out = x.narrow(1, 1, 2)
+    res = torch.logspace(0, 3, 4, base=2, out=out)
+    assert res is out
+    assert out.shape == (2, 2)
+    np.testing.assert_allclose(x.numpy(), [[0.0, 1.0, 2.0], [0.0, 4.0, 8.0]])
+
+
+@pytest.mark.parametrize("factory", [torch.rand, torch.randn])
+def test_random_factory_out_aliases_output_cpu(factory):
+    out = torch.empty((2, 3), dtype=torch.float32)
+    res = factory((2, 3), out=out)
+    assert res is out
+    assert out.shape == (2, 3)
+
+
+def test_randint_out_aliases_output_cpu():
+    out = torch.empty((2, 3), dtype=torch.int64)
+    res = torch.randint(0, 10, (2, 3), out=out)
+    assert res is out
+    assert out.shape == (2, 3)
+    assert out.dtype == torch.int64
+
+
+def test_randperm_out_aliases_output_cpu():
+    out = torch.empty((0,), dtype=torch.int64)
+    res = torch.randperm(5, out=out)
+    assert res is out
+    assert out.shape == (5,)
+    assert out.dtype == torch.int64
+
+
+# ---------------------------------------------------------------------------
+# stack helpers with scalar inputs (PyTorch parity)
+# ---------------------------------------------------------------------------
+
+
+def test_hstack_accepts_scalar_inputs_cpu():
+    out = torch.hstack((torch.tensor(1.0), torch.tensor(2.0)))
+    assert out.shape == (2,)
+    np.testing.assert_allclose(out.numpy(), [1.0, 2.0])
+
+
+def test_vstack_accepts_scalar_inputs_cpu():
+    out = torch.vstack((torch.tensor(1.0), torch.tensor(2.0)))
+    assert out.shape == (2, 1)
+    np.testing.assert_allclose(out.numpy(), [[1.0], [2.0]])
+
+
+def test_dstack_accepts_scalar_inputs_cpu():
+    out = torch.dstack((torch.tensor(1.0), torch.tensor(2.0)))
+    assert out.shape == (1, 1, 2)
+    np.testing.assert_allclose(out.numpy(), [[[1.0, 2.0]]])
+
+
+def test_column_stack_accepts_scalar_inputs_cpu():
+    out = torch.column_stack((torch.tensor(1.0), torch.tensor(2.0)))
+    assert out.shape == (1, 2)
+    np.testing.assert_allclose(out.numpy(), [[1.0, 2.0]])
+
+
+def test_column_stack_accepts_mixed_1d_and_2d_cpu():
+    one_dim = torch.arange(0, 3)
+    two_dim = torch.arange(0, 9).reshape(3, 3)
+    out = torch.column_stack((two_dim, one_dim, two_dim, one_dim))
+    assert out.shape == (3, 8)
+    np.testing.assert_allclose(
+        out.numpy(),
+        np.column_stack((two_dim.numpy(), one_dim.numpy(), two_dim.numpy(), one_dim.numpy())),
+    )
+
+
+@pytest.mark.parametrize("factory", [torch.hstack, torch.vstack, torch.dstack, torch.column_stack, torch.row_stack])
+def test_stack_helpers_reject_single_tensor_input_cpu(factory):
+    with pytest.raises(TypeError, match="must be tuple of Tensors, not Tensor"):
+        factory(torch.tensor([1.0, 2.0]))
+
+
+# ---------------------------------------------------------------------------
+# random_ bounds (PyTorch parity)
+# ---------------------------------------------------------------------------
+
+
+def test_random_single_arg_uses_zero_as_lower_bound_cpu():
+    t = torch.empty((200,), dtype=torch.int64)
+    t.random_(4)
+    assert t.min().item() == 0
+    assert t.max().item() == 3
+
+
+def test_random_bool_generates_false_and_true_cpu():
+    t = torch.empty((2000,), dtype=torch.bool)
+    t.random_()
+    assert t.min().item() is False
+    assert t.max().item() is True
+
+
+def test_random_bool_rejects_out_of_bounds_cpu():
+    t = torch.empty((8,), dtype=torch.bool)
+    with pytest.raises(RuntimeError, match="from is out of bounds"):
+        t.random_(-1, 1)
+    with pytest.raises(RuntimeError, match="to - 1 is out of bounds"):
+        t.random_(0, 3)
+
+
+# ---------------------------------------------------------------------------
+# missing creation APIs (PyTorch parity)
+# ---------------------------------------------------------------------------
+
+
+def test_vander_cpu():
+    x = torch.tensor([1, 2, 3])
+    out = torch.vander(x, 3)
+    np.testing.assert_allclose(out.numpy(), [[1, 1, 1], [4, 2, 1], [9, 3, 1]])
+
+
+def test_empty_strided_cpu():
+    out = torch.empty_strided((2, 3), (1, 2))
+    assert out.shape == (2, 3)
+    assert out.stride() == (1, 2)
+
+
+def test_chalf_alias_cpu():
+    assert torch.chalf is torch.complex32
+
+
+def test_kaiser_window_cpu():
+    out = torch.kaiser_window(5, False, 2.0)
+    np.testing.assert_allclose(out.numpy(), np.kaiser(5, 2.0), rtol=1e-6, atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# asarray requires_grad propagation (PyTorch parity)
+# ---------------------------------------------------------------------------
+
+
+def test_asarray_clears_requires_grad_on_alias_cpu():
+    t = torch.tensor([1.0, 2.0, 3.0], requires_grad=True)
+    r = torch.asarray(t, requires_grad=False)
+    assert r.requires_grad is False
+    assert r.data_ptr() == t.data_ptr()
+
+
+def test_asarray_default_clears_requires_grad_on_alias_cpu():
+    t = torch.tensor([1.0, 2.0, 3.0], requires_grad=True)
+    r = torch.asarray(t)
+    assert r.requires_grad is False
+
+
+def test_asarray_propagates_requires_grad_true_on_alias_cpu():
+    t = torch.tensor([1.0, 2.0, 3.0], requires_grad=False)
+    r = torch.asarray(t, requires_grad=True)
+    assert r.requires_grad is True
+
+
+def test_asarray_default_keeps_requires_grad_false_cpu():
+    t = torch.tensor([1.0, 2.0, 3.0])
+    r = torch.asarray(t)
+    assert r.requires_grad is False

--- a/tests/cpu/test_meta_device.py
+++ b/tests/cpu/test_meta_device.py
@@ -313,11 +313,11 @@ def test_meta_tril_triu_indices_shape():
 
 
 def test_meta_vsplit_shape():
-    x = torch.tensor([1.0, 2.0, 3.0, 4.0], device="meta")
-    out = torch.vsplit(x, 2)
+    y = torch.tensor([[1.0, 2.0], [3.0, 4.0]], device="meta")
+    out = torch.vsplit(y, 2)
     assert len(out) == 2
-    assert out[0].shape == (2,)
-    assert out[1].shape == (2,)
+    assert out[0].shape == (1, 2)
+    assert out[1].shape == (1, 2)
 
 
 def test_meta_hsplit_shape():
@@ -340,7 +340,7 @@ def test_meta_dsplit_shape():
     assert out[0].shape == (1, 2, 1)
     assert out[1].shape == (1, 2, 1)
     y = torch.tensor([[1.0, 2.0], [3.0, 4.0]], device="meta")
-    with pytest.raises(ValueError):
+    with pytest.raises(RuntimeError, match=r"torch\.dsplit requires a tensor with at least 3 dimension"):
         torch.dsplit(y, 2)
 
 

--- a/tests/cpu/test_ops_cpu.py
+++ b/tests/cpu/test_ops_cpu.py
@@ -712,11 +712,6 @@ def test_triu_indices_cpu():
 
 
 def test_vsplit_cpu():
-    x = torch.tensor([1.0, 2.0, 3.0, 4.0])
-    out = torch.vsplit(x, 2)
-    assert len(out) == 2
-    np.testing.assert_allclose(out[0].numpy(), np.array([1.0, 2.0]))
-    np.testing.assert_allclose(out[1].numpy(), np.array([3.0, 4.0]))
     y = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
     out = torch.vsplit(y, 2)
     assert len(out) == 2
@@ -744,8 +739,34 @@ def test_dsplit_cpu():
     np.testing.assert_allclose(out[0].numpy(), np.array([[[1.0], [3.0]]]))
     np.testing.assert_allclose(out[1].numpy(), np.array([[[2.0], [4.0]]]))
     y = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
-    with pytest.raises(ValueError):
+    with pytest.raises(RuntimeError, match=r"torch\.dsplit requires a tensor with at least 3 dimension"):
         torch.dsplit(y, 2)
+
+
+def test_hsplit_rejects_zero_dim_cpu():
+    x = torch.tensor(1.0)
+    with pytest.raises(RuntimeError, match=r"torch\.hsplit requires a tensor with at least 1 dimension"):
+        torch.hsplit(x, 3)
+    with pytest.raises(RuntimeError, match=r"torch\.hsplit requires a tensor with at least 1 dimension"):
+        torch.hsplit(x, [2, 4, 6])
+
+
+def test_hsplit_rejects_non_divisible_cpu():
+    x = torch.arange(6)
+    with pytest.raises(RuntimeError, match=r"torch\.hsplit attempted to split along dimension 0"):
+        torch.hsplit(x, 4)
+
+
+def test_vsplit_rejects_low_rank_cpu():
+    x = torch.arange(6)
+    with pytest.raises(RuntimeError, match=r"torch\.vsplit requires a tensor with at least 2 dimension"):
+        torch.vsplit(x, 2)
+
+
+def test_dsplit_rejects_low_rank_cpu():
+    x = torch.arange(6)
+    with pytest.raises(RuntimeError, match=r"torch\.dsplit requires a tensor with at least 3 dimension"):
+        torch.dsplit(x, 4)
 
 
 def test_take_cpu():

--- a/tests/cpu/test_tensor_api_contract.py
+++ b/tests/cpu/test_tensor_api_contract.py
@@ -250,6 +250,11 @@ class TestClone:
         a = torch.tensor([1.0, 2.0], requires_grad=True)
         assert a.clone().grad_fn is not None
 
+    def test_participates_in_autograd(self):
+        a = torch.tensor([1.0, 2.0], requires_grad=True)
+        b = a.clone()
+        assert b.grad_fn is not None
+
 
 # ===========================================================================
 # 7. detach
@@ -276,6 +281,25 @@ class TestDetach:
 
     def test_detach_shape_preserved(self):
         a = torch.tensor([[1.0, 2.0], [3.0, 4.0]], requires_grad=True)
+        assert a.detach().shape == (2, 2)
+
+    def test_breaks_grad(self):
+        a = torch.tensor([1.0, 2.0], requires_grad=True)
+        assert a.detach().requires_grad is False
+
+    def test_returns_tensor(self):
+        assert isinstance(torch.tensor([1.0, 2.0]).detach(), Tensor)
+
+    def test_values_match(self):
+        a = torch.tensor([1.0, 2.0, 3.0])
+        _allclose(a.detach(), [1.0, 2.0, 3.0])
+
+    def test_grad_fn_is_none(self):
+        a = torch.tensor([1.0, 2.0], requires_grad=True)
+        assert a.detach().grad_fn is None
+
+    def test_shape_preserved(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
         assert a.detach().shape == (2, 2)
 
 
@@ -344,6 +368,26 @@ class TestTo:
         assert b.shape == (2, 3, 4, 5)
         assert b.stride() == (60, 1, 15, 3)
         assert b.is_contiguous(memory_format=torch.channels_last) is True
+
+    def test_same_device_returns_tensor(self):
+        a = torch.tensor([1.0, 2.0])
+        assert isinstance(a.to("cpu"), Tensor)
+
+    def test_same_device_values_preserved(self):
+        a = torch.tensor([1.0, 2.0, 3.0])
+        _allclose(a.to("cpu"), [1.0, 2.0, 3.0])
+
+    def test_dtype_float32_to_float64(self):
+        a = torch.tensor([1.0, 2.0])
+        assert a.to(torch.float64).dtype == torch.float64
+
+    def test_dtype_values_preserved(self):
+        a = torch.tensor([1.0, 2.0, 3.0])
+        _allclose(a.to(torch.float64), [1.0, 2.0, 3.0])
+
+    def test_device_kwarg_string(self):
+        a = torch.tensor([1.0, 2.0])
+        assert a.to(device="cpu").device.type == "cpu"
 
 
 class TestCreationMemoryFormat:
@@ -518,467 +562,6 @@ class TestCreationMemoryFormat:
     def test_grad_fn_when_requires_grad(self):
         a = torch.tensor([-1.0, 2.0], requires_grad=True)
         assert a.relu().grad_fn is not None
-
-
-# ===========================================================================
-# 10. reshape
-# ===========================================================================
-
-class TestReshape:
-
-    def test_basic_shape(self):
-        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
-        assert a.reshape(4).shape == (4,)
-
-    def test_values_preserved(self):
-        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
-        _allclose(a.reshape(4), [1.0, 2.0, 3.0, 4.0])
-
-    def test_returns_tensor(self):
-        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
-        assert isinstance(a.reshape(4), Tensor)
-
-    def test_infer_dimension(self):
-        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
-        assert a.reshape(-1).shape == (4,)
-
-    def test_grad_fn_when_requires_grad(self):
-        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]], requires_grad=True)
-        assert a.reshape(4).grad_fn is not None
-
-
-# ===========================================================================
-# 11. transpose
-# ===========================================================================
-
-class TestTranspose:
-
-    def test_shape_swapped(self):
-        a = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
-        assert a.transpose(0, 1).shape == (3, 2)
-
-    def test_values_transposed(self):
-        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
-        _allclose(a.transpose(0, 1), [1.0, 3.0, 2.0, 4.0])
-
-    def test_returns_tensor(self):
-        a = torch.tensor([[1.0, 2.0]])
-        assert isinstance(a.transpose(0, 1), Tensor)
-
-    def test_no_copy_semantics_not_required_but_shape_correct(self):
-        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
-        b = a.transpose(0, 1)
-        assert b.shape == (2, 2)
-
-    def test_grad_fn_when_requires_grad(self):
-        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]], requires_grad=True)
-        assert a.transpose(0, 1).grad_fn is not None
-
-
-# ===========================================================================
-# 12. view
-# ===========================================================================
-
-class TestView:
-
-    def test_basic_shape(self):
-        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
-        assert a.view(4).shape == (4,)
-
-    def test_values_preserved(self):
-        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
-        _allclose(a.view(4), [1.0, 2.0, 3.0, 4.0])
-
-    def test_returns_tensor(self):
-        a = torch.tensor([[1.0, 2.0]])
-        assert isinstance(a.view(2), Tensor)
-
-    def test_requires_contiguous_input(self):
-        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
-        b = a.transpose(0, 1)
-        with pytest.raises(RuntimeError):
-            b.view(4)
-
-    def test_grad_fn_when_requires_grad(self):
-        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]], requires_grad=True)
-        assert a.view(4).grad_fn is not None
-
-
-# ===========================================================================
-# 13. backward
-# ===========================================================================
-
-class TestBackward:
-
-    def test_scalar_backward_populates_grad(self):
-        x = torch.tensor([3.0], requires_grad=True)
-        y = x * x
-        y.backward()
-        assert x.grad is not None
-        _allclose(x.grad, [6.0])
-
-    def test_backward_with_external_gradient(self):
-        x = torch.tensor([2.0, 3.0], requires_grad=True)
-        y = x * 2.0
-        y.backward(torch.tensor([1.0, 1.0]))
-        _allclose(x.grad, [2.0, 2.0])
-
-    def test_backward_returns_none(self):
-        x = torch.tensor([3.0], requires_grad=True)
-        y = x * x
-        assert y.backward() is None
-
-
-# ===========================================================================
-# 14. property stability
-# ===========================================================================
-
-class TestPropertyStability:
-
-    def test_shape_device_dtype_exist(self):
-        x = torch.tensor([[1.0, 2.0]])
-        assert x.shape == (1, 2)
-        assert x.device.type == "cpu"
-        assert x.dtype == torch.float32
-
-    def test_grad_default_none(self):
-        x = torch.tensor([1.0, 2.0])
-        assert x.grad is None
-
-    def test_grad_after_backward(self):
-        x = torch.tensor([2.0], requires_grad=True)
-        y = x * x
-        y.backward()
-        assert x.grad is not None
-
-    def test_requires_grad_roundtrip(self):
-        x = torch.tensor([1.0], requires_grad=True)
-        assert x.requires_grad is True
-
-
-# ===========================================================================
-# 15. __torch_function__ forwarding path
-# ===========================================================================
-
-class TestTensorMethodTorchFunctionPath:
-
-    class Wrapper(Tensor):
-        called = None
-
-        @classmethod
-        def __torch_function__(cls, func, types, args=(), kwargs=None):
-            cls.called = func.__name__
-            return torch.tensor([123.0])
-
-    def setup_method(self):
-        self.Wrapper.called = None
-
-    def test___add___uses_torch_function(self):
-        x = torch.tensor([1.0]).as_subclass(self.Wrapper)
-        out = x + torch.tensor([2.0])
-        assert self.Wrapper.called == "__add__"
-        _allclose(out, [123.0])
-
-    def test_clone_uses_torch_function(self):
-        x = torch.tensor([1.0]).as_subclass(self.Wrapper)
-        out = x.clone()
-        assert self.Wrapper.called == "clone"
-        _allclose(out, [123.0])
-
-    def test_relu_uses_torch_function(self):
-        x = torch.tensor([1.0]).as_subclass(self.Wrapper)
-        out = x.relu()
-        assert self.Wrapper.called == "relu"
-        _allclose(out, [123.0])
-
-# 1. __add__
-# ===========================================================================
-
-class TestDunderAdd:
-
-    def test_basic_values(self):
-        a = torch.tensor([1.0, 2.0, 3.0])
-        b = torch.tensor([4.0, 5.0, 6.0])
-        _allclose(a + b, [5.0, 7.0, 9.0])
-
-    def test_returns_tensor(self):
-        a = torch.tensor([1.0])
-        b = torch.tensor([2.0])
-        assert isinstance(a + b, Tensor)
-
-    def test_shape_preserved(self):
-        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
-        b = torch.tensor([[0.1, 0.2], [0.3, 0.4]])
-        assert (a + b).shape == (2, 2)
-
-    def test_scalar_rhs(self):
-        a = torch.tensor([1.0, 2.0, 3.0])
-        _allclose(a + 10.0, [11.0, 12.0, 13.0])
-
-    def test_scalar_lhs_radd_not_supported(self):
-        # Current behavior: float.__add__(Tensor) falls back to NotImplemented and
-        # Tensor has no __radd__, so Python raises TypeError.
-        # This test locks that behavior; if __radd__ is added later, update it.
-        a = torch.tensor([1.0, 2.0, 3.0])
-        with pytest.raises(TypeError):
-            _ = 10.0 + a
-
-    def test_does_not_modify_inputs(self):
-        a = torch.tensor([1.0, 2.0])
-        b = torch.tensor([3.0, 4.0])
-        _ = a + b
-        _allclose(a, [1.0, 2.0])
-        _allclose(b, [3.0, 4.0])
-
-    def test_grad_fn_when_requires_grad(self):
-        a = torch.tensor([1.0, 2.0], requires_grad=True)
-        b = torch.tensor([3.0, 4.0])
-        assert (a + b).grad_fn is not None
-
-    def test_no_grad_fn_without_requires_grad(self):
-        a = torch.tensor([1.0, 2.0])
-        b = torch.tensor([3.0, 4.0])
-        assert (a + b).grad_fn is None
-
-
-# ===========================================================================
-# 2. __mul__
-# ===========================================================================
-
-class TestDunderMul:
-
-    def test_basic_values(self):
-        a = torch.tensor([2.0, 3.0, 4.0])
-        b = torch.tensor([5.0, 6.0, 7.0])
-        _allclose(a * b, [10.0, 18.0, 28.0])
-
-    def test_returns_tensor(self):
-        assert isinstance(torch.tensor([2.0]) * torch.tensor([3.0]), Tensor)
-
-    def test_scalar_rhs(self):
-        a = torch.tensor([1.0, 2.0, 3.0])
-        _allclose(a * 3.0, [3.0, 6.0, 9.0])
-
-    def test_scalar_lhs_rmul(self):
-        a = torch.tensor([1.0, 2.0, 3.0])
-        _allclose(3.0 * a, [3.0, 6.0, 9.0])
-
-    def test_shape_preserved(self):
-        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
-        b = torch.tensor([[2.0, 2.0], [2.0, 2.0]])
-        assert (a * b).shape == (2, 2)
-
-    def test_does_not_modify_inputs(self):
-        a = torch.tensor([1.0, 2.0])
-        b = torch.tensor([3.0, 4.0])
-        _ = a * b
-        _allclose(a, [1.0, 2.0])
-        _allclose(b, [3.0, 4.0])
-
-    def test_grad_fn_when_requires_grad(self):
-        a = torch.tensor([2.0, 3.0], requires_grad=True)
-        b = torch.tensor([4.0, 5.0])
-        assert (a * b).grad_fn is not None
-
-
-# ===========================================================================
-# 3. __matmul__
-# ===========================================================================
-
-class TestDunderMatmul:
-
-    def test_2d_identity(self):
-        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
-        b = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
-        _allclose(a @ b, [1.0, 2.0, 3.0, 4.0])
-
-    def test_returns_tensor(self):
-        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
-        b = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
-        assert isinstance(a @ b, Tensor)
-
-    def test_output_shape(self):
-        a = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])  # (2,3)
-        b = torch.tensor([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])  # (3,2)
-        assert (a @ b).shape == (2, 2)
-
-    def test_mv(self):
-        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
-        v = torch.tensor([1.0, 1.0])
-        _allclose(a @ v, [3.0, 7.0])
-
-    def test_grad_fn_when_requires_grad(self):
-        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]], requires_grad=True)
-        b = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
-        assert (a @ b).grad_fn is not None
-
-    def test_rmatmul(self):
-        # b.__rmatmul__(a) computes matmul(a, b) per Python's reflected op protocol
-        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
-        b = torch.tensor([[0.0, 1.0], [1.0, 0.0]])
-        out = b.__rmatmul__(a)   # == matmul(a, b)
-        assert isinstance(out, Tensor)
-        assert out.shape == (2, 2)
-        # a @ b = [[2, 1], [4, 3]], distinct from b @ a = [[3, 4], [1, 2]]
-        _allclose(out, [2.0, 1.0, 4.0, 3.0])
-
-
-# ===========================================================================
-# 4. __iadd__
-# ===========================================================================
-
-class TestDunderIadd:
-
-    def test_basic(self):
-        a = torch.tensor([1.0, 2.0, 3.0])
-        a += torch.tensor([4.0, 5.0, 6.0])
-        _allclose(a, [5.0, 7.0, 9.0])
-
-    def test_returns_same_object(self):
-        a = torch.tensor([1.0, 2.0])
-        orig_id = id(a)
-        a += torch.tensor([1.0, 1.0])
-        assert id(a) == orig_id
-
-    def test_scalar(self):
-        a = torch.tensor([1.0, 2.0, 3.0])
-        a += 10.0
-        _allclose(a, [11.0, 12.0, 13.0])
-
-    def test_raises_for_leaf_with_requires_grad(self):
-        a = torch.tensor([1.0, 2.0], requires_grad=True)
-        with pytest.raises(RuntimeError):
-            a += torch.tensor([1.0, 1.0])
-
-
-# ===========================================================================
-# 5. __imul__
-# ===========================================================================
-
-class TestDunderImul:
-
-    def test_basic(self):
-        a = torch.tensor([2.0, 3.0, 4.0])
-        a *= torch.tensor([5.0, 6.0, 7.0])
-        _allclose(a, [10.0, 18.0, 28.0])
-
-    def test_returns_same_object(self):
-        a = torch.tensor([1.0, 2.0])
-        orig_id = id(a)
-        a *= torch.tensor([2.0, 2.0])
-        assert id(a) == orig_id
-
-    def test_scalar(self):
-        a = torch.tensor([1.0, 2.0, 3.0])
-        a *= 3.0
-        _allclose(a, [3.0, 6.0, 9.0])
-
-    def test_raises_for_leaf_with_requires_grad(self):
-        a = torch.tensor([1.0, 2.0], requires_grad=True)
-        with pytest.raises(RuntimeError):
-            a *= torch.tensor([2.0, 2.0])
-
-
-# ===========================================================================
-# 6. clone
-# ===========================================================================
-
-class TestClone:
-
-    def test_values_match(self):
-        a = torch.tensor([1.0, 2.0, 3.0])
-        _allclose(a.clone(), [1.0, 2.0, 3.0])
-
-    def test_returns_tensor(self):
-        assert isinstance(torch.tensor([1.0, 2.0]).clone(), Tensor)
-
-    def test_is_copy_not_alias(self):
-        a = torch.tensor([1.0, 2.0, 3.0])
-        b = a.clone()
-        b += torch.tensor([10.0, 10.0, 10.0])
-        _allclose(a, [1.0, 2.0, 3.0])  # original unchanged
-
-    def test_shape_preserved(self):
-        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
-        assert a.clone().shape == (2, 2)
-
-    def test_dtype_preserved(self):
-        a = torch.tensor([1.0, 2.0])
-        assert a.clone().dtype == a.dtype
-
-    def test_device_preserved(self):
-        a = torch.tensor([1.0, 2.0])
-        assert a.clone().device.type == a.device.type
-
-    def test_participates_in_autograd(self):
-        a = torch.tensor([1.0, 2.0], requires_grad=True)
-        b = a.clone()
-        assert b.grad_fn is not None
-
-
-# ===========================================================================
-# 7. detach
-# ===========================================================================
-
-class TestDetach:
-
-    def test_breaks_grad(self):
-        a = torch.tensor([1.0, 2.0], requires_grad=True)
-        assert a.detach().requires_grad is False
-
-    def test_returns_tensor(self):
-        assert isinstance(torch.tensor([1.0, 2.0]).detach(), Tensor)
-
-    def test_values_match(self):
-        a = torch.tensor([1.0, 2.0, 3.0])
-        _allclose(a.detach(), [1.0, 2.0, 3.0])
-
-    def test_grad_fn_is_none(self):
-        a = torch.tensor([1.0, 2.0], requires_grad=True)
-        assert a.detach().grad_fn is None
-
-    def test_shape_preserved(self):
-        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
-        assert a.detach().shape == (2, 2)
-
-
-# ===========================================================================
-# 8. to
-# ===========================================================================
-
-class TestTo:
-
-    def test_same_device_returns_tensor(self):
-        a = torch.tensor([1.0, 2.0])
-        assert isinstance(a.to("cpu"), Tensor)
-
-    def test_same_device_values_preserved(self):
-        a = torch.tensor([1.0, 2.0, 3.0])
-        _allclose(a.to("cpu"), [1.0, 2.0, 3.0])
-
-    def test_dtype_float32_to_float64(self):
-        a = torch.tensor([1.0, 2.0])
-        assert a.to(torch.float64).dtype == torch.float64
-
-    def test_dtype_values_preserved(self):
-        a = torch.tensor([1.0, 2.0, 3.0])
-        _allclose(a.to(torch.float64), [1.0, 2.0, 3.0])
-
-    def test_dtype_kwarg(self):
-        a = torch.tensor([1.0, 2.0])
-        assert a.to(dtype=torch.float64).dtype == torch.float64
-
-    def test_device_kwarg_string(self):
-        a = torch.tensor([1.0, 2.0])
-        assert a.to(device="cpu").device.type == "cpu"
-
-    def test_shape_preserved_after_to(self):
-        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
-        assert a.to("cpu").shape == (2, 2)
-
-
-# ===========================================================================
-# 9. relu
 # ===========================================================================
 
 class TestRelu:
@@ -1012,22 +595,50 @@ class TestRelu:
         _allclose(a, [-1.0, 2.0])
 
 
+class _MemoryFormatRecorder:
+    seen = object()
+
+    def clone(self, *, memory_format):
+        self.seen = memory_format
+        return self
+
+    def contiguous(self, memory_format):
+        self.seen = memory_format
+        return self
+
+
+
+
+
 # ===========================================================================
 # 10. reshape
 # ===========================================================================
 
 class TestReshape:
 
+    def test_basic_shape(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        assert a.reshape(4).shape == (4,)
+
+    def test_values_preserved(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        _allclose(a.reshape(4), [1.0, 2.0, 3.0, 4.0])
+
+    def test_returns_tensor(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        assert isinstance(a.reshape(4), Tensor)
+
+    def test_infer_dimension(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        assert a.reshape(-1).shape == (4,)
+
+    def test_grad_fn_when_requires_grad(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]], requires_grad=True)
+        assert a.reshape(4).grad_fn is not None
+
     def test_basic(self):
         a = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
         assert a.reshape(2, 3).shape == (2, 3)
-
-    def test_returns_tensor(self):
-        assert isinstance(torch.tensor([1.0, 2.0, 3.0, 4.0]).reshape(2, 2), Tensor)
-
-    def test_values_preserved(self):
-        a = torch.tensor([1.0, 2.0, 3.0, 4.0])
-        _allclose(a.reshape(2, 2), [1.0, 2.0, 3.0, 4.0])
 
     def test_tuple_arg(self):
         a = torch.tensor([1.0, 2.0, 3.0, 4.0])
@@ -1053,13 +664,30 @@ class TestReshape:
 
 class TestTranspose:
 
-    def test_shape_2d(self):
+    def test_shape_swapped(self):
         a = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         assert a.transpose(0, 1).shape == (3, 2)
 
-    def test_returns_tensor(self):
+    def test_values_transposed(self):
         a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        _allclose(a.transpose(0, 1), [1.0, 3.0, 2.0, 4.0])
+
+    def test_returns_tensor(self):
+        a = torch.tensor([[1.0, 2.0]])
         assert isinstance(a.transpose(0, 1), Tensor)
+
+    def test_no_copy_semantics_not_required_but_shape_correct(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        b = a.transpose(0, 1)
+        assert b.shape == (2, 2)
+
+    def test_grad_fn_when_requires_grad(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]], requires_grad=True)
+        assert a.transpose(0, 1).grad_fn is not None
+
+    def test_shape_2d(self):
+        a = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        assert a.transpose(0, 1).shape == (3, 2)
 
     def test_values(self):
         a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
@@ -1081,16 +709,31 @@ class TestTranspose:
 
 class TestView:
 
+    def test_basic_shape(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        assert a.view(4).shape == (4,)
+
+    def test_values_preserved(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        _allclose(a.view(4), [1.0, 2.0, 3.0, 4.0])
+
+    def test_returns_tensor(self):
+        a = torch.tensor([[1.0, 2.0]])
+        assert isinstance(a.view(2), Tensor)
+
+    def test_requires_contiguous_input(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        b = a.transpose(0, 1)
+        with pytest.raises(RuntimeError):
+            b.view(4)
+
+    def test_grad_fn_when_requires_grad(self):
+        a = torch.tensor([[1.0, 2.0], [3.0, 4.0]], requires_grad=True)
+        assert a.view(4).grad_fn is not None
+
     def test_basic(self):
         a = torch.tensor([1.0, 2.0, 3.0, 4.0])
         assert a.view(2, 2).shape == (2, 2)
-
-    def test_returns_tensor(self):
-        assert isinstance(torch.tensor([1.0, 2.0, 3.0, 4.0]).view(2, 2), Tensor)
-
-    def test_values_preserved(self):
-        a = torch.tensor([1.0, 2.0, 3.0, 4.0])
-        _allclose(a.view(2, 2), [1.0, 2.0, 3.0, 4.0])
 
     def test_tuple_arg(self):
         a = torch.tensor([1.0, 2.0, 3.0, 4.0])
@@ -1112,6 +755,24 @@ class TestView:
 
 class TestBackward:
 
+    def test_scalar_backward_populates_grad(self):
+        x = torch.tensor([3.0], requires_grad=True)
+        y = x * x
+        y.backward()
+        assert x.grad is not None
+        _allclose(x.grad, [6.0])
+
+    def test_backward_with_external_gradient(self):
+        x = torch.tensor([2.0, 3.0], requires_grad=True)
+        y = x * 2.0
+        y.backward(torch.tensor([1.0, 1.0]))
+        _allclose(x.grad, [2.0, 2.0])
+
+    def test_backward_returns_none(self):
+        x = torch.tensor([3.0], requires_grad=True)
+        y = x * x
+        assert y.backward() is None
+
     def test_scalar_no_grad_arg(self):
         x = torch.tensor([1.0, 2.0], requires_grad=True)
         (x * x).sum().backward()
@@ -1126,6 +787,7 @@ class TestBackward:
         second = x.grad.flatten().tolist()
         # gradients accumulate exactly: second pass adds another [2.0, 4.0]
         assert second == [4.0, 8.0]
+
     def test_non_scalar_without_grad_raises(self):
         x = torch.tensor([1.0, 2.0], requires_grad=True)
         with pytest.raises(RuntimeError):
@@ -1151,10 +813,30 @@ class TestBackward:
 
 
 # ===========================================================================
-# 14. Property/attribute stability: .grad, .shape, .device, .dtype
+# 14. property stability
 # ===========================================================================
 
 class TestPropertyStability:
+
+    def test_shape_device_dtype_exist(self):
+        x = torch.tensor([[1.0, 2.0]])
+        assert x.shape == (1, 2)
+        assert x.device.type == "cpu"
+        assert x.dtype == torch.float32
+
+    def test_grad_default_none(self):
+        x = torch.tensor([1.0, 2.0])
+        assert x.grad is None
+
+    def test_grad_after_backward(self):
+        x = torch.tensor([2.0], requires_grad=True)
+        y = x * x
+        y.backward()
+        assert x.grad is not None
+
+    def test_requires_grad_roundtrip(self):
+        x = torch.tensor([1.0], requires_grad=True)
+        assert x.requires_grad is True
 
     def test_shape_is_tuple(self):
         a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
@@ -1214,6 +896,9 @@ class TestPropertyStability:
         assert a.ndim == len(a.shape)
 
 
+# ===========================================================================
+# 15. __torch_function__ forwarding path
+# ===========================================================================
 
 class TestTensorMethodTorchFunctionPath:
 
@@ -1243,27 +928,9 @@ class TestTensorMethodTorchFunctionPath:
         assert len(TrackedTensor._ops_called) > 0
         _allclose(out, [4.0, 6.0])
 
+# 1. __add__
+# ===========================================================================
 
-def test_size_and_dim_contracts():
-    a = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
-    assert a.size() == (2, 3)
-    assert a.size(0) == 2
-    assert a.size(-1) == 3
-    assert a.dim() == 2
-    with pytest.raises(IndexError):
-        a.size(2)
-
-
-class _MemoryFormatRecorder:
-    seen = object()
-
-    def clone(self, *, memory_format):
-        self.seen = memory_format
-        return self
-
-    def contiguous(self, memory_format):
-        self.seen = memory_format
-        return self
 
 
 def test_top_level_clone_passes_none_memory_format():

--- a/tests/cpu/test_tensor_scalar_protocol.py
+++ b/tests/cpu/test_tensor_scalar_protocol.py
@@ -78,7 +78,7 @@ def test_tensor_len_iter_hash_and_properties():
     assert x.is_meta is False
     assert x.is_leaf is True
     assert x.is_sparse is False
-    assert x.layout == "strided"
+    assert x.layout is torch.strided
     assert x.is_quantized is False
     assert x.storage_offset() == 0
     assert x.get_device() == -1

--- a/tests/cpu/test_tensor_view.py
+++ b/tests/cpu/test_tensor_view.py
@@ -1,3 +1,5 @@
+import pytest
+
 import candle as torch
 from candle._tensor import Tensor
 
@@ -270,6 +272,24 @@ def test_toplevel_as_strided_bypasses_python_common_view_backend(monkeypatch):
     assert x.tolist() == [[1, 2, 3], [4, 5, 6]]
     x._version_counter.bump()
     assert y._version_counter.value == x._version_counter.value
+
+
+def test_toplevel_as_strided_rejects_negative_stride_cpu():
+    x = torch.arange(6)
+    with pytest.raises(RuntimeError, match="Negative strides are not supported"):
+        torch.as_strided(x, (2, 3), (-1, 1), 0)
+
+
+def test_toplevel_as_strided_rejects_negative_size_cpu():
+    x = torch.arange(6)
+    with pytest.raises(RuntimeError, match="Storage size calculation overflowed"):
+        torch.as_strided(x, (-1,), (1,), 0)
+
+
+def test_toplevel_as_strided_rejects_negative_storage_offset_cpu():
+    x = torch.arange(6)
+    with pytest.raises(RuntimeError, match="invalid storage offset -1"):
+        torch.as_strided(x, (2,), (1,), -1)
 
 
 

--- a/tests/cpu/test_testing.py
+++ b/tests/cpu/test_testing.py
@@ -10,6 +10,33 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
 
 import candle as torch
+from candle.testing._internal.common_utils import TestCase as TorchTestCase
+
+
+
+
+class TestInternalCommonUtilsTestCase:
+    """Tests for torch.testing._internal.common_utils.TestCase."""
+
+    def test_assert_equal_compares_tuple_and_list_elementwise(self):
+        case = TorchTestCase()
+        case.assertEqual(
+            (torch.tensor([1.0, 2.0]), torch.tensor([3.0, 4.0])),
+            [np.array([1.0, 2.0], dtype=np.float32), np.array([3.0, 4.0], dtype=np.float32)],
+        )
+
+    def test_assert_equal_compares_tensor_and_list(self):
+        case = TorchTestCase()
+        case.assertEqual(torch.tensor([0.6, 0.7, 0.8]), [0.6, 0.7, 0.8])
+
+    def test_assert_equal_compares_tensor_scalar_and_python_scalar(self):
+        case = TorchTestCase()
+        case.assertEqual(torch.tensor(9.7), 9.7)
+
+    def test_assert_equal_checks_sequence_length(self):
+        case = TorchTestCase()
+        with pytest.raises(AssertionError):
+            case.assertEqual((torch.tensor([1.0]),), [np.array([1.0]), np.array([2.0])])
 
 
 class TestAssertClose:

--- a/tests/cpu/test_top_level_ops.py
+++ b/tests/cpu/test_top_level_ops.py
@@ -334,12 +334,41 @@ class TestCategoryC1:
         imag = torch.tensor([3.0, 4.0])
         out = torch.complex(real, imag)
         assert out.shape == (2,)
+        assert out.dtype == torch.complex64
+
+    def test_complex_float64_outputs_complex128(self):
+        real = torch.tensor([1.0, 2.0], dtype=torch.float64)
+        imag = torch.tensor([3.0, 4.0], dtype=torch.float64)
+        assert torch.complex(real, imag).dtype == torch.complex128
+
+    @pytest.mark.parametrize("op", [torch.complex, torch.polar])
+    def test_complex_like_rejects_non_floating_inputs(self, op):
+        real = torch.tensor([1, 2], dtype=torch.int32)
+        imag = torch.tensor([3.0, 4.0], dtype=torch.float32)
+        with pytest.raises(RuntimeError, match="Expected both inputs to be Half, Float or Double tensors"):
+            op(real, imag)
+
+    @pytest.mark.parametrize("op", [torch.complex, torch.polar])
+    def test_complex_like_rejects_mismatched_floating_dtype(self, op):
+        real = torch.tensor([1.0, 2.0], dtype=torch.float32)
+        imag = torch.tensor([3.0, 4.0], dtype=torch.float64)
+        with pytest.raises(RuntimeError, match="Expected object of scalar type Float but got scalar type Double"):
+            op(real, imag)
+
+    @pytest.mark.parametrize("op", [torch.complex, torch.polar])
+    def test_complex_like_rejects_wrong_out_dtype(self, op):
+        real = torch.tensor([1.0, 2.0], dtype=torch.float32)
+        imag = torch.tensor([3.0, 4.0], dtype=torch.float32)
+        out = torch.empty((2,), dtype=torch.float32)
+        with pytest.raises(RuntimeError, match="Expected object of scalar type ComplexFloat"):
+            op(real, imag, out=out)
 
     def test_polar(self):
         abs_t = torch.tensor([1.0, 1.0])
         angle = torch.tensor([0.0, math.pi / 2])
         out = torch.polar(abs_t, angle)
         assert out.shape == (2,)
+        assert out.dtype == torch.complex64
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Aligns the CPU compatibility layer with PyTorch semantics across creation /
validation surfaces. Lifts official `compat/_pytorch/test/test_tensor_creation_ops.py`
from **158/509 → 380/509 (+222)**, plus a separate fix that lets `frombuffer`
emit the canonical non-writable warning.

Two commits:

1. `fix(compat): align frombuffer non-writable warning with PyTorch`
   `torch.frombuffer` now emits the TORCH_WARN_ONCE-style warning on read-only
   buffers; adds `set_warn_always` / `is_warn_always_enabled` to defeat the once
   gate under tests.

2. `fix(compat): align CPU creation/validation APIs with PyTorch`
   - Factory kwargs: `out=`, `layout=`, `size=` on zeros/ones/empty/arange/linspace/logspace.
     Resize-with-warning on non-empty output; reshape-and-copy when numel matches;
     reject memory overlap (stride==0).
   - Stack helpers (`hstack`/`vstack`/`dstack`/`column_stack`): accept 0-d inputs and
     mixed 1-d/2-d; reject single-Tensor arg with PyTorch's TypeError.
   - `random_`: 1-arg form uses 0 lower bound; bool tensors generate both values;
     out-of-bounds bool raises aligned `RuntimeError`.
   - Missing APIs: `vander`, `empty_strided`, `kaiser_window`, `chalf` alias.
   - Validation messages:
     - linspace/logspace negative steps → "number of steps must be non-negative".
     - arange non-finite → "unsupported range: X -> Y"; zero step → "step must be nonzero";
       overflow → "overflow when unpacking long".
     - hsplit/vsplit/dsplit dim/divisibility → `RuntimeError` (was `ValueError`).
     - as_strided negative sizes/strides/offset → `RuntimeError`.
     - `torch.complex` / `torch.polar`: validate float16/32/64; pick correct complex
       output dtype (float16→complex32, float32→complex64, float64→complex128).
   - `asarray` propagates `requires_grad=False/True` on alias path.
   - `Tensor.layout` returns the `torch.strided` singleton (was a string).
   - `TestCase.assertEqual` accepts `exact_dtype`, compares tuple/list elementwise,
     handles 0-d Tensor ↔ Python scalar.

## Test plan
- [x] `pytest tests/cpu/ tests/contract/` — 3271 passed / 30 skipped / 0 failed.
- [x] `pylint src/candle/` — 10.00/10.
- [x] Official `compat/_pytorch/test/test_tensor_creation_ops.py` — 380/509 (was 158/509).
- [ ] CI: pylint + test-cpu green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)