### PR TITLE
fix(npu): avoid fmin/fmax where-chain segfault

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -3212,13 +3212,23 @@ def fast_hypot(a, b):
 
 
 def fast_fmin(a, b):
-    """NPU fmin(a, b) implemented as an on-device Cython composite."""
-    return fast_where(fast_binary_op(a, b, None, "le"), a, b)
+    """NPU fmin(a, b) routed through aclnnMinimum.
+
+    Note: PyTorch fmin differs from min in NaN handling (fmin(x, NaN) = x).
+    We currently treat fmin as minimum because the previous SWhere-based
+    composite segfaults on 310B; NaN-aware semantics will be revisited.
+    """
+    return fast_binary_op(a, b, None, "minimum")
 
 
 def fast_fmax(a, b):
-    """NPU fmax(a, b) implemented as an on-device Cython composite."""
-    return fast_where(fast_binary_op(a, b, None, "ge"), a, b)
+    """NPU fmax(a, b) routed through aclnnMaximum.
+
+    Note: PyTorch fmax differs from max in NaN handling (fmax(x, NaN) = x).
+    We currently treat fmax as maximum because the previous SWhere-based
+    composite segfaults on 310B; NaN-aware semantics will be revisited.
+    """
+    return fast_binary_op(a, b, None, "maximum")
 
 
 def fast_sin(a):


### PR DESCRIPTION
## Summary
- route Cython NPU `fast_fmin` / `fast_fmax` through `aclnnMinimum` / `aclnnMaximum`
- avoid the 310B segfault seen in the previous bool-mask + `fast_where` composite path
- keep the implementation on-device and in Cython while leaving NaN-aware `fmin` / `fmax` semantics for a separate follow-up

## Test plan
- [x] `PYTHONPATH="$PWD/src" python setup.py build_ext --inplace`
- [x] `PYTHONPATH="$PWD/src" python -m pytest tests/contract/test_npu_mechanism_audit.py -v --tb=short`
- [x] `PYTHONPATH="$PWD/src" python -m pytest tests/contract/ -v --tb=short` (947 passed, 5 skipped)
- [x] `PYTHONPATH="$PWD/src" pylint src/candle/ --rcfile=.github/pylint.conf` (10.00/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)