### PR TITLE
refactor(npu): hard-delegate unary wrappers to Cython

### DIFF
--- a/src/candle/_backends/npu/ops/activation.py
+++ b/src/candle/_backends/npu/ops/activation.py
@@ -374,103 +374,21 @@ def rrelu_op(a, lower=0.125, upper=0.3333333333333333, training=False):
 
 
 def softmax(a, dim=-1):
-    """Compute softmax along a dimension using aclnnSoftmax."""
-    if not aclnn.softmax_symbols_ok():
-        raise RuntimeError("aclnnSoftmax not available")
     if _HAS_FAST_SOFTMAX:
         return _fast_softmax_impl(a, dim)
-
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
-
-    # Normalize dim
-    if dim < 0:
-        dim += len(a.shape)
-
-    out_shape = a.shape
-    out_stride = npu_runtime._contiguous_stride(out_shape)
-    out_numel = _numel(out_shape)
-    itemsize = _dtype_itemsize(a.dtype)
-    out_ptr = npu_runtime._alloc_device(out_numel * itemsize, runtime=runtime)
-
-    aclnn.softmax(
-        _unwrap_storage(a).data_ptr(),
-        out_ptr,
-        a.shape, a.stride, a.dtype,
-        dim,
-        runtime, stream=stream.stream
-    )
-
-    out_storage = npu_typed_storage_from_ptr(out_ptr, out_numel, a.dtype, device=a.device)
-    return _wrap_tensor(out_storage, out_shape, out_stride)
+    raise RuntimeError("Cython NPU softmax implementation is unavailable")
 
 
 def log_softmax(a, dim=-1):
-    """Compute log_softmax along a dimension using aclnnLogSoftmax."""
-    if not aclnn.log_softmax_symbols_ok():
-        raise RuntimeError("aclnnLogSoftmax not available")
     if _HAS_FAST_LOG_SOFTMAX:
         return _fast_log_softmax_impl(a, dim)
-
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
-
-    # Normalize dim
-    if dim < 0:
-        dim += len(a.shape)
-
-    out_shape = a.shape
-    out_stride = npu_runtime._contiguous_stride(out_shape)
-    out_numel = _numel(out_shape)
-    itemsize = _dtype_itemsize(a.dtype)
-    out_ptr = npu_runtime._alloc_device(out_numel * itemsize, runtime=runtime)
-
-    aclnn.log_softmax(
-        _unwrap_storage(a).data_ptr(),
-        out_ptr,
-        a.shape, a.stride, a.dtype,
-        dim,
-        runtime, stream=stream.stream
-    )
-
-    out_storage = npu_typed_storage_from_ptr(out_ptr, out_numel, a.dtype, device=a.device)
-    return _wrap_tensor(out_storage, out_shape, out_stride)
+    raise RuntimeError("Cython NPU log_softmax implementation is unavailable")
 
 
 def embedding(weight, indices, padding_idx=None, scale_grad_by_freq=False, sparse=False):
-    """Compute embedding lookup using aclnnEmbedding."""
-    runtime = npu_runtime.get_runtime((weight.device.index or 0))
-    stream = npu_state.current_stream((weight.device.index or 0))
-
-    if not aclnn.embedding_symbols_ok():
-        raise RuntimeError("aclnnEmbedding not available")
     if _HAS_FAST_EMBEDDING:
         return _fast_embedding_impl(weight, indices)
-
-    # Output shape: indices.shape + (embedding_dim,)
-    embedding_dim = weight.shape[1] if len(weight.shape) > 1 else weight.shape[0]
-    out_shape = indices.shape + (embedding_dim,)
-    out_stride = npu_runtime._contiguous_stride(out_shape)
-    out_numel = _numel(out_shape)
-    itemsize = _dtype_itemsize(weight.dtype)
-    out_ptr = npu_runtime._alloc_device(out_numel * itemsize, runtime=runtime)
-
-    # Note: aclnnEmbedding doesn't support padding_idx, scale_grad_by_freq, sparse parameters
-    # These are ignored for now
-    aclnn.embedding(
-        _unwrap_storage(weight).data_ptr(),
-        _unwrap_storage(indices).data_ptr(),
-        out_ptr,
-        weight.shape, weight.stride,
-        indices.shape, indices.stride,
-        out_shape, out_stride,
-        weight.dtype,
-        indices.dtype,
-        runtime, stream=stream.stream
-    )
-
-    out_storage = npu_typed_storage_from_ptr(out_ptr, out_numel, weight.dtype, device=weight.device)
-    return _wrap_tensor(out_storage, out_shape, out_stride)
+    raise RuntimeError("Cython NPU embedding implementation is unavailable")
 
 
 def _dropout_310b_mask(a, keep_prob):

--- a/src/candle/_backends/npu/ops/comparison.py
+++ b/src/candle/_backends/npu/ops/comparison.py
@@ -142,7 +142,7 @@ def logical_or(a, b):
 def logical_not(a):
     if _HAS_FAST_LOGICAL_NOT:
         return _fast_logical_not_impl(a)
-    return _unary_op(a, aclnn.logical_not, "logical_not", out_dtype=bool_dtype)
+    raise RuntimeError("Cython NPU logical_not implementation is unavailable")
 
 
 def logical_xor(a, b):

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -364,25 +364,25 @@ def div_(a, b):
 def abs(a):
     if _HAS_FAST_ABS:
         return _fast_abs_impl(a)
-    return _unary_op(a, aclnn.abs, "abs")
+    raise RuntimeError("Cython NPU abs implementation is unavailable")
 
 
 def neg(a):
     if _HAS_FAST_NEG:
         return _fast_neg_impl(a)
-    return _unary_op(a, aclnn.neg, "neg")
+    raise RuntimeError("Cython NPU neg implementation is unavailable")
 
 
 def sign(a):
     if _HAS_FAST_SIGN:
         return _fast_sign_impl(a)
-    return _unary_op(a, aclnn.sign, "sign")
+    raise RuntimeError("Cython NPU sign implementation is unavailable")
 
 
 def signbit(a):
     if _HAS_FAST_SIGNBIT:
         return _fast_signbit_impl(a)
-    return _unary_op(a, aclnn.signbit, "signbit", out_dtype=bool_dtype)
+    raise RuntimeError("Cython NPU signbit implementation is unavailable")
 
 
 def square(a):
@@ -403,7 +403,7 @@ def square(a):
 def isfinite(a):
     if _HAS_FAST_ISFINITE:
         return _fast_isfinite_impl(a)
-    return _unary_op(a, aclnn.isfinite, "isfinite", out_dtype=bool_dtype)
+    raise RuntimeError("Cython NPU isfinite implementation is unavailable")
 
 
 def isinf(a):
@@ -511,113 +511,109 @@ def isneginf(a):
 def exp(a):
     if _HAS_FAST_EXP:
         return _fast_exp_impl(a)
-    return _unary_op(a, aclnn.exp, "exp")
+    raise RuntimeError("Cython NPU exp implementation is unavailable")
 
 
 def log(a):
     if _HAS_FAST_LOG:
         return _fast_log_impl(a)
-    return _unary_op(a, aclnn.log, "log")
+    raise RuntimeError("Cython NPU log implementation is unavailable")
 
 
 def expm1(a):
     if _HAS_FAST_EXPM1:
         return _fast_expm1_impl(a)
-    if not aclnn.expm1_symbols_ok():
-        raise RuntimeError("aclnnExpm1 symbols not available")
-    return _unary_op(a, aclnn.expm1, "expm1")
+    raise RuntimeError("Cython NPU expm1 implementation is unavailable")
 
 
 def log1p(a):
     if _HAS_FAST_LOG1P:
         return _fast_log1p_impl(a)
-    if not aclnn.log1p_symbols_ok():
-        raise RuntimeError("aclnnLog1p symbols not available")
-    return _unary_op(a, aclnn.log1p, "log1p")
+    raise RuntimeError("Cython NPU log1p implementation is unavailable")
 
 
 def sqrt(a):
     if _HAS_FAST_SQRT:
         return _fast_sqrt_impl(a)
-    return _unary_op(a, aclnn.sqrt, "sqrt")
+    raise RuntimeError("Cython NPU sqrt implementation is unavailable")
 
 
 def rsqrt(a):
     if _HAS_FAST_RSQRT:
         return _fast_rsqrt_impl(a)
-    return _unary_op(a, aclnn.rsqrt, "rsqrt")
+    raise RuntimeError("Cython NPU rsqrt implementation is unavailable")
 
 
 def sin(a):
     if _HAS_FAST_SIN:
         return _fast_sin_impl(a)
-    return _unary_op(a, aclnn.sin, "sin")
+    raise RuntimeError("Cython NPU sin implementation is unavailable")
 
 
 def cos(a):
     if _HAS_FAST_COS:
         return _fast_cos_impl(a)
-    return _unary_op(a, aclnn.cos, "cos")
+    raise RuntimeError("Cython NPU cos implementation is unavailable")
 
 
 def tan(a):
     if _HAS_FAST_TAN:
         return _fast_tan_impl(a)
-    return _unary_op(a, aclnn.tan, "tan")
+    raise RuntimeError("Cython NPU tan implementation is unavailable")
 
 
 def tanh(a):
     if _HAS_FAST_TANH:
         return _fast_tanh_impl(a)
-    return _unary_op(a, aclnn.tanh, "tanh")
+    raise RuntimeError("Cython NPU tanh implementation is unavailable")
 
 
 def sigmoid(a):
     if _HAS_FAST_SIGMOID:
         return _fast_sigmoid_impl(a)
-    return _unary_op(a, aclnn.sigmoid, "sigmoid")
+    raise RuntimeError("Cython NPU sigmoid implementation is unavailable")
 
 
 def sinh(a):
     if _HAS_FAST_SINH:
         return _fast_sinh_impl(a)
-    return _unary_op(a, aclnn.sinh, "sinh")
+    raise RuntimeError("Cython NPU sinh implementation is unavailable")
 
 
 def cosh(a):
     if _HAS_FAST_COSH:
         return _fast_cosh_impl(a)
-    return _unary_op(a, aclnn.cosh, "cosh")
+    raise RuntimeError("Cython NPU cosh implementation is unavailable")
 
 
 def erf(a):
     if _HAS_FAST_ERF:
         return _fast_erf_impl(a)
-    return _unary_op(a, aclnn.erf, "erf")
+    raise RuntimeError("Cython NPU erf implementation is unavailable")
 
 
 def erfc(a):
     if _HAS_FAST_ERFC:
         return _fast_erfc_impl(a)
-    return _unary_op(a, aclnn.erfc, "erfc")
+    raise RuntimeError("Cython NPU erfc implementation is unavailable")
 
 
 def floor(a):
     if _HAS_FAST_FLOOR:
         return _fast_floor_impl(a)
-    return _unary_op(a, aclnn.floor, "floor")
+    raise RuntimeError("Cython NPU floor implementation is unavailable")
 
 
 def ceil(a):
     if _HAS_FAST_CEIL:
         return _fast_ceil_impl(a)
-    return _unary_op(a, aclnn.ceil, "ceil")
+    raise RuntimeError("Cython NPU ceil implementation is unavailable")
 
 
 def round(a):
     if _HAS_FAST_ROUND:
         return _fast_round_impl(a)
-    return _unary_op(a, aclnn.round, "round")
+    raise RuntimeError("Cython NPU round implementation is unavailable")
 
 
 def trunc(a):
@@ -647,54 +643,55 @@ def frac(a):
 def log2(a):
     if _HAS_FAST_LOG2:
         return _fast_log2_impl(a)
-    return _unary_op(a, aclnn.log2, "log2")
+    raise RuntimeError("Cython NPU log2 implementation is unavailable")
 
 
 def log10(a):
     if _HAS_FAST_LOG10:
         return _fast_log10_impl(a)
-    return _unary_op(a, aclnn.log10, "log10")
+    raise RuntimeError("Cython NPU log10 implementation is unavailable")
 
 
 def exp2(a):
     if _HAS_FAST_EXP2:
         return _fast_exp2_impl(a)
-    return _unary_op(a, aclnn.exp2, "exp2")
+    raise RuntimeError("Cython NPU exp2 implementation is unavailable")
+
 
 def asinh(a):
     if _HAS_FAST_ASINH:
         return _fast_asinh_impl(a)
-    return _unary_op(a, aclnn.asinh, "asinh")
+    raise RuntimeError("Cython NPU asinh implementation is unavailable")
 
 
 def acosh(a):
     if _HAS_FAST_ACOSH:
         return _fast_acosh_impl(a)
-    return _unary_op(a, aclnn.acosh, "acosh")
+    raise RuntimeError("Cython NPU acosh implementation is unavailable")
 
 
 def atanh(a):
     if _HAS_FAST_ATANH:
         return _fast_atanh_impl(a)
-    return _unary_op(a, aclnn.atanh, "atanh")
+    raise RuntimeError("Cython NPU atanh implementation is unavailable")
 
 
 def atan(a):
     if _HAS_FAST_ATAN:
         return _fast_atan_impl(a)
-    return _unary_op(a, aclnn.atan, "atan")
+    raise RuntimeError("Cython NPU atan implementation is unavailable")
 
 
 def asin(a):
     if _HAS_FAST_ASIN:
         return _fast_asin_impl(a)
-    return _unary_op(a, aclnn.asin, "asin")
+    raise RuntimeError("Cython NPU asin implementation is unavailable")
 
 
 def acos(a):
     if _HAS_FAST_ACOS:
         return _fast_acos_impl(a)
-    return _unary_op(a, aclnn.acos, "acos")
+    raise RuntimeError("Cython NPU acos implementation is unavailable")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -200,6 +200,57 @@ def test_npu_thin_binary_wrappers_delegate_to_cython():
             assert "return _binary_op(" not in body
 
 
+def test_npu_unary_math_wrappers_delegate_to_cython():
+    math_src = _source("src/candle/_backends/npu/ops/math.py")
+    comparison_src = _source("src/candle/_backends/npu/ops/comparison.py")
+
+    math_expectations = {
+        "abs": "_fast_abs_impl",
+        "neg": "_fast_neg_impl",
+        "sign": "_fast_sign_impl",
+        "exp": "_fast_exp_impl",
+        "log": "_fast_log_impl",
+        "sqrt": "_fast_sqrt_impl",
+        "rsqrt": "_fast_rsqrt_impl",
+        "sin": "_fast_sin_impl",
+        "cos": "_fast_cos_impl",
+        "tan": "_fast_tan_impl",
+        "tanh": "_fast_tanh_impl",
+        "sigmoid": "_fast_sigmoid_impl",
+        "sinh": "_fast_sinh_impl",
+        "cosh": "_fast_cosh_impl",
+        "erf": "_fast_erf_impl",
+        "erfc": "_fast_erfc_impl",
+        "floor": "_fast_floor_impl",
+        "ceil": "_fast_ceil_impl",
+        "round": "_fast_round_impl",
+        "log2": "_fast_log2_impl",
+        "log10": "_fast_log10_impl",
+        "exp2": "_fast_exp2_impl",
+        "asinh": "_fast_asinh_impl",
+        "acosh": "_fast_acosh_impl",
+        "atanh": "_fast_atanh_impl",
+        "atan": "_fast_atan_impl",
+        "asin": "_fast_asin_impl",
+        "acos": "_fast_acos_impl",
+        "expm1": "_fast_expm1_impl",
+        "log1p": "_fast_log1p_impl",
+        "signbit": "_fast_signbit_impl",
+        "isfinite": "_fast_isfinite_impl",
+    }
+    forbidden = ["return _unary_op(", "aclnn.", "_wrap_tensor(", "npu_runtime._alloc_device", "_unwrap_storage("]
+    for name, fast_name in math_expectations.items():
+        body = _function_source(math_src, name)
+        assert fast_name in body, f"{name} does not delegate to {fast_name}"
+        for marker in forbidden:
+            assert marker not in body
+
+    logical_not_body = _function_source(comparison_src, "logical_not")
+    assert "_fast_logical_not_impl" in logical_not_body
+    for marker in forbidden:
+        assert marker not in logical_not_body
+
+
 def test_npu_activation_native_wrappers_delegate_to_cython():
     activation_src = _source("src/candle/_backends/npu/ops/activation.py")
     expectations = {
@@ -209,6 +260,9 @@ def test_npu_activation_native_wrappers_delegate_to_cython():
         "leaky_relu": "_fast_leaky_relu_impl",
         "elu": "_fast_elu_impl",
         "prelu": "_fast_prelu_impl",
+        "softmax": "_fast_softmax_impl",
+        "log_softmax": "_fast_log_softmax_impl",
+        "embedding": "_fast_embedding_impl",
     }
     forbidden = ["return _unary_op(", "aclnn.", "_wrap_tensor(", "npu_runtime._alloc_device", "_unwrap_storage("]
     for name, fast_name in expectations.items():


### PR DESCRIPTION
## Summary
- Hard-delegate NPU softmax, log_softmax, and embedding Python shims to existing Cython helpers.
- Hard-delegate 32 unary math wrappers and logical_not to existing Cython helpers, removing Python-side ACLNN fallback bodies.
- Extend the NPU mechanism audit so these wrappers cannot drift back into Python implementation logic.

## Test plan
- [x] `PYTHONPATH="$PWD/src" /home/jenkins/anaconda3/envs/candle311/bin/python -m pytest tests/contract/test_npu_mechanism_audit.py::test_npu_unary_math_wrappers_delegate_to_cython -v --tb=short`
- [x] `PYTHONPATH="$PWD/src" /home/jenkins/anaconda3/envs/candle311/bin/python -m pytest tests/contract/ -q --tb=short`
- [x] `PYTHONPATH="$PWD/src" /home/jenkins/anaconda3/envs/candle311/bin/python -m pytest tests/cpu/ -q --tb=short`
- [x] `PYTHONPATH="$PWD/src" /home/jenkins/anaconda3/envs/candle311/bin/pylint src/candle/_backends/npu/ops/activation.py src/candle/_backends/npu/ops/math.py src/candle/_backends/npu/ops/comparison.py tests/contract/test_npu_mechanism_audit.py --rcfile=.github/pylint.conf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)