### PR TITLE
refactor(npu): remove Python fallback bodies from zero and reciprocal inplace

### DIFF
--- a/src/candle/_backends/npu/ops/random.py
+++ b/src/candle/_backends/npu/ops/random.py
@@ -71,11 +71,8 @@ def randperm(n, dtype=None, device=None, generator=None):
 
 
 def zero_(a):
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
     if a.device.type != "npu":
         raise ValueError("NPU zero_ expects NPU tensors")
-
     fill_(a, 0.0)
     return a
 
@@ -374,24 +371,10 @@ def erfinv_(a):
 
 def reciprocal_(a):
     """In-place reciprocal: output written back to a's storage."""
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
     if a.device.type != "npu":
         raise ValueError("NPU reciprocal_ expects NPU tensors")
-
+    if not _HAS_FAST_COPY_INPLACE:
+        raise RuntimeError("Cython NPU reciprocal_ implementation is unavailable")
     from .math import pow as pow_op
-
     out = pow_op(a, -1.0)
-    aclnn.inplace_copy(
-        _unwrap_storage(a).data_ptr(),
-        _unwrap_storage(out).data_ptr(),
-        a.shape,
-        a.stride,
-        a.dtype,
-        out.shape,
-        out.stride,
-        out.dtype,
-        runtime,
-        stream=stream.stream,
-    )
-    return a
+    return _fast_copy_inplace_impl(a, out)

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -450,6 +450,22 @@ def test_npu_inplace_copy_and_clamp_wrappers_delegate_to_cython():
             assert marker not in body
 
 
+def test_npu_zero_and_reciprocal_inplace_have_no_python_fallback_bodies():
+    random_src = _source("src/candle/_backends/npu/ops/random.py")
+    forbidden = ["aclnn.", "npu_runtime._alloc_device", "_unwrap_storage(", "_wrap_tensor("]
+
+    zero_body = _function_source(random_src, "zero_")
+    assert "fill_(" in zero_body, "zero_ should delegate to fill_"
+    for marker in forbidden:
+        assert marker not in zero_body, f"zero_ still references {marker}"
+
+    reciprocal_body = _function_source(random_src, "reciprocal_")
+    assert "_fast_copy_inplace_impl" in reciprocal_body, \
+        "reciprocal_ does not delegate to _fast_copy_inplace_impl"
+    for marker in forbidden:
+        assert marker not in reciprocal_body, f"reciprocal_ still references {marker}"
+
+
 def test_core_npu_training_ops_have_forward_and_autograd_registration():
     forward_ops = _npu_forward_ops()
     autograd_ops = _npu_autograd_ops()


### PR DESCRIPTION
## Summary
- Route `reciprocal_` through the Cython-backed `copy_` path after computing the reciprocal result, and trim `zero_` down to its existing `fill_` delegation.
- This removes the direct ACLNN `inplace_copy` wrapper body from `reciprocal_` and the unused runtime/stream setup from `zero_`.
- `test_npu_zero_and_reciprocal_inplace_have_no_python_fallback_bodies` locks these wrappers against `aclnn.*`, `_unwrap_storage`, `_wrap_tensor`, and `npu_runtime._alloc_device` usage.

Stacks on #447 (in-place copy/fill/clamp).

## Test plan
- [x] `pytest tests/contract/test_npu_mechanism_audit.py -v --tb=short`
- [x] `pytest tests/cpu/ tests/contract/ -q --tb=short`
- [x] `pylint src/candle/ --rcfile=.github/pylint.conf`