### PR TITLE
refactor(npu): hard-delegate randint_/random_ floor step to Cython

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -5475,6 +5475,53 @@ def fast_floor(a):
     return _cy_make_npu_tensor(out_ptr, n, a_dtype, a_dev, out_shape, out_stride)
 
 
+def fast_floor_inplace(a):
+    """In-place floor_(a) using aclnnFloor with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_floor()
+
+    if a.device.type != "npu":
+        raise ValueError("NPU floor_ expects NPU tensors")
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _floor_getws_ptr, _floor_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _floor_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnFloor execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
 def fast_ceil(a):
     """Optimized out-of-place ceil(a) that calls _ffi.unary_op directly."""
     _ensure_npu_imports()

--- a/src/candle/_backends/npu/ops/random.py
+++ b/src/candle/_backends/npu/ops/random.py
@@ -23,17 +23,21 @@ try:
         fast_clamp_inplace as _fast_clamp_inplace_impl,
         fast_copy_inplace as _fast_copy_inplace_impl,
         fast_fill_inplace as _fast_fill_inplace_impl,
+        fast_floor_inplace as _fast_floor_inplace_impl,
     )  # pylint: disable=import-error,no-name-in-module
     _HAS_FAST_CLAMP_INPLACE = True
     _HAS_FAST_COPY_INPLACE = True
     _HAS_FAST_FILL_INPLACE = True
+    _HAS_FAST_FLOOR_INPLACE = True
 except ImportError:
     _fast_clamp_inplace_impl = None  # type: ignore[assignment]
     _fast_copy_inplace_impl = None  # type: ignore[assignment]
     _fast_fill_inplace_impl = None  # type: ignore[assignment]
+    _fast_floor_inplace_impl = None  # type: ignore[assignment]
     _HAS_FAST_CLAMP_INPLACE = False
     _HAS_FAST_COPY_INPLACE = False
     _HAS_FAST_FILL_INPLACE = False
+    _HAS_FAST_FLOOR_INPLACE = False
 
 
 def randperm(n, dtype=None, device=None, generator=None):
@@ -198,14 +202,10 @@ def randint_(a, low, high=None, generator=None):
     """In-place randint — fills tensor with random integers from [low, high)."""
     if high is None:
         low, high = 0, low
-    # Fill with uniform [low, high), then floor to get integers
     uniform_(a, float(low), float(high), generator=generator)
-    # In-place floor
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
-    a_storage = _unwrap_storage(a)
-    aclnn.floor(a_storage.data_ptr(), a_storage.data_ptr(), a.shape, a.stride, a.dtype, runtime, stream=stream.stream)
-    return a
+    if _HAS_FAST_FLOOR_INPLACE:
+        return _fast_floor_inplace_impl(a)
+    raise RuntimeError("Cython NPU randint_ floor implementation is unavailable")
 
 
 def random_(a, from_=0, to=None, generator=None):
@@ -218,13 +218,10 @@ def random_(a, from_=0, to=None, generator=None):
             to = 2**24 if np_dtype == np.float32 else 2**53
         else:
             to = int(np.iinfo(np_dtype).max) + 1
-    # Fill with uniform [from_, to), then floor
     uniform_(a, float(from_), float(to), generator=generator)
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
-    a_storage = _unwrap_storage(a)
-    aclnn.floor(a_storage.data_ptr(), a_storage.data_ptr(), a.shape, a.stride, a.dtype, runtime, stream=stream.stream)
-    return a
+    if _HAS_FAST_FLOOR_INPLACE:
+        return _fast_floor_inplace_impl(a)
+    raise RuntimeError("Cython NPU random_ floor implementation is unavailable")
 
 
 def bernoulli_(a, p=0.5, generator=None):

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -466,6 +466,17 @@ def test_npu_zero_and_reciprocal_inplace_have_no_python_fallback_bodies():
         assert marker not in reciprocal_body, f"reciprocal_ still references {marker}"
 
 
+def test_npu_random_integer_inplace_wrappers_delegate_floor_to_cython():
+    random_src = _source("src/candle/_backends/npu/ops/random.py")
+    forbidden = ["aclnn.", "npu_runtime._alloc_device", "_unwrap_storage(", "_wrap_tensor("]
+    for name in ["randint_", "random_"]:
+        body = _function_source(random_src, name)
+        assert "_fast_floor_inplace_impl" in body, \
+            f"{name} does not delegate floor to _fast_floor_inplace_impl"
+        for marker in forbidden:
+            assert marker not in body, f"{name} still references {marker}"
+
+
 def test_core_npu_training_ops_have_forward_and_autograd_registration():
     forward_ops = _npu_forward_ops()
     autograd_ops = _npu_autograd_ops()


### PR DESCRIPTION
## Summary
- Add `fast_floor_inplace` in `_C/_npu_ops.pyx` that calls `_ffi.unary_op` on `aclnnFloor` with the output pointer aliased to the input, skipping the separate allocation.
- Re-route `randint_` and `random_` in `_backends/npu/ops/random.py` to delegate to that helper after their `uniform_` fill, eliminating the direct `aclnn.floor` body, `_unwrap_storage` call, and runtime/stream plumbing.
- `test_npu_random_integer_inplace_wrappers_delegate_floor_to_cython` locks the new contract.

## Test plan
- [x] `pytest tests/contract/test_npu_mechanism_audit.py -v --tb=short`
- [x] `pytest tests/cpu/ tests/contract/ -q --tb=short`
- [x] `pylint src/candle/ --rcfile=.github/pylint.conf`