### PR TITLE
fix(npu): remove forward CPU fallbacks

### DIFF
--- a/src/candle/_backends/npu/ops/comparison.py
+++ b/src/candle/_backends/npu/ops/comparison.py
@@ -125,10 +125,7 @@ def allclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
     if not isinstance(a, Tensor) or not isinstance(b, Tensor):
         raise ValueError("NPU allclose expects tensors")
     if _use_soc_fallback("allclose"):
-        import numpy as np
-        a_cpu = a.to("cpu").numpy().astype(np.float32, copy=False)
-        b_cpu = b.to("cpu").numpy().astype(np.float32, copy=False)
-        return bool(np.allclose(a_cpu, b_cpu, rtol=rtol, atol=atol, equal_nan=equal_nan))
+        raise RuntimeError("NPU allclose requires on-device comparison support")
     from .math import abs, sub, mul, add
     from .math import isnan
     diff = abs(sub(a, b))

--- a/src/candle/_backends/npu/ops/elementwise.py
+++ b/src/candle/_backends/npu/ops/elementwise.py
@@ -215,15 +215,7 @@ def logaddexp2(a, b):
 
 
 def hypot(a, b):
-    import numpy as np
-    from ...._creation import tensor as create_tensor
-
-    # Match torch_npu behavior: aten::hypot.out falls back to CPU, then returns
-    # the result on the original NPU device with the original dtype.
-    a_cpu = a.to("cpu").numpy()
-    b_cpu = b.to("cpu").numpy()
-    out_cpu = np.hypot(a_cpu, b_cpu)
-    return create_tensor(out_cpu, dtype=a.dtype, device=a.device)
+    return sqrt(add(mul(a, a), mul(b, b)))
 
 
 def _remainder_310b_fallback(a, b):

--- a/src/candle/_backends/npu/ops/reduce.py
+++ b/src/candle/_backends/npu/ops/reduce.py
@@ -484,27 +484,17 @@ def minimum(a, b):
 
 
 def fmin(a, b):
-    import numpy as np
-    from ...._creation import tensor as create_tensor
+    from .comparison import le
+    from .elementwise import where
 
-    # Match torch_npu behavior: aten::fmin.out falls back to CPU, then returns
-    # the result on the original NPU device with the original dtype.
-    a_cpu = a.to("cpu").numpy()
-    b_cpu = b.to("cpu").numpy()
-    out_cpu = np.fmin(a_cpu, b_cpu)
-    return create_tensor(out_cpu, dtype=a.dtype, device=a.device)
+    return where(le(a, b), a, b)
 
 
 def fmax(a, b):
-    import numpy as np
-    from ...._creation import tensor as create_tensor
+    from .comparison import ge
+    from .elementwise import where
 
-    # Match torch_npu behavior: aten::fmax.out falls back to CPU, then returns
-    # the result on the original NPU device with the original dtype.
-    a_cpu = a.to("cpu").numpy()
-    b_cpu = b.to("cpu").numpy()
-    out_cpu = np.fmax(a_cpu, b_cpu)
-    return create_tensor(out_cpu, dtype=a.dtype, device=a.device)
+    return where(ge(a, b), a, b)
 
 
 def searchsorted(sorted_sequence, values, out_int32=False, right=False, side=None, sorter=None):

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -43,6 +43,13 @@ def test_cython_and_python_npu_dispatch_key_constants_stay_in_sync():
         assert re.search(pattern, core_src), f"_dispatcher_core.pyx {name} key constant drifted"
 
 
+def _function_source(src, name):
+    pattern = rf"^def {name}\(.*?(?=^def |\Z)"
+    match = re.search(pattern, src, flags=re.MULTILINE | re.DOTALL)
+    assert match is not None, f"missing function {name}"
+    return match.group(0)
+
+
 def test_npu_autograd_overrides_do_not_use_cpu_fallbacks():
     autograd_src = _source("src/candle/_backends/autograd.py")
     npu_override_src = autograd_src.split("# NPU ACLNN fused backward kernels", 1)[1]
@@ -50,6 +57,22 @@ def test_npu_autograd_overrides_do_not_use_cpu_fallbacks():
     forbidden = ["from .cpu", "import numpy", "_to_numpy", "_from_numpy"]
     for marker in forbidden:
         assert marker not in npu_override_src
+
+
+def test_npu_forward_paths_do_not_copy_registered_ops_to_cpu():
+    checked = {
+        "src/candle/_backends/npu/ops/comparison.py": ["allclose"],
+        "src/candle/_backends/npu/ops/elementwise.py": ["hypot"],
+        "src/candle/_backends/npu/ops/reduce.py": ["fmin", "fmax"],
+    }
+    forbidden = ['.to("cpu")', ".to('cpu')", "_copy_npu_to_cpu"]
+
+    for path, names in checked.items():
+        src = _source(path)
+        for name in names:
+            body = _function_source(src, name)
+            for marker in forbidden:
+                assert marker not in body
 
 
 def test_core_npu_training_ops_have_forward_and_autograd_registration():


### PR DESCRIPTION
## Summary
- Replace selected registered NPU forward CPU round-trips with on-device composites for `hypot`, `fmin`, and `fmax`
- Make the unsupported NPU `allclose` SoC fallback fail explicitly instead of copying tensors to CPU
- Extend the NPU mechanism audit to guard these registered forward paths against future CPU copies

## Test plan
- [x] `/home/jenkins/anaconda3/envs/candle311/bin/python -m pytest tests/contract/test_npu_mechanism_audit.py -v --tb=short`
- [x] `/home/jenkins/anaconda3/envs/candle311/bin/python -m pytest tests/contract/ -v --tb=short`
- [x] `/home/jenkins/anaconda3/envs/candle311/bin/pylint src/candle/ --rcfile=.github/pylint.conf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)