### PR TITLE
refactor(npu): hard-delegate clamp wrappers to Cython fast helpers

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -1338,6 +1338,8 @@ cdef object _log_softmax_getws_ptr = None # cached LogSoftmax getws pointer
 cdef object _log_softmax_exec_ptr = None  # cached LogSoftmax exec pointer
 cdef object _hardtanh_getws_ptr = None   # cached Hardtanh getws pointer
 cdef object _hardtanh_exec_ptr = None    # cached Hardtanh exec pointer
+cdef object _clamp_getws_ptr = None      # cached Clamp getws pointer
+cdef object _clamp_exec_ptr = None       # cached Clamp exec pointer
 cdef object _gelu_getws_ptr = None       # cached Gelu getws pointer
 cdef object _gelu_exec_ptr = None        # cached Gelu exec pointer
 cdef object _silu_getws_ptr = None       # cached Silu getws pointer
@@ -1817,6 +1819,16 @@ cdef inline void _ensure_ffi_hardtanh() except *:
     if _ffi_ref is None:
         _ensure_ffi_binary()
     _hardtanh_getws_ptr, _hardtanh_exec_ptr = _ffi_ref.resolve_op("Hardtanh")
+    _ensure_ffi_scalar_helpers()
+
+
+cdef inline void _ensure_ffi_clamp() except *:
+    global _ffi_ref, _clamp_getws_ptr, _clamp_exec_ptr
+    if _clamp_getws_ptr is not None:
+        return
+    if _ffi_ref is None:
+        _ensure_ffi_binary()
+    _clamp_getws_ptr, _clamp_exec_ptr = _ffi_ref.resolve_op("Clamp")
     _ensure_ffi_scalar_helpers()
 
 
@@ -3973,6 +3985,95 @@ def fast_elu(a, alpha):
         _destroy_scalar_fn(int(input_scale_scalar))
 
     return _cy_make_npu_tensor(out_ptr, n, a_dtype, a_dev, out_shape, out_stride)
+
+
+def fast_clamp(a, min_val=None, max_val=None):
+    """Optimized clamp(a, min_val, max_val) that calls _ffi.clamp_optional_scalars_op directly."""
+    _ensure_npu_imports()
+    _ensure_ffi_clamp()
+
+    if a.device.type != "npu":
+        raise ValueError("NPU clamp expects NPU tensors")
+    if min_val is None and max_val is None:
+        raise ValueError("clamp requires min or max")
+
+    cdef int dev_idx = a.device.index or 0
+    a_dev = _device_obj_fast(a)
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    out_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    out_stride = a.stride
+    cdef int64_t n = 1
+    for size in out_shape:
+        n *= size
+
+    cdef int isize = c_dtype_itemsize(a_dtype)
+    cdef int64_t alloc_size_fclamp = n * isize
+    if dev_idx == 0:
+        _ensure_allocator_dev0()
+        out_ptr = _fast_allocator_dev0.malloc(alloc_size_fclamp, stream=stream.stream)
+    else:
+        out_ptr = _get_allocator_fn_ref(dev_idx).malloc(alloc_size_fclamp, stream=stream.stream)
+
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr, o_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    o_ptr = out_ptr
+
+    cdef uintptr_t min_scalar = 0
+    cdef uintptr_t max_scalar = 0
+    if min_val is not None:
+        min_scalar = _create_scalar_fn(_scalar_bytes_fn(min_val, a_dtype), dtype_code)
+    if max_val is not None:
+        max_scalar = _create_scalar_fn(_scalar_bytes_fn(max_val, a_dtype), dtype_code)
+    cdef uintptr_t stream_raw = int(stream.stream)
+    try:
+        ws_size, executor = _ffi_ref.clamp_optional_scalars_op(
+            _clamp_getws_ptr, _clamp_exec_ptr,
+            a.shape, a.stride,
+            out_shape, out_stride,
+            dtype_code, 2,
+            a_ptr, o_ptr,
+            min_scalar, max_scalar,
+            stream_raw)
+
+        if ws_size:
+            workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+            if ret != 0:
+                raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+            try:
+                ret = _ffi_ref.execute(
+                    _clamp_exec_ptr, int(workspace_ptr), ws_size,
+                    executor, stream_raw)
+                if ret != 0:
+                    raise RuntimeError(f"aclnnClamp execute failed: {ret}")
+            finally:
+                runtime.defer_raw_free(workspace_ptr)
+
+        _defer_executor_fn(executor)
+    finally:
+        if min_scalar:
+            _destroy_scalar_fn(int(min_scalar))
+        if max_scalar:
+            _destroy_scalar_fn(int(max_scalar))
+
+    return _cy_make_npu_tensor(out_ptr, n, a_dtype, a_dev, out_shape, out_stride)
+
+
+
+def fast_clamp_min(a, min_val):
+    return fast_clamp(a, min_val, None)
+
+
+
+def fast_clamp_max(a, max_val):
+    return fast_clamp(a, None, max_val)
+
 
 
 def fast_hardtanh(a, min_val, max_val):

--- a/src/candle/_backends/npu/ops/elementwise.py
+++ b/src/candle/_backends/npu/ops/elementwise.py
@@ -11,6 +11,9 @@ try:
         fast_logaddexp as _fast_logaddexp_impl,
         fast_logaddexp2 as _fast_logaddexp2_impl,
         fast_remainder as _fast_remainder_impl,
+        fast_clamp as _fast_clamp_impl,
+        fast_clamp_min as _fast_clamp_min_impl,
+        fast_clamp_max as _fast_clamp_max_impl,
     )  # pylint: disable=import-error,no-name-in-module
     _HAS_FAST_WHERE = True
     _HAS_FAST_LERP_TENSOR = True
@@ -22,6 +25,9 @@ try:
     _HAS_FAST_LOGADDEXP = True
     _HAS_FAST_LOGADDEXP2 = True
     _HAS_FAST_REMAINDER = True
+    _HAS_FAST_CLAMP = True
+    _HAS_FAST_CLAMP_MIN = True
+    _HAS_FAST_CLAMP_MAX = True
 except ImportError:
     _fast_where_impl = None  # type: ignore[assignment]
     _fast_lerp_tensor_impl = None  # type: ignore[assignment]
@@ -33,6 +39,9 @@ except ImportError:
     _fast_logaddexp_impl = None  # type: ignore[assignment]
     _fast_logaddexp2_impl = None  # type: ignore[assignment]
     _fast_remainder_impl = None  # type: ignore[assignment]
+    _fast_clamp_impl = None  # type: ignore[assignment]
+    _fast_clamp_min_impl = None  # type: ignore[assignment]
+    _fast_clamp_max_impl = None  # type: ignore[assignment]
     _HAS_FAST_WHERE = False
     _HAS_FAST_LERP_TENSOR = False
     _HAS_FAST_LERP_SCALAR = False
@@ -43,6 +52,9 @@ except ImportError:
     _HAS_FAST_LOGADDEXP = False
     _HAS_FAST_LOGADDEXP2 = False
     _HAS_FAST_REMAINDER = False
+    _HAS_FAST_CLAMP = False
+    _HAS_FAST_CLAMP_MIN = False
+    _HAS_FAST_CLAMP_MAX = False
 
 from ._helpers import (
     _unwrap_storage, _wrap_tensor, _unary_op, _binary_op,
@@ -173,100 +185,48 @@ def fmod(a, b):
 
 
 def clamp(a, min_val=None, max_val=None):
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
     if a.device.type != "npu":
         raise ValueError("NPU clamp expects NPU tensors")
     if min_val is None and max_val is None:
         raise ValueError("clamp requires min or max")
-    out_shape = a.shape
-    out_stride = npu_runtime._contiguous_stride(out_shape)
-    out_size = _numel(out_shape) * _dtype_itemsize(a.dtype)
-    out_ptr = npu_runtime._alloc_device(out_size, runtime=runtime)
-    storage = _unwrap_storage(a)
     if hasattr(min_val, "shape") and hasattr(max_val, "shape"):
         from .reduce import maximum, minimum
         return minimum(maximum(a, min_val), max_val)
-    elif hasattr(min_val, "shape"):
+    if hasattr(min_val, "shape"):
         temp_tensor = clamp_min(a, min_val)
         if max_val is not None:
             return clamp_max(temp_tensor, max_val)
         return temp_tensor
-    elif hasattr(max_val, "shape"):
+    if hasattr(max_val, "shape"):
         temp_tensor = clamp_max(a, max_val)
         if min_val is not None:
             return clamp_min(temp_tensor, min_val)
         return temp_tensor
-    else:
-        aclnn.clamp_scalar(
-            storage.data_ptr(),
-            out_ptr,
-            a.shape,
-            a.stride,
-            a.dtype,
-            min_val,
-            max_val,
-            runtime,
-            stream=stream.stream,
-        )
-    out_storage = npu_typed_storage_from_ptr(out_ptr, _numel(out_shape), a.dtype, device=a.device)
-    return _wrap_tensor(out_storage, out_shape, out_stride)
+    if _HAS_FAST_CLAMP:
+        return _fast_clamp_impl(a, min_val, max_val)
+    raise RuntimeError("Cython NPU clamp implementation is unavailable")
 
 
 def clamp_min(a, min_val):
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
     if a.device.type != "npu":
         raise ValueError("NPU clamp_min expects NPU tensors")
-    storage = _unwrap_storage(a)
     if hasattr(min_val, "shape"):
         from .reduce import maximum
         return maximum(a, min_val)
-    else:
-        out_shape = a.shape
-        out_stride = npu_runtime._contiguous_stride(out_shape)
-        out_size = _numel(out_shape) * _dtype_itemsize(a.dtype)
-        out_ptr = npu_runtime._alloc_device(out_size, runtime=runtime)
-        aclnn.clamp_min_scalar(
-            storage.data_ptr(),
-            out_ptr,
-            a.shape,
-            a.stride,
-            a.dtype,
-            min_val,
-            runtime,
-            stream=stream.stream,
-        )
-    out_storage = npu_typed_storage_from_ptr(out_ptr, _numel(out_shape), a.dtype, device=a.device)
-    return _wrap_tensor(out_storage, out_shape, out_stride)
+    if _HAS_FAST_CLAMP_MIN:
+        return _fast_clamp_min_impl(a, min_val)
+    raise RuntimeError("Cython NPU clamp_min implementation is unavailable")
 
 
 def clamp_max(a, max_val):
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
     if a.device.type != "npu":
         raise ValueError("NPU clamp_max expects NPU tensors")
-    storage = _unwrap_storage(a)
     if hasattr(max_val, "shape"):
         from .reduce import minimum
         return minimum(a, max_val)
-    else:
-        out_shape = a.shape
-        out_stride = npu_runtime._contiguous_stride(out_shape)
-        out_size = _numel(out_shape) * _dtype_itemsize(a.dtype)
-        out_ptr = npu_runtime._alloc_device(out_size, runtime=runtime)
-        aclnn.clamp_max_scalar(
-            storage.data_ptr(),
-            out_ptr,
-            a.shape,
-            a.stride,
-            a.dtype,
-            max_val,
-            runtime,
-            stream=stream.stream,
-        )
-    out_storage = npu_typed_storage_from_ptr(out_ptr, _numel(out_shape), a.dtype, device=a.device)
-    return _wrap_tensor(out_storage, out_shape, out_stride)
+    if _HAS_FAST_CLAMP_MAX:
+        return _fast_clamp_max_impl(a, max_val)
+    raise RuntimeError("Cython NPU clamp_max implementation is unavailable")
 
 
 def heaviside_op(a, values):

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -404,6 +404,20 @@ def test_npu_activation_native_wrappers_delegate_to_cython():
         for marker in forbidden:
             assert marker not in body
 
+def test_npu_clamp_wrappers_delegate_to_cython():
+    elementwise_src = _source("src/candle/_backends/npu/ops/elementwise.py")
+    expectations = {
+        "clamp": "_fast_clamp_impl",
+        "clamp_min": "_fast_clamp_min_impl",
+        "clamp_max": "_fast_clamp_max_impl",
+    }
+    forbidden = ["aclnn.", "npu_runtime._alloc_device", "_unwrap_storage(", "_wrap_tensor("]
+    for name, fast_name in expectations.items():
+        body = _function_source(elementwise_src, name)
+        assert fast_name in body, f"{name} does not delegate to {fast_name}"
+        for marker in forbidden:
+            assert marker not in body
+
 
 def test_core_npu_training_ops_have_forward_and_autograd_registration():
     forward_ops = _npu_forward_ops()


### PR DESCRIPTION
## Summary
- Add `fast_clamp`/`fast_clamp_min`/`fast_clamp_max` in `_C/_npu_ops.pyx` reusing the existing `_ffi.clamp_optional_scalars_op` primitive.
- Re-route the Python wrappers in `_backends/npu/ops/elementwise.py` to delegate to those Cython helpers; tensor-bound clamp cases remain a same-device composite of `maximum`/`minimum`.
- Lock the new contract via `test_npu_clamp_wrappers_delegate_to_cython`, which forbids `aclnn.`, `npu_runtime._alloc_device`, `_unwrap_storage` and `_wrap_tensor` from the wrapper bodies.

## Test plan
- [x] `pytest tests/contract/test_npu_mechanism_audit.py -v --tb=short`
- [x] `pytest tests/cpu/ tests/contract/ -v --tb=short`
- [x] `pylint src/candle/ --rcfile=.github/pylint.conf`