### PR TITLE
refactor(npu): hard-delegate cauchy_ to Cython sub/mul/tan/add inplace

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -4081,6 +4081,53 @@ def fast_tan(a):
     return _cy_make_npu_tensor(out_ptr, n, a_dtype, a_dev, out_shape, out_stride)
 
 
+def fast_tan_inplace(a):
+    """In-place tan_(a) using aclnnTan with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_tan()
+
+    if a.device.type != "npu":
+        raise ValueError("NPU tan_ expects NPU tensors")
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _tan_getws_ptr, _tan_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _tan_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnTan execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
 def fast_tanh(a):
     """Optimized out-of-place tanh(a) that calls _ffi.unary_op directly."""
     _ensure_npu_imports()

--- a/src/candle/_backends/npu/ops/random.py
+++ b/src/candle/_backends/npu/ops/random.py
@@ -20,6 +20,7 @@ from .math import abs, add, ceil, cos, div, exp, floor, frac, log, mul, neg, sin
 
 try:
     from candle._C._npu_ops import (
+        fast_add_inplace as _fast_add_inplace_impl,
         fast_ceil_inplace as _fast_ceil_inplace_impl,
         fast_clamp_inplace as _fast_clamp_inplace_impl,
         fast_copy_inplace as _fast_copy_inplace_impl,
@@ -30,7 +31,10 @@ try:
         fast_log_inplace as _fast_log_inplace_impl,
         fast_mul_inplace as _fast_mul_inplace_impl,
         fast_neg_inplace as _fast_neg_inplace_impl,
+        fast_sub_inplace as _fast_sub_inplace_impl,
+        fast_tan_inplace as _fast_tan_inplace_impl,
     )  # pylint: disable=import-error,no-name-in-module
+    _HAS_FAST_ADD_INPLACE = True
     _HAS_FAST_CEIL_INPLACE = True
     _HAS_FAST_CLAMP_INPLACE = True
     _HAS_FAST_COPY_INPLACE = True
@@ -41,7 +45,10 @@ try:
     _HAS_FAST_LOG_INPLACE = True
     _HAS_FAST_MUL_INPLACE = True
     _HAS_FAST_NEG_INPLACE = True
+    _HAS_FAST_SUB_INPLACE = True
+    _HAS_FAST_TAN_INPLACE = True
 except ImportError:
+    _fast_add_inplace_impl = None  # type: ignore[assignment]
     _fast_ceil_inplace_impl = None  # type: ignore[assignment]
     _fast_clamp_inplace_impl = None  # type: ignore[assignment]
     _fast_copy_inplace_impl = None  # type: ignore[assignment]
@@ -52,6 +59,9 @@ except ImportError:
     _fast_log_inplace_impl = None  # type: ignore[assignment]
     _fast_mul_inplace_impl = None  # type: ignore[assignment]
     _fast_neg_inplace_impl = None  # type: ignore[assignment]
+    _fast_sub_inplace_impl = None  # type: ignore[assignment]
+    _fast_tan_inplace_impl = None  # type: ignore[assignment]
+    _HAS_FAST_ADD_INPLACE = False
     _HAS_FAST_CEIL_INPLACE = False
     _HAS_FAST_CLAMP_INPLACE = False
     _HAS_FAST_COPY_INPLACE = False
@@ -62,6 +72,8 @@ except ImportError:
     _HAS_FAST_LOG_INPLACE = False
     _HAS_FAST_MUL_INPLACE = False
     _HAS_FAST_NEG_INPLACE = False
+    _HAS_FAST_SUB_INPLACE = False
+    _HAS_FAST_TAN_INPLACE = False
 
 
 def randperm(n, dtype=None, device=None, generator=None):
@@ -286,39 +298,18 @@ def cauchy_(a, median=0.0, sigma=1.0, generator=None):
     """In-place Cauchy — fills with median + sigma * tan(pi * (U - 0.5))."""
     import math
     uniform_(a, 0.0, 1.0, generator=generator)
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
-    a_storage = _unwrap_storage(a)
-    numel = _numel(a.shape)
-    # sub 0.5
-    aclnn.sub_scalar(a_storage.data_ptr(), 0.5, a_storage.data_ptr(), a.shape, a.stride, a.dtype, runtime, stream=stream.stream)
-    # mul pi
-    pi_tensor = _scalar_to_npu_tensor(math.pi, a)
-    pi_storage = _unwrap_storage(pi_tensor)
-    tmp_ptr = npu_runtime._alloc_device(numel * _dtype_itemsize(a.dtype), runtime=runtime)
-    aclnn.mul(a_storage.data_ptr(), pi_storage.data_ptr(), tmp_ptr,
-              a.shape, a.stride, pi_tensor.shape, pi_tensor.stride, a.shape, a.stride,
-              a.dtype, runtime, stream=stream.stream)
-    aclnn.inplace_copy(a_storage.data_ptr(), tmp_ptr, a.shape, a.stride, a.dtype, a.shape, a.stride, a.dtype, runtime, stream=stream.stream)
-    runtime.defer_free(tmp_ptr)
-    # tan in-place
-    aclnn.tan(a_storage.data_ptr(), a_storage.data_ptr(), a.shape, a.stride, a.dtype, runtime, stream=stream.stream)
-    # mul sigma
+    if not (_HAS_FAST_SUB_INPLACE and _HAS_FAST_MUL_INPLACE and _HAS_FAST_TAN_INPLACE):
+        raise RuntimeError("Cython NPU cauchy_ implementation is unavailable")
+    _fast_sub_inplace_impl(a, _scalar_to_npu_tensor(0.5, a))
+    _fast_mul_inplace_impl(a, _scalar_to_npu_tensor(math.pi, a))
+    _fast_tan_inplace_impl(a)
     if sigma != 1.0:
-        sigma_tensor = _scalar_to_npu_tensor(sigma, a)
-        sigma_storage = _unwrap_storage(sigma_tensor)
-        tmp_ptr2 = npu_runtime._alloc_device(numel * _dtype_itemsize(a.dtype), runtime=runtime)
-        aclnn.mul(a_storage.data_ptr(), sigma_storage.data_ptr(), tmp_ptr2,
-                  a.shape, a.stride, sigma_tensor.shape, sigma_tensor.stride, a.shape, a.stride,
-                  a.dtype, runtime, stream=stream.stream)
-        aclnn.inplace_copy(a_storage.data_ptr(), tmp_ptr2, a.shape, a.stride, a.dtype, a.shape, a.stride, a.dtype, runtime, stream=stream.stream)
-        runtime.defer_free(tmp_ptr2)
-    # add median
+        _fast_mul_inplace_impl(a, _scalar_to_npu_tensor(sigma, a))
     if median != 0.0:
-        aclnn.add_scalar(a_storage.data_ptr(), median, a_storage.data_ptr(), a.shape, a.stride, a.dtype, runtime, stream=stream.stream)
+        if not _HAS_FAST_ADD_INPLACE:
+            raise RuntimeError("Cython NPU cauchy_ median implementation is unavailable")
+        _fast_add_inplace_impl(a, _scalar_to_npu_tensor(median, a))
     return a
-
-
 def geometric_(a, p, generator=None):
     """In-place geometric — fills with ceil(ln(U) / ln(1-p))."""
     import math

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -525,6 +525,21 @@ def test_npu_geometric_inplace_delegates_to_cython():
         assert marker not in body, f"geometric_ still references {marker}"
 
 
+def test_npu_cauchy_inplace_delegates_to_cython():
+    random_src = _source("src/candle/_backends/npu/ops/random.py")
+    body = _function_source(random_src, "cauchy_")
+    for fast_name in [
+        "_fast_sub_inplace_impl",
+        "_fast_mul_inplace_impl",
+        "_fast_tan_inplace_impl",
+        "_fast_add_inplace_impl",
+    ]:
+        assert fast_name in body, f"cauchy_ does not delegate to {fast_name}"
+    forbidden = ["aclnn.", "npu_runtime._alloc_device", "_unwrap_storage(", "_wrap_tensor("]
+    for marker in forbidden:
+        assert marker not in body, f"cauchy_ still references {marker}"
+
+
 def test_core_npu_training_ops_have_forward_and_autograd_registration():
     forward_ops = _npu_forward_ops()
     autograd_ops = _npu_autograd_ops()


### PR DESCRIPTION
## Summary
- Add fast_tan_inplace Cython helper for in-place NPU tan.
- Rewrite NPU cauchy_ to delegate scalar sub, multiply, tan, and median add through Cython in-place helpers.
- Add a static audit so cauchy_ stays delegated to those helpers with no raw aclnn./_unwrap_storage/_alloc_device usage.

## Test plan
- [x] /home/jenkins/anaconda3/bin/conda run -n candle311 python -m pytest tests/contract/test_npu_mechanism_audit.py::test_npu_cauchy_inplace_delegates_to_cython -q --tb=short
- [x] /home/jenkins/anaconda3/bin/conda run -n candle311 python -m pytest tests/contract/test_npu_mechanism_audit.py -q --tb=short
- [x] /home/jenkins/anaconda3/bin/conda run -n candle311 python -m pytest tests/cpu/ tests/contract/ -q --tb=short
- [x] /home/jenkins/anaconda3/bin/conda run -n candle311 pylint src/candle/ --rcfile=.github/pylint.conf

🤖 Generated with [Claude Code](https://claude.com/claude-code)