### PR TITLE
fix(npu): move frac and reciprocal composites to Cython

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -3310,6 +3310,14 @@ def fast_rrelu(a, lower=0.125, upper=0.3333333333333333, training=False):
     return fast_where(fast_binary_op(a, zero, None, "gt"), a, fast_mul(a, slope_t))
 
 
+def fast_frac(a):
+    return fast_add(a, fast_neg(fast_trunc(a)))
+
+
+def fast_reciprocal(a):
+    return fast_div(_npu_scalar_like(1.0, a), a)
+
+
 def fast_sin(a):
     """Optimized out-of-place sin(a) that calls _ffi.unary_op directly."""
     _ensure_npu_imports()

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -36,6 +36,7 @@ try:
         fast_exp2 as _fast_exp2_impl,
         fast_expm1 as _fast_expm1_impl,
         fast_floor as _fast_floor_impl,
+        fast_frac as _fast_frac_impl,
         fast_isfinite as _fast_isfinite_impl,
         fast_isneginf as _fast_isneginf_impl,
         fast_isposinf as _fast_isposinf_impl,
@@ -45,6 +46,7 @@ try:
         fast_log2 as _fast_log2_impl,
         fast_mul as _fast_mul_impl,
         fast_neg as _fast_neg_impl,
+        fast_reciprocal as _fast_reciprocal_impl,
         fast_round as _fast_round_impl,
         fast_rsqrt as _fast_rsqrt_impl,
         fast_sigmoid as _fast_sigmoid_impl,
@@ -83,6 +85,8 @@ try:
     _HAS_FAST_ERF = True
     _HAS_FAST_ERFC = True
     _HAS_FAST_FLOOR = True
+    _HAS_FAST_FRAC = True
+    _HAS_FAST_RECIPROCAL = True
     _HAS_FAST_CEIL = True
     _HAS_FAST_ROUND = True
     _HAS_FAST_TRUNC = True
@@ -122,6 +126,8 @@ except ImportError:
     _fast_erf_impl = None  # type: ignore[assignment]
     _fast_erfc_impl = None  # type: ignore[assignment]
     _fast_floor_impl = None  # type: ignore[assignment]
+    _fast_frac_impl = None  # type: ignore[assignment]
+    _fast_reciprocal_impl = None  # type: ignore[assignment]
     _fast_ceil_impl = None  # type: ignore[assignment]
     _fast_round_impl = None  # type: ignore[assignment]
     _fast_trunc_impl = None  # type: ignore[assignment]
@@ -160,6 +166,8 @@ except ImportError:
     _HAS_FAST_ERF = False
     _HAS_FAST_ERFC = False
     _HAS_FAST_FLOOR = False
+    _HAS_FAST_FRAC = False
+    _HAS_FAST_RECIPROCAL = False
     _HAS_FAST_CEIL = False
     _HAS_FAST_ROUND = False
     _HAS_FAST_TRUNC = False
@@ -590,17 +598,9 @@ def trunc(a):
 
 
 def frac(a):
-    if _use_soc_fallback("frac"):
-        # TODO: re-enable native kernel when CANN fixes aclnnFrac on 910A (561000)
-        out = trunc(a)
-        return add(a, neg(out))
-    try:
-        return _unary_op(a, aclnn.frac, "frac")
-    except RuntimeError as exc:
-        if "561103" not in str(exc):
-            raise
-    out = trunc(a)
-    return add(a, neg(out))
+    if _HAS_FAST_FRAC:
+        return _fast_frac_impl(a)
+    raise RuntimeError("Cython NPU frac implementation is unavailable")
 
 
 def log2(a):
@@ -712,7 +712,9 @@ def _pow_tensor_scalar_op(a, exponent):
 
 
 def reciprocal(a):
-    return pow(a, -1.0)
+    if _HAS_FAST_RECIPROCAL:
+        return _fast_reciprocal_impl(a)
+    raise RuntimeError("Cython NPU reciprocal implementation is unavailable")
 
 
 def pow(a, b):

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -79,6 +79,7 @@ def test_npu_operator_parity_shims_delegate_to_cython():
     elementwise_src = _source("src/candle/_backends/npu/ops/elementwise.py")
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
     activation_src = _source("src/candle/_backends/npu/ops/activation.py")
+    math_src = _source("src/candle/_backends/npu/ops/math.py")
 
     hypot_body = _function_source(elementwise_src, "hypot")
     assert "_fast_hypot_impl" in hypot_body
@@ -104,6 +105,12 @@ def test_npu_operator_parity_shims_delegate_to_cython():
     forbidden = ["return where(", "return clamp(", "= where(", "= clamp(", "return mul(", "return div(", "return add(", "return sub("]
     for name, fast_name in activation_fast_names.items():
         body = _function_source(activation_src, name)
+        assert fast_name in body
+        for marker in forbidden:
+            assert marker not in body
+
+    for name, fast_name in {"frac": "_fast_frac_impl", "reciprocal": "_fast_reciprocal_impl"}.items():
+        body = _function_source(math_src, name)
         assert fast_name in body
         for marker in forbidden:
             assert marker not in body


### PR DESCRIPTION
## Summary
- move NPU `frac` and `reciprocal` composites into the Cython `_npu_ops` layer
- keep Python math shims as thin delegates that fail explicitly if Cython is unavailable
- extend the NPU mechanism audit to guard the new math shims against Python-side composites

## Test plan
- [x] `PYTHONPATH="$PWD/src" python setup.py build_ext --inplace`
- [x] `PYTHONPATH="$PWD/src" python -m pytest tests/contract/test_npu_mechanism_audit.py -v --tb=short` (6 passed)
- [x] `PYTHONPATH="$PWD/src" python -m pytest tests/contract/ -v --tb=short` (947 passed, 5 skipped)
- [x] `PYTHONPATH="$PWD/src" pylint src/candle/ --rcfile=.github/pylint.conf` (10.00/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)