### PR TITLE
refactor(npu): hard-delegate isnan to Cython fast helper

### DIFF
--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -73,6 +73,8 @@ try:
     _HAS_FAST_SIGN = True
     _HAS_FAST_SIGNBIT = True
     _HAS_FAST_ISFINITE = True
+    _HAS_FAST_ISINF = True
+    _HAS_FAST_ISNAN = True
     _HAS_FAST_ISPOSINF = True
     _HAS_FAST_ISNEGINF = True
     _HAS_FAST_SQUARE = True
@@ -166,6 +168,8 @@ except ImportError:
     _HAS_FAST_SIGN = False
     _HAS_FAST_SIGNBIT = False
     _HAS_FAST_ISFINITE = False
+    _HAS_FAST_ISINF = False
+    _HAS_FAST_ISNAN = False
     _HAS_FAST_ISPOSINF = False
     _HAS_FAST_ISNEGINF = False
     _HAS_FAST_SQUARE = False
@@ -415,19 +419,12 @@ def isinf(a):
 def isnan(a):
     if _HAS_FAST_ISNAN and a.dtype.is_floating_point:
         return _fast_isnan_impl(a)
-    # Lazy import to avoid circular dependency with comparison/logical ops
-    from . import logical_and, logical_not
-
     if a.device.type != "npu":
         raise ValueError("NPU isnan expects NPU tensors")
     if not a.dtype.is_floating_point:
+        from . import logical_not
         return logical_not(isfinite(a))
-    if not (aclnn.logical_not_symbols_ok() and aclnn.logical_and_symbols_ok()):
-        raise RuntimeError("aclnn logical ops missing for isnan")
-    finite = isfinite(a)
-    recip = pow(a, -1.0)
-    recip_finite = isfinite(recip)
-    return logical_and(logical_not(finite), logical_not(recip_finite))
+    raise RuntimeError("Cython NPU isnan implementation is unavailable")
 
 
 def isposinf(a):

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -155,6 +155,7 @@ def test_npu_bulk_fast_helpers_have_no_python_fallback_bodies():
     expectations = {
         "square": "_fast_square_impl",
         "isinf": "_fast_isinf_impl",
+        "isnan": "_fast_isnan_impl",
         "isposinf": "_fast_isposinf_impl",
         "isneginf": "_fast_isneginf_impl",
         "trunc": "_fast_trunc_impl",


### PR DESCRIPTION
## Summary

- Stops `isnan` from composing through the Python aclnn path (`recip = pow(a, -1.0)` etc.) when the Cython `_fast_isnan_impl` helper is available — mirrors the isposinf/isneginf/isinf batch.
- Normalizes the `_HAS_FAST_ISINF` / `_HAS_FAST_ISNAN` flag pair in both the try and except blocks of `src/candle/_backends/npu/ops/math.py` so the import-failure path matches the success path.
- Locks the new contract by extending `test_npu_bulk_fast_helpers_have_no_python_fallback_bodies` to require `_fast_isnan_impl` in `isnan`.

Stacks on top of #440 (batch 7); merging order: #440 first, then this PR.

## Test Plan

- [x] `pytest tests/contract/test_npu_mechanism_audit.py -v` → 14 passed
- [x] `pytest tests/contract/` → 955 passed, 5 skipped
- [x] `pylint src/candle/_backends/npu/ops/math.py --rcfile=.github/pylint.conf` → 10.00/10

�� Generated with [Claude Code](https://claude.com/claude-code)