### PR TITLE
refactor(npu): remove remaining fast-helper Python fallbacks

### DIFF
--- a/src/candle/_backends/npu/ops/comparison.py
+++ b/src/candle/_backends/npu/ops/comparison.py
@@ -155,11 +155,9 @@ def logical_xor(a, b):
 
 # Bitwise operations
 def bitwise_not(a):
-    if not aclnn.bitwise_not_symbols_ok():
-        raise RuntimeError("aclnnBitwiseNot symbols not available")
     if _HAS_FAST_BITWISE_NOT:
         return _fast_bitwise_not_impl(a)
-    return _unary_op(a, aclnn.bitwise_not, "bitwise_not")
+    raise RuntimeError("Cython NPU bitwise_not implementation is unavailable")
 
 
 def bitwise_and(a, b):

--- a/src/candle/_backends/npu/ops/elementwise.py
+++ b/src/candle/_backends/npu/ops/elementwise.py
@@ -173,53 +173,15 @@ def lerp(a, b, weight):
 
 
 def addcmul(a, b, c, value=1.0):
-    if hasattr(value, "shape"):
-        value = float(_to_numpy(value))
     if _HAS_FAST_ADDCMUL:
         return _fast_addcmul_impl(a, b, c, float(value))
-
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
-    a_storage = _unwrap_storage(a)
-    b_storage = _unwrap_storage(b)
-    c_storage = _unwrap_storage(c)
-    out_shape = _broadcast_shape(_broadcast_shape(a.shape, b.shape), c.shape)
-    out_stride = npu_runtime._contiguous_stride(out_shape)
-    out_size = _numel(out_shape) * _dtype_itemsize(a.dtype)
-    out_ptr = npu_runtime._alloc_device(out_size, runtime=runtime)
-    aclnn.addcmul(
-        a_storage.data_ptr(), b_storage.data_ptr(), c_storage.data_ptr(), out_ptr,
-        a.shape, a.stride, b.shape, b.stride,
-        c.shape, c.stride, out_shape, out_stride,
-        a.dtype, float(value), runtime, stream=stream.stream,
-    )
-    out_storage = npu_typed_storage_from_ptr(out_ptr, _numel(out_shape), a.dtype, device=a.device)
-    return _wrap_tensor(out_storage, out_shape, out_stride)
+    raise RuntimeError("Cython NPU addcmul implementation is unavailable")
 
 
 def addcdiv(a, b, c, value=1.0):
-    if hasattr(value, "shape"):
-        value = float(_to_numpy(value))
     if _HAS_FAST_ADDCDIV:
         return _fast_addcdiv_impl(a, b, c, float(value))
-
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
-    a_storage = _unwrap_storage(a)
-    b_storage = _unwrap_storage(b)
-    c_storage = _unwrap_storage(c)
-    out_shape = _broadcast_shape(_broadcast_shape(a.shape, b.shape), c.shape)
-    out_stride = npu_runtime._contiguous_stride(out_shape)
-    out_size = _numel(out_shape) * _dtype_itemsize(a.dtype)
-    out_ptr = npu_runtime._alloc_device(out_size, runtime=runtime)
-    aclnn.addcdiv(
-        a_storage.data_ptr(), b_storage.data_ptr(), c_storage.data_ptr(), out_ptr,
-        a.shape, a.stride, b.shape, b.stride,
-        c.shape, c.stride, out_shape, out_stride,
-        a.dtype, float(value), runtime, stream=stream.stream,
-    )
-    out_storage = npu_typed_storage_from_ptr(out_ptr, _numel(out_shape), a.dtype, device=a.device)
-    return _wrap_tensor(out_storage, out_shape, out_stride)
+    raise RuntimeError("Cython NPU addcdiv implementation is unavailable")
 
 
 def logaddexp(a, b):

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -212,7 +212,7 @@ def add(a, b):
         b = _scalar_to_npu_tensor(b, a)
     if _HAS_FAST_ADD:
         return _fast_add_impl(a, b)
-    return _binary_op(a, b, aclnn.add, "add")
+    raise RuntimeError("Cython NPU add implementation is unavailable")
 
 
 def mul(a, b):
@@ -220,7 +220,7 @@ def mul(a, b):
         b = _scalar_to_npu_tensor(b, a)
     if _HAS_FAST_MUL:
         return _fast_mul_impl(a, b)
-    return _binary_op(a, b, aclnn.mul, "mul")
+    raise RuntimeError("Cython NPU mul implementation is unavailable")
 
 
 def sub(a, b):

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -200,6 +200,41 @@ def test_npu_thin_binary_wrappers_delegate_to_cython():
             assert "return _binary_op(" not in body
 
 
+def test_npu_existing_fast_helpers_have_no_python_fallback_bodies():
+    math_src = _source("src/candle/_backends/npu/ops/math.py")
+    comparison_src = _source("src/candle/_backends/npu/ops/comparison.py")
+    elementwise_src = _source("src/candle/_backends/npu/ops/elementwise.py")
+
+    expectations = {
+        math_src: {
+            "add": "_fast_add_impl",
+            "mul": "_fast_mul_impl",
+        },
+        comparison_src: {
+            "bitwise_not": "_fast_bitwise_not_impl",
+        },
+        elementwise_src: {
+            "addcmul": "_fast_addcmul_impl",
+            "addcdiv": "_fast_addcdiv_impl",
+        },
+    }
+    forbidden = [
+        "return _unary_op(",
+        "return _binary_op(",
+        "aclnn.",
+        "_wrap_tensor(",
+        "npu_runtime._alloc_device",
+        "_unwrap_storage(",
+        "_to_numpy(",
+    ]
+    for src, mapping in expectations.items():
+        for name, fast_name in mapping.items():
+            body = _function_source(src, name)
+            assert fast_name in body, f"{name} does not delegate to {fast_name}"
+            for marker in forbidden:
+                assert marker not in body
+
+
 def test_npu_unary_math_wrappers_delegate_to_cython():
     math_src = _source("src/candle/_backends/npu/ops/math.py")
     comparison_src = _source("src/candle/_backends/npu/ops/comparison.py")


### PR DESCRIPTION
## Summary
- Hard-delegate NPU add/mul and bitwise_not to existing Cython helpers after RED audit coverage.
- Hard-delegate addcmul/addcdiv to existing Cython helpers and remove duplicate Python-side ACLNN allocation/fallback bodies.
- Extend NPU mechanism audit coverage so existing fast-helper wrappers cannot reintroduce Python fallback logic.

## Test plan
- [x] `PYTHONPATH="$PWD/src" /home/jenkins/anaconda3/envs/candle311/bin/python -m pytest tests/contract/test_npu_mechanism_audit.py::test_npu_existing_fast_helpers_have_no_python_fallback_bodies -v --tb=short`
- [x] `PYTHONPATH="$PWD/src" /home/jenkins/anaconda3/envs/candle311/bin/python -m pytest tests/contract/ -q --tb=short`
- [x] `PYTHONPATH="$PWD/src" /home/jenkins/anaconda3/envs/candle311/bin/python -m pytest tests/cpu/ -q --tb=short`
- [x] `PYTHONPATH="$PWD/src" /home/jenkins/anaconda3/envs/candle311/bin/pylint src/candle/_backends/npu/ops/math.py src/candle/_backends/npu/ops/comparison.py src/candle/_backends/npu/ops/elementwise.py tests/contract/test_npu_mechanism_audit.py --rcfile=.github/pylint.conf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)