### PR TITLE
refactor(npu): remove comparison symbol checks from Python

### DIFF
--- a/src/candle/_backends/npu/ops/comparison.py
+++ b/src/candle/_backends/npu/ops/comparison.py
@@ -78,8 +78,6 @@ from ._helpers import (
 def eq(a, b):
     if isinstance(b, (int, float, bool)):
         b = _scalar_to_npu_tensor(b, a)
-    if not aclnn.eq_tensor_symbols_ok():
-        raise RuntimeError("aclnnEqTensor symbols not available")
     if _HAS_FAST_EQ:
         return _fast_eq_impl(a, b)
     raise RuntimeError("Cython NPU eq implementation is unavailable")
@@ -88,8 +86,6 @@ def eq(a, b):
 def ne(a, b):
     if isinstance(b, (int, float, bool)):
         b = _scalar_to_npu_tensor(b, a)
-    if not aclnn.ne_tensor_symbols_ok():
-        raise RuntimeError("aclnnNeTensor symbols not available")
     if _HAS_FAST_NE:
         return _fast_ne_impl(a, b)
     raise RuntimeError("Cython NPU ne implementation is unavailable")
@@ -161,24 +157,18 @@ def bitwise_not(a):
 
 
 def bitwise_and(a, b):
-    if not aclnn.bitwise_and_symbols_ok():
-        raise RuntimeError("aclnnBitwiseAndTensor symbols not available")
     if _HAS_FAST_BITWISE_AND:
         return _fast_bitwise_and_impl(a, b)
     raise RuntimeError("Cython NPU bitwise_and implementation is unavailable")
 
 
 def bitwise_or(a, b):
-    if not aclnn.bitwise_or_symbols_ok():
-        raise RuntimeError("aclnnBitwiseOrTensor symbols not available")
     if _HAS_FAST_BITWISE_OR:
         return _fast_bitwise_or_impl(a, b)
     raise RuntimeError("Cython NPU bitwise_or implementation is unavailable")
 
 
 def bitwise_xor(a, b):
-    if not aclnn.bitwise_xor_symbols_ok():
-        raise RuntimeError("aclnnBitwiseXorTensor symbols not available")
     if _HAS_FAST_BITWISE_XOR:
         return _fast_bitwise_xor_impl(a, b)
     raise RuntimeError("Cython NPU bitwise_xor implementation is unavailable")

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -165,10 +165,12 @@ def test_npu_comparison_thin_wrappers_delegate_to_cython():
         "bitwise_or": "_fast_bitwise_or_impl",
         "bitwise_xor": "_fast_bitwise_xor_impl",
     }
+    forbidden = ["return _binary_op(", "aclnn.", "_unwrap_storage(", "_wrap_tensor(", "npu_runtime._alloc_device"]
     for name, fast_name in expectations.items():
         body = _function_source(comparison_src, name)
         assert fast_name in body, f"{name} does not delegate to {fast_name}"
-        assert "return _binary_op(" not in body
+        for marker in forbidden:
+            assert marker not in body
 
 
 def test_npu_thin_binary_wrappers_delegate_to_cython():


### PR DESCRIPTION
## Summary
- Remove Python-side ACLNN symbol checks from NPU comparison/bitwise thin wrappers that already delegate to Cython helpers.
- Strengthen the NPU mechanism audit so comparison wrappers cannot reintroduce Python backend execution or symbol-resolution logic.

## Test plan
- [x] `PYTHONPATH="$PWD/src" /home/jenkins/anaconda3/envs/candle311/bin/python -m pytest tests/contract/test_npu_mechanism_audit.py::test_npu_comparison_thin_wrappers_delegate_to_cython -v --tb=short`
- [x] `PYTHONPATH="$PWD/src" /home/jenkins/anaconda3/envs/candle311/bin/python -m pytest tests/contract/ -q --tb=short`
- [x] `PYTHONPATH="$PWD/src" /home/jenkins/anaconda3/envs/candle311/bin/python -m pytest tests/cpu/ -q --tb=short`
- [x] `PYTHONPATH="$PWD/src" /home/jenkins/anaconda3/envs/candle311/bin/pylint src/candle/_backends/npu/ops/comparison.py tests/contract/test_npu_mechanism_audit.py --rcfile=.github/pylint.conf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)