### PR TITLE
refactor(npu): remove SOC-guarded Python fallback bodies

### DIFF
--- a/src/candle/_backends/npu/ops/activation.py
+++ b/src/candle/_backends/npu/ops/activation.py
@@ -191,8 +191,6 @@ def relu6(a):
 
 
 def softplus(a, beta=1.0, threshold=20.0):
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
     if a.device.type != "npu":
         raise ValueError("NPU softplus expects NPU tensors")
 
@@ -210,23 +208,7 @@ def softplus(a, beta=1.0, threshold=20.0):
 
     if _HAS_FAST_SOFTPLUS:
         return _fast_softplus_impl(a, beta, threshold)
-
-    out_size = _numel(a.shape) * _dtype_itemsize(a.dtype)
-    out_ptr = npu_runtime._alloc_device(out_size, runtime=runtime)
-    storage = _unwrap_storage(a)
-    aclnn.softplus(
-        storage.data_ptr(),
-        out_ptr,
-        a.shape,
-        a.stride,
-        a.dtype,
-        beta,
-        threshold,
-        runtime,
-        stream=stream.stream,
-    )
-    out_storage = npu_typed_storage_from_ptr(out_ptr, _numel(a.shape), a.dtype, device=a.device)
-    return _wrap_tensor(out_storage, a.shape, a.stride)
+    raise RuntimeError("Cython NPU softplus implementation is unavailable")
 
 
 def hardtanh(a, min_val=-1.0, max_val=1.0):
@@ -236,37 +218,8 @@ def hardtanh(a, min_val=-1.0, max_val=1.0):
         except RuntimeError as exc:
             if "561103" not in str(exc):
                 raise
-            # Fallback to clamp when hardtanh kernel is unsupported.
             return clamp(a, min_val, max_val)
-
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
-    if a.device.type != "npu":
-        raise ValueError("NPU hardtanh expects NPU tensors")
-    out_shape = a.shape
-    out_stride = npu_runtime._contiguous_stride(out_shape)
-    out_size = _numel(out_shape) * _dtype_itemsize(a.dtype)
-    out_ptr = npu_runtime._alloc_device(out_size, runtime=runtime)
-    storage = _unwrap_storage(a)
-    try:
-        aclnn.hardtanh(
-            storage.data_ptr(),
-            out_ptr,
-            a.shape,
-            a.stride,
-            a.dtype,
-            min_val,
-            max_val,
-            runtime,
-            stream=stream.stream,
-        )
-    except RuntimeError as exc:
-        if "561103" not in str(exc):
-            raise
-        # Fallback to clamp when hardtanh kernel is unsupported.
-        return clamp(a, min_val, max_val)
-    out_storage = npu_typed_storage_from_ptr(out_ptr, _numel(out_shape), a.dtype, device=a.device)
-    return _wrap_tensor(out_storage, out_shape, out_stride)
+    raise RuntimeError("Cython NPU hardtanh implementation is unavailable")
 
 
 def silu(a):
@@ -294,14 +247,11 @@ def elu(a, alpha=1.0):
 
 
 def mish(a):
-    """Compute Mish activation using aclnnMish."""
     if _use_soc_fallback("mish"):
         return mul(a, tanh(softplus(a)))
-    if not aclnn.mish_symbols_ok():
-        raise RuntimeError("aclnnMish not available")
     if _HAS_FAST_MISH:
         return _fast_mish_impl(a)
-    return _unary_op(a, aclnn.mish, "mish")
+    raise RuntimeError("Cython NPU mish implementation is unavailable")
 
 
 def prelu(a, weight):
@@ -415,7 +365,6 @@ def _dropout_310b_mask(a, keep_prob):
 
 
 def dropout(a, p=0.5, training=True):
-    """Compute dropout using aclnnDropoutGenMask + aclnnDropoutDoMask."""
     if not training or p == 0:
         return a
 
@@ -430,50 +379,9 @@ def dropout(a, p=0.5, training=True):
         out = where(keep, a, 0)
         return mul(out, 1.0 / keep_prob)
 
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
-
-    if not aclnn.dropout_symbols_ok():
-        raise RuntimeError("aclnnDropout symbols not available")
-
     if _HAS_FAST_DROPOUT:
         out, mask_ptr, mask_numel = _fast_dropout_impl(a, p)
         out._backward_data = {"mask_ptr": mask_ptr, "mask_numel": mask_numel, "p": p}
         return out
+    raise RuntimeError("Cython NPU dropout implementation is unavailable")
 
-    out_shape = a.shape
-    out_stride = npu_runtime._contiguous_stride(out_shape)
-    out_numel = _numel(out_shape)
-    itemsize = _dtype_itemsize(a.dtype)
-    out_ptr = npu_runtime._alloc_device(out_numel * itemsize, runtime=runtime)
-
-    # Allocate mask (bit-packed: align(numel, 128) / 8 bytes)
-    mask_numel = (out_numel + 127) // 128 * 128 // 8
-    mask_ptr = npu_runtime._alloc_device(mask_numel, runtime=runtime)
-
-    # Get seed and offset from npu module
-    from .... import npu as npu_mod
-    seed, offset = npu_mod._get_and_advance_offset(device_index=(a.device.index or 0), increment=10)
-
-    # Step 1: Generate mask
-    aclnn.dropout_gen_mask(
-        a.shape, p, seed, offset,
-        mask_ptr, mask_numel,
-        runtime, stream=stream.stream
-    )
-
-    # Step 2: Apply mask
-    aclnn.dropout_do_mask(
-        _unwrap_storage(a).data_ptr(),
-        mask_ptr,
-        out_ptr,
-        a.shape, a.stride, a.dtype,
-        mask_numel, p,
-        runtime, stream=stream.stream
-    )
-
-    # Save mask for backward (dropout backward reuses the same mask)
-    out_storage = npu_typed_storage_from_ptr(out_ptr, out_numel, a.dtype, device=a.device)
-    out = _wrap_tensor(out_storage, out_shape, out_stride)
-    out._backward_data = {"mask_ptr": mask_ptr, "mask_numel": mask_numel, "p": p}
-    return out

--- a/src/candle/_backends/npu/ops/elementwise.py
+++ b/src/candle/_backends/npu/ops/elementwise.py
@@ -85,51 +85,18 @@ def where(cond, x, y):
         cond = _npu_broadcast_to(cond, out_shape)
 
     if _use_soc_fallback("where"):
-        # Arithmetic composite: avoid nonzero/index_put_ which poison 310B state.
-        # out = cond_f * x + (1 - cond_f) * y
         cond_f = _cast_tensor_dtype(cond, x.dtype)
         one_minus = sub(_scalar_to_npu_tensor(1.0, cond_f), cond_f)
         return add(mul(cond_f, x), mul(one_minus, y))
 
     if _HAS_FAST_WHERE:
         return _fast_where_impl(cond, x, y)
-
-    if not aclnn.s_where_symbols_ok():
-        raise RuntimeError("aclnnSWhere symbols not available")
-
-    runtime = npu_runtime.get_runtime((x.device.index or 0))
-    stream = npu_state.current_stream((x.device.index or 0))
-    out_stride = npu_runtime._contiguous_stride(out_shape)
-    out_ptr = npu_runtime._alloc_device(_numel(out_shape) * _dtype_itemsize(x.dtype), runtime=runtime)
-    aclnn.s_where(
-        _unwrap_storage(cond).data_ptr(),
-        _unwrap_storage(x).data_ptr(),
-        _unwrap_storage(y).data_ptr(),
-        out_ptr,
-        cond.shape,
-        cond.stride,
-        cond.dtype,
-        x.shape,
-        x.stride,
-        x.dtype,
-        y.shape,
-        y.stride,
-        y.dtype,
-        out_shape,
-        out_stride,
-        x.dtype,
-        runtime,
-        stream=stream.stream,
-    )
-    out_storage = npu_typed_storage_from_ptr(out_ptr, _numel(out_shape), x.dtype, device=x.device)
-    return _wrap_tensor(out_storage, out_shape, out_stride)
+    raise RuntimeError("Cython NPU where implementation is unavailable")
 
 
 def lerp(a, b, weight):
-    # 310B native aclnnLerps is still broken for float16, but works for float32.
     use_fallback = _use_soc_fallback("lerp") and a.dtype.name != "float32"
     if use_fallback:
-        # Static small-op fallback on 310B to avoid aclnnLerp 561103.
         delta = sub(b, a)
         scaled = mul(delta, weight)
         return add(a, scaled)
@@ -138,38 +105,7 @@ def lerp(a, b, weight):
         return _fast_lerp_tensor_impl(a, b, weight)
     if not hasattr(weight, "shape") and _HAS_FAST_LERP_SCALAR:
         return _fast_lerp_scalar_impl(a, b, float(weight))
-
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
-    a_storage = _unwrap_storage(a)
-    b_storage = _unwrap_storage(b)
-    if hasattr(weight, "shape"):
-        # Tensor weight path
-        w_storage = _unwrap_storage(weight)
-        out_shape = _broadcast_shape(_broadcast_shape(a.shape, b.shape), weight.shape)
-        out_stride = npu_runtime._contiguous_stride(out_shape)
-        out_size = _numel(out_shape) * _dtype_itemsize(a.dtype)
-        out_ptr = npu_runtime._alloc_device(out_size, runtime=runtime)
-        aclnn.lerp_tensor(
-            a_storage.data_ptr(), b_storage.data_ptr(), w_storage.data_ptr(), out_ptr,
-            a.shape, a.stride, b.shape, b.stride,
-            weight.shape, weight.stride, out_shape, out_stride,
-            a.dtype, runtime, stream=stream.stream,
-        )
-    else:
-        # Scalar weight path
-        out_shape = _broadcast_shape(a.shape, b.shape)
-        out_stride = npu_runtime._contiguous_stride(out_shape)
-        out_size = _numel(out_shape) * _dtype_itemsize(a.dtype)
-        out_ptr = npu_runtime._alloc_device(out_size, runtime=runtime)
-        aclnn.lerp_scalar(
-            a_storage.data_ptr(), b_storage.data_ptr(), out_ptr,
-            a.shape, a.stride, b.shape, b.stride,
-            out_shape, out_stride, a.dtype, float(weight),
-            runtime, stream=stream.stream,
-        )
-    out_storage = npu_typed_storage_from_ptr(out_ptr, _numel(out_shape), a.dtype, device=a.device)
-    return _wrap_tensor(out_storage, out_shape, out_stride)
+    raise RuntimeError("Cython NPU lerp implementation is unavailable")
 
 
 def addcmul(a, b, c, value=1.0):

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -288,6 +288,38 @@ def test_npu_unary_math_wrappers_delegate_to_cython():
         assert marker not in logical_not_body
 
 
+def test_npu_soc_guarded_fast_helpers_do_not_keep_native_python_fallbacks():
+    activation_src = _source("src/candle/_backends/npu/ops/activation.py")
+    elementwise_src = _source("src/candle/_backends/npu/ops/elementwise.py")
+
+    expectations = {
+        activation_src: {
+            "softplus": "_fast_softplus_impl",
+            "hardtanh": "_fast_hardtanh_impl",
+            "mish": "_fast_mish_impl",
+            "dropout": "_fast_dropout_impl",
+        },
+        elementwise_src: {
+            "where": "_fast_where_impl",
+            "lerp": "_fast_lerp_tensor_impl",
+        },
+    }
+    forbidden = [
+        "return _unary_op(",
+        "return _binary_op(",
+        "aclnn.",
+        "npu_runtime._alloc_device",
+        "_unwrap_storage(",
+        "_wrap_tensor(",
+    ]
+    for src, mapping in expectations.items():
+        for name, fast_name in mapping.items():
+            body = _function_source(src, name)
+            assert fast_name in body, f"{name} does not delegate to {fast_name}"
+            for marker in forbidden:
+                assert marker not in body
+
+
 def test_npu_activation_native_wrappers_delegate_to_cython():
     activation_src = _source("src/candle/_backends/npu/ops/activation.py")
     expectations = {


### PR DESCRIPTION
## Summary
- Remove native Python ACLNN fallback bodies from remaining SOC-guarded NPU wrappers now backed by Cython fast helpers.
- Keep explicit 310B on-device composite guards where they are still the intentional workaround.
- Add a contract audit preventing these wrappers from regressing to Python-side native fallback bodies.

## Test plan
- [x] `conda run -n candle311 python -m pytest tests/contract/test_npu_mechanism_audit.py -v --tb=short`
- [x] `conda run -n candle311 python -m pytest tests/contract/ -v --tb=short`
- [x] `conda run -n candle311 python -m pytest tests/cpu/ -v --tb=short`
- [x] `conda run -n candle311 pylint src/candle/_backends/npu/ops/activation.py src/candle/_backends/npu/ops/elementwise.py --rcfile=.github/pylint.conf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)