### PR TITLE
refactor(npu): hard-delegate atan2 to Cython fast helper

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -1222,6 +1222,10 @@ def fast_logaddexp2(a, b):
     return fast_binary_op(a, b, None, "logaddexp2")
 
 
+def fast_atan2(a, b):
+    return fast_binary_op(a, b, None, "atan2")
+
+
 def fast_fmod(a, b):
     return fast_binary_op(a, b, None, "fmod")
 

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -26,6 +26,7 @@ try:
         fast_asin as _fast_asin_impl,
         fast_asinh as _fast_asinh_impl,
         fast_atan as _fast_atan_impl,
+        fast_atan2 as _fast_atan2_impl,
         fast_atanh as _fast_atanh_impl,
         fast_ceil as _fast_ceil_impl,
         fast_cos as _fast_cos_impl,
@@ -106,6 +107,7 @@ try:
     _HAS_FAST_ACOSH = True
     _HAS_FAST_ATANH = True
     _HAS_FAST_ATAN = True
+    _HAS_FAST_ATAN2 = True
     _HAS_FAST_ASIN = True
     _HAS_FAST_ACOS = True
     _HAS_FAST_DIV = True
@@ -159,6 +161,7 @@ except ImportError:
     _fast_acosh_impl = None  # type: ignore[assignment]
     _fast_atanh_impl = None  # type: ignore[assignment]
     _fast_atan_impl = None  # type: ignore[assignment]
+    _fast_atan2_impl = None  # type: ignore[assignment]
     _fast_asin_impl = None  # type: ignore[assignment]
     _fast_acos_impl = None  # type: ignore[assignment]
     _fast_mul_impl = None  # type: ignore[assignment]
@@ -201,6 +204,7 @@ except ImportError:
     _HAS_FAST_ACOSH = False
     _HAS_FAST_ATANH = False
     _HAS_FAST_ATAN = False
+    _HAS_FAST_ATAN2 = False
     _HAS_FAST_ASIN = False
     _HAS_FAST_ACOS = False
     _HAS_FAST_DIV = False
@@ -647,7 +651,9 @@ def atan2(a, b):
         out = where(logical_and(x_eq0, y_eq0), zero, out)
         return out
 
-    return _binary_op(a, b, aclnn.atan2, "atan2")
+    if _HAS_FAST_ATAN2:
+        return _fast_atan2_impl(a, b)
+    raise RuntimeError("Cython NPU atan2 implementation is unavailable")
 
 
 def _pow_tensor_scalar_op(a, exponent):

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -346,6 +346,7 @@ def test_npu_unary_math_wrappers_delegate_to_cython():
 def test_npu_soc_guarded_fast_helpers_do_not_keep_native_python_fallbacks():
     activation_src = _source("src/candle/_backends/npu/ops/activation.py")
     elementwise_src = _source("src/candle/_backends/npu/ops/elementwise.py")
+    math_src = _source("src/candle/_backends/npu/ops/math.py")
 
     expectations = {
         activation_src: {
@@ -357,6 +358,9 @@ def test_npu_soc_guarded_fast_helpers_do_not_keep_native_python_fallbacks():
         elementwise_src: {
             "where": "_fast_where_impl",
             "lerp": "_fast_lerp_tensor_impl",
+        },
+        math_src: {
+            "atan2": "_fast_atan2_impl",
         },
     }
     forbidden = [


### PR DESCRIPTION
## Summary

- Adds `fast_atan2` to `src/candle/_C/_npu_ops.pyx` — one-line dispatch through `fast_binary_op`, which already routes `\"atan2\"` to the existing `aclnn.atan2` path.
- Switches the Python wrapper in `src/candle/_backends/npu/ops/math.py:atan2` from `_binary_op(a, b, aclnn.atan2, \"atan2\")` to `_fast_atan2_impl(a, b)`.
- Preserves the SOC fallback composite path (310B quadrant correction via where/lt/ge/eq) unchanged.
- Locks the new contract by extending `test_npu_soc_guarded_fast_helpers_do_not_keep_native_python_fallbacks` to require `_fast_atan2_impl` in `atan2` with the standard forbidden markers.

## Test Plan

- [x] RED proof: audit failed for `atan2 does not delegate to _fast_atan2_impl` before refactor, passed after.
- [x] `pytest tests/contract/test_npu_mechanism_audit.py -v` → 15 passed
- [x] `pytest tests/contract/` → 956 passed, 5 skipped
- [x] `pytest tests/cpu/` → 2366 passed, 25 skipped
- [x] `pylint src/candle/_backends/npu/ops/math.py --rcfile=.github/pylint.conf` → 10.00/10

�� Generated with [Claude Code](https://claude.com/claude-code)