### PR TITLE
fix(compat): align meshgrid validation semantics

### DIFF
--- a/src/candle/_creation.py
+++ b/src/candle/_creation.py
@@ -1,4 +1,4 @@
-from ._C._creation_ops import (  # pylint: disable=no-name-in-module
+from ._C._creation_ops import (  # pylint: disable=import-error,no-name-in-module
     arange,
     as_tensor,
     asarray,

--- a/src/candle/_functional.py
+++ b/src/candle/_functional.py
@@ -1637,13 +1637,29 @@ def argwhere(a):
 # Category C1: Pure-Python functions (no dispatch needed)
 # ---------------------------------------------------------------------------
 
-def meshgrid(*tensors, indexing='ij'):
+def meshgrid(*tensors, indexing=None):
     if len(tensors) == 1 and isinstance(tensors[0], (list, tuple)):
         tensors = tuple(tensors[0])
+    if indexing is None:
+        import warnings
+        warnings.warn(
+            "torch.meshgrid: in an upcoming release, it will be required to pass the indexing arg.",
+            UserWarning,
+            stacklevel=2,
+        )
+        indexing = 'ij'
     if indexing not in ('ij', 'xy'):
-        raise ValueError(f"meshgrid: indexing must be 'ij' or 'xy', got '{indexing}'")
+        raise RuntimeError('torch.meshgrid: indexing must be one of "xy" or "ij"')
     if len(tensors) == 0:
-        return []
+        raise RuntimeError("torch.meshgrid: expects a non-empty TensorList")
+    first = tensors[0]
+    for t in tensors:
+        if t.ndim > 1:
+            raise RuntimeError("torch.meshgrid: Expected 0D or 1D tensor in the tensor list")
+        if t.dtype != first.dtype:
+            raise RuntimeError("torch.meshgrid: expects all tensors to have the same dtype")
+        if t.device != first.device:
+            raise RuntimeError("torch.meshgrid: expects all tensors to have the same device")
     # For 'xy' indexing, swap the first two inputs, build 'ij', then swap outputs
     if indexing == 'xy' and len(tensors) >= 2:
         swapped = (tensors[1], tensors[0]) + tensors[2:]

--- a/src/candle/_functional.py
+++ b/src/candle/_functional.py
@@ -3,7 +3,7 @@ from ._dispatch.dispatcher import dispatch
 from .autograd.grad_mode import GradMode, no_grad
 from ._device import device as Device, get_default_device
 from ._dtype import to_numpy_dtype
-from ._C._creation_ops import finalize_out as _finalize_out  # pylint: disable=no-name-in-module
+from ._C._creation_ops import finalize_out as _finalize_out  # pylint: disable=import-error,no-name-in-module
 
 import builtins as _builtins
 

--- a/tests/cpu/test_top_level_ops.py
+++ b/tests/cpu/test_top_level_ops.py
@@ -257,12 +257,44 @@ class TestCategoryC1:
         assert gx[0].tolist() == [1, 1]
         assert gy[0].tolist() == [4, 5]
 
+    def test_meshgrid_warns_if_indexing_omitted(self):
+        x = torch.tensor([1, 2])
+        with pytest.warns(UserWarning, match="will be required to pass the indexing arg"):
+            (gx,) = torch.meshgrid(x)
+        assert gx.shape == (2,)
+
     def test_meshgrid_xy(self):
         x = torch.tensor([1, 2, 3])
         y = torch.tensor([4, 5])
         gx, gy = torch.meshgrid(x, y, indexing='xy')
         assert gx.shape == (2, 3)
         assert gy.shape == (2, 3)
+
+    def test_meshgrid_rejects_empty_input(self):
+        with pytest.raises(RuntimeError, match="expects a non-empty TensorList"):
+            torch.meshgrid()
+
+    def test_meshgrid_rejects_unsupported_indexing(self):
+        x = torch.tensor([1, 2])
+        with pytest.raises(RuntimeError, match='indexing must be one of "xy" or "ij"'):
+            torch.meshgrid(x, indexing='')
+
+    def test_meshgrid_rejects_non_1d_tensor(self):
+        x = torch.tensor([[1, 2], [3, 4]])
+        with pytest.raises(RuntimeError, match="Expected 0D or 1D tensor"):
+            torch.meshgrid(x)
+
+    def test_meshgrid_rejects_mixed_dtypes(self):
+        x = torch.tensor([1], dtype=torch.int32)
+        y = torch.tensor([2], dtype=torch.float32)
+        with pytest.raises(RuntimeError, match="expects all tensors to have the same dtype"):
+            torch.meshgrid(x, y)
+
+    def test_meshgrid_rejects_mixed_devices(self):
+        x = torch.tensor([1], device="cpu")
+        y = torch.tensor([2], device="meta")
+        with pytest.raises(RuntimeError, match="expects all tensors to have the same device"):
+            torch.meshgrid(x, y)
 
     def test_atleast_1d_scalar(self):
         a = torch.tensor(5.0)


### PR DESCRIPTION
## Summary
- Reject empty input list, mixed devices/dtypes, and >1D tensors in ``torch.meshgrid`` with PyTorch's RuntimeError messages.
- Switch unsupported ``indexing`` from ValueError to RuntimeError using PyTorch's wording.
- Emit the omitted-indexing UserWarning when the caller does not pass ``indexing``, matching PyTorch's deprecation notice.

## Test plan
- [x] ``PYTHONPATH=/home/jenkins/lvyufeng/candle/.claude/worktrees/pytorch-cpu-buffer-protocol/src conda run -n candle311 python -m pytest tests/cpu/test_top_level_ops.py -k meshgrid -v --tb=short``
- [x] ``PYTHONPATH=/home/jenkins/lvyufeng/candle/.claude/worktrees/pytorch-cpu-buffer-protocol/src conda run -n candle311 python -m pytest tests/cpu/ tests/contract/ --tb=short -q``
- [x] ``conda run -n candle311 pylint src/candle/ --rcfile=.github/pylint.conf``
- [x] ``PYTHONPATH=/home/jenkins/lvyufeng/candle/.claude/worktrees/pytorch-cpu-buffer-protocol/src:\$PYTHONPATH USE_CANDLE=1 conda run -n candle311 python -m pytest compat/_pytorch/test/test_tensor_creation_ops.py --tb=no -q --no-header --ignore-glob='**/test/jit/*'`` (413 passed, +5 from main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)