### PR TITLE
refactor(npu): hard-delegate exponential inplace to Cython

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -2722,6 +2722,53 @@ def fast_neg(a):
     return _cy_make_npu_tensor(out_ptr, n, a_dtype, a_dev, out_shape, out_stride)
 
 
+def fast_neg_inplace(a):
+    """In-place neg_(a) using aclnnNeg with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_neg()
+
+    if a.device.type != "npu":
+        raise ValueError("NPU neg_ expects NPU tensors")
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _neg_getws_ptr, _neg_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _neg_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnNeg execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
 def fast_sign(a):
     """Optimized out-of-place sign(a) that calls _ffi.unary_op directly."""
     _ensure_npu_imports()
@@ -3504,6 +3551,53 @@ def fast_log(a):
 
     _defer_executor_fn(executor)
     return _cy_make_npu_tensor(out_ptr, n, a_dtype, a_dev, out_shape, out_stride)
+
+
+def fast_log_inplace(a):
+    """In-place log_(a) using aclnnLog with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_log()
+
+    if a.device.type != "npu":
+        raise ValueError("NPU log_ expects NPU tensors")
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _log_getws_ptr, _log_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _log_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnLog execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
 
 
 def fast_rsqrt(a):

--- a/src/candle/_backends/npu/ops/random.py
+++ b/src/candle/_backends/npu/ops/random.py
@@ -25,23 +25,35 @@ try:
         fast_exp_inplace as _fast_exp_inplace_impl,
         fast_fill_inplace as _fast_fill_inplace_impl,
         fast_floor_inplace as _fast_floor_inplace_impl,
+        fast_log_inplace as _fast_log_inplace_impl,
+        fast_mul_inplace as _fast_mul_inplace_impl,
+        fast_neg_inplace as _fast_neg_inplace_impl,
     )  # pylint: disable=import-error,no-name-in-module
     _HAS_FAST_CLAMP_INPLACE = True
     _HAS_FAST_COPY_INPLACE = True
     _HAS_FAST_EXP_INPLACE = True
     _HAS_FAST_FILL_INPLACE = True
     _HAS_FAST_FLOOR_INPLACE = True
+    _HAS_FAST_LOG_INPLACE = True
+    _HAS_FAST_MUL_INPLACE = True
+    _HAS_FAST_NEG_INPLACE = True
 except ImportError:
     _fast_clamp_inplace_impl = None  # type: ignore[assignment]
     _fast_copy_inplace_impl = None  # type: ignore[assignment]
     _fast_exp_inplace_impl = None  # type: ignore[assignment]
     _fast_fill_inplace_impl = None  # type: ignore[assignment]
     _fast_floor_inplace_impl = None  # type: ignore[assignment]
+    _fast_log_inplace_impl = None  # type: ignore[assignment]
+    _fast_mul_inplace_impl = None  # type: ignore[assignment]
+    _fast_neg_inplace_impl = None  # type: ignore[assignment]
     _HAS_FAST_CLAMP_INPLACE = False
     _HAS_FAST_COPY_INPLACE = False
     _HAS_FAST_EXP_INPLACE = False
     _HAS_FAST_FILL_INPLACE = False
     _HAS_FAST_FLOOR_INPLACE = False
+    _HAS_FAST_LOG_INPLACE = False
+    _HAS_FAST_MUL_INPLACE = False
+    _HAS_FAST_NEG_INPLACE = False
 
 
 def randperm(n, dtype=None, device=None, generator=None):
@@ -254,21 +266,15 @@ def bernoulli_(a, p=0.5, generator=None):
 def exponential_(a, lambd=1.0, generator=None):
     """In-place exponential — fills with samples from Exp(lambd)."""
     uniform_(a, 0.0, 1.0, generator=generator)
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
-    a_storage = _unwrap_storage(a)
-    aclnn.log(a_storage.data_ptr(), a_storage.data_ptr(), a.shape, a.stride, a.dtype, runtime, stream=stream.stream)
-    aclnn.neg(a_storage.data_ptr(), a_storage.data_ptr(), a.shape, a.stride, a.dtype, runtime, stream=stream.stream)
+    if not (_HAS_FAST_LOG_INPLACE and _HAS_FAST_NEG_INPLACE):
+        raise RuntimeError("Cython NPU exponential_ implementation is unavailable")
+    _fast_log_inplace_impl(a)
+    _fast_neg_inplace_impl(a)
     if lambd != 1.0:
+        if not _HAS_FAST_MUL_INPLACE:
+            raise RuntimeError("Cython NPU exponential_ scale implementation is unavailable")
         scale = _scalar_to_npu_tensor(1.0 / lambd, a)
-        scale_storage = _unwrap_storage(scale)
-        numel = _numel(a.shape)
-        tmp_ptr = npu_runtime._alloc_device(numel * _dtype_itemsize(a.dtype), runtime=runtime)
-        aclnn.mul(a_storage.data_ptr(), scale_storage.data_ptr(), tmp_ptr,
-                  a.shape, a.stride, scale.shape, scale.stride, a.shape, a.stride,
-                  a.dtype, runtime, stream=stream.stream)
-        aclnn.inplace_copy(a_storage.data_ptr(), tmp_ptr, a.shape, a.stride, a.dtype, a.shape, a.stride, a.dtype, runtime, stream=stream.stream)
-        runtime.defer_free(tmp_ptr)
+        return _fast_mul_inplace_impl(a, scale)
     return a
 
 

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -487,6 +487,20 @@ def test_npu_log_normal_inplace_exp_delegates_to_cython():
         assert marker not in body, f"log_normal_ still references {marker}"
 
 
+def test_npu_exponential_inplace_delegates_to_cython():
+    random_src = _source("src/candle/_backends/npu/ops/random.py")
+    body = _function_source(random_src, "exponential_")
+    for fast_name in [
+        "_fast_log_inplace_impl",
+        "_fast_neg_inplace_impl",
+        "_fast_mul_inplace_impl",
+    ]:
+        assert fast_name in body, f"exponential_ does not delegate to {fast_name}"
+    forbidden = ["aclnn.", "npu_runtime._alloc_device", "_unwrap_storage(", "_wrap_tensor("]
+    for marker in forbidden:
+        assert marker not in body, f"exponential_ still references {marker}"
+
+
 def test_core_npu_training_ops_have_forward_and_autograd_registration():
     forward_ops = _npu_forward_ops()
     autograd_ops = _npu_autograd_ops()


### PR DESCRIPTION
## Summary
- Add Cython fast helpers for in-place NPU log and neg execution.
- Rewrite NPU exponential_ so log, neg, and scale phases delegate to Cython fast helpers.
- Add a static mechanism audit to prevent Python raw ACLNN fallback from returning.

## Test plan
- [x] /home/jenkins/anaconda3/bin/conda run -n candle311 python -m pytest tests/contract/test_npu_mechanism_audit.py::test_npu_exponential_inplace_delegates_to_cython -q --tb=short
- [x] /home/jenkins/anaconda3/bin/conda run -n candle311 python -m pytest tests/contract/test_npu_mechanism_audit.py -q --tb=short
- [x] /home/jenkins/anaconda3/bin/conda run -n candle311 python -m pytest tests/cpu/ tests/contract/ -q --tb=short
- [x] /home/jenkins/anaconda3/bin/conda run -n candle311 pylint src/candle/ --rcfile=.github/pylint.conf

🤖 Generated with [Claude Code](https://claude.com/claude-code)