### PR TITLE
fix(compat): align cat out and complex linspace semantics

### DIFF
--- a/src/candle/_C/_TensorBase.pyx
+++ b/src/candle/_C/_TensorBase.pyx
@@ -604,6 +604,7 @@ def _install_tensor_api(TensorBase):
     TensorBase.is_pinned = _tensor_api_mod.tensor_is_pinned
 
     TensorBase.__add__ = _tensor_api_mod.tensor_add
+    TensorBase.__radd__ = _tensor_api_mod.tensor_radd
     TensorBase.__sub__ = _tensor_api_mod.tensor_sub
     TensorBase.__mul__ = _tensor_api_mod.tensor_mul
     TensorBase.__matmul__ = _tensor_api_mod.tensor_matmul

--- a/src/candle/_C/_creation_ops.pyx
+++ b/src/candle/_C/_creation_ops.pyx
@@ -131,6 +131,10 @@ cdef object _finalize_out(object value, object out):
     return out
 
 
+def finalize_out(value, out):
+    return _finalize_out(value, out)
+
+
 def tensor(data, *, dtype=None, device=None, requires_grad=False):
     from candle._functional import tensor as tensor_dispatch
 
@@ -264,14 +268,57 @@ def arange(start, end=None, step=1, dtype=None, device=None, layout=None, out=No
     return _apply_requires_grad(value, requires_grad)
 
 
+cdef object _is_complex_scalar(object value):
+    try:
+        if isinstance(value, complex):
+            return True
+    except TypeError:
+        pass
+    return False
+
+
+cdef object _check_linspace_logspace_dtype(str fn_name, object start, object end, object dtype):
+    if not (_is_complex_scalar(start) or _is_complex_scalar(end)):
+        return dtype
+    from candle._dtype import complex64, float32
+    inferred = complex64
+    if dtype is None:
+        return inferred
+    name = getattr(dtype, "name", str(dtype))
+    if name in ("complex32", "complex64", "complex128"):
+        return dtype
+    cxx_name = {
+        "complex32": "c10::complex<at::Half>",
+        "complex64": "c10::complex<float>",
+        "complex128": "c10::complex<double>",
+    }.get(getattr(inferred, "name", "complex64"), "c10::complex<float>")
+    passed_name = {
+        "float16": "Half",
+        "float32": "Float",
+        "float64": "Double",
+        "bfloat16": "BFloat16",
+        "bool": "Bool",
+        "uint8": "Byte",
+        "int8": "Char",
+        "int16": "Short",
+        "int32": "Int",
+        "int64": "Long",
+    }.get(name, name)
+    raise RuntimeError(
+        f"torch.{fn_name}(): inferred dtype {cxx_name} can't be safely cast to passed dtype {passed_name}"
+    )
+
+
 def linspace(start, end, steps, dtype=None, device=None, layout=None, out=None, requires_grad=False):
     from candle._functional import linspace as linspace_dispatch
 
     _validate_layout(layout)
     if int(steps) < 0:
         raise RuntimeError(f"number of steps must be non-negative, but got steps={int(steps)}")
+    dtype_for_check = dtype if dtype is not None else (out.dtype if out is not None else None)
+    dtype = _check_linspace_logspace_dtype("linspace", start, end, dtype_for_check)
     if dtype is None:
-        dtype = _get_default_dtype() if out is None else out.dtype
+        dtype = _get_default_dtype()
     value = linspace_dispatch(start, end, steps, dtype=dtype, device=device)
     if out is not None:
         return _apply_requires_grad(_finalize_out(value, out), requires_grad)
@@ -296,8 +343,10 @@ def logspace(start, end, steps, base=10.0, dtype=None, device=None, layout=None,
     _validate_layout(layout)
     if int(steps) < 0:
         raise RuntimeError(f"number of steps must be non-negative, but got steps={int(steps)}")
+    dtype_for_check = dtype if dtype is not None else (out.dtype if out is not None else None)
+    dtype = _check_linspace_logspace_dtype("logspace", start, end, dtype_for_check)
     if dtype is None:
-        dtype = _get_default_dtype() if out is None else out.dtype
+        dtype = _get_default_dtype()
     if base != 10.0:
         # Fallback: compute via linspace + base ** x to support arbitrary base.
         from candle._functional import linspace as linspace_dispatch

--- a/src/candle/_C/_tensor_api.pyx
+++ b/src/candle/_C/_tensor_api.pyx
@@ -2498,6 +2498,11 @@ def tensor_sub_method(self, other, *, alpha=1):
     return _functional_sub_fn(self, other, alpha=alpha)
 
 
+def tensor_radd(self, other):
+    _ensure_functional_add_sub_ref()
+    return _functional_add_fn(self, other)
+
+
 def tensor_mul_method(self, other):
     _ensure_dispatch_ref()
     return _dispatch_fn("mul", self.device.type, self, other)

--- a/src/candle/_functional.py
+++ b/src/candle/_functional.py
@@ -3,6 +3,7 @@ from ._dispatch.dispatcher import dispatch
 from .autograd.grad_mode import GradMode, no_grad
 from ._device import device as Device, get_default_device
 from ._dtype import to_numpy_dtype
+from ._C._creation_ops import finalize_out as _finalize_out
 
 import builtins as _builtins
 
@@ -704,13 +705,7 @@ def cummax(a, dim=0):
 def argsort(a, dim=-1, descending=False, stable=False, out=None):
     result = dispatch("argsort", a.device.type, a, dim=dim, descending=descending, stable=stable)
     if out is not None:
-        out._storage = result.storage()
-        out.shape = result.shape
-        out.stride = result.stride
-        out.offset = result.offset
-        out._base = result._base
-        out._view_meta = result._view_meta
-        return out
+        return _finalize_out(result, out)
     return result
 
 
@@ -760,13 +755,7 @@ def stack(tensors, dim=0, out=None):
         return r
     result = dispatch("stack", tensors[0].device.type, tensors, dim=dim)
     if out is not None:
-        out._storage = result.storage()
-        out.shape = result.shape
-        out.stride = result.stride
-        out.offset = result.offset
-        out._base = result._base
-        out._view_meta = result._view_meta
-        return out
+        return _finalize_out(result, out)
     return result
 
 
@@ -776,13 +765,7 @@ def cat(tensors, dim=0, out=None):
         return r
     result = dispatch("cat", tensors[0].device.type, tensors, dim=dim)
     if out is not None:
-        out._storage = result.storage()
-        out.shape = result.shape
-        out.stride = result.stride
-        out.offset = result.offset
-        out._base = result._base
-        out._view_meta = result._view_meta
-        return out
+        return _finalize_out(result, out)
     return result
 
 
@@ -802,13 +785,7 @@ def hstack(tensors, out=None):
     _check_stack_tensors_arg("hstack", tensors)
     result = dispatch("hstack", tensors[0].device.type, tensors)
     if out is not None:
-        out._storage = result.storage()
-        out.shape = result.shape
-        out.stride = result.stride
-        out.offset = result.offset
-        out._base = result._base
-        out._view_meta = result._view_meta
-        return out
+        return _finalize_out(result, out)
     return result
 
 
@@ -816,13 +793,7 @@ def vstack(tensors, out=None):
     _check_stack_tensors_arg("vstack", tensors)
     result = dispatch("vstack", tensors[0].device.type, tensors)
     if out is not None:
-        out._storage = result.storage()
-        out.shape = result.shape
-        out.stride = result.stride
-        out.offset = result.offset
-        out._base = result._base
-        out._view_meta = result._view_meta
-        return out
+        return _finalize_out(result, out)
     return result
 
 
@@ -830,13 +801,8 @@ def column_stack(tensors, out=None):
     _check_stack_tensors_arg("column_stack", tensors)
     result = dispatch("column_stack", tensors[0].device.type, tensors)
     if out is not None:
-        out._storage = result.storage()
-        out.shape = result.shape
-        out.stride = result.stride
-        out.offset = result.offset
-        out._base = result._base
-        out._view_meta = result._view_meta
-        return out
+        return _finalize_out(result, out)
+    return result
     return result
 
 

--- a/tests/cpu/test_creation.py
+++ b/tests/cpu/test_creation.py
@@ -71,6 +71,31 @@ def test_logspace_rejects_negative_steps_cpu():
         torch.logspace(0.0, 1.0, -1)
 
 
+def test_linspace_infers_complex_dtype_from_complex_endpoints_cpu():
+    # PyTorch parity: complex start/end with dtype=None deduces complex64.
+    for start, end in [(1j, 2j), (0.0, 2j), (1j, 2)]:
+        assert torch.linspace(start, end, 100).dtype == torch.complex64
+
+
+def test_logspace_infers_complex_dtype_from_complex_endpoints_cpu():
+    for start, end in [(1j, 2j), (0.0, 2j), (1j, 2)]:
+        assert torch.logspace(start, end, 100).dtype == torch.complex64
+
+
+def test_linspace_rejects_complex_endpoints_with_real_dtype_cpu():
+    with pytest.raises(RuntimeError, match=r"torch.linspace\(\): inferred dtype"):
+        torch.linspace(0, 1j, 5, dtype=torch.float32)
+    with pytest.raises(RuntimeError, match=r"torch.linspace\(\): inferred dtype"):
+        torch.linspace(0j, 1, 5, dtype=torch.float32)
+    with pytest.raises(RuntimeError, match=r"torch.linspace\(\): inferred dtype"):
+        torch.linspace(0j, 1j, 5, dtype=torch.float32)
+
+
+def test_logspace_rejects_complex_endpoints_with_real_dtype_cpu():
+    with pytest.raises(RuntimeError, match=r"torch.logspace\(\): inferred dtype"):
+        torch.logspace(0, 1j, 5, dtype=torch.float32)
+
+
 def test_full_cpu():
     x = torch.full((2, 3), 1.5)
     assert x.shape == (2, 3)

--- a/tests/cpu/test_ops_cpu.py
+++ b/tests/cpu/test_ops_cpu.py
@@ -524,6 +524,29 @@ def test_cat_out_cpu():
     np.testing.assert_allclose(out.numpy(), expected)
 
 
+def test_cat_out_writes_into_view_storage_cpu():
+    # PyTorch parity: cat(out=view) must write through the view into its base
+    # storage rather than rebinding the view to a freshly allocated buffer.
+    y = torch.arange(0, 24, dtype=torch.float32).reshape(4, 6)
+    w = y.reshape(-1).clone()
+    a = torch.cat([w[:2], w[4:6]])
+    b = torch.cat([w[:2], w[4:6]], out=w[6:10])
+    assert b.data_ptr() == w[6:10].data_ptr()
+    np.testing.assert_allclose(b.numpy(), a.numpy())
+    np.testing.assert_allclose(w[6:10].numpy(), a.numpy())
+    np.testing.assert_allclose(w[:6].numpy(), y.reshape(-1)[:6].numpy())
+
+
+def test_cat_out_resizes_empty_out_cpu():
+    a = torch.tensor([[1.0, 2.0]])
+    b = torch.tensor([[3.0, 4.0]])
+    out = torch.empty((0,), dtype=torch.float32)
+    result = torch.cat([a, b], dim=0, out=out)
+    assert result is out
+    assert out.shape == (2, 2)
+    np.testing.assert_allclose(out.numpy(), [[1.0, 2.0], [3.0, 4.0]])
+
+
 def test_hstack_cpu():
     a = torch.tensor([1.0, 2.0])
     b = torch.tensor([3.0, 4.0])
@@ -1111,6 +1134,19 @@ def test_scalar_rmul_cpu():
     out = 0.5 * x
     expected = 0.5 * x.numpy()
     np.testing.assert_allclose(out.numpy(), expected)
+
+
+def test_scalar_radd_cpu():
+    x = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    out = 0.5 + x
+    expected = 0.5 + x.numpy()
+    np.testing.assert_allclose(out.numpy(), expected)
+
+
+def test_complex_scalar_radd_cpu():
+    x = torch.tensor([1.0 + 2.0j, 3.0 + 4.0j], dtype=torch.complex64)
+    out = (5.0 + 6.0j) + x
+    np.testing.assert_allclose(out.numpy(), [6.0 + 8.0j, 8.0 + 10.0j])
 
 
 def test_std_axis_keyword_cpu():

--- a/tests/cpu/test_tensor_api_contract.py
+++ b/tests/cpu/test_tensor_api_contract.py
@@ -51,13 +51,9 @@ class TestDunderAdd:
         a = torch.tensor([1.0, 2.0, 3.0])
         _allclose(a + 10.0, [11.0, 12.0, 13.0])
 
-    def test_scalar_lhs_radd_not_supported(self):
-        # Current behavior: float.__add__(Tensor) falls back to NotImplemented and
-        # Tensor has no __radd__, so Python raises TypeError.
-        # This test locks that behavior; if __radd__ is added later, update it.
+    def test_scalar_lhs_radd(self):
         a = torch.tensor([1.0, 2.0, 3.0])
-        with pytest.raises(TypeError):
-            _ = 10.0 + a
+        _allclose(10.0 + a, [11.0, 12.0, 13.0])
 
     def test_does_not_modify_inputs(self):
         a = torch.tensor([1.0, 2.0])


### PR DESCRIPTION
## Summary

Next CPU tensor-creation compatibility batch after #420. Raises official
`compat/_pytorch/test/test_tensor_creation_ops.py` from **380/509 → 400/509**.

Changes:
- `cat`/`stack`/`hstack`/`vstack`/`column_stack`/`argsort` `out=` now write through
  existing output storage using the shared `finalize_out` helper instead of rebinding
  `out._storage`. This preserves PyTorch view-alias semantics for cases like
  `torch.cat([...], out=w[6:10])`.
- `linspace`/`logspace` infer `complex64` from complex endpoints when `dtype=None`.
- `linspace`/`logspace` reject unsafe explicit real dtype casts from complex endpoints
  with PyTorch-style `RuntimeError` wording.
- `Tensor.__radd__` supports scalar-left addition (`scalar + tensor`), including
  complex scalar + complex Tensor, unblocking complex linspace/logspace official tests.

## Test plan
- [x] `python setup.py build_ext --inplace -j4`
- [x] `pytest tests/cpu/ tests/contract/ --tb=short -q` — 3279 passed / 30 skipped
- [x] `pylint src/candle/ --rcfile=.github/pylint.conf` — 10.00/10
- [x] Official `compat/_pytorch/test/test_tensor_creation_ops.py` — 400 passed / 109 failed
- [ ] CI: pylint + test-cpu green

🤖 Generated with [Claude Code](https://claude.com/claude-code)