### PR TITLE
fix(npu): reject CPU fallback in dropout backward

### DIFF
--- a/src/candle/_backends/autograd.py
+++ b/src/candle/_backends/autograd.py
@@ -7641,26 +7641,9 @@ def _npu_autograd_dropout():
             node_holder = {}
 
             def _backward(grad):
-                if backward_data is not None:
-                    return _npu_dropout_backward(grad, backward_data, out, a, args, kwargs)
-                # fallback: mask * scale
-                from .cpu.ops import _to_numpy, _from_numpy
-                import numpy as _np
-                g_np = _to_numpy(grad)
-                p = args[0] if args else kwargs.get("p", 0.5)
-                training = args[1] if len(args) > 1 else kwargs.get("training", True)
-                if not training or p == 0:
-                    return (grad,)
-                if backward_data is not None and "mask" in backward_data:
-                    mask_np = backward_data["mask"].astype(g_np.dtype)
-                    p = backward_data["p"]
-                else:
-                    out_np = _to_numpy(out)
-                    a_np = _to_numpy(a)
-                    mask_np = _np.where(_np.abs(a_np) > 0, (out_np != 0).astype(g_np.dtype), 1.0)
-                scale = 1.0 / (1.0 - p) if p < 1.0 else 0.0
-                grad_np = g_np * mask_np * scale
-                return (_from_numpy(grad_np, grad.dtype, grad.device),)
+                if backward_data is None:
+                    raise RuntimeError("NPU dropout backward requires device mask metadata")
+                return _npu_dropout_backward(grad, backward_data, out, a, args, kwargs)
 
             node = Node(_backward, (a,), name=f"{op_name.capitalize()}Backward0")
             annotate_node_creation(node)

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -43,6 +43,15 @@ def test_cython_and_python_npu_dispatch_key_constants_stay_in_sync():
         assert re.search(pattern, core_src), f"_dispatcher_core.pyx {name} key constant drifted"
 
 
+def test_npu_autograd_overrides_do_not_use_cpu_fallbacks():
+    autograd_src = _source("src/candle/_backends/autograd.py")
+    npu_override_src = autograd_src.split("# NPU ACLNN fused backward kernels", 1)[1]
+
+    forbidden = ["from .cpu", "import numpy", "_to_numpy", "_from_numpy"]
+    for marker in forbidden:
+        assert marker not in npu_override_src
+
+
 def test_core_npu_training_ops_have_forward_and_autograd_registration():
     forward_ops = _npu_forward_ops()
     autograd_ops = _npu_autograd_ops()


### PR DESCRIPTION
## Summary
- Remove the CPU/NumPy fallback from NPU dropout backward when device mask metadata is missing
- Add a mechanism audit guard that prevents NPU autograd override code from referencing CPU fallback helpers

## Test plan
- [x] `/home/jenkins/anaconda3/envs/candle311/bin/python -m pytest tests/contract/test_npu_mechanism_audit.py -v --tb=short`
- [x] `/home/jenkins/anaconda3/envs/candle311/bin/python -m pytest tests/contract/ -v --tb=short`
- [x] `/home/jenkins/anaconda3/envs/candle311/bin/pylint src/candle/ --rcfile=.github/pylint.conf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)