### PR TITLE
refactor(npu): lift dispatch-redundant validation out of pad_sequence memcpy loop

### DIFF
--- a/src/candle/_backends/npu/ops/shape.py
+++ b/src/candle/_backends/npu/ops/shape.py
@@ -2307,7 +2307,7 @@ def pad_sequence(seqs, batch_first=False, padding_value=0.0, padding_side="right
     dst_base = int(_unwrap_storage(out).data_ptr())
     out_stride = out.stride
 
-    for i, t in enumerate(seqs):
+    for t in seqs[1:]:
         if t.device.type != "npu":
             raise ValueError("all tensors must be NPU tensors")
         if t.dtype != first.dtype:
@@ -2315,6 +2315,7 @@ def pad_sequence(seqs, batch_first=False, padding_value=0.0, padding_side="right
         if tuple(t.shape[1:]) != trailing:
             raise ValueError("all tensors must have the same trailing dimensions")
 
+    for i, t in enumerate(seqs):
         src = t if t.is_contiguous() else contiguous(t)
         length = int(src.shape[0])
         start_idx = max_len - length if padding_side == "left" else 0

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -707,6 +707,22 @@ def test_npu_sequence_input_shims_skip_dispatched_primary_in_parity_loop():
         )
 
 
+def test_npu_pad_sequence_lifts_dispatch_redundant_validation_out_of_memcpy_loop():
+    """`pad_sequence` is dispatched by `seqs[0].device.type`. The validation
+    block for `seqs[0]` (device dispatch-redundant, dtype vacuous, trailing
+    shape vacuous) must be lifted out of the `enumerate(seqs)` memcpy loop and
+    iterated over `seqs[1:]` instead. The memcpy loop still needs index `i`
+    for offsets so it remains over `enumerate(seqs)`.
+    """
+    shape_src = _source("src/candle/_backends/npu/ops/shape.py")
+    body = _function_source(shape_src, "pad_sequence")
+    assert "for t in seqs[1:]:" in body, (
+        "shape.py::pad_sequence should validate cross-input parity in a "
+        "separate `for t in seqs[1:]:` pre-loop so the dispatched primary "
+        "`seqs[0]` is skipped"
+    )
+
+
 def test_npu_std_sqrt_delegates_through_cython_sqrt_shim():
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
     body = _function_source(reduce_src, "std_")


### PR DESCRIPTION
## Summary

`pad_sequence` is dispatched by `seqs[0].device.type`. Its current
`enumerate(seqs)` loop combines validation and per-tensor memcpy, but the
validation block is dead code when `t is first` (i.e. `i == 0`):

- `t.device.type != "npu"` is dispatch-redundant.
- `t.dtype != first.dtype` is vacuous.
- `tuple(t.shape[1:]) != trailing` is vacuous (`trailing` derived from
  `first.shape[1:]`).

This PR splits validation into a `for t in seqs[1:]:` pre-loop. The
`enumerate(seqs)` memcpy loop is unchanged — index `i` is still needed
for output offsets.

## Test plan

- [x] New audit `test_npu_pad_sequence_lifts_dispatch_redundant_validation_out_of_memcpy_loop`
      (RED first, GREEN after).
- [x] `tests/contract/test_npu_mechanism_audit.py` — 37 passed (was 36).
- [x] `tests/cpu/ tests/contract/` — 3344 passed (was 3343).
- [x] `pylint src/candle/ tools/autograd/` — 10.00/10.

�� Generated with [Claude Code](https://claude.com/claude-code)