### PR TITLE
refactor(npu): hard-delegate remainder/min_/max_ to Cython fast helpers

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -1230,6 +1230,10 @@ def fast_fmod(a, b):
     return fast_binary_op(a, b, None, "fmod")
 
 
+def fast_remainder(a, b):
+    return fast_binary_op(a, b, None, "remainder")
+
+
 def fast_maximum(a, b):
     return fast_binary_op(a, b, None, "maximum")
 

--- a/src/candle/_backends/npu/ops/elementwise.py
+++ b/src/candle/_backends/npu/ops/elementwise.py
@@ -10,6 +10,7 @@ try:
         fast_hypot as _fast_hypot_impl,
         fast_logaddexp as _fast_logaddexp_impl,
         fast_logaddexp2 as _fast_logaddexp2_impl,
+        fast_remainder as _fast_remainder_impl,
     )  # pylint: disable=import-error,no-name-in-module
     _HAS_FAST_WHERE = True
     _HAS_FAST_LERP_TENSOR = True
@@ -20,6 +21,7 @@ try:
     _HAS_FAST_HYPOT = True
     _HAS_FAST_LOGADDEXP = True
     _HAS_FAST_LOGADDEXP2 = True
+    _HAS_FAST_REMAINDER = True
 except ImportError:
     _fast_where_impl = None  # type: ignore[assignment]
     _fast_lerp_tensor_impl = None  # type: ignore[assignment]
@@ -30,6 +32,7 @@ except ImportError:
     _fast_hypot_impl = None  # type: ignore[assignment]
     _fast_logaddexp_impl = None  # type: ignore[assignment]
     _fast_logaddexp2_impl = None  # type: ignore[assignment]
+    _fast_remainder_impl = None  # type: ignore[assignment]
     _HAS_FAST_WHERE = False
     _HAS_FAST_LERP_TENSOR = False
     _HAS_FAST_LERP_SCALAR = False
@@ -39,6 +42,7 @@ except ImportError:
     _HAS_FAST_HYPOT = False
     _HAS_FAST_LOGADDEXP = False
     _HAS_FAST_LOGADDEXP2 = False
+    _HAS_FAST_REMAINDER = False
 
 from ._helpers import (
     _unwrap_storage, _wrap_tensor, _unary_op, _binary_op,
@@ -155,7 +159,9 @@ def remainder(a, b):
         b = _scalar_to_npu_tensor(b, a)
     if _use_soc_fallback("remainder"):
         return _remainder_310b_fallback(a, b)
-    return _binary_op(a, b, aclnn.sremainder, "remainder")
+    if _HAS_FAST_REMAINDER:
+        return _fast_remainder_impl(a, b)
+    raise RuntimeError("Cython NPU remainder implementation is unavailable")
 
 
 def fmod(a, b):

--- a/src/candle/_backends/npu/ops/reduce.py
+++ b/src/candle/_backends/npu/ops/reduce.py
@@ -480,7 +480,10 @@ def min_(a, b):
     from . import where
     from .math import isnan, add
     from .comparison import logical_or
-    result = _binary_op(a, b, aclnn.minimum, "min")
+    if _HAS_FAST_MINIMUM:
+        result = _fast_minimum_impl(a, b)
+    else:
+        raise RuntimeError("Cython NPU minimum implementation is unavailable")
     nan_mask = logical_or(isnan(a), isnan(b))
     return where(nan_mask, add(a, b), result)
 
@@ -489,7 +492,10 @@ def max_(a, b):
     from . import where
     from .math import isnan, add
     from .comparison import logical_or
-    result = _binary_op(a, b, aclnn.maximum, "max")
+    if _HAS_FAST_MAXIMUM:
+        result = _fast_maximum_impl(a, b)
+    else:
+        raise RuntimeError("Cython NPU maximum implementation is unavailable")
     nan_mask = logical_or(isnan(a), isnan(b))
     return where(nan_mask, add(a, b), result)
 

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -244,10 +244,13 @@ def test_npu_thin_binary_wrappers_delegate_to_cython():
             "logaddexp": "_fast_logaddexp_impl",
             "logaddexp2": "_fast_logaddexp2_impl",
             "fmod": "_fast_fmod_impl",
+            "remainder": "_fast_remainder_impl",
         },
         reduce_src: {
             "maximum": "_fast_maximum_impl",
             "minimum": "_fast_minimum_impl",
+            "min_": "_fast_minimum_impl",
+            "max_": "_fast_maximum_impl",
         },
     }
     for src, mapping in expectations.items():
@@ -255,6 +258,8 @@ def test_npu_thin_binary_wrappers_delegate_to_cython():
             body = _function_source(src, name)
             assert fast_name in body, f"{name} does not delegate to {fast_name}"
             assert "return _binary_op(" not in body
+            assert "_binary_op(" not in body, f"{name} still references _binary_op"
+            assert "aclnn." not in body, f"{name} still references aclnn"
 
 
 def test_npu_existing_fast_helpers_have_no_python_fallback_bodies():


### PR DESCRIPTION
## Summary

- Adds `fast_remainder` to `src/candle/_C/_npu_ops.pyx` — one-line dispatch through the existing `fast_binary_op` `"remainder"` branch backed by `aclnnRemainderTensorTensor`.
- `elementwise.py:remainder` now calls `_fast_remainder_impl` after the SOC fallback path (replacing `_binary_op(a, b, aclnn.sremainder, \"remainder\")`).
- `reduce.py:min_` and `reduce.py:max_` now call `_fast_minimum_impl` / `_fast_maximum_impl` for the underlying tensor min/max. The NaN-propagation composite that follows (used to mirror PyTorch's `torch.min(a, b)` / `torch.max(a, b)` semantics) is preserved unchanged.
- Strengthens `test_npu_thin_binary_wrappers_delegate_to_cython` to also assert no `_binary_op(` or `aclnn.` references survive in any wrapper it covers, and adds `remainder`, `min_`, `max_` to its expectations.

Stacks on top of #443 (batch 10); intended merge order: #443 → this PR.

## Test Plan

- [x] RED proof: audit failed for `remainder does not delegate to _fast_remainder_impl` before refactor, passed after.
- [x] `pytest tests/contract/test_npu_mechanism_audit.py -v` → 15 passed
- [x] `pytest tests/contract/ tests/cpu/` → 3322 passed, 30 skipped
- [x] `pylint src/candle/_backends/npu/ops/{elementwise,reduce}.py --rcfile=.github/pylint.conf` → 10.00/10

�� Generated with [Claude Code](https://claude.com/claude-code)