### PR TITLE
refactor(npu): drop dispatch-redundant first-arg guard in _binary_op_slow

### DIFF
--- a/src/candle/_backends/npu/ops/_helpers.py
+++ b/src/candle/_backends/npu/ops/_helpers.py
@@ -319,7 +319,7 @@ def _unary_op(a, fn, name, out_dtype=None):
 def _binary_op_slow(a, b, fn, name):
     runtime = npu_runtime.get_runtime((a.device.index or 0))
     stream = npu_state.current_stream((a.device.index or 0))
-    if a.device.type != "npu" or b.device.type != "npu":
+    if b.device.type != "npu":
         raise ValueError(f"NPU {name} expects NPU tensors")
     if a.dtype != b.dtype:
         raise ValueError(f"NPU {name} requires matching dtypes")

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -660,6 +660,7 @@ def test_npu_multi_input_shims_drop_dispatched_first_arg_guard():
         ("src/candle/_backends/npu/ops/linalg.py", "outer", "a"),
         ("src/candle/_backends/npu/ops/reduce.py", "searchsorted", "sorted_sequence"),
         ("src/candle/_backends/npu/ops/comparison.py", "equal", "a"),
+        ("src/candle/_backends/npu/ops/_helpers.py", "_binary_op_slow", "a"),
     ]
     for path, name, primary in expectations:
         body = _function_source(_source(path), name)


### PR DESCRIPTION
## Summary

`_binary_op_slow(a, b, fn, name)` is the Python fallback path of the Cython
`fast_binary_op` (used only when the Cython module fails to load). It is
reached only after the dispatcher has already routed by `a.device.type`,
so the `a.device.type != "npu" or` half of the OR clause is dispatch-
redundant. The `b.device.type != "npu"` half remains as the legitimate
secondary-arg parity check.

Same pattern as PR #463 — extends the existing audit
`test_npu_multi_input_shims_drop_dispatched_first_arg_guard` to pin the
invariant for this helper too.

## Test plan

- [x] Existing audit extended (RED first, GREEN after).
- [x] `tests/contract/test_npu_mechanism_audit.py` — 37 passed.
- [x] `tests/cpu/ tests/contract/` — 3344 passed.
- [x] `pylint src/candle/ tools/autograd/` — 10.00/10.

�� Generated with [Claude Code](https://claude.com/claude-code)