### PR TITLE
refactor(npu): hard-delegate isinf/isposinf/isneginf/trunc/square to Cython

### DIFF
--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -388,12 +388,7 @@ def signbit(a):
 def square(a):
     if _HAS_FAST_SQUARE:
         return _fast_square_impl(a)
-    if aclnn.square_symbols_ok():
-        try:
-            return _unary_op(a, aclnn.square, "square")
-        except RuntimeError:
-            pass
-    return mul(a, a)
+    raise RuntimeError("Cython NPU square implementation is unavailable")
 
 
 # ---------------------------------------------------------------------------
@@ -410,46 +405,11 @@ def isinf(a):
     """Check for infinity values.
 
     When fallback is active (910B): aclnnIsInf returns 161001 (unavailable),
-    so we use composite: !isfinite(x) & isfinite(1/x).
+    so the Cython composite (!isfinite(x) & isfinite(1/x)) is used instead.
     """
-    if _HAS_FAST_ISINF and a.dtype.is_floating_point and _use_soc_fallback("isinf"):
+    if _HAS_FAST_ISINF:
         return _fast_isinf_impl(a)
-    # Lazy import to avoid circular dependency with comparison/logical ops
-    from . import logical_and, logical_not
-
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
-    if a.device.type != "npu":
-        raise ValueError("NPU isinf expects NPU tensors")
-    out_shape = a.shape
-    out_stride = npu_runtime._contiguous_stride(out_shape)
-    out_size = _numel(out_shape) * _dtype_itemsize(bool_dtype)
-    out_ptr = npu_runtime._alloc_device(out_size, runtime=runtime)
-    storage = _unwrap_storage(a)
-    if not a.dtype.is_floating_point:
-        runtime.defer_free(out_ptr)
-        return logical_not(isfinite(a))
-    if _use_soc_fallback("isinf"):
-        # Composite: !isfinite(x) & isfinite(1/x)
-        if not (aclnn.logical_not_symbols_ok() and aclnn.logical_and_symbols_ok()):
-            raise RuntimeError("aclnnIsInf unavailable and logical ops missing")
-        runtime.defer_free(out_ptr)
-        finite = isfinite(a)
-        recip = pow(a, -1.0)
-        recip_finite = isfinite(recip)
-        return logical_and(logical_not(finite), recip_finite)
-    # TODO: re-enable native aclnnIsInf when CANN fixes 161001
-    aclnn.isinf(
-        storage.data_ptr(),
-        out_ptr,
-        a.shape,
-        a.stride,
-        a.dtype,
-        runtime,
-        stream=stream.stream,
-    )
-    out_storage = npu_typed_storage_from_ptr(out_ptr, _numel(out_shape), bool_dtype, device=a.device)
-    return _wrap_tensor(out_storage, out_shape, out_stride)
+    raise RuntimeError("Cython NPU isinf implementation is unavailable")
 
 
 def isnan(a):
@@ -472,36 +432,14 @@ def isnan(a):
 
 def isposinf(a):
     if _HAS_FAST_ISPOSINF:
-        try:
-            return _fast_isposinf_impl(a)
-        except RuntimeError:
-            pass
-    # Lazy import to avoid circular dependency with comparison/logical ops
-    from . import logical_and, gt
-
-    if aclnn.isposinf_symbols_ok():
-        try:
-            return _unary_op(a, aclnn.isposinf, "isposinf", out_dtype=bool_dtype)
-        except RuntimeError:
-            pass
-    return logical_and(isinf(a), gt(a, _scalar_to_npu_tensor(0, a)))
+        return _fast_isposinf_impl(a)
+    raise RuntimeError("Cython NPU isposinf implementation is unavailable")
 
 
 def isneginf(a):
     if _HAS_FAST_ISNEGINF:
-        try:
-            return _fast_isneginf_impl(a)
-        except RuntimeError:
-            pass
-    # Lazy import to avoid circular dependency with comparison/logical ops
-    from . import logical_and, lt
-
-    if aclnn.isneginf_symbols_ok():
-        try:
-            return _unary_op(a, aclnn.isneginf, "isneginf", out_dtype=bool_dtype)
-        except RuntimeError:
-            pass
-    return logical_and(isinf(a), lt(a, _scalar_to_npu_tensor(0, a)))
+        return _fast_isneginf_impl(a)
+    raise RuntimeError("Cython NPU isneginf implementation is unavailable")
 
 
 # ---------------------------------------------------------------------------
@@ -618,20 +556,8 @@ def round(a):
 
 def trunc(a):
     if _HAS_FAST_TRUNC:
-        try:
-            return _fast_trunc_impl(a)
-        except RuntimeError:
-            pass
-    try:
-        return _unary_op(a, aclnn.trunc, "trunc")
-    except RuntimeError as exc:
-        if "561103" not in str(exc):
-            raise
-    if not a.dtype.is_floating_point:
-        return a
-    if not aclnn.sign_symbols_ok():
-        raise RuntimeError("aclnnTrunc not available and aclnnSign unavailable")
-    return mul(sign(a), floor(abs(a)))
+        return _fast_trunc_impl(a)
+    raise RuntimeError("Cython NPU trunc implementation is unavailable")
 
 
 def frac(a):

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -149,6 +149,31 @@ def test_bulk_npu_parity_shims_delegate_to_cython():
             assert fast_name in body, f"{name} does not delegate to {fast_name}"
 
 
+def test_npu_bulk_fast_helpers_have_no_python_fallback_bodies():
+    math_src = _source("src/candle/_backends/npu/ops/math.py")
+
+    expectations = {
+        "square": "_fast_square_impl",
+        "isinf": "_fast_isinf_impl",
+        "isposinf": "_fast_isposinf_impl",
+        "isneginf": "_fast_isneginf_impl",
+        "trunc": "_fast_trunc_impl",
+    }
+    forbidden = [
+        "return _unary_op(",
+        "return _binary_op(",
+        "aclnn.",
+        "_wrap_tensor(",
+        "npu_runtime._alloc_device",
+        "_unwrap_storage(",
+    ]
+    for name, fast_name in expectations.items():
+        body = _function_source(math_src, name)
+        assert fast_name in body, f"{name} does not delegate to {fast_name}"
+        for marker in forbidden:
+            assert marker not in body
+
+
 def test_npu_comparison_thin_wrappers_delegate_to_cython():
     comparison_src = _source("src/candle/_backends/npu/ops/comparison.py")
     expectations = {


### PR DESCRIPTION
## Summary
- Drop Python ACLNN fallback bodies from \`square\`, \`isinf\`, \`isposinf\`, \`isneginf\`, and \`trunc\` so each only delegates to its Cython fast helper or raises a clear unavailable error.
- Add \`test_npu_bulk_fast_helpers_have_no_python_fallback_bodies\` to lock these wrappers against regressing back to native Python fallbacks.

## Test plan
- [x] \`conda run -n candle311 python -m pytest tests/contract/test_npu_mechanism_audit.py::test_npu_bulk_fast_helpers_have_no_python_fallback_bodies tests/contract/test_npu_mechanism_audit.py::test_npu_comparison_thin_wrappers_delegate_to_cython -v --tb=short\`
- [x] \`conda run -n candle311 python -m pytest tests/contract/ -v --tb=short\`
- [x] \`conda run -n candle311 python -m pytest tests/cpu/ -q --tb=short\`
- [x] \`conda run -n candle311 pylint src/candle/_backends/npu/ops/math.py --rcfile=.github/pylint.conf\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)