### PR TITLE
refactor(npu): migrate std_ sqrt to Cython-backed shim

### DIFF
--- a/src/candle/_backends/npu/ops/reduce.py
+++ b/src/candle/_backends/npu/ops/reduce.py
@@ -21,7 +21,7 @@ except ImportError:
     _HAS_FAST_MINIMUM = False
 
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor, _unary_op, _binary_op,
+    _unwrap_storage, _wrap_tensor,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,
@@ -797,9 +797,9 @@ def std_(a, dim=None, unbiased=True, keepdim=False):
     same reduction identity as PyTorch's composite math (mean -> squared diff ->
     reduction -> sqrt) rather than a result-only shortcut.
     """
-    if _use_soc_fallback("std"):
-        from .math import div, mul, sub
+    from .math import div, mul, sub, sqrt
 
+    if _use_soc_fallback("std"):
         mean_t = mean(a, dim=dim, keepdim=True)
         diff = sub(a, mean_t)
         sq = mul(diff, diff)
@@ -815,10 +815,10 @@ def std_(a, dim=None, unbiased=True, keepdim=False):
         if denom <= 0:
             raise ValueError("std requires at least one element")
         v = div(var_sum, _scalar_to_npu_tensor(float(denom), var_sum))
-        return _unary_op(v, aclnn.sqrt, "sqrt")
+        return sqrt(v)
     # TODO: re-enable native aclnnStd when CANN fixes 161002 for all-reduce
     v = var_(a, dim=dim, unbiased=unbiased, keepdim=keepdim)
-    return _unary_op(v, aclnn.sqrt, "sqrt")
+    return sqrt(v)
 
 
 def norm_(a, p=2, dim=None, keepdim=False):

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -634,6 +634,16 @@ def test_npu_shape_single_tensor_shims_have_no_dispatch_redundant_device_guard()
         )
 
 
+def test_npu_std_sqrt_delegates_through_cython_sqrt_shim():
+    reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
+    body = _function_source(reduce_src, "std_")
+    forbidden = ["_unary_op(", "aclnn.sqrt"]
+    for marker in forbidden:
+        assert marker not in body, (
+            f"reduce.py::std_ still references {marker}; must delegate to Cython-backed sqrt"
+        )
+
+
 def test_core_npu_training_ops_have_forward_and_autograd_registration():
     forward_ops = _npu_forward_ops()
     autograd_ops = _npu_autograd_ops()


### PR DESCRIPTION
## Summary

- `std_` previously called `_unary_op(v, aclnn.sqrt, "sqrt")` in both the 910B fallback and the native paths. Both branches now call the existing Cython-delegated `sqrt` shim in `math.py`, which routes to `fast_sqrt`.
- Removes the last two `_unary_op` callers in the NPU backend and drops the now-unused `_unary_op`/`_binary_op` imports from `reduce.py`.
- Pinned by a new static-text audit asserting `std_` no longer references `_unary_op` or `aclnn.sqrt`.

## Test plan

- [x] `pytest tests/contract/test_npu_mechanism_audit.py -v` — 31 passed
- [x] `pytest tests/cpu/ tests/contract/ -v --tb=short` — 3338 passed, 30 skipped
- [x] `pylint src/candle/ --rcfile=.github/pylint.conf` — 10.00/10

Generated with Claude Code