### PR TITLE
refactor(npu): hard-delegate geometric_ to Cython log/div/ceil inplace

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -5724,6 +5724,53 @@ def fast_ceil(a):
     return _cy_make_npu_tensor(out_ptr, n, a_dtype, a_dev, out_shape, out_stride)
 
 
+def fast_ceil_inplace(a):
+    """In-place ceil_(a) using aclnnCeil with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_ceil()
+
+    if a.device.type != "npu":
+        raise ValueError("NPU ceil_ expects NPU tensors")
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _ceil_getws_ptr, _ceil_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _ceil_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnCeil execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
 def fast_round(a):
     """Optimized out-of-place round(a) that calls _ffi.unary_op directly."""
     _ensure_npu_imports()

--- a/src/candle/_backends/npu/ops/random.py
+++ b/src/candle/_backends/npu/ops/random.py
@@ -20,8 +20,10 @@ from .math import abs, add, ceil, cos, div, exp, floor, frac, log, mul, neg, sin
 
 try:
     from candle._C._npu_ops import (
+        fast_ceil_inplace as _fast_ceil_inplace_impl,
         fast_clamp_inplace as _fast_clamp_inplace_impl,
         fast_copy_inplace as _fast_copy_inplace_impl,
+        fast_div_inplace as _fast_div_inplace_impl,
         fast_exp_inplace as _fast_exp_inplace_impl,
         fast_fill_inplace as _fast_fill_inplace_impl,
         fast_floor_inplace as _fast_floor_inplace_impl,
@@ -29,8 +31,10 @@ try:
         fast_mul_inplace as _fast_mul_inplace_impl,
         fast_neg_inplace as _fast_neg_inplace_impl,
     )  # pylint: disable=import-error,no-name-in-module
+    _HAS_FAST_CEIL_INPLACE = True
     _HAS_FAST_CLAMP_INPLACE = True
     _HAS_FAST_COPY_INPLACE = True
+    _HAS_FAST_DIV_INPLACE = True
     _HAS_FAST_EXP_INPLACE = True
     _HAS_FAST_FILL_INPLACE = True
     _HAS_FAST_FLOOR_INPLACE = True
@@ -38,16 +42,20 @@ try:
     _HAS_FAST_MUL_INPLACE = True
     _HAS_FAST_NEG_INPLACE = True
 except ImportError:
+    _fast_ceil_inplace_impl = None  # type: ignore[assignment]
     _fast_clamp_inplace_impl = None  # type: ignore[assignment]
     _fast_copy_inplace_impl = None  # type: ignore[assignment]
+    _fast_div_inplace_impl = None  # type: ignore[assignment]
     _fast_exp_inplace_impl = None  # type: ignore[assignment]
     _fast_fill_inplace_impl = None  # type: ignore[assignment]
     _fast_floor_inplace_impl = None  # type: ignore[assignment]
     _fast_log_inplace_impl = None  # type: ignore[assignment]
     _fast_mul_inplace_impl = None  # type: ignore[assignment]
     _fast_neg_inplace_impl = None  # type: ignore[assignment]
+    _HAS_FAST_CEIL_INPLACE = False
     _HAS_FAST_CLAMP_INPLACE = False
     _HAS_FAST_COPY_INPLACE = False
+    _HAS_FAST_DIV_INPLACE = False
     _HAS_FAST_EXP_INPLACE = False
     _HAS_FAST_FILL_INPLACE = False
     _HAS_FAST_FLOOR_INPLACE = False
@@ -315,24 +323,12 @@ def geometric_(a, p, generator=None):
     """In-place geometric — fills with ceil(ln(U) / ln(1-p))."""
     import math
     uniform_(a, 0.0, 1.0, generator=generator)
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
-    a_storage = _unwrap_storage(a)
-    aclnn.log(a_storage.data_ptr(), a_storage.data_ptr(), a.shape, a.stride, a.dtype, runtime, stream=stream.stream)
-    # divide by log(1-p)
-    log_1_minus_p = math.log(1.0 - float(p))
-    divisor = _scalar_to_npu_tensor(log_1_minus_p, a)
-    divisor_storage = _unwrap_storage(divisor)
-    numel = _numel(a.shape)
-    tmp_ptr = npu_runtime._alloc_device(numel * _dtype_itemsize(a.dtype), runtime=runtime)
-    aclnn.div(a_storage.data_ptr(), divisor_storage.data_ptr(), tmp_ptr,
-              a.shape, a.stride, divisor.shape, divisor.stride, a.shape, a.stride,
-              a.dtype, runtime, stream=stream.stream)
-    aclnn.inplace_copy(a_storage.data_ptr(), tmp_ptr, a.shape, a.stride, a.dtype, a.shape, a.stride, a.dtype, runtime, stream=stream.stream)
-    runtime.defer_free(tmp_ptr)
-    # ceil in-place
-    aclnn.ceil(a_storage.data_ptr(), a_storage.data_ptr(), a.shape, a.stride, a.dtype, runtime, stream=stream.stream)
-    return a
+    if not (_HAS_FAST_LOG_INPLACE and _HAS_FAST_DIV_INPLACE and _HAS_FAST_CEIL_INPLACE):
+        raise RuntimeError("Cython NPU geometric_ implementation is unavailable")
+    _fast_log_inplace_impl(a)
+    divisor = _scalar_to_npu_tensor(math.log(1.0 - float(p)), a)
+    _fast_div_inplace_impl(a, divisor)
+    return _fast_ceil_inplace_impl(a)
 
 
 def fill_(a, value):

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -511,6 +511,20 @@ def test_npu_bernoulli_inplace_delegates_to_device_ops_and_cython_copy():
         assert marker not in body, f"bernoulli_ still references {marker}"
 
 
+def test_npu_geometric_inplace_delegates_to_cython():
+    random_src = _source("src/candle/_backends/npu/ops/random.py")
+    body = _function_source(random_src, "geometric_")
+    for fast_name in [
+        "_fast_log_inplace_impl",
+        "_fast_div_inplace_impl",
+        "_fast_ceil_inplace_impl",
+    ]:
+        assert fast_name in body, f"geometric_ does not delegate to {fast_name}"
+    forbidden = ["aclnn.", "npu_runtime._alloc_device", "_unwrap_storage(", "_wrap_tensor("]
+    for marker in forbidden:
+        assert marker not in body, f"geometric_ still references {marker}"
+
+
 def test_core_npu_training_ops_have_forward_and_autograd_registration():
     forward_ops = _npu_forward_ops()
     autograd_ops = _npu_autograd_ops()


### PR DESCRIPTION
## Summary
- Add fast_ceil_inplace Cython helper for in-place NPU ceil.
- Rewrite NPU geometric_ to delegate log, scalar divide, and ceil through Cython in-place helpers.
- Add a static mechanism audit so geometric_ stays delegated to those helpers without raw ACLNN buffer plumbing.

## Test plan
- [x] /home/jenkins/anaconda3/bin/conda run -n candle311 python -m pytest tests/contract/test_npu_mechanism_audit.py::test_npu_geometric_inplace_delegates_to_cython -q --tb=short
- [x] /home/jenkins/anaconda3/bin/conda run -n candle311 python -m pytest tests/contract/test_npu_mechanism_audit.py -q --tb=short
- [x] /home/jenkins/anaconda3/bin/conda run -n candle311 python -m pytest tests/cpu/ tests/contract/ -q --tb=short
- [x] /home/jenkins/anaconda3/bin/conda run -n candle311 pylint src/candle/ --rcfile=.github/pylint.conf

🤖 Generated with [Claude Code](https://claude.com/claude-code)