### PR TITLE
refactor(npu): hard-delegate in-place arithmetic to Cython fast helpers

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -1202,6 +1202,270 @@ def fast_div(a, b):
     return _cy_make_npu_tensor(out_ptr, n, a_dtype, a_dev, out_shape, out_stride)
 
 
+# ---------------------------------------------------------------------------
+# In-place arithmetic — hardwired add_/mul_/sub_/div_ that skip aclnn.py
+# ---------------------------------------------------------------------------
+
+def fast_add_inplace(a, b):
+    """In-place add_(a, b) that calls _ffi.binary_op_with_alpha with output aliased to a."""
+    _ensure_npu_imports()
+    _ensure_ffi_binary()
+
+    cdef int dev_idx
+    _validate_npu_binary(a, b, "add_", &dev_idx)
+
+    a_dtype = a.dtype
+    stream = _get_stream_fast(dev_idx)
+
+    py_a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    py_b_shape = (<TensorImpl>b)._shape_tuple if isinstance(b, TensorImpl) else b.shape
+    cdef int a_ndim = len(py_a_shape)
+    cdef int b_ndim = len(py_b_shape)
+    if a_ndim > MAX_NDIM or b_ndim > MAX_NDIM:
+        raise ValueError(f"ndim exceeds MAX_NDIM ({MAX_NDIM})")
+
+    cdef int64_t[MAX_NDIM] a_shape_buf, b_shape_buf, out_shape_buf
+    _fill_shape(py_a_shape, a_shape_buf, a_ndim)
+    _fill_shape(py_b_shape, b_shape_buf, b_ndim)
+    cdef int out_ndim
+    with nogil:
+        out_ndim = c_broadcast_shape(
+            a_shape_buf, a_ndim, b_shape_buf, b_ndim, out_shape_buf)
+    if out_ndim != a_ndim:
+        raise ValueError("NPU add_ requires broadcastable to self shape")
+    cdef int i
+    for i in range(out_ndim):
+        if out_shape_buf[i] != a_shape_buf[i]:
+            raise ValueError("NPU add_ requires broadcastable to self shape")
+
+    runtime = _get_runtime_fast(dev_idx)
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t alpha_handle = _get_alpha_one(dtype_code)
+    cdef uintptr_t a_ptr = a._storage._untyped._device_ptr
+    cdef uintptr_t b_ptr = b._storage._untyped._device_ptr
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.binary_op_with_alpha(
+        _add_getws_ptr, _add_exec_ptr,
+        py_a_shape, a.stride,
+        py_b_shape, b.stride,
+        py_a_shape, a.stride,
+        dtype_code, 2,
+        a_ptr, b_ptr, a_ptr,
+        alpha_handle,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _add_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnAdd execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
+def fast_sub_inplace(a, b):
+    """In-place sub_(a, b) that calls _ffi.binary_op_with_alpha with output aliased to a."""
+    _ensure_npu_imports()
+    _ensure_ffi_binary()
+
+    cdef int dev_idx
+    _validate_npu_binary(a, b, "sub_", &dev_idx)
+
+    a_dtype = a.dtype
+    stream = _get_stream_fast(dev_idx)
+
+    py_a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    py_b_shape = (<TensorImpl>b)._shape_tuple if isinstance(b, TensorImpl) else b.shape
+    cdef int a_ndim = len(py_a_shape)
+    cdef int b_ndim = len(py_b_shape)
+    if a_ndim > MAX_NDIM or b_ndim > MAX_NDIM:
+        raise ValueError(f"ndim exceeds MAX_NDIM ({MAX_NDIM})")
+
+    cdef int64_t[MAX_NDIM] a_shape_buf, b_shape_buf, out_shape_buf
+    _fill_shape(py_a_shape, a_shape_buf, a_ndim)
+    _fill_shape(py_b_shape, b_shape_buf, b_ndim)
+    cdef int out_ndim
+    with nogil:
+        out_ndim = c_broadcast_shape(
+            a_shape_buf, a_ndim, b_shape_buf, b_ndim, out_shape_buf)
+    if out_ndim != a_ndim:
+        raise ValueError("NPU sub_ requires broadcastable to self shape")
+    cdef int i
+    for i in range(out_ndim):
+        if out_shape_buf[i] != a_shape_buf[i]:
+            raise ValueError("NPU sub_ requires broadcastable to self shape")
+
+    runtime = _get_runtime_fast(dev_idx)
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t alpha_handle = _get_alpha_one(dtype_code)
+    cdef uintptr_t a_ptr = a._storage._untyped._device_ptr
+    cdef uintptr_t b_ptr = b._storage._untyped._device_ptr
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.binary_op_with_alpha(
+        _sub_getws_ptr, _sub_exec_ptr,
+        py_a_shape, a.stride,
+        py_b_shape, b.stride,
+        py_a_shape, a.stride,
+        dtype_code, 2,
+        a_ptr, b_ptr, a_ptr,
+        alpha_handle,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _sub_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnSub execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
+def fast_mul_inplace(a, b):
+    """In-place mul_(a, b) that calls _ffi.binary_op_no_alpha with output aliased to a."""
+    _ensure_npu_imports()
+    _ensure_ffi_binary()
+
+    cdef int dev_idx
+    _validate_npu_binary(a, b, "mul_", &dev_idx)
+
+    a_dtype = a.dtype
+    stream = _get_stream_fast(dev_idx)
+
+    py_a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    py_b_shape = (<TensorImpl>b)._shape_tuple if isinstance(b, TensorImpl) else b.shape
+    cdef int a_ndim = len(py_a_shape)
+    cdef int b_ndim = len(py_b_shape)
+    if a_ndim > MAX_NDIM or b_ndim > MAX_NDIM:
+        raise ValueError(f"ndim exceeds MAX_NDIM ({MAX_NDIM})")
+
+    cdef int64_t[MAX_NDIM] a_shape_buf, b_shape_buf, out_shape_buf
+    _fill_shape(py_a_shape, a_shape_buf, a_ndim)
+    _fill_shape(py_b_shape, b_shape_buf, b_ndim)
+    cdef int out_ndim
+    with nogil:
+        out_ndim = c_broadcast_shape(
+            a_shape_buf, a_ndim, b_shape_buf, b_ndim, out_shape_buf)
+    if out_ndim != a_ndim:
+        raise ValueError("NPU mul_ requires broadcastable to self shape")
+    cdef int i
+    for i in range(out_ndim):
+        if out_shape_buf[i] != a_shape_buf[i]:
+            raise ValueError("NPU mul_ requires broadcastable to self shape")
+
+    runtime = _get_runtime_fast(dev_idx)
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr = a._storage._untyped._device_ptr
+    cdef uintptr_t b_ptr = b._storage._untyped._device_ptr
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.binary_op_no_alpha(
+        _mul_getws_ptr, _mul_exec_ptr,
+        py_a_shape, a.stride,
+        py_b_shape, b.stride,
+        py_a_shape, a.stride,
+        dtype_code, 2,
+        a_ptr, b_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _mul_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnMul execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
+def fast_div_inplace(a, b):
+    """In-place div_(a, b) that calls _ffi.binary_op_no_alpha with output aliased to a."""
+    _ensure_npu_imports()
+    _ensure_ffi_binary()
+
+    cdef int dev_idx
+    _validate_npu_binary(a, b, "div_", &dev_idx)
+
+    a_dtype = a.dtype
+    stream = _get_stream_fast(dev_idx)
+
+    py_a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    py_b_shape = (<TensorImpl>b)._shape_tuple if isinstance(b, TensorImpl) else b.shape
+    cdef int a_ndim = len(py_a_shape)
+    cdef int b_ndim = len(py_b_shape)
+    if a_ndim > MAX_NDIM or b_ndim > MAX_NDIM:
+        raise ValueError(f"ndim exceeds MAX_NDIM ({MAX_NDIM})")
+
+    cdef int64_t[MAX_NDIM] a_shape_buf, b_shape_buf, out_shape_buf
+    _fill_shape(py_a_shape, a_shape_buf, a_ndim)
+    _fill_shape(py_b_shape, b_shape_buf, b_ndim)
+    cdef int out_ndim
+    with nogil:
+        out_ndim = c_broadcast_shape(
+            a_shape_buf, a_ndim, b_shape_buf, b_ndim, out_shape_buf)
+    if out_ndim != a_ndim:
+        raise ValueError("NPU div_ requires broadcastable to self shape")
+    cdef int i
+    for i in range(out_ndim):
+        if out_shape_buf[i] != a_shape_buf[i]:
+            raise ValueError("NPU div_ requires broadcastable to self shape")
+
+    runtime = _get_runtime_fast(dev_idx)
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr = a._storage._untyped._device_ptr
+    cdef uintptr_t b_ptr = b._storage._untyped._device_ptr
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.binary_op_no_alpha(
+        _div_getws_ptr, _div_exec_ptr,
+        py_a_shape, a.stride,
+        py_b_shape, b.stride,
+        py_a_shape, a.stride,
+        dtype_code, 2,
+        a_ptr, b_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _div_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnDiv execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
 def fast_pow(a, b):
     return fast_binary_op(a, b, None, "pow")
 

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -23,6 +23,7 @@ try:
         fast_acos as _fast_acos_impl,
         fast_acosh as _fast_acosh_impl,
         fast_add as _fast_add_impl,
+        fast_add_inplace as _fast_add_inplace_impl,
         fast_asin as _fast_asin_impl,
         fast_asinh as _fast_asinh_impl,
         fast_atan as _fast_atan_impl,
@@ -33,6 +34,7 @@ try:
         fast_cosh as _fast_cosh_impl,
         fast_erf as _fast_erf_impl,
         fast_div as _fast_div_impl,
+        fast_div_inplace as _fast_div_inplace_impl,
         fast_erfc as _fast_erfc_impl,
         fast_exp as _fast_exp_impl,
         fast_exp2 as _fast_exp2_impl,
@@ -50,6 +52,7 @@ try:
         fast_log2 as _fast_log2_impl,
         fast_floor_divide as _fast_floor_divide_impl,
         fast_mul as _fast_mul_impl,
+        fast_mul_inplace as _fast_mul_inplace_impl,
         fast_neg as _fast_neg_impl,
         fast_pow as _fast_pow_impl,
         fast_pow_tensor_scalar as _fast_pow_tensor_scalar_impl,
@@ -64,6 +67,7 @@ try:
         fast_sqrt as _fast_sqrt_impl,
         fast_square as _fast_square_impl,
         fast_sub as _fast_sub_impl,
+        fast_sub_inplace as _fast_sub_inplace_impl,
         fast_tan as _fast_tan_impl,
         fast_tanh as _fast_tanh_impl,
         fast_trunc as _fast_trunc_impl,
@@ -116,6 +120,10 @@ try:
     _HAS_FAST_POW = True
     _HAS_FAST_POW_TENSOR_SCALAR = True
     _HAS_FAST_SUB = True
+    _HAS_FAST_ADD_INPLACE = True
+    _HAS_FAST_SUB_INPLACE = True
+    _HAS_FAST_MUL_INPLACE = True
+    _HAS_FAST_DIV_INPLACE = True
 except ImportError:
     _fast_add_impl = None  # type: ignore[assignment]
     _fast_abs_impl = None  # type: ignore[assignment]
@@ -213,6 +221,14 @@ except ImportError:
     _HAS_FAST_POW = False
     _HAS_FAST_POW_TENSOR_SCALAR = False
     _HAS_FAST_SUB = False
+    _HAS_FAST_ADD_INPLACE = False
+    _HAS_FAST_SUB_INPLACE = False
+    _HAS_FAST_MUL_INPLACE = False
+    _HAS_FAST_DIV_INPLACE = False
+    _fast_add_inplace_impl = None  # type: ignore[assignment]
+    _fast_sub_inplace_impl = None  # type: ignore[assignment]
+    _fast_mul_inplace_impl = None  # type: ignore[assignment]
+    _fast_div_inplace_impl = None  # type: ignore[assignment]
 
 
 def add(a, b):
@@ -252,117 +268,35 @@ def div(a, b):
 # ---------------------------------------------------------------------------
 
 def add_(a, b):
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
     if isinstance(b, (int, float)):
         b = _scalar_to_npu_tensor(b, a)
-    if a.device.type != "npu" or b.device.type != "npu":
-        raise ValueError("NPU add_ expects NPU tensors")
-    if a.dtype != b.dtype:
-        raise ValueError("NPU add_ requires matching dtypes")
-    out_shape = _broadcast_shape(a.shape, b.shape)
-    if out_shape != a.shape:
-        raise ValueError("NPU add_ requires broadcastable to self shape")
-    a_storage = _unwrap_storage(a)
-    b_storage = _unwrap_storage(b)
-    aclnn.add(
-        a_storage.data_ptr(),
-        b_storage.data_ptr(),
-        a_storage.data_ptr(),
-        a.shape,
-        a.stride,
-        b.shape,
-        b.stride,
-        out_shape,
-        a.stride,
-        a.dtype,
-        runtime,
-        stream=stream.stream,
-    )
-    return a
+    if _HAS_FAST_ADD_INPLACE:
+        return _fast_add_inplace_impl(a, b)
+    raise RuntimeError("Cython NPU add_ implementation is unavailable")
 
 
 def mul_(a, b):
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
     if isinstance(b, (int, float)):
         b = _scalar_to_npu_tensor(b, a)
-    if a.device.type != "npu" or b.device.type != "npu":
-        raise ValueError("NPU mul_ expects NPU tensors")
-    if a.dtype != b.dtype:
-        raise ValueError("NPU mul_ requires matching dtypes")
-    out_shape = _broadcast_shape(a.shape, b.shape)
-    if out_shape != a.shape:
-        raise ValueError("NPU mul_ requires broadcastable to self shape")
-    a_storage = _unwrap_storage(a)
-    b_storage = _unwrap_storage(b)
-    aclnn.mul(
-        a_storage.data_ptr(),
-        b_storage.data_ptr(),
-        a_storage.data_ptr(),
-        a.shape,
-        a.stride,
-        b.shape,
-        b.stride,
-        out_shape,
-        a.stride,
-        a.dtype,
-        runtime,
-        stream=stream.stream,
-    )
-    return a
+    if _HAS_FAST_MUL_INPLACE:
+        return _fast_mul_inplace_impl(a, b)
+    raise RuntimeError("Cython NPU mul_ implementation is unavailable")
 
 
 def sub_(a, b):
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
     if isinstance(b, (int, float)):
         b = _scalar_to_npu_tensor(b, a)
-    if a.device.type != "npu" or b.device.type != "npu":
-        raise ValueError("NPU sub_ expects NPU tensors")
-    a_storage = _unwrap_storage(a)
-    b_storage = _unwrap_storage(b)
-    aclnn.sub(
-        a_storage.data_ptr(),
-        b_storage.data_ptr(),
-        a_storage.data_ptr(),
-        a.shape,
-        a.stride,
-        b.shape,
-        b.stride,
-        a.shape,
-        a.stride,
-        a.dtype,
-        runtime,
-        stream=stream.stream,
-    )
-    return a
+    if _HAS_FAST_SUB_INPLACE:
+        return _fast_sub_inplace_impl(a, b)
+    raise RuntimeError("Cython NPU sub_ implementation is unavailable")
 
 
 def div_(a, b):
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
     if isinstance(b, (int, float)):
         b = _scalar_to_npu_tensor(b, a)
-    if a.device.type != "npu" or b.device.type != "npu":
-        raise ValueError("NPU div_ expects NPU tensors")
-    a_storage = _unwrap_storage(a)
-    b_storage = _unwrap_storage(b)
-    aclnn.div(
-        a_storage.data_ptr(),
-        b_storage.data_ptr(),
-        a_storage.data_ptr(),
-        a.shape,
-        a.stride,
-        b.shape,
-        b.stride,
-        a.shape,
-        a.stride,
-        a.dtype,
-        runtime,
-        stream=stream.stream,
-    )
-    return a
+    if _HAS_FAST_DIV_INPLACE:
+        return _fast_div_inplace_impl(a, b)
+    raise RuntimeError("Cython NPU div_ implementation is unavailable")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -419,6 +419,22 @@ def test_npu_clamp_wrappers_delegate_to_cython():
             assert marker not in body
 
 
+def test_npu_inplace_arithmetic_wrappers_delegate_to_cython():
+    math_src = _source("src/candle/_backends/npu/ops/math.py")
+    expectations = {
+        "add_": "_fast_add_inplace_impl",
+        "mul_": "_fast_mul_inplace_impl",
+        "sub_": "_fast_sub_inplace_impl",
+        "div_": "_fast_div_inplace_impl",
+    }
+    forbidden = ["aclnn.", "npu_runtime._alloc_device", "_unwrap_storage(", "_wrap_tensor("]
+    for name, fast_name in expectations.items():
+        body = _function_source(math_src, name)
+        assert fast_name in body, f"{name} does not delegate to {fast_name}"
+        for marker in forbidden:
+            assert marker not in body
+
+
 def test_core_npu_training_ops_have_forward_and_autograd_registration():
     forward_ops = _npu_forward_ops()
     autograd_ops = _npu_autograd_ops()


### PR DESCRIPTION
## Summary
- Add `fast_add_inplace`/`fast_sub_inplace`/`fast_mul_inplace`/`fast_div_inplace` in `_C/_npu_ops.pyx`. Each reuses the existing `_ffi.binary_op_with_alpha` (for `add_`/`sub_`) or `binary_op_no_alpha` (for `mul_`/`div_`) primitive, but aliases the output pointer to `a._storage._untyped._device_ptr` so no fresh allocation is made.
- Re-route the Python wrappers `add_`/`mul_`/`sub_`/`div_` in `_backends/npu/ops/math.py` to delegate to those helpers, eliminating `aclnn.*`, `_unwrap_storage`, and `npu_runtime._alloc_device` from their bodies.
- `test_npu_inplace_arithmetic_wrappers_delegate_to_cython` locks the new contract.

Stacks on #445 (clamp helpers).

## Test plan
- [x] `pytest tests/contract/test_npu_mechanism_audit.py -v --tb=short`
- [x] `pytest tests/cpu/ tests/contract/ -v --tb=short`
- [x] `pylint src/candle/ --rcfile=.github/pylint.conf`