### PR TITLE
refactor(npu): drop dispatch-redundant first-arg guards in multi-input shims

### DIFF
--- a/src/candle/_backends/npu/ops/comparison.py
+++ b/src/candle/_backends/npu/ops/comparison.py
@@ -179,7 +179,7 @@ def equal(a, b):
         return False
     if a.dtype != b.dtype:
         return False
-    if a.device.type != "npu" or b.device.type != "npu":
+    if b.device.type != "npu":
         raise ValueError("NPU equal expects NPU tensors")
     neq = ne(a, b)
     # any_ is in __init__.py; use lazy import to avoid circular dependency

--- a/src/candle/_backends/npu/ops/linalg.py
+++ b/src/candle/_backends/npu/ops/linalg.py
@@ -32,7 +32,7 @@ def matmul(a, b, out=None):
 
     runtime = npu_runtime.get_runtime((a.device.index or 0))
     stream = npu_state.current_stream((a.device.index or 0))
-    if a.device.type != "npu" or b.device.type != "npu":
+    if b.device.type != "npu":
         raise ValueError("NPU matmul expects NPU tensors")
     if a.dtype != b.dtype:
         raise ValueError("NPU matmul requires matching dtypes")
@@ -142,7 +142,7 @@ def matmul(a, b, out=None):
 
 def dot(a, b):
     """Dot product of two 1D tensors."""
-    if a.device.type != "npu" or b.device.type != "npu":
+    if b.device.type != "npu":
         raise ValueError("NPU dot expects NPU tensors")
     if a.dtype != b.dtype:
         raise ValueError("NPU dot requires matching dtypes")
@@ -191,7 +191,7 @@ def mv(a, b):
         raise RuntimeError("aclnnMv symbols not available")
     runtime = npu_runtime.get_runtime((a.device.index or 0))
     stream = npu_state.current_stream((a.device.index or 0))
-    if a.device.type != "npu" or b.device.type != "npu":
+    if b.device.type != "npu":
         raise ValueError("NPU mv expects NPU tensors")
     if a.dtype != b.dtype:
         raise ValueError("NPU mv requires matching dtypes")
@@ -242,7 +242,7 @@ def outer(a, b):
         raise RuntimeError("aclnnGer symbols not available")
     runtime = npu_runtime.get_runtime((a.device.index or 0))
     stream = npu_state.current_stream((a.device.index or 0))
-    if a.device.type != "npu" or b.device.type != "npu":
+    if b.device.type != "npu":
         raise ValueError("NPU outer expects NPU tensors")
     if a.dtype != b.dtype:
         raise ValueError("NPU outer requires matching dtypes")

--- a/src/candle/_backends/npu/ops/reduce.py
+++ b/src/candle/_backends/npu/ops/reduce.py
@@ -514,7 +514,7 @@ def searchsorted(sorted_sequence, values, out_int32=False, right=False, side=Non
         raise RuntimeError("aclnnSearchSorted symbols not available")
     runtime = npu_runtime.get_runtime((sorted_sequence.device.index or 0))
     stream = npu_state.current_stream((sorted_sequence.device.index or 0))
-    if sorted_sequence.device.type != "npu" or values.device.type != "npu":
+    if values.device.type != "npu":
         raise ValueError("NPU searchsorted expects NPU tensors")
     if sorted_sequence.dtype != values.dtype:
         raise ValueError("NPU searchsorted requires matching dtypes")

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -646,6 +646,30 @@ def test_npu_conv_single_tensor_shims_have_no_dispatch_redundant_device_guard():
         )
 
 
+def test_npu_multi_input_shims_drop_dispatched_first_arg_guard():
+    """Multi-input NPU shims must not include the dispatcher-routed first arg in
+    cross-device parity checks. The dispatcher has already validated the primary
+    arg before the shim runs, so `<primary>.device.type != "npu" or` is dead
+    code on the normal path. Cross-input parity for secondary args is still
+    required.
+    """
+    expectations = [
+        ("src/candle/_backends/npu/ops/linalg.py", "matmul", "a"),
+        ("src/candle/_backends/npu/ops/linalg.py", "dot", "a"),
+        ("src/candle/_backends/npu/ops/linalg.py", "mv", "a"),
+        ("src/candle/_backends/npu/ops/linalg.py", "outer", "a"),
+        ("src/candle/_backends/npu/ops/reduce.py", "searchsorted", "sorted_sequence"),
+        ("src/candle/_backends/npu/ops/comparison.py", "equal", "a"),
+    ]
+    for path, name, primary in expectations:
+        body = _function_source(_source(path), name)
+        forbidden = f'{primary}.device.type != "npu" or'
+        assert forbidden not in body, (
+            f"{path}::{name} still has dispatch-redundant first-arg device guard: "
+            f"{forbidden}"
+        )
+
+
 def test_npu_std_sqrt_delegates_through_cython_sqrt_shim():
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
     body = _function_source(reduce_src, "std_")


### PR DESCRIPTION
## Summary

Continues the NPU Python-shim cleanup stream. The dispatcher routes by the
primary tensor's device key before any NPU shim runs, so the first-arg half
of `a.device.type != "npu" or b.device.type != "npu":` clauses is dead code
on the normal path. Cross-input parity for secondary args is still enforced.

Shims updated (6 ops):
- `linalg.py`: `matmul`, `dot`, `mv`, `outer` (drop `a` half, keep `b` half)
- `reduce.py`: `searchsorted` (drop `sorted_sequence` half, keep `values`)
- `comparison.py`: `equal` (drop `a` half, keep `b` half)

No behavior change. Pure dead-code removal in dispatch-redundant guards.

## Test plan

- [x] New audit `test_npu_multi_input_shims_drop_dispatched_first_arg_guard`
      in `tests/contract/test_npu_mechanism_audit.py` pins the cleanup
      (RED first, then GREEN after source change).
- [x] `tests/contract/test_npu_mechanism_audit.py` — 34 passed (was 33).
- [x] `tests/cpu/ tests/contract/` — 3341 passed (was 3340).
- [x] `pylint src/candle/ tools/autograd/` — 10.00/10.

�� Generated with [Claude Code](https://claude.com/claude-code)