### PR TITLE
refactor(npu): hard-delegate in-place copy/fill/clamp to Cython fast helpers

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -1604,6 +1604,8 @@ cdef object _hardtanh_getws_ptr = None   # cached Hardtanh getws pointer
 cdef object _hardtanh_exec_ptr = None    # cached Hardtanh exec pointer
 cdef object _clamp_getws_ptr = None      # cached Clamp getws pointer
 cdef object _clamp_exec_ptr = None       # cached Clamp exec pointer
+cdef object _inplace_copy_getws_ptr = None  # cached InplaceCopy getws pointer
+cdef object _inplace_copy_exec_ptr = None   # cached InplaceCopy exec pointer
 cdef object _gelu_getws_ptr = None       # cached Gelu getws pointer
 cdef object _gelu_exec_ptr = None        # cached Gelu exec pointer
 cdef object _silu_getws_ptr = None       # cached Silu getws pointer
@@ -2094,6 +2096,15 @@ cdef inline void _ensure_ffi_clamp() except *:
         _ensure_ffi_binary()
     _clamp_getws_ptr, _clamp_exec_ptr = _ffi_ref.resolve_op("Clamp")
     _ensure_ffi_scalar_helpers()
+
+
+cdef inline void _ensure_ffi_inplace_copy() except *:
+    global _ffi_ref, _inplace_copy_getws_ptr, _inplace_copy_exec_ptr
+    if _inplace_copy_getws_ptr is not None:
+        return
+    if _ffi_ref is None:
+        _ensure_ffi_binary()
+    _inplace_copy_getws_ptr, _inplace_copy_exec_ptr = _ffi_ref.resolve_op("InplaceCopy")
 
 
 cdef inline void _ensure_ffi_gelu() except *:
@@ -4337,6 +4348,128 @@ def fast_clamp_min(a, min_val):
 
 def fast_clamp_max(a, max_val):
     return fast_clamp(a, None, max_val)
+
+
+def fast_clamp_inplace(a, min_val=None, max_val=None):
+    """In-place clamp_(a, min_val, max_val) reusing _ffi.clamp_optional_scalars_op."""
+    _ensure_npu_imports()
+    _ensure_ffi_clamp()
+
+    if a.device.type != "npu":
+        raise ValueError("NPU clamp_ expects NPU tensors")
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+
+    cdef uintptr_t min_scalar = 0
+    cdef uintptr_t max_scalar = 0
+    if min_val is not None:
+        min_scalar = _create_scalar_fn(_scalar_bytes_fn(min_val, a_dtype), dtype_code)
+    if max_val is not None:
+        max_scalar = _create_scalar_fn(_scalar_bytes_fn(max_val, a_dtype), dtype_code)
+    cdef uintptr_t stream_raw = int(stream.stream)
+    try:
+        ws_size, executor = _ffi_ref.clamp_optional_scalars_op(
+            _clamp_getws_ptr, _clamp_exec_ptr,
+            a_shape, a_stride,
+            a_shape, a_stride,
+            dtype_code, 2,
+            a_ptr, a_ptr,
+            min_scalar, max_scalar,
+            stream_raw)
+
+        if ws_size:
+            workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+            if ret != 0:
+                raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+            try:
+                ret = _ffi_ref.execute(
+                    _clamp_exec_ptr, int(workspace_ptr), ws_size,
+                    executor, stream_raw)
+                if ret != 0:
+                    raise RuntimeError(f"aclnnClamp execute failed: {ret}")
+            finally:
+                runtime.defer_raw_free(workspace_ptr)
+
+        _defer_executor_fn(executor)
+    finally:
+        if min_scalar:
+            _destroy_scalar_fn(int(min_scalar))
+        if max_scalar:
+            _destroy_scalar_fn(int(max_scalar))
+
+    return a
+
+
+def fast_copy_inplace(a, src):
+    """In-place copy_(a, src) using _ffi.inplace_copy_op."""
+    _ensure_npu_imports()
+    _ensure_ffi_inplace_copy()
+
+    if a.device.type != "npu":
+        raise ValueError("NPU copy_ expects NPU tensors")
+
+    cdef int dev_idx = a.device.index or 0
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    src_shape = (<TensorImpl>src)._shape_tuple if isinstance(src, TensorImpl) else src.shape
+    cdef int dtype_code_dst = _dtype_to_acl_code(a.dtype)
+    cdef int dtype_code_src = _dtype_to_acl_code(src.dtype)
+    cdef uintptr_t a_ptr, src_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    if isinstance(src, TensorImpl):
+        src_ptr = <uintptr_t>(<TensorImpl>src)._storage._untyped._device_ptr
+    else:
+        src_ptr = <uintptr_t>src.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.inplace_copy_op(
+        _inplace_copy_getws_ptr, _inplace_copy_exec_ptr,
+        a_shape, a.stride,
+        src_shape, src.stride,
+        dtype_code_dst, dtype_code_src, 2,
+        a_ptr, src_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _inplace_copy_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnInplaceCopy execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
+def fast_fill_inplace(a, value):
+    """In-place fill_(a, value) by broadcasting a scalar tensor via InplaceCopy."""
+    if a.device.type != "npu":
+        raise ValueError("NPU fill_ expects NPU tensors")
+    src = _npu_scalar_like(float(value), a)
+    return fast_copy_inplace(a, src)
 
 
 

--- a/src/candle/_backends/npu/ops/random.py
+++ b/src/candle/_backends/npu/ops/random.py
@@ -18,6 +18,23 @@ from .comparison import lt
 from .elementwise import clamp
 from .math import abs, add, ceil, cos, div, exp, floor, frac, log, mul, neg, sin, sqrt, tan
 
+try:
+    from candle._C._npu_ops import (
+        fast_clamp_inplace as _fast_clamp_inplace_impl,
+        fast_copy_inplace as _fast_copy_inplace_impl,
+        fast_fill_inplace as _fast_fill_inplace_impl,
+    )  # pylint: disable=import-error,no-name-in-module
+    _HAS_FAST_CLAMP_INPLACE = True
+    _HAS_FAST_COPY_INPLACE = True
+    _HAS_FAST_FILL_INPLACE = True
+except ImportError:
+    _fast_clamp_inplace_impl = None  # type: ignore[assignment]
+    _fast_copy_inplace_impl = None  # type: ignore[assignment]
+    _fast_fill_inplace_impl = None  # type: ignore[assignment]
+    _HAS_FAST_CLAMP_INPLACE = False
+    _HAS_FAST_COPY_INPLACE = False
+    _HAS_FAST_FILL_INPLACE = False
+
 
 def randperm(n, dtype=None, device=None, generator=None):
     """Random permutation of integers from 0 to n-1."""
@@ -330,72 +347,23 @@ def geometric_(a, p, generator=None):
 
 def fill_(a, value):
     """In-place fill using scalar tensor copy-back."""
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
-    if a.device.type != "npu":
-        raise ValueError("NPU fill_ expects NPU tensors")
-
-    src = _scalar_to_npu_tensor(float(value), a)
-    aclnn.inplace_copy(
-        _unwrap_storage(a).data_ptr(),
-        _unwrap_storage(src).data_ptr(),
-        a.shape,
-        a.stride,
-        a.dtype,
-        src.shape,
-        src.stride,
-        src.dtype,
-        runtime,
-        stream=stream.stream,
-    )
-    return a
+    if _HAS_FAST_FILL_INPLACE:
+        return _fast_fill_inplace_impl(a, value)
+    raise RuntimeError("Cython NPU fill_ implementation is unavailable")
 
 
 def clamp_(a, min_val=None, max_val=None):
     """In-place clamp: output written back to a's storage."""
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
-    if a.device.type != "npu":
-        raise ValueError("NPU clamp_ expects NPU tensors")
-
-    a_storage = _unwrap_storage(a)
-    # Use clamp_scalar with output == input for in-place
-    aclnn.clamp_scalar(
-        a_storage.data_ptr(),
-        a_storage.data_ptr(),
-        a.shape,
-        a.stride,
-        a.dtype,
-        min_val,
-        max_val,
-        runtime,
-        stream=stream.stream,
-    )
-    return a
+    if _HAS_FAST_CLAMP_INPLACE:
+        return _fast_clamp_inplace_impl(a, min_val, max_val)
+    raise RuntimeError("Cython NPU clamp_ implementation is unavailable")
 
 
 def copy_(a, src):
     """In-place copy from src into a."""
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
-    if a.device.type != "npu":
-        raise ValueError("NPU copy_ expects NPU tensors")
-
-    a_storage = _unwrap_storage(a)
-    src_storage = _unwrap_storage(src)
-    aclnn.inplace_copy(
-        a_storage.data_ptr(),
-        src_storage.data_ptr(),
-        a.shape,
-        a.stride,
-        a.dtype,
-        src.shape,
-        src.stride,
-        src.dtype,
-        runtime,
-        stream=stream.stream,
-    )
-    return a
+    if _HAS_FAST_COPY_INPLACE:
+        return _fast_copy_inplace_impl(a, src)
+    raise RuntimeError("Cython NPU copy_ implementation is unavailable")
 
 
 def erfinv_(a):

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -435,6 +435,21 @@ def test_npu_inplace_arithmetic_wrappers_delegate_to_cython():
             assert marker not in body
 
 
+def test_npu_inplace_copy_and_clamp_wrappers_delegate_to_cython():
+    random_src = _source("src/candle/_backends/npu/ops/random.py")
+    expectations = {
+        "fill_": "_fast_fill_inplace_impl",
+        "copy_": "_fast_copy_inplace_impl",
+        "clamp_": "_fast_clamp_inplace_impl",
+    }
+    forbidden = ["aclnn.", "npu_runtime._alloc_device", "_unwrap_storage(", "_wrap_tensor("]
+    for name, fast_name in expectations.items():
+        body = _function_source(random_src, name)
+        assert fast_name in body, f"{name} does not delegate to {fast_name}"
+        for marker in forbidden:
+            assert marker not in body
+
+
 def test_core_npu_training_ops_have_forward_and_autograd_registration():
     forward_ops = _npu_forward_ops()
     autograd_ops = _npu_autograd_ops()


### PR DESCRIPTION
## Summary
- Add three Cython fast helpers in `_C/_npu_ops.pyx`:
  - `fast_clamp_inplace` reuses `_ffi.clamp_optional_scalars_op` with input pointer aliased to output, skipping the allocation.
  - `fast_copy_inplace` calls a new cached `_ffi.inplace_copy_op` resolver against `InplaceCopy`.
  - `fast_fill_inplace` builds a scalar NPU tensor via `_npu_scalar_like` and delegates to `fast_copy_inplace`.
- Re-route the Python wrappers `clamp_`/`copy_`/`fill_` in `_backends/npu/ops/random.py` to delegate to these helpers, eliminating `aclnn.*`, `_unwrap_storage`, and `npu_runtime._alloc_device` from their bodies.
- `test_npu_inplace_copy_and_clamp_wrappers_delegate_to_cython` locks the new contract.

Stacks on #446 (in-place arithmetic).

## Test plan
- [x] `pytest tests/contract/test_npu_mechanism_audit.py -v --tb=short`
- [x] `pytest tests/cpu/ tests/contract/ -v --tb=short`
- [x] `pylint src/candle/ --rcfile=.github/pylint.conf`