### PR TITLE
refactor(npu): drop dispatch-redundant conv.pad guard

### DIFF
--- a/src/candle/_backends/npu/ops/conv.py
+++ b/src/candle/_backends/npu/ops/conv.py
@@ -1200,8 +1200,6 @@ def affine_grid_op(theta, size, align_corners=None):
 
 
 def pad(input, pad, mode='constant', value=0):
-    if input.device.type != "npu":
-        raise ValueError("NPU pad expects NPU tensors")
     if not isinstance(pad, (tuple, list)):
         raise TypeError("pad must be a tuple/list of ints")
     if len(pad) % 2 != 0:

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -634,6 +634,18 @@ def test_npu_shape_single_tensor_shims_have_no_dispatch_redundant_device_guard()
         )
 
 
+def test_npu_conv_single_tensor_shims_have_no_dispatch_redundant_device_guard():
+    conv_src = _source("src/candle/_backends/npu/ops/conv.py")
+    targets = [
+        "pad",
+    ]
+    for name in targets:
+        body = _function_source(conv_src, name)
+        assert 'input.device.type != "npu"' not in body, (
+            f"conv.py::{name} still has dispatch-redundant device guard on `input`"
+        )
+
+
 def test_npu_std_sqrt_delegates_through_cython_sqrt_shim():
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
     body = _function_source(reduce_src, "std_")


### PR DESCRIPTION
## Summary
- Drop the dispatch-redundant `if input.device.type != \"npu\":` guard from `conv.py::pad` — the dispatcher already routes by `input` device key for the single-tensor shim, so the inline check is dead code on the normal path.
- Add an anchored mechanism audit so single-tensor conv shims cannot reintroduce that pattern.

## Test plan
- [x] `/home/jenkins/anaconda3/bin/conda run -n candle311 python -m pytest tests/contract/test_npu_mechanism_audit.py -v --tb=short` — 33 passed
- [x] `/home/jenkins/anaconda3/bin/conda run -n candle311 python -m pytest tests/cpu/ tests/contract/ --tb=short -q` — 3340 passed, 30 skipped
- [x] `/home/jenkins/anaconda3/bin/conda run -n candle311 pylint src/candle/ --rcfile=.github/pylint.conf` — 10.00/10

Generated with Claude Code