### PR TITLE
fix(compat): align Tensor.new family with PyTorch

### DIFF
--- a/src/candle/_C/_TensorBase.pyx
+++ b/src/candle/_C/_TensorBase.pyx
@@ -717,6 +717,7 @@ def _install_tensor_api(TensorBase):
     TensorBase.new_ones = _tensor_api_mod.tensor_new_ones
     TensorBase.new_zeros = _tensor_api_mod.tensor_new_zeros
     TensorBase.new_full = _tensor_api_mod.tensor_new_full
+    TensorBase.new = _tensor_api_mod.tensor_new_legacy
     TensorBase.div_ = _tensor_api_mod.tensor_div_
     TensorBase.unflatten = _tensor_api_mod.tensor_unflatten
     TensorBase.bitwise_and_ = _tensor_api_mod.tensor_bitwise_and_

--- a/src/candle/_C/_tensor_api.pyx
+++ b/src/candle/_C/_tensor_api.pyx
@@ -1545,36 +1545,27 @@ def tensor_new_empty(self, size, *, dtype=None, device=None, requires_grad=False
     cdef object dev = device if device is not None else self.device
     if memory_format is not None:
         raise TypeError("new_empty() got an unexpected keyword argument 'memory_format'")
-    return empty(size, dtype=dt, device=dev)
+    return empty(size, dtype=dt, device=dev, requires_grad=requires_grad)
 
 
 def tensor_new_tensor(self, data, *, dtype=None, device=None, requires_grad=False):
     from candle._creation import tensor
     cdef object dt = dtype if dtype is not None else self.dtype
     cdef object dev = device if device is not None else self.device
-    return tensor(data, dtype=dt, device=dev)
+    return tensor(data, dtype=dt, device=dev, requires_grad=requires_grad)
 
 
 def tensor_new_empty_strided(self, size, stride, *, dtype=None, device=None, requires_grad=False):
-    from candle._creation import empty
+    from candle._creation import empty_strided
     cdef object dt = dtype if dtype is not None else self.dtype
     cdef object dev = device if device is not None else self.device
-    cdef Py_ssize_t numel = 1
-    cdef object arr
-    cdef object storage
-    cdef object t
-    cdef object s
-
-    if dev.type == "cpu":
-        _ensure_conversion_refs()
-        _ensure_tensor_factory_ref()
-        for s in size:
-            numel *= s
-        arr = np.empty(numel, dtype=_to_numpy_dtype_fn(dt))
-        storage = _typed_storage_from_numpy_fn(arr, dt, device=dev)
-        return _cy_make_tensor_from_storage_fn(storage, tuple(size), tuple(stride), 0, requires_grad)
-    t = empty(size, dtype=dt, device=dev)
-    return t
+    cdef Py_ssize_t size_len = len(size)
+    cdef Py_ssize_t stride_len = len(stride)
+    if size_len != stride_len:
+        raise RuntimeError(
+            f"dimensionality of sizes ({size_len}) must match dimensionality of strides ({stride_len})"
+        )
+    return empty_strided(size, stride, dtype=dt, device=dev, requires_grad=requires_grad)
 
 
 def tensor_ones_like(self):
@@ -1598,7 +1589,7 @@ def tensor_ones_like(self):
     return tensor
 
 
-def tensor_new_ones(self, size, dtype=None, device=None, memory_format=None):
+def tensor_new_ones(self, size, *, dtype=None, device=None, requires_grad=False, memory_format=None):
     from candle._creation import ones
     if dtype is None:
         dtype = self.dtype
@@ -1606,10 +1597,10 @@ def tensor_new_ones(self, size, dtype=None, device=None, memory_format=None):
         device = self.device
     if memory_format is not None:
         raise TypeError("new_ones() got an unexpected keyword argument 'memory_format'")
-    return ones(size, dtype=dtype, device=device)
+    return ones(size, dtype=dtype, device=device, requires_grad=requires_grad)
 
 
-def tensor_new_zeros(self, size, dtype=None, device=None, memory_format=None):
+def tensor_new_zeros(self, size, *, dtype=None, device=None, requires_grad=False, memory_format=None):
     from candle._creation import zeros
     if dtype is None:
         dtype = self.dtype
@@ -1617,14 +1608,21 @@ def tensor_new_zeros(self, size, dtype=None, device=None, memory_format=None):
         device = self.device
     if memory_format is not None:
         raise TypeError("new_zeros() got an unexpected keyword argument 'memory_format'")
-    return zeros(size, dtype=dtype, device=device)
+    return zeros(size, dtype=dtype, device=device, requires_grad=requires_grad)
 
 
 def tensor_new_full(self, size, fill_value, *, dtype=None, device=None, requires_grad=False):
     from candle._creation import full
     cdef object dt = dtype if dtype is not None else self.dtype
     cdef object dev = device if device is not None else self.device
-    return full(size, fill_value, dtype=dt, device=dev)
+    return full(size, fill_value, dtype=dt, device=dev, requires_grad=requires_grad)
+
+
+def tensor_new_legacy(self, *args, **kwargs):
+    """Legacy ``Tensor.new`` factory: behaves like ``new_empty`` when called with a size."""
+    if not args:
+        raise TypeError("Tensor.new() requires at least one positional argument (size)")
+    return tensor_new_empty(self, *args, **kwargs)
 
 
 def tensor_div_(self, other):

--- a/tests/cpu/test_tensor_api_contract.py
+++ b/tests/cpu/test_tensor_api_contract.py
@@ -1239,3 +1239,50 @@ def test_frombuffer_requires_grad_only_for_floating_dtype():
     ints = array.array("i", [1, 2])
     with pytest.raises(RuntimeError, match="floating point"):
         torch.frombuffer(ints, dtype=torch.int32, requires_grad=True)
+
+
+# ---------------------------------------------------------------------------
+# Tensor.new family parity (PyTorch parity)
+# ---------------------------------------------------------------------------
+
+
+def test_tensor_new_size_factory_returns_new_empty_cpu():
+    x = torch.zeros((3, 4), dtype=torch.float32)
+    out = x.new((2, 5))
+    assert out.shape == (2, 5)
+    assert out.dtype == torch.float32
+    assert out.device.type == x.device.type
+
+
+@pytest.mark.parametrize("method", ["new_empty", "new_ones", "new_zeros", "new_full"])
+def test_tensor_new_methods_honor_requires_grad_true_cpu(method):
+    x = torch.zeros((2,), dtype=torch.float32)
+    args = ((3,),)
+    if method == "new_full":
+        args = ((3,), 1.0)
+    out = getattr(x, method)(*args, requires_grad=True)
+    assert out.requires_grad is True
+
+
+@pytest.mark.parametrize("method", ["new_empty", "new_ones", "new_zeros", "new_full"])
+def test_tensor_new_methods_reject_requires_grad_on_int_dtype_cpu(method):
+    x = torch.zeros((2,), dtype=torch.int64)
+    args = ((3,),)
+    if method == "new_full":
+        args = ((3,), 1)
+    with pytest.raises(RuntimeError, match="floating point and complex"):
+        getattr(x, method)(*args, requires_grad=True)
+
+
+def test_new_empty_strided_accepts_string_device_cpu():
+    x = torch.zeros((3, 3), dtype=torch.float32)
+    out = x.new_empty_strided((2, 3), (3, 1), dtype=torch.float32, device="cpu")
+    assert out.shape == (2, 3)
+    assert out.stride() == (3, 1)
+    assert out.device.type == "cpu"
+
+
+def test_new_empty_strided_validates_size_stride_length_cpu():
+    x = torch.zeros((2,), dtype=torch.float32)
+    with pytest.raises(RuntimeError, match="dimensionality of sizes"):
+        x.new_empty_strided((2,), ())


### PR DESCRIPTION
## Summary
- Restore the legacy ``Tensor.new(size)`` factory that PyTorch exposes (delegating to ``new_empty``).
- Make ``new_empty`` / ``new_ones`` / ``new_zeros`` / ``new_full`` / ``new_empty_strided`` / ``new_tensor`` honor ``requires_grad`` and raise the standard ``RuntimeError`` on integer/bool dtypes.
- Accept string ``device`` arguments on ``new_empty_strided`` and validate ``size``/``stride`` dimensionality with PyTorch's error message.

## Test plan
- [x] `PYTHONPATH=/home/jenkins/lvyufeng/candle/.claude/worktrees/pytorch-cpu-buffer-protocol/src conda run -n candle311 python -m pytest tests/cpu/test_tensor_api_contract.py -k 'tensor_new_size_factory or tensor_new_methods_honor or new_methods_reject_requires_grad or new_empty_strided_accepts_string_device or new_empty_strided_validates' -v --tb=short`
- [x] `PYTHONPATH=/home/jenkins/lvyufeng/candle/.claude/worktrees/pytorch-cpu-buffer-protocol/src conda run -n candle311 python -m pytest tests/cpu/ tests/contract/ --tb=short -q`
- [x] `conda run -n candle311 pylint src/candle/ --rcfile=.github/pylint.conf`
- [x] `PYTHONPATH=/home/jenkins/lvyufeng/candle/.claude/worktrees/pytorch-cpu-buffer-protocol/src:$PYTHONPATH USE_CANDLE=1 conda run -n candle311 python -m pytest compat/_pytorch/test/test_tensor_creation_ops.py --tb=no -q --no-header --ignore-glob='**/test/jit/*'` (408 passed, +3 from main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)