### PR TITLE
refactor(npu): hard-delegate log_normal_ exp step to Cython

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -3276,6 +3276,53 @@ def fast_exp(a):
     return _cy_make_npu_tensor(out_ptr, n, a_dtype, a_dev, out_shape, out_stride)
 
 
+def fast_exp_inplace(a):
+    """In-place exp_(a) using aclnnExp with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_exp()
+
+    if a.device.type != "npu":
+        raise ValueError("NPU exp_ expects NPU tensors")
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _exp_getws_ptr, _exp_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _exp_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnExp execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
 def fast_expm1(a):
     """Optimized out-of-place expm1(a) that calls _ffi.unary_op directly."""
     _ensure_npu_imports()

--- a/src/candle/_backends/npu/ops/random.py
+++ b/src/candle/_backends/npu/ops/random.py
@@ -22,20 +22,24 @@ try:
     from candle._C._npu_ops import (
         fast_clamp_inplace as _fast_clamp_inplace_impl,
         fast_copy_inplace as _fast_copy_inplace_impl,
+        fast_exp_inplace as _fast_exp_inplace_impl,
         fast_fill_inplace as _fast_fill_inplace_impl,
         fast_floor_inplace as _fast_floor_inplace_impl,
     )  # pylint: disable=import-error,no-name-in-module
     _HAS_FAST_CLAMP_INPLACE = True
     _HAS_FAST_COPY_INPLACE = True
+    _HAS_FAST_EXP_INPLACE = True
     _HAS_FAST_FILL_INPLACE = True
     _HAS_FAST_FLOOR_INPLACE = True
 except ImportError:
     _fast_clamp_inplace_impl = None  # type: ignore[assignment]
     _fast_copy_inplace_impl = None  # type: ignore[assignment]
+    _fast_exp_inplace_impl = None  # type: ignore[assignment]
     _fast_fill_inplace_impl = None  # type: ignore[assignment]
     _fast_floor_inplace_impl = None  # type: ignore[assignment]
     _HAS_FAST_CLAMP_INPLACE = False
     _HAS_FAST_COPY_INPLACE = False
+    _HAS_FAST_EXP_INPLACE = False
     _HAS_FAST_FILL_INPLACE = False
     _HAS_FAST_FLOOR_INPLACE = False
 
@@ -271,11 +275,9 @@ def exponential_(a, lambd=1.0, generator=None):
 def log_normal_(a, mean=1.0, std=2.0, generator=None):
     """In-place log-normal — fills with exp(N(mean, std))."""
     normal_(a, mean, std, generator=generator)
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
-    a_storage = _unwrap_storage(a)
-    aclnn.exp(a_storage.data_ptr(), a_storage.data_ptr(), a.shape, a.stride, a.dtype, runtime, stream=stream.stream)
-    return a
+    if _HAS_FAST_EXP_INPLACE:
+        return _fast_exp_inplace_impl(a)
+    raise RuntimeError("Cython NPU log_normal_ implementation is unavailable")
 
 
 def cauchy_(a, median=0.0, sigma=1.0, generator=None):

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -477,6 +477,16 @@ def test_npu_random_integer_inplace_wrappers_delegate_floor_to_cython():
             assert marker not in body, f"{name} still references {marker}"
 
 
+def test_npu_log_normal_inplace_exp_delegates_to_cython():
+    random_src = _source("src/candle/_backends/npu/ops/random.py")
+    body = _function_source(random_src, "log_normal_")
+    assert "_fast_exp_inplace_impl" in body, \
+        "log_normal_ does not delegate exp to _fast_exp_inplace_impl"
+    forbidden = ["aclnn.", "npu_runtime._alloc_device", "_unwrap_storage(", "_wrap_tensor("]
+    for marker in forbidden:
+        assert marker not in body, f"log_normal_ still references {marker}"
+
+
 def test_core_npu_training_ops_have_forward_and_autograd_registration():
     forward_ops = _npu_forward_ops()
     autograd_ops = _npu_autograd_ops()


### PR DESCRIPTION
## Summary
- Add `fast_exp_inplace` in `_C/_npu_ops.pyx` that calls `_ffi.unary_op` on `aclnnExp` with the output pointer aliased to the input.
- Re-route `log_normal_` in `_backends/npu/ops/random.py` to delegate to that helper after its `normal_` fill, eliminating the direct `aclnn.exp` body, `_unwrap_storage` call, and runtime/stream setup.
- `test_npu_log_normal_inplace_exp_delegates_to_cython` locks the new contract.

## Test plan
- [x] `pytest tests/contract/test_npu_mechanism_audit.py -v --tb=short`
- [x] `pytest tests/cpu/ tests/contract/ -q --tb=short`
- [x] `pylint src/candle/ --rcfile=.github/pylint.conf`