### PR TITLE
refactor(npu): drop dispatch-redundant unary device guards

### DIFF
--- a/src/candle/_backends/npu/ops/_helpers.py
+++ b/src/candle/_backends/npu/ops/_helpers.py
@@ -306,8 +306,6 @@ def _batch_offset(index, stride):
 def _unary_op(a, fn, name, out_dtype=None):
     runtime = npu_runtime.get_runtime((a.device.index or 0))
     stream = npu_state.current_stream((a.device.index or 0))
-    if a.device.type != "npu":
-        raise ValueError(f"NPU {name} expects NPU tensors")
     if out_dtype is None:
         out_dtype = a.dtype
     out_size = _numel(a.shape) * _dtype_itemsize(out_dtype)

--- a/src/candle/_backends/npu/ops/activation.py
+++ b/src/candle/_backends/npu/ops/activation.py
@@ -165,9 +165,6 @@ def relu6(a):
 
 
 def softplus(a, beta=1.0, threshold=20.0):
-    if a.device.type != "npu":
-        raise ValueError("NPU softplus expects NPU tensors")
-
     if _use_soc_fallback("softplus"):
         beta = float(beta)
         threshold = float(threshold)

--- a/src/candle/_backends/npu/ops/elementwise.py
+++ b/src/candle/_backends/npu/ops/elementwise.py
@@ -185,8 +185,6 @@ def fmod(a, b):
 
 
 def clamp(a, min_val=None, max_val=None):
-    if a.device.type != "npu":
-        raise ValueError("NPU clamp expects NPU tensors")
     if min_val is None and max_val is None:
         raise ValueError("clamp requires min or max")
     if hasattr(min_val, "shape") and hasattr(max_val, "shape"):
@@ -208,8 +206,6 @@ def clamp(a, min_val=None, max_val=None):
 
 
 def clamp_min(a, min_val):
-    if a.device.type != "npu":
-        raise ValueError("NPU clamp_min expects NPU tensors")
     if hasattr(min_val, "shape"):
         from .reduce import maximum
         return maximum(a, min_val)
@@ -219,8 +215,6 @@ def clamp_min(a, min_val):
 
 
 def clamp_max(a, max_val):
-    if a.device.type != "npu":
-        raise ValueError("NPU clamp_max expects NPU tensors")
     if hasattr(max_val, "shape"):
         from .reduce import minimum
         return minimum(a, max_val)

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -357,8 +357,6 @@ def isinf(a):
 def isnan(a):
     if _HAS_FAST_ISNAN and a.dtype.is_floating_point:
         return _fast_isnan_impl(a)
-    if a.device.type != "npu":
-        raise ValueError("NPU isnan expects NPU tensors")
     if not a.dtype.is_floating_point:
         from . import logical_not
         return logical_not(isfinite(a))

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -565,6 +565,23 @@ def test_npu_relu_inplace_delegates_to_cython():
         assert marker not in body, f"relu_ still references {marker}"
 
 
+def test_npu_single_tensor_unary_shims_have_no_dispatch_redundant_device_guard():
+    targets = [
+        ("src/candle/_backends/npu/ops/activation.py", "softplus"),
+        ("src/candle/_backends/npu/ops/math.py", "isnan"),
+        ("src/candle/_backends/npu/ops/elementwise.py", "clamp"),
+        ("src/candle/_backends/npu/ops/elementwise.py", "clamp_min"),
+        ("src/candle/_backends/npu/ops/elementwise.py", "clamp_max"),
+        ("src/candle/_backends/npu/ops/_helpers.py", "_unary_op"),
+    ]
+    for path, name in targets:
+        src = _source(path)
+        body = _function_source(src, name)
+        assert 'a.device.type != "npu"' not in body, (
+            f"{path}::{name} still has dispatch-redundant device guard"
+        )
+
+
 def test_core_npu_training_ops_have_forward_and_autograd_registration():
     forward_ops = _npu_forward_ops()
     autograd_ops = _npu_autograd_ops()


### PR DESCRIPTION
## Summary

- Remove dispatch-redundant `a.device.type != "npu"` guards from a focused single-input unary subset: `softplus`, `isnan`, `clamp`, `clamp_min`, `clamp_max`, and the shared `_unary_op` helper.
- The dispatcher already routes these wrappers by NPU device key on the normal path.
- Keep multi-input mixed-device checks intentionally out of scope.
- Pin the cleanup with a static audit so the guards do not return.

## Test Plan

- [x] `tests/contract/test_npu_mechanism_audit.py` — 28 passed
- [x] `tests/cpu/ tests/contract/` — 3335 passed, 30 skipped
- [x] `pylint src/candle/ --rcfile=.github/pylint.conf` — 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)