### PR TITLE
refactor(npu): skip dispatched primary in cartesian_prod/block_diag parity loops

### DIFF
--- a/src/candle/_backends/npu/ops/shape.py
+++ b/src/candle/_backends/npu/ops/shape.py
@@ -1852,7 +1852,9 @@ def cartesian_prod(*tensors):
     if len(tensors) == 0:
         raise RuntimeError("cartesian_prod expects at least one tensor")
     first = tensors[0]
-    for t in tensors:
+    if first.dim() != 1:
+        raise ValueError("cartesian_prod expects 1D tensors")
+    for t in tensors[1:]:
         if t.device.type != "npu":
             raise ValueError("NPU cartesian_prod expects NPU tensors")
         if t.dim() != 1:
@@ -1879,7 +1881,9 @@ def block_diag(*tensors):
         raise RuntimeError("block_diag expects at least one tensor")
 
     first = tensors[0]
-    for t in tensors:
+    if first.dim() != 2:
+        raise ValueError("block_diag expects 2D tensors")
+    for t in tensors[1:]:
         if t.device.type != "npu":
             raise ValueError("NPU block_diag expects NPU tensors")
         if t.dim() != 2:

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -691,6 +691,22 @@ def test_npu_multi_input_shims_drop_standalone_primary_arg_guard():
         )
 
 
+def test_npu_sequence_input_shims_skip_dispatched_primary_in_parity_loop():
+    """`cartesian_prod` and `block_diag` are dispatched by
+    `tensors[0].device.type`. Their cross-input parity loop must iterate over
+    `tensors[1:]` so the dispatch-redundant device/dtype check against
+    `tensors[0]` (which is also `first` for the dtype comparison and would be
+    vacuous) is skipped. The dim check on `first` must happen standalone.
+    """
+    shape_src = _source("src/candle/_backends/npu/ops/shape.py")
+    for name in ("cartesian_prod", "block_diag"):
+        body = _function_source(shape_src, name)
+        assert "for t in tensors[1:]:" in body, (
+            f"shape.py::{name} should iterate cross-input parity over "
+            f"`tensors[1:]` so it skips the dispatched primary `tensors[0]`"
+        )
+
+
 def test_npu_std_sqrt_delegates_through_cython_sqrt_shim():
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
     body = _function_source(reduce_src, "std_")


### PR DESCRIPTION
## Summary

`cartesian_prod` and `block_diag` are dispatched by `tensors[0].device.type`,
so iterating the cross-input parity loop over `tensors` (starting at index 0)
re-checks the dispatched primary. The device check against `tensors[0]` is
dispatch-redundant, and `t.dtype != first.dtype` is vacuous when `t is first`.

This PR:

- Lifts the dim check on `first` out of the loop into a standalone
  validation (still runs for `tensors[0]`).
- Iterates the cross-input parity loop over `tensors[1:]` only.

## Test plan

- [x] New audit `test_npu_sequence_input_shims_skip_dispatched_primary_in_parity_loop`
      in `tests/contract/test_npu_mechanism_audit.py` (RED first, GREEN
      after).
- [x] `tests/contract/test_npu_mechanism_audit.py` — 36 passed (was 35).
- [x] `tests/cpu/ tests/contract/` — 3343 passed (was 3342).
- [x] `pylint src/candle/ tools/autograd/` — 10.00/10.

�� Generated with [Claude Code](https://claude.com/claude-code)