### PR TITLE
fix(compat): align CPU factory dtype/layout semantics

### DIFF
--- a/src/candle/_C/_creation_ops.pyx
+++ b/src/candle/_C/_creation_ops.pyx
@@ -89,11 +89,16 @@ cdef bint _device_matches(object tensor, object target_device):
 cdef _validate_layout(object layout_arg):
     if layout_arg is None:
         return
-    from candle import strided
-    if layout_arg is not strided:
-        raise TypeError(
+    from candle import strided, layout as _layout_cls
+    if layout_arg is strided:
+        return
+    if isinstance(layout_arg, _layout_cls):
+        raise RuntimeError(
             f"candle currently only supports torch.strided layout, got {layout_arg!r}"
         )
+    raise TypeError(
+        f"candle currently only supports torch.strided layout, got {layout_arg!r}"
+    )
 
 
 cdef _check_no_internal_overlap(object out):
@@ -160,6 +165,10 @@ def zeros(*shape, dtype=None, device=None, memory_format=None, layout=None, out=
     _validate_layout(layout)
     if dtype is None:
         dtype = _get_default_dtype() if out is None else out.dtype
+    elif out is not None and out.dtype != dtype:
+        raise RuntimeError(
+            f"zeros() expected a tensor of dtype {dtype} but got dtype {out.dtype} for argument 'out'"
+        )
     value = zeros_dispatch(*shape, dtype=dtype, device=device, memory_format=memory_format)
     if out is not None:
         return _apply_requires_grad(_finalize_out(value, out), requires_grad)
@@ -173,6 +182,10 @@ def ones(*shape, dtype=None, device=None, memory_format=None, layout=None, out=N
     _validate_layout(layout)
     if dtype is None:
         dtype = _get_default_dtype() if out is None else out.dtype
+    elif out is not None and out.dtype != dtype:
+        raise RuntimeError(
+            f"ones() expected a tensor of dtype {dtype} but got dtype {out.dtype} for argument 'out'"
+        )
     value = ones_dispatch(*shape, dtype=dtype, device=device, memory_format=memory_format)
     if out is not None:
         return _apply_requires_grad(_finalize_out(value, out), requires_grad)
@@ -186,6 +199,10 @@ def empty(*shape, dtype=None, device=None, memory_format=None, layout=None, out=
     _validate_layout(layout)
     if dtype is None:
         dtype = _get_default_dtype() if out is None else out.dtype
+    elif out is not None and out.dtype != dtype:
+        raise RuntimeError(
+            f"empty() expected a tensor of dtype {dtype} but got dtype {out.dtype} for argument 'out'"
+        )
     value = empty_dispatch(*shape, dtype=dtype, device=device, memory_format=memory_format)
     if out is not None:
         return _apply_requires_grad(_finalize_out(value, out), requires_grad)
@@ -329,8 +346,30 @@ def full(*args, dtype=None, device=None, requires_grad=False, memory_format=None
     from candle._functional import full as full_dispatch
 
     _validate_layout(layout)
+    cdef Py_ssize_t _nargs = len(args)
+    fill_value = args[_nargs - 1] if _nargs > 0 else None
     if dtype is None:
-        dtype = _get_default_dtype() if out is None else out.dtype
+        if out is not None:
+            dtype = out.dtype
+        elif isinstance(fill_value, bool):
+            dtype = bool_dtype
+        elif isinstance(fill_value, int):
+            dtype = int64
+        elif isinstance(fill_value, complex):
+            default_dtype = _get_default_dtype()
+            if getattr(default_dtype, "name", None) == "float64":
+                from candle._dtype import complex128 as _complex128
+                dtype = _complex128
+            else:
+                from candle._dtype import complex64 as _complex64
+                dtype = _complex64
+        else:
+            dtype = _get_default_dtype()
+    elif out is not None and out.dtype != dtype:
+        raise RuntimeError(
+            "full() expected a tensor of dtype "
+            f"{dtype} but got dtype {out.dtype} for argument 'out'"
+        )
     value = full_dispatch(*args, dtype=dtype, device=device, memory_format=memory_format)
     if out is not None:
         return _apply_requires_grad(_finalize_out(value, out), requires_grad)

--- a/src/candle/_functional.py
+++ b/src/candle/_functional.py
@@ -3,7 +3,7 @@ from ._dispatch.dispatcher import dispatch
 from .autograd.grad_mode import GradMode, no_grad
 from ._device import device as Device, get_default_device
 from ._dtype import to_numpy_dtype
-from ._C._creation_ops import finalize_out as _finalize_out
+from ._C._creation_ops import finalize_out as _finalize_out  # pylint: disable=no-name-in-module
 
 import builtins as _builtins
 

--- a/tests/cpu/test_creation.py
+++ b/tests/cpu/test_creation.py
@@ -96,6 +96,35 @@ def test_logspace_rejects_complex_endpoints_with_real_dtype_cpu():
         torch.logspace(0, 1j, 5, dtype=torch.float32)
 
 
+def test_full_infers_bool_dtype_from_bool_fill_cpu():
+    with torch.testing._internal.common_utils.set_default_dtype(torch.float16):
+        assert torch.full((2, 2), True).dtype == torch.bool
+
+
+def test_full_infers_int64_dtype_from_int_fill_cpu():
+    with torch.testing._internal.common_utils.set_default_dtype(torch.float16):
+        assert torch.full((2, 2), 1).dtype == torch.int64
+
+
+def test_full_infers_complex_dtype_from_complex_fill_cpu():
+    with torch.testing._internal.common_utils.set_default_dtype(torch.float16):
+        assert torch.full((2, 2), 1 + 1j).dtype == torch.complex64
+    with torch.testing._internal.common_utils.set_default_dtype(torch.float64):
+        assert torch.full((2, 2), 1 + 1j).dtype == torch.complex128
+
+
+def test_full_out_dtype_overrides_inference_cpu():
+    out = torch.empty((5,), dtype=torch.int64)
+    assert torch.full((5,), 1.0, out=out).dtype == torch.int64
+    assert torch.full((5,), 1, out=out).dtype == torch.int64
+
+
+def test_full_rejects_dtype_out_conflict_cpu():
+    out = torch.empty((5,), dtype=torch.int64)
+    with pytest.raises(RuntimeError):
+        torch.full((5,), 1.0, dtype=torch.float32, out=out)
+
+
 def test_full_cpu():
     x = torch.full((2, 3), 1.5)
     assert x.shape == (2, 3)
@@ -169,6 +198,21 @@ def test_factory_accepts_layout_strided_cpu(factory):
 def test_factory_rejects_non_strided_layout_cpu(factory):
     with pytest.raises(TypeError, match="layout"):
         factory((2, 3), layout="not-a-layout")
+
+
+@pytest.mark.parametrize("factory_name", ["zeros", "ones", "empty"])
+def test_factory_rejects_sparse_layout_cpu(factory_name):
+    factory = getattr(torch, factory_name)
+    with pytest.raises(RuntimeError, match="strided layout"):
+        factory((2, 3), layout=torch.sparse_coo)
+
+
+@pytest.mark.parametrize("factory_name", ["zeros", "ones", "empty"])
+def test_factory_rejects_dtype_out_conflict_cpu(factory_name):
+    factory = getattr(torch, factory_name)
+    out = torch.empty((3, 4), dtype=torch.float32)
+    with pytest.raises(RuntimeError):
+        factory((3, 4), dtype=torch.int64, out=out)
 
 
 def test_linspace_out_aliases_output_storage_cpu():


### PR DESCRIPTION
## Summary
- Match PyTorch `torch.full` dtype inference for bool, int, and complex fill values.
- Make factory `out=` tensors control inferred dtype while rejecting explicit dtype conflicts.
- Reject non-strided Candle layout enums with RuntimeError while keeping invalid layout objects as TypeError.

## Test plan
- [x] `PYTHONPATH=/home/jenkins/lvyufeng/candle/.claude/worktrees/pytorch-cpu-buffer-protocol/src conda run -n candle311 python -m pytest tests/cpu/test_creation.py -q --tb=short`
- [x] `PYTHONPATH=/home/jenkins/lvyufeng/candle/.claude/worktrees/pytorch-cpu-buffer-protocol/src conda run -n candle311 python -m pytest tests/cpu/ tests/contract/ --tb=short -q`
- [x] `conda run -n candle311 pylint src/candle/ --rcfile=.github/pylint.conf`
- [x] `PYTHONPATH=/home/jenkins/lvyufeng/candle/.claude/worktrees/pytorch-cpu-buffer-protocol/src:$PYTHONPATH USE_CANDLE=1 conda run -n candle311 python -m pytest compat/_pytorch/test/test_tensor_creation_ops.py --tb=no -q --no-header --ignore-glob='**/test/jit/*'` (expected remaining failures; 405 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)