### PR TITLE
refactor(npu): drop dispatch-redundant device guards from random in-place shims

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -2727,8 +2727,6 @@ def fast_neg_inplace(a):
     _ensure_npu_imports()
     _ensure_ffi_neg()
 
-    if a.device.type != "npu":
-        raise ValueError("NPU neg_ expects NPU tensors")
     cdef int dev_idx = a.device.index or 0
     a_dtype = a.dtype
     runtime = _get_runtime_fast(dev_idx)
@@ -3328,8 +3326,6 @@ def fast_exp_inplace(a):
     _ensure_npu_imports()
     _ensure_ffi_exp()
 
-    if a.device.type != "npu":
-        raise ValueError("NPU exp_ expects NPU tensors")
     cdef int dev_idx = a.device.index or 0
     a_dtype = a.dtype
     runtime = _get_runtime_fast(dev_idx)
@@ -3558,8 +3554,6 @@ def fast_log_inplace(a):
     _ensure_npu_imports()
     _ensure_ffi_log()
 
-    if a.device.type != "npu":
-        raise ValueError("NPU log_ expects NPU tensors")
     cdef int dev_idx = a.device.index or 0
     a_dtype = a.dtype
     runtime = _get_runtime_fast(dev_idx)
@@ -4086,8 +4080,6 @@ def fast_tan_inplace(a):
     _ensure_npu_imports()
     _ensure_ffi_tan()
 
-    if a.device.type != "npu":
-        raise ValueError("NPU tan_ expects NPU tensors")
     cdef int dev_idx = a.device.index or 0
     a_dtype = a.dtype
     runtime = _get_runtime_fast(dev_idx)
@@ -5668,8 +5660,6 @@ def fast_floor_inplace(a):
     _ensure_npu_imports()
     _ensure_ffi_floor()
 
-    if a.device.type != "npu":
-        raise ValueError("NPU floor_ expects NPU tensors")
     cdef int dev_idx = a.device.index or 0
     a_dtype = a.dtype
     runtime = _get_runtime_fast(dev_idx)
@@ -5776,8 +5766,6 @@ def fast_ceil_inplace(a):
     _ensure_npu_imports()
     _ensure_ffi_ceil()
 
-    if a.device.type != "npu":
-        raise ValueError("NPU ceil_ expects NPU tensors")
     cdef int dev_idx = a.device.index or 0
     a_dtype = a.dtype
     runtime = _get_runtime_fast(dev_idx)

--- a/src/candle/_backends/npu/ops/random.py
+++ b/src/candle/_backends/npu/ops/random.py
@@ -111,8 +111,6 @@ def randperm(n, dtype=None, device=None, generator=None):
 
 
 def zero_(a):
-    if a.device.type != "npu":
-        raise ValueError("NPU zero_ expects NPU tensors")
     fill_(a, 0.0)
     return a
 
@@ -120,8 +118,6 @@ def zero_(a):
 def uniform_(a, low=0.0, high=1.0, generator=None):
     runtime = npu_runtime.get_runtime((a.device.index or 0))
     stream = npu_state.current_stream((a.device.index or 0))
-    if a.device.type != "npu":
-        raise ValueError("NPU uniform_ expects NPU tensors")
 
     if _use_soc_fallback("uniform_"):
         from .... import npu as npu_mod
@@ -173,8 +169,6 @@ def uniform_(a, low=0.0, high=1.0, generator=None):
 def normal_(a, mean=0.0, std=1.0, generator=None):
     runtime = npu_runtime.get_runtime((a.device.index or 0))
     stream = npu_state.current_stream((a.device.index or 0))
-    if a.device.type != "npu":
-        raise ValueError("NPU normal_ expects NPU tensors")
 
     if _use_soc_fallback("normal_"):
         # Deterministic NPU-only fallback built from small ops.
@@ -351,8 +345,6 @@ def erfinv_(a):
 
 def reciprocal_(a):
     """In-place reciprocal: output written back to a's storage."""
-    if a.device.type != "npu":
-        raise ValueError("NPU reciprocal_ expects NPU tensors")
     if not _HAS_FAST_COPY_INPLACE:
         raise RuntimeError("Cython NPU reciprocal_ implementation is unavailable")
     from .math import pow as pow_op

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -540,6 +540,15 @@ def test_npu_cauchy_inplace_delegates_to_cython():
         assert marker not in body, f"cauchy_ still references {marker}"
 
 
+def test_npu_random_inplace_shims_have_no_dispatch_redundant_device_guard():
+    random_src = _source("src/candle/_backends/npu/ops/random.py")
+    for name in ["zero_", "uniform_", "normal_", "reciprocal_"]:
+        body = _function_source(random_src, name)
+        assert 'a.device.type != "npu"' not in body, (
+            f"{name} still has dispatch-redundant device guard"
+        )
+
+
 def test_core_npu_training_ops_have_forward_and_autograd_registration():
     forward_ops = _npu_forward_ops()
     autograd_ops = _npu_autograd_ops()


### PR DESCRIPTION
## Summary

- The dispatcher already routes by device key, so `a.device.type != "npu"` checks inside NPU backend wrappers and Cython in-place helpers are dead code on the normal path.
- Drop those guards from `zero_`, `uniform_`, `normal_`, `reciprocal_` in `src/candle/_backends/npu/ops/random.py`, and from the six in-place Cython helpers added across the recent migration stream (`fast_neg_inplace`, `fast_exp_inplace`, `fast_log_inplace`, `fast_tan_inplace`, `fast_floor_inplace`, `fast_ceil_inplace`).
- Pin the cleanup with a new static audit `test_npu_random_inplace_shims_have_no_dispatch_redundant_device_guard` so the dead guards do not return.

Scope intentionally limited to single-tensor in-place wrappers I migrated this stream. Multi-tensor checks (e.g. `a.device.type != "npu" or b.device.type != "npu"`) are kept to catch mixed-device bugs.

## Test Plan

- [x] `tests/contract/test_npu_mechanism_audit.py` — 26 passed
- [x] `tests/cpu/ tests/contract/` — 3333 passed, 30 skipped
- [x] `pylint src/candle/ --rcfile=.github/pylint.conf` — 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)