### PR TITLE
fix(npu): move hypot composite to Cython

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -3206,6 +3206,11 @@ def fast_sqrt(a):
     return _cy_make_npu_tensor(out_ptr, n, a_dtype, a_dev, out_shape, out_stride)
 
 
+def fast_hypot(a, b):
+    """NPU hypot(a, b) implemented as an on-device Cython composite."""
+    return fast_sqrt(fast_add(fast_mul(a, a), fast_mul(b, b)))
+
+
 def fast_sin(a):
     """Optimized out-of-place sin(a) that calls _ffi.unary_op directly."""
     _ensure_npu_imports()

--- a/src/candle/_backends/npu/ops/elementwise.py
+++ b/src/candle/_backends/npu/ops/elementwise.py
@@ -6,23 +6,27 @@ try:
         fast_lerp_scalar as _fast_lerp_scalar_impl,
         fast_addcmul as _fast_addcmul_impl,
         fast_addcdiv as _fast_addcdiv_impl,
+        fast_hypot as _fast_hypot_impl,
     )  # pylint: disable=import-error,no-name-in-module
     _HAS_FAST_WHERE = True
     _HAS_FAST_LERP_TENSOR = True
     _HAS_FAST_LERP_SCALAR = True
     _HAS_FAST_ADDCMUL = True
     _HAS_FAST_ADDCDIV = True
+    _HAS_FAST_HYPOT = True
 except ImportError:
     _fast_where_impl = None  # type: ignore[assignment]
     _fast_lerp_tensor_impl = None  # type: ignore[assignment]
     _fast_lerp_scalar_impl = None  # type: ignore[assignment]
     _fast_addcmul_impl = None  # type: ignore[assignment]
     _fast_addcdiv_impl = None  # type: ignore[assignment]
+    _fast_hypot_impl = None  # type: ignore[assignment]
     _HAS_FAST_WHERE = False
     _HAS_FAST_LERP_TENSOR = False
     _HAS_FAST_LERP_SCALAR = False
     _HAS_FAST_ADDCMUL = False
     _HAS_FAST_ADDCDIV = False
+    _HAS_FAST_HYPOT = False
 
 from ._helpers import (
     _unwrap_storage, _wrap_tensor, _unary_op, _binary_op,
@@ -215,7 +219,9 @@ def logaddexp2(a, b):
 
 
 def hypot(a, b):
-    return sqrt(add(mul(a, a), mul(b, b)))
+    if _HAS_FAST_HYPOT:
+        return _fast_hypot_impl(a, b)
+    raise RuntimeError("Cython NPU hypot implementation is unavailable")
 
 
 def _remainder_310b_fallback(a, b):

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -75,6 +75,14 @@ def test_npu_forward_paths_do_not_copy_registered_ops_to_cpu():
                 assert marker not in body
 
 
+def test_npu_operator_parity_shims_delegate_to_cython():
+    src = _source("src/candle/_backends/npu/ops/elementwise.py")
+    body = _function_source(src, "hypot")
+
+    assert "_fast_hypot_impl" in body
+    assert "sqrt(add(mul(" not in body
+
+
 def test_core_npu_training_ops_have_forward_and_autograd_registration():
     forward_ops = _npu_forward_ops()
     autograd_ops = _npu_autograd_ops()


### PR DESCRIPTION
## Summary
- Move the NPU `hypot` on-device composite behind a Cython `_npu_ops.fast_hypot` helper
- Keep the Python NPU backend as a thin shim that delegates to the Cython implementation
- Add a mechanism audit guard for NPU operator parity shims delegating to Cython

## Test plan
- [x] `PYTHONPATH="$PWD/src" /home/jenkins/anaconda3/envs/candle311/bin/python setup.py build_ext --inplace`
- [x] `PYTHONPATH="$PWD/src" /home/jenkins/anaconda3/envs/candle311/bin/python -m pytest tests/contract/test_npu_mechanism_audit.py -v --tb=short`
- [x] `PYTHONPATH="$PWD/src" /home/jenkins/anaconda3/envs/candle311/bin/python -m pytest tests/contract/ -v --tb=short`
- [x] `PYTHONPATH="$PWD/src" /home/jenkins/anaconda3/envs/candle311/bin/pylint src/candle/ --rcfile=.github/pylint.conf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)