### PR TITLE
test(npu): lock contract for digamma/erfinv/lgamma Cython delegates

### DIFF
--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -175,6 +175,35 @@ def test_npu_bulk_fast_helpers_have_no_python_fallback_bodies():
             assert marker not in body
 
 
+def test_npu_special_gamma_and_erfinv_wrappers_delegate_to_cython():
+    special_src = _source("src/candle/_backends/npu/ops/special.py")
+    random_src = _source("src/candle/_backends/npu/ops/random.py")
+
+    special_expectations = {
+        "special_digamma": "_fast_digamma_impl",
+        "special_erfinv": "_fast_erfinv_impl",
+        "special_gammaln": "_fast_lgamma_impl",
+    }
+    forbidden = [
+        "return _unary_op(",
+        "return _binary_op(",
+        "aclnn.",
+        "_wrap_tensor(",
+        "npu_runtime._alloc_device",
+        "_unwrap_storage(",
+    ]
+    for name, fast_name in special_expectations.items():
+        body = _function_source(special_src, name)
+        assert fast_name in body, f"{name} does not delegate to {fast_name}"
+        for marker in forbidden:
+            assert marker not in body
+
+    erfinv_body = _function_source(random_src, "erfinv_")
+    assert "_fast_erfinv_impl" in erfinv_body
+    for marker in forbidden:
+        assert marker not in erfinv_body
+
+
 def test_npu_comparison_thin_wrappers_delegate_to_cython():
     comparison_src = _source("src/candle/_backends/npu/ops/comparison.py")
     expectations = {


### PR DESCRIPTION
## Summary

Adds `test_npu_special_gamma_and_erfinv_wrappers_delegate_to_cython` to guard the already-pure Cython thin-wrapper bodies for:

- `special.special_digamma` -> `fast_digamma`
- `special.special_erfinv` -> `fast_erfinv`
- `special.special_gammaln` -> `fast_lgamma`
- `random.erfinv_` -> `fast_erfinv_`

Test-only batch — no runtime behavior change. Locks the static-string contract so any future regression that re-introduces `aclnn.*`, `_unwrap_storage`, `_wrap_tensor`, or `npu_runtime._alloc_device` into these wrappers gets caught in CI.

Stacks on top of #440 (batch 7) and #441 (batch 8); intended merge order: #440 → #441 → this PR.

## Test Plan

- [x] RED proof: temporarily inserted `aclnn.foo()` into `special_gammaln` body, audit failed with the expected `'aclnn.' not in body` assertion, reverted.
- [x] `pytest tests/contract/test_npu_mechanism_audit.py -v` → 15 passed
- [x] `pytest tests/contract/` → 956 passed, 5 skipped
- [x] `pylint tests/contract/test_npu_mechanism_audit.py --rcfile=.github/pylint.conf` → 10.00/10

�� Generated with [Claude Code](https://claude.com/claude-code)