### PR TITLE
refactor(npu): drop standalone primary-arg device guards in where and pad_sequence

### DIFF
--- a/src/candle/_backends/npu/ops/elementwise.py
+++ b/src/candle/_backends/npu/ops/elementwise.py
@@ -78,8 +78,6 @@ from .shape import contiguous, index_put_, index_select, masked_select, nonzero,
 
 
 def where(cond, x, y):
-    if x.device.type != "npu":
-        raise ValueError("NPU where expects NPU tensors")
     if isinstance(cond, (int, float)):
         cond = _scalar_to_npu_tensor(cond, x)
     if isinstance(y, (int, float)):

--- a/src/candle/_backends/npu/ops/shape.py
+++ b/src/candle/_backends/npu/ops/shape.py
@@ -2280,8 +2280,6 @@ def pad_sequence(seqs, batch_first=False, padding_value=0.0, padding_side="right
         raise ValueError("pad_sequence expects a non-empty list of tensors")
 
     first = seqs[0]
-    if first.device.type != "npu":
-        raise ValueError("NPU pad_sequence expects NPU tensors")
     if padding_side not in ("left", "right"):
         raise ValueError("padding_side must be 'left' or 'right'")
 

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -670,6 +670,27 @@ def test_npu_multi_input_shims_drop_dispatched_first_arg_guard():
         )
 
 
+def test_npu_multi_input_shims_drop_standalone_primary_arg_guard():
+    """Multi-input NPU shims must not include a standalone `if <primary>.device.type
+    != "npu":` guard on the dispatcher-routed primary arg. The dispatcher has
+    already validated the primary's device key before the shim runs, so the
+    standalone guard is dead code on the normal path. Cross-input parity
+    checks on secondary args remain required.
+    """
+    expectations = [
+        # (path, function, primary-arg local name)
+        ("src/candle/_backends/npu/ops/elementwise.py", "where", "x"),
+        ("src/candle/_backends/npu/ops/shape.py", "pad_sequence", "first"),
+    ]
+    for path, name, primary in expectations:
+        body = _function_source(_source(path), name)
+        forbidden = f'if {primary}.device.type != "npu":'
+        assert forbidden not in body, (
+            f"{path}::{name} still has dispatch-redundant standalone primary-arg "
+            f"device guard: `{forbidden}`"
+        )
+
+
 def test_npu_std_sqrt_delegates_through_cython_sqrt_shim():
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
     body = _function_source(reduce_src, "std_")


### PR DESCRIPTION
## Summary

Continues the NPU shim cleanup stream. Two more dispatch-redundant
primary-arg guards removed:

- `elementwise.py::where` — drop `if x.device.type != "npu":`
  (`x` is the dispatched arg per `_functional.py`).
- `shape.py::pad_sequence` — drop `if first.device.type != "npu":`
  on `first = seqs[0]` (`seqs[0]` is the dispatched arg).

Cross-input parity checks on the remaining args (cond, y for where; loop
parity for pad_sequence) stay in place.

## Test plan

- [x] New audit `test_npu_multi_input_shims_drop_standalone_primary_arg_guard`
      in `tests/contract/test_npu_mechanism_audit.py` (RED first, GREEN
      after).
- [x] `tests/contract/test_npu_mechanism_audit.py` — 35 passed (was 34).
- [x] `tests/cpu/ tests/contract/` — 3342 passed (was 3341).
- [x] `pylint src/candle/ tools/autograd/` — 10.00/10.

�� Generated with [Claude Code](https://claude.com/claude-code)