### PR TITLE
refactor(npu): migrate _adam_step_op orchestration to Cython fast_adam_step

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -6860,3 +6860,48 @@ def cy_npu_synchronize(int device_id=0):
         from candle._backends.npu import runtime as _rt_mod
         for ptr in host_frees:
             _rt_mod.acl.rt.free_host(ptr)
+
+
+def fast_adam_step(param, grad, exp_avg, exp_avg_sq, max_exp_avg_sq,
+                   step, double lr, double beta1, double beta2,
+                   double eps, double weight_decay,
+                   bint amsgrad, bint maximize):
+    """Cython entry point for AdamW step. Replaces the Python orchestration
+    that lived in `_backends/npu/ops/optim.py::_adam_step_op`. The actual
+    aclnn kernel invocation continues to flow through `aclnn.apply_adam_w_v2`
+    which delegates to the Cython `_aclnn_ffi.six_tensor_five_floats_two_bools_op`.
+    """
+    _ensure_npu_imports()
+
+    if param.device.type != "npu":
+        raise ValueError("NPU adam_step expects NPU param tensor")
+
+    cdef int dev_idx = param.device.index or 0
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    p_s = param.storage()
+    g_s = grad.storage()
+    ea_s = exp_avg.storage()
+    eas_s = exp_avg_sq.storage()
+
+    import numpy as _np
+    step_np = _np.array([float(step)], dtype=_np.float32)
+    step_ptr, _ = _npu_runtime._copy_cpu_to_npu(step_np, runtime=runtime)
+
+    max_v_ptr = None
+    if amsgrad and max_exp_avg_sq is not None:
+        max_v_ptr = max_exp_avg_sq.storage().data_ptr()
+
+    from candle._backends.npu import aclnn as _aclnn_mod
+    _aclnn_mod.apply_adam_w_v2(
+        p_s.data_ptr(), ea_s.data_ptr(), eas_s.data_ptr(),
+        max_v_ptr, g_s.data_ptr(), step_ptr,
+        param.shape, param.stride, (1,), (1,),
+        param.dtype,
+        lr, beta1, beta2,
+        weight_decay, eps,
+        amsgrad, maximize,
+        runtime=runtime, stream=stream.stream,
+    )
+    return param

--- a/src/candle/_backends/npu/ops/optim.py
+++ b/src/candle/_backends/npu/ops/optim.py
@@ -20,38 +20,26 @@ from .math import abs, add, div, mul, neg, sign, sqrt, sub
 from .random import copy_
 from .reduce import maximum, minimum
 
+try:
+    from candle._C._npu_ops import (
+        fast_adam_step as _fast_adam_step_impl,
+    )  # pylint: disable=import-error,no-name-in-module
+    _HAS_FAST_ADAM_STEP = True
+except ImportError:
+    _fast_adam_step_impl = None  # type: ignore[assignment]
+    _HAS_FAST_ADAM_STEP = False
+
 
 def _adam_step_op(param, grad, exp_avg, exp_avg_sq, max_exp_avg_sq,
                   step, lr, beta1, beta2, eps, weight_decay, amsgrad, maximize):
-    runtime = npu_runtime.get_runtime((param.device.index or 0))
-    stream = npu_state.current_stream((param.device.index or 0))
-
-    p_s = _unwrap_storage(param)
-    g_s = _unwrap_storage(grad)
-    ea_s = _unwrap_storage(exp_avg)
-    eas_s = _unwrap_storage(exp_avg_sq)
-    # Create step tensor on device
-    import numpy as _np
-    step_np = _np.array([float(step)], dtype=_np.float32)
-    step_ptr, _ = npu_runtime._copy_cpu_to_npu(step_np, runtime=runtime)
-    step_shape = (1,)
-    step_stride = (1,)
-
-    max_v_ptr = None
-    if amsgrad and max_exp_avg_sq is not None:
-        max_v_ptr = _unwrap_storage(max_exp_avg_sq).data_ptr()
-
-    aclnn.apply_adam_w_v2(
-        p_s.data_ptr(), ea_s.data_ptr(), eas_s.data_ptr(),
-        max_v_ptr, g_s.data_ptr(), step_ptr,
-        param.shape, param.stride, step_shape, step_stride,
-        param.dtype,
-        float(lr), float(beta1), float(beta2),
-        float(weight_decay), float(eps),
-        bool(amsgrad), bool(maximize),
-        runtime=runtime, stream=stream.stream,
-    )
-    return param
+    if _HAS_FAST_ADAM_STEP:
+        return _fast_adam_step_impl(
+            param, grad, exp_avg, exp_avg_sq, max_exp_avg_sq,
+            step, float(lr), float(beta1), float(beta2),
+            float(eps), float(weight_decay),
+            bool(amsgrad), bool(maximize),
+        )
+    raise RuntimeError("Cython NPU adam_step implementation is unavailable")
 
 
 def _adamw_step_op(param, grad, exp_avg, exp_avg_sq, max_exp_avg_sq,

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -724,6 +724,19 @@ def test_npu_pad_sequence_lifts_dispatch_redundant_validation_out_of_memcpy_loop
     )
 
 
+def test_npu_adam_step_delegates_through_cython_fast_adam_step():
+    """`optim.py::_adam_step_op` must delegate to the Cython `fast_adam_step`
+    helper. The Python shim should not reference `aclnn.apply_adam_w_v2`
+    directly — backend implementation lives in `_C/_npu_ops.pyx`.
+    """
+    optim_src = _source("src/candle/_backends/npu/ops/optim.py")
+    body = _function_source(optim_src, "_adam_step_op")
+    assert "aclnn.apply_adam_w_v2" not in body, (
+        "optim.py::_adam_step_op still calls aclnn.apply_adam_w_v2 directly; "
+        "should delegate to the Cython fast_adam_step helper"
+    )
+
+
 def test_npu_std_sqrt_delegates_through_cython_sqrt_shim():
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
     body = _function_source(reduce_src, "std_")


### PR DESCRIPTION
## Summary

- Add a new Cython entry point ``fast_adam_step`` in ``src/candle/_C/_npu_ops.pyx`` that owns the per-step AdamW orchestration: param/grad/moment storage lookups, step-buffer host->device copy, and the ``apply_adam_w_v2`` dispatch.
- Rewrite ``_backends/npu/ops/optim.py::_adam_step_op`` to import ``fast_adam_step`` and delegate to it. If the Cython module is unavailable, the shim raises ``RuntimeError`` instead of running a Python fallback.
- Add audit ``test_npu_adam_step_delegates_through_cython_fast_adam_step`` to lock down that the Python shim does not re-introduce direct ``aclnn.apply_adam_w_v2`` calls.

This continues the Python-shim-to-Cython migration: the Python side stays a thin PyTorch-aligned wrapper, the C++/CANN orchestration lives in ``_C``.

## Test Plan

- [x] ``conda run -n candle311 python -m pytest tests/contract/test_npu_mechanism_audit.py -v --tb=short`` (38 passed)
- [x] ``conda run -n candle311 python -m pytest tests/cpu/ tests/contract/ --tb=short -q`` (3345 passed, 30 skipped)
- [x] ``conda run -n candle311 pylint src/candle/ tools/autograd/ --rcfile=.github/pylint.conf`` (10.00/10)