### PR TITLE
refactor(npu): hard-delegate bernoulli_ to device ops and Cython copy

### DIFF
--- a/src/candle/_backends/npu/ops/random.py
+++ b/src/candle/_backends/npu/ops/random.py
@@ -243,24 +243,12 @@ def random_(a, from_=0, to=None, generator=None):
 def bernoulli_(a, p=0.5, generator=None):
     """In-place Bernoulli — fills tensor with 0/1 from Bernoulli(p)."""
     uniform_(a, 0.0, 1.0, generator=generator)
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
-    a_storage = _unwrap_storage(a)
-    numel = _numel(a.shape)
-    if hasattr(p, 'storage'):
-        p_storage = _unwrap_storage(p)
-        p_shape, p_stride = p.shape, p.stride
-    else:
-        p_tensor = _scalar_to_npu_tensor(float(p), a)
-        p_storage = _unwrap_storage(p_tensor)
-        p_shape, p_stride = p_tensor.shape, p_tensor.stride
-    bool_ptr = npu_runtime._alloc_device(numel * _dtype_itemsize("bool"), runtime=runtime)
-    aclnn.lt(a_storage.data_ptr(), p_storage.data_ptr(), bool_ptr,
-             a.shape, a.stride, p_shape, p_stride, a.shape, a.stride,
-             a.dtype, runtime, stream=stream.stream)
-    aclnn.cast(bool_ptr, a_storage.data_ptr(), a.shape, a.stride, "bool", a.dtype, runtime, stream=stream.stream)
-    runtime.defer_free(bool_ptr)
-    return a
+    if not _HAS_FAST_COPY_INPLACE:
+        raise RuntimeError("Cython NPU bernoulli_ implementation is unavailable")
+    if not hasattr(p, 'storage'):
+        p = _scalar_to_npu_tensor(float(p), a)
+    out = _cast_tensor_dtype(lt(a, p), a.dtype)
+    return _fast_copy_inplace_impl(a, out)
 
 
 def exponential_(a, lambd=1.0, generator=None):

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -501,6 +501,16 @@ def test_npu_exponential_inplace_delegates_to_cython():
         assert marker not in body, f"exponential_ still references {marker}"
 
 
+def test_npu_bernoulli_inplace_delegates_to_device_ops_and_cython_copy():
+    random_src = _source("src/candle/_backends/npu/ops/random.py")
+    body = _function_source(random_src, "bernoulli_")
+    for expected in ["lt(", "_cast_tensor_dtype(", "_fast_copy_inplace_impl"]:
+        assert expected in body, f"bernoulli_ does not delegate to {expected}"
+    forbidden = ["aclnn.", "npu_runtime._alloc_device", "_unwrap_storage(", "_wrap_tensor("]
+    for marker in forbidden:
+        assert marker not in body, f"bernoulli_ still references {marker}"
+
+
 def test_core_npu_training_ops_have_forward_and_autograd_registration():
     forward_ops = _npu_forward_ops()
     autograd_ops = _npu_autograd_ops()


### PR DESCRIPTION
## Summary
- Replace NPU bernoulli_'s raw ACLNN lt/cast/bool scratch buffer path with on-device lt, _cast_tensor_dtype, and the Cython in-place copy helper.
- Add a static audit asserting bernoulli_ stays delegated to those helpers with no raw aclnn./_unwrap_storage/_alloc_device usage.

## Test plan
- [x] /home/jenkins/anaconda3/bin/conda run -n candle311 python -m pytest tests/contract/test_npu_mechanism_audit.py::test_npu_bernoulli_inplace_delegates_to_device_ops_and_cython_copy -q --tb=short
- [x] /home/jenkins/anaconda3/bin/conda run -n candle311 python -m pytest tests/contract/test_npu_mechanism_audit.py -q --tb=short
- [x] /home/jenkins/anaconda3/bin/conda run -n candle311 python -m pytest tests/cpu/ tests/contract/ -q --tb=short
- [x] /home/jenkins/anaconda3/bin/conda run -n candle311 pylint src/candle/ --rcfile=.github/pylint.conf

🤖 Generated with [Claude Code](https://claude.com/claude-code)