### PR TITLE
fix(npu): move fmin fmax composites to Cython

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -3211,6 +3211,16 @@ def fast_hypot(a, b):
     return fast_sqrt(fast_add(fast_mul(a, a), fast_mul(b, b)))
 
 
+def fast_fmin(a, b):
+    """NPU fmin(a, b) implemented as an on-device Cython composite."""
+    return fast_where(fast_binary_op(a, b, None, "le"), a, b)
+
+
+def fast_fmax(a, b):
+    """NPU fmax(a, b) implemented as an on-device Cython composite."""
+    return fast_where(fast_binary_op(a, b, None, "ge"), a, b)
+
+
 def fast_sin(a):
     """Optimized out-of-place sin(a) that calls _ffi.unary_op directly."""
     _ensure_npu_imports()

--- a/src/candle/_backends/npu/ops/reduce.py
+++ b/src/candle/_backends/npu/ops/reduce.py
@@ -1,4 +1,17 @@
 """Reduction and cumulative operations for NPU."""
+try:
+    from candle._C._npu_ops import (  # pylint: disable=import-error,no-name-in-module
+        fast_fmin as _fast_fmin_impl,
+        fast_fmax as _fast_fmax_impl,
+    )
+    _HAS_FAST_FMIN = True
+    _HAS_FAST_FMAX = True
+except ImportError:
+    _fast_fmin_impl = None  # type: ignore[assignment]
+    _fast_fmax_impl = None  # type: ignore[assignment]
+    _HAS_FAST_FMIN = False
+    _HAS_FAST_FMAX = False
+
 from ._helpers import (
     _unwrap_storage, _wrap_tensor, _unary_op, _binary_op,
     _broadcast_shape, _broadcast_shape_checked,
@@ -484,17 +497,15 @@ def minimum(a, b):
 
 
 def fmin(a, b):
-    from .comparison import le
-    from .elementwise import where
-
-    return where(le(a, b), a, b)
+    if _HAS_FAST_FMIN:
+        return _fast_fmin_impl(a, b)
+    raise RuntimeError("Cython NPU fmin implementation is unavailable")
 
 
 def fmax(a, b):
-    from .comparison import ge
-    from .elementwise import where
-
-    return where(ge(a, b), a, b)
+    if _HAS_FAST_FMAX:
+        return _fast_fmax_impl(a, b)
+    raise RuntimeError("Cython NPU fmax implementation is unavailable")
 
 
 def searchsorted(sorted_sequence, values, out_int32=False, right=False, side=None, sorter=None):

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -76,11 +76,17 @@ def test_npu_forward_paths_do_not_copy_registered_ops_to_cpu():
 
 
 def test_npu_operator_parity_shims_delegate_to_cython():
-    src = _source("src/candle/_backends/npu/ops/elementwise.py")
-    body = _function_source(src, "hypot")
+    elementwise_src = _source("src/candle/_backends/npu/ops/elementwise.py")
+    reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
 
-    assert "_fast_hypot_impl" in body
-    assert "sqrt(add(mul(" not in body
+    hypot_body = _function_source(elementwise_src, "hypot")
+    assert "_fast_hypot_impl" in hypot_body
+    assert "sqrt(add(mul(" not in hypot_body
+
+    for name, fast_name in {"fmin": "_fast_fmin_impl", "fmax": "_fast_fmax_impl"}.items():
+        body = _function_source(reduce_src, name)
+        assert fast_name in body
+        assert "where(" not in body
 
 
 def test_core_npu_training_ops_have_forward_and_autograd_registration():


### PR DESCRIPTION
## Summary
- move NPU `fmin` and `fmax` parity composites into the Cython `_npu_ops` layer
- keep Python NPU reduce shims as thin delegates to Cython implementations
- extend the NPU mechanism audit to guard against reintroducing Python-side composites

## Test plan
- [x] `PYTHONPATH="$PWD/src" /home/jenkins/anaconda3/envs/candle311/bin/python setup.py build_ext --inplace`
- [x] `PYTHONPATH="$PWD/src" /home/jenkins/anaconda3/envs/candle311/bin/python -m pytest tests/contract/test_npu_mechanism_audit.py -v --tb=short`
- [x] `PYTHONPATH="$PWD/src" /home/jenkins/anaconda3/envs/candle311/bin/python -m pytest tests/contract/ -v --tb=short`
- [x] `PYTHONPATH="$PWD/src" /home/jenkins/anaconda3/envs/candle311/bin/pylint src/candle/ --rcfile=.github/pylint.conf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)