### PR TITLE
fix(npu): move activation composites to Cython

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -3221,6 +3221,85 @@ def fast_fmax(a, b):
     return fast_where(fast_binary_op(a, b, None, "ge"), a, b)
 
 
+def _npu_scalar_like(value, a):
+    from candle._backends.npu.ops._helpers import _scalar_to_npu_tensor
+    return _scalar_to_npu_tensor(value, a)
+
+
+def fast_relu6(a):
+    zero = _npu_scalar_like(0.0, a)
+    six = _npu_scalar_like(6.0, a)
+    return fast_binary_op(fast_binary_op(a, zero, None, "maximum"), six, None, "minimum")
+
+
+def fast_selu(a):
+    alpha = 1.6732632423543772848170429916717
+    scale = 1.0507009873554804934193349852946
+    return fast_mul(fast_elu(a, alpha), _npu_scalar_like(scale, a))
+
+
+def fast_celu(a, alpha=1.0):
+    inv_alpha = _npu_scalar_like(1.0 / alpha, a)
+    alpha_t = _npu_scalar_like(alpha, a)
+    one = _npu_scalar_like(1.0, a)
+    zero = _npu_scalar_like(0.0, a)
+    exp_part = fast_sub(fast_exp(fast_mul(a, inv_alpha)), one)
+    neg_part = fast_mul(alpha_t, fast_binary_op(exp_part, zero, None, "minimum"))
+    pos_part = fast_binary_op(a, zero, None, "maximum")
+    return fast_add(pos_part, neg_part)
+
+
+def fast_threshold(a, threshold_val, value):
+    thresh_t = _npu_scalar_like(threshold_val, a)
+    value_t = _npu_scalar_like(value, a)
+    return fast_where(fast_binary_op(a, thresh_t, None, "gt"), a, value_t)
+
+
+def fast_hardshrink(a, lambd=0.5):
+    zero = _npu_scalar_like(0.0, a)
+    lambd_t = _npu_scalar_like(lambd, a)
+    return fast_where(fast_binary_op(fast_abs(a), lambd_t, None, "gt"), a, zero)
+
+
+def fast_softshrink(a, lambd=0.5):
+    zero = _npu_scalar_like(0.0, a)
+    lambd_t = _npu_scalar_like(lambd, a)
+    neg_lambd_t = _npu_scalar_like(-lambd, a)
+    pos_mask = fast_binary_op(a, lambd_t, None, "gt")
+    neg_mask = fast_binary_op(a, neg_lambd_t, None, "lt")
+    result = fast_where(pos_mask, fast_sub(a, lambd_t), zero)
+    return fast_where(neg_mask, fast_add(a, lambd_t), result)
+
+
+def _fast_clamp06(t):
+    zero = _npu_scalar_like(0.0, t)
+    six = _npu_scalar_like(6.0, t)
+    return fast_binary_op(fast_binary_op(t, zero, None, "maximum"), six, None, "minimum")
+
+
+def fast_hardswish(a):
+    three = _npu_scalar_like(3.0, a)
+    six = _npu_scalar_like(6.0, a)
+    return fast_div(fast_mul(a, _fast_clamp06(fast_add(a, three))), six)
+
+
+def fast_hardsigmoid(a):
+    three = _npu_scalar_like(3.0, a)
+    six = _npu_scalar_like(6.0, a)
+    return fast_div(_fast_clamp06(fast_add(a, three)), six)
+
+
+def fast_softsign(a):
+    one = _npu_scalar_like(1.0, a)
+    return fast_div(a, fast_add(one, fast_abs(a)))
+
+
+def fast_rrelu(a, lower=0.125, upper=0.3333333333333333, training=False):
+    zero = _npu_scalar_like(0.0, a)
+    slope_t = _npu_scalar_like((lower + upper) / 2.0, a)
+    return fast_where(fast_binary_op(a, zero, None, "gt"), a, fast_mul(a, slope_t))
+
+
 def fast_sin(a):
     """Optimized out-of-place sin(a) that calls _ffi.unary_op directly."""
     _ensure_npu_imports()

--- a/src/candle/_backends/npu/ops/activation.py
+++ b/src/candle/_backends/npu/ops/activation.py
@@ -91,6 +91,33 @@ except ImportError:
     _fast_mish_impl = None  # type: ignore[assignment]
     _HAS_FAST_MISH = False
 
+try:
+    from candle._C._npu_ops import (  # pylint: disable=import-error,no-name-in-module
+        fast_relu6 as _fast_relu6_impl,
+        fast_selu as _fast_selu_impl,
+        fast_celu as _fast_celu_impl,
+        fast_threshold as _fast_threshold_impl,
+        fast_hardshrink as _fast_hardshrink_impl,
+        fast_softshrink as _fast_softshrink_impl,
+        fast_hardswish as _fast_hardswish_impl,
+        fast_hardsigmoid as _fast_hardsigmoid_impl,
+        fast_softsign as _fast_softsign_impl,
+        fast_rrelu as _fast_rrelu_impl,
+    )
+    _HAS_FAST_ACTIVATION_COMPOSITES = True
+except ImportError:
+    _fast_relu6_impl = None  # type: ignore[assignment]
+    _fast_selu_impl = None  # type: ignore[assignment]
+    _fast_celu_impl = None  # type: ignore[assignment]
+    _fast_threshold_impl = None  # type: ignore[assignment]
+    _fast_hardshrink_impl = None  # type: ignore[assignment]
+    _fast_softshrink_impl = None  # type: ignore[assignment]
+    _fast_hardswish_impl = None  # type: ignore[assignment]
+    _fast_hardsigmoid_impl = None  # type: ignore[assignment]
+    _fast_softsign_impl = None  # type: ignore[assignment]
+    _fast_rrelu_impl = None  # type: ignore[assignment]
+    _HAS_FAST_ACTIVATION_COMPOSITES = False
+
 from ._helpers import (
     _unwrap_storage, _wrap_tensor, _unary_op, _binary_op,
     _broadcast_shape, _broadcast_shape_checked,
@@ -178,7 +205,9 @@ def relu_(a):
 
 
 def relu6(a):
-    return clamp(a, 0.0, 6.0)
+    if _HAS_FAST_ACTIVATION_COMPOSITES:
+        return _fast_relu6_impl(a)
+    raise RuntimeError("Cython NPU relu6 implementation is unavailable")
 
 
 def softplus(a, beta=1.0, threshold=20.0):
@@ -395,78 +424,65 @@ def prelu(a, weight):
 
 def selu_op(a):
     """SELU activation: scale * (max(0,x) + min(0, alpha*(exp(x)-1)))."""
-    _alpha = 1.6732632423543772848170429916717
-    _scale = 1.0507009873554804934193349852946
-    return mul(elu(a, alpha=_alpha), _scalar_to_npu_tensor(_scale, a))
+    if _HAS_FAST_ACTIVATION_COMPOSITES:
+        return _fast_selu_impl(a)
+    raise RuntimeError("Cython NPU selu implementation is unavailable")
 
 
 def celu_op(a, alpha=1.0):
     """CELU activation: max(0,x) + min(0, alpha*(exp(x/alpha)-1))."""
-    inv_alpha = _scalar_to_npu_tensor(1.0 / alpha, a)
-    alpha_t = _scalar_to_npu_tensor(alpha, a)
-    one = _scalar_to_npu_tensor(1.0, a)
-    zero = _scalar_to_npu_tensor(0.0, a)
-    # exp(x / alpha) - 1
-    exp_part = sub(exp(mul(a, inv_alpha)), one)
-    neg_part = mul(alpha_t, minimum(exp_part, zero))
-    pos_part = maximum(a, zero)
-    return add(pos_part, neg_part)
+    if _HAS_FAST_ACTIVATION_COMPOSITES:
+        return _fast_celu_impl(a, float(alpha))
+    raise RuntimeError("Cython NPU celu implementation is unavailable")
 
 
 def threshold_op(a, threshold_val, value):
     """Threshold: x if x > threshold else value."""
-    thresh_t = _scalar_to_npu_tensor(threshold_val, a)
-    value_t = _scalar_to_npu_tensor(value, a)
-    mask = gt(a, thresh_t)
-    return where(mask, a, value_t)
+    if _HAS_FAST_ACTIVATION_COMPOSITES:
+        return _fast_threshold_impl(a, float(threshold_val), float(value))
+    raise RuntimeError("Cython NPU threshold implementation is unavailable")
 
 
 def hardshrink_op(a, lambd=0.5):
     """Hard shrink: x if |x| > lambd else 0."""
-    zero = _scalar_to_npu_tensor(0.0, a)
-    lambd_t = _scalar_to_npu_tensor(lambd, a)
-    mask = gt(abs(a), lambd_t)
-    return where(mask, a, zero)
+    if _HAS_FAST_ACTIVATION_COMPOSITES:
+        return _fast_hardshrink_impl(a, float(lambd))
+    raise RuntimeError("Cython NPU hardshrink implementation is unavailable")
 
 
 def softshrink_op(a, lambd=0.5):
     """Soft shrink: x-lambd if x>lambd, x+lambd if x<-lambd, else 0."""
-    zero = _scalar_to_npu_tensor(0.0, a)
-    lambd_t = _scalar_to_npu_tensor(lambd, a)
-    neg_lambd_t = _scalar_to_npu_tensor(-lambd, a)
-    pos_mask = gt(a, lambd_t)
-    neg_mask = lt(a, neg_lambd_t)
-    result = where(pos_mask, sub(a, lambd_t), zero)
-    return where(neg_mask, add(a, lambd_t), result)
+    if _HAS_FAST_ACTIVATION_COMPOSITES:
+        return _fast_softshrink_impl(a, float(lambd))
+    raise RuntimeError("Cython NPU softshrink implementation is unavailable")
 
 
 def hardswish_op(a):
     """HardSwish: x * clamp(x + 3, 0, 6) / 6."""
-    three = _scalar_to_npu_tensor(3.0, a)
-    six = _scalar_to_npu_tensor(6.0, a)
-    return div(mul(a, clamp(add(a, three), min_val=0.0, max_val=6.0)), six)
+    if _HAS_FAST_ACTIVATION_COMPOSITES:
+        return _fast_hardswish_impl(a)
+    raise RuntimeError("Cython NPU hardswish implementation is unavailable")
 
 
 def hardsigmoid_op(a):
     """HardSigmoid: clamp(x + 3, 0, 6) / 6."""
-    six = _scalar_to_npu_tensor(6.0, a)
-    three = _scalar_to_npu_tensor(3.0, a)
-    return div(clamp(add(a, three), min_val=0.0, max_val=6.0), six)
+    if _HAS_FAST_ACTIVATION_COMPOSITES:
+        return _fast_hardsigmoid_impl(a)
+    raise RuntimeError("Cython NPU hardsigmoid implementation is unavailable")
 
 
 def softsign_op(a):
     """Softsign: x / (1 + |x|)."""
-    one = _scalar_to_npu_tensor(1.0, a)
-    return div(a, add(one, abs(a)))
+    if _HAS_FAST_ACTIVATION_COMPOSITES:
+        return _fast_softsign_impl(a)
+    raise RuntimeError("Cython NPU softsign implementation is unavailable")
 
 
 def rrelu_op(a, lower=0.125, upper=0.3333333333333333, training=False):
     """RReLU: if training, random slope from [lower, upper]; else fixed (lower+upper)/2."""
-    zero = _scalar_to_npu_tensor(0.0, a)
-    slope = (lower + upper) / 2.0
-    slope_t = _scalar_to_npu_tensor(slope, a)
-    mask = gt(a, zero)
-    return where(mask, a, mul(a, slope_t))
+    if _HAS_FAST_ACTIVATION_COMPOSITES:
+        return _fast_rrelu_impl(a, float(lower), float(upper), bool(training))
+    raise RuntimeError("Cython NPU rrelu implementation is unavailable")
 
 
 def softmax(a, dim=-1):

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -78,6 +78,7 @@ def test_npu_forward_paths_do_not_copy_registered_ops_to_cpu():
 def test_npu_operator_parity_shims_delegate_to_cython():
     elementwise_src = _source("src/candle/_backends/npu/ops/elementwise.py")
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
+    activation_src = _source("src/candle/_backends/npu/ops/activation.py")
 
     hypot_body = _function_source(elementwise_src, "hypot")
     assert "_fast_hypot_impl" in hypot_body
@@ -87,6 +88,25 @@ def test_npu_operator_parity_shims_delegate_to_cython():
         body = _function_source(reduce_src, name)
         assert fast_name in body
         assert "where(" not in body
+
+    activation_fast_names = {
+        "relu6": "_fast_relu6_impl",
+        "selu_op": "_fast_selu_impl",
+        "celu_op": "_fast_celu_impl",
+        "threshold_op": "_fast_threshold_impl",
+        "hardshrink_op": "_fast_hardshrink_impl",
+        "softshrink_op": "_fast_softshrink_impl",
+        "hardswish_op": "_fast_hardswish_impl",
+        "hardsigmoid_op": "_fast_hardsigmoid_impl",
+        "softsign_op": "_fast_softsign_impl",
+        "rrelu_op": "_fast_rrelu_impl",
+    }
+    forbidden = ["return where(", "return clamp(", "= where(", "= clamp(", "return mul(", "return div(", "return add(", "return sub("]
+    for name, fast_name in activation_fast_names.items():
+        body = _function_source(activation_src, name)
+        assert fast_name in body
+        for marker in forbidden:
+            assert marker not in body
 
 
 def test_core_npu_training_ops_have_forward_and_autograd_registration():


### PR DESCRIPTION
## Summary
- migrate `relu6` / `selu` / `celu` / `threshold` / `hardshrink` / `softshrink` / `hardswish` / `hardsigmoid` / `softsign` / `rrelu` NPU parity composites into the Cython `_npu_ops` layer
- keep the Python NPU activation module as thin delegates that error if the Cython backend is missing
- extend the NPU mechanism audit so each migrated shim is locked to its Cython `fast_*` implementation

## Test plan
- [x] `PYTHONPATH="$PWD/src" python setup.py build_ext --inplace`
- [x] `PYTHONPATH="$PWD/src" python -m pytest tests/contract/test_npu_mechanism_audit.py -v --tb=short`
- [x] `PYTHONPATH="$PWD/src" python -m pytest tests/contract/ -v --tb=short` (947 passed, 5 skipped)
- [x] `PYTHONPATH="$PWD/src" pylint src/candle/ --rcfile=.github/pylint.conf` (10.00/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)