### PR TITLE
refactor(npu): move relu_ in-place to Cython fast_relu_inplace

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -4304,6 +4304,51 @@ def fast_relu(a):
     return _cy_make_npu_tensor(out_ptr, n, a_dtype, a_dev, out_shape, out_stride)
 
 
+def fast_relu_inplace(a):
+    """In-place relu_(a) using aclnnRelu with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_relu()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _relu_getws_ptr, _relu_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _relu_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnRelu execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
 def fast_leaky_relu(a, negative_slope):
     """Optimized out-of-place leaky_relu(a) that calls _ffi.leaky_relu_op directly."""
     _ensure_npu_imports()

--- a/src/candle/_backends/npu/ops/activation.py
+++ b/src/candle/_backends/npu/ops/activation.py
@@ -8,6 +8,13 @@ except ImportError:
     _HAS_FAST_RELU = False
 
 try:
+    from candle._C._npu_ops import fast_relu_inplace as _fast_relu_inplace_impl  # pylint: disable=import-error,no-name-in-module
+    _HAS_FAST_RELU_INPLACE = True
+except ImportError:
+    _fast_relu_inplace_impl = None  # type: ignore[assignment]
+    _HAS_FAST_RELU_INPLACE = False
+
+try:
     from candle._C._npu_ops import fast_hardtanh as _fast_hardtanh_impl  # pylint: disable=import-error,no-name-in-module
     _HAS_FAST_HARDTANH = True
 except ImportError:
@@ -146,42 +153,9 @@ def relu(a):
 
 
 def relu_(a):
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
-    if a.device.type != "npu":
-        raise ValueError("NPU relu_ expects NPU tensors")
-
-    a_storage = _unwrap_storage(a)
-    out_size = _numel(a.shape) * _dtype_itemsize(a.dtype)
-
-    if _HAS_FAST_RELU:
-        out = _fast_relu_impl(a)
-        npu_runtime.memcpy_d2d(
-            a_storage.data_ptr(),
-            out_size,
-            _unwrap_storage(out).data_ptr(),
-            runtime=runtime,
-        )
-        return a
-
-    out_ptr = npu_runtime._alloc_device(out_size, runtime=runtime)
-    aclnn.relu(
-        a_storage.data_ptr(),
-        out_ptr,
-        a.shape,
-        a.stride,
-        a.dtype,
-        runtime,
-        stream=stream.stream,
-    )
-    npu_runtime.memcpy_d2d(
-        a_storage.data_ptr(),
-        out_size,
-        out_ptr,
-        runtime=runtime,
-    )
-    npu_runtime.get_runtime((a.device.index or 0)).defer_free(out_ptr)
-    return a
+    if _HAS_FAST_RELU_INPLACE:
+        return _fast_relu_inplace_impl(a)
+    raise RuntimeError("Cython NPU relu_ implementation is unavailable")
 
 
 def relu6(a):

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -549,6 +549,22 @@ def test_npu_random_inplace_shims_have_no_dispatch_redundant_device_guard():
         )
 
 
+def test_npu_relu_inplace_delegates_to_cython():
+    activation_src = _source("src/candle/_backends/npu/ops/activation.py")
+    body = _function_source(activation_src, "relu_")
+    assert "_fast_relu_inplace_impl" in body, (
+        "relu_ does not delegate to _fast_relu_inplace_impl"
+    )
+    forbidden = [
+        "aclnn.",
+        "npu_runtime._alloc_device",
+        "npu_runtime.memcpy_d2d",
+        "_unwrap_storage(",
+    ]
+    for marker in forbidden:
+        assert marker not in body, f"relu_ still references {marker}"
+
+
 def test_core_npu_training_ops_have_forward_and_autograd_registration():
     forward_ops = _npu_forward_ops()
     autograd_ops = _npu_autograd_ops()


### PR DESCRIPTION
## Summary

- `relu_` was a Python wrapper that ran the out-of-place `aclnn.relu`, allocated a fresh device buffer, and `memcpy_d2d`'d the result back into the input. That is the same Python-side orchestration pattern Batches 18-21 already removed for other in-place ops.
- Add `fast_relu_inplace(a)` in `src/candle/_C/_npu_ops.pyx`: runs `aclnnRelu` with output aliased to the input pointer (no extra alloc, no memcpy back), same template as the other in-place Cython helpers.
- Rewrite the Python `relu_` shim to delegate to `_fast_relu_inplace_impl` (1-line body that raises if the Cython helper is missing).
- Pin the delegation with a new static audit `test_npu_relu_inplace_delegates_to_cython`.

## Test Plan

- [x] `tests/contract/test_npu_mechanism_audit.py` — 27 passed (includes the new RED-then-GREEN audit)
- [x] `tests/cpu/ tests/contract/` — 3334 passed, 30 skipped
- [x] `pylint src/candle/ --rcfile=.github/pylint.conf` — 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)