### PR TITLE
refactor(npu): migrate trace_op orchestration to Cython fast_trace

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -1638,6 +1638,8 @@ cdef object _addcmul_getws_ptr = None    # cached Addcmul getws pointer
 cdef object _addcmul_exec_ptr = None     # cached Addcmul exec pointer
 cdef object _addcdiv_getws_ptr = None    # cached Addcdiv getws pointer
 cdef object _addcdiv_exec_ptr = None     # cached Addcdiv exec pointer
+cdef object _trace_getws_ptr = None      # cached Trace getws pointer
+cdef object _trace_exec_ptr = None       # cached Trace exec pointer
 
 
 cdef object _scalar_bytes_fn = None      # aclnn._scalar_bytes
@@ -1675,6 +1677,15 @@ cdef inline void _ensure_ffi_addcdiv() except *:
         _ensure_ffi_binary()
     _addcdiv_getws_ptr, _addcdiv_exec_ptr = _ffi_ref.resolve_op("Addcdiv")
     _ensure_ffi_scalar_helpers()
+
+
+cdef inline void _ensure_ffi_trace() except *:
+    global _ffi_ref, _trace_getws_ptr, _trace_exec_ptr
+    if _trace_getws_ptr is not None:
+        return
+    if _ffi_ref is None:
+        _ensure_ffi_binary()
+    _trace_getws_ptr, _trace_exec_ptr = _ffi_ref.resolve_op("Trace")
 
 
 
@@ -6905,3 +6916,61 @@ def fast_adam_step(param, grad, exp_avg, exp_avg_sq, max_exp_avg_sq,
         runtime=runtime, stream=stream.stream,
     )
     return param
+
+
+def fast_trace(a):
+    """Cython entry point for aclnnTrace. Replaces the Python orchestration
+    that lived in `_backends/npu/ops/linalg.py::trace_op`. Sum of diagonal
+    elements of a 2-D matrix — output is a 0-d scalar tensor.
+    """
+    _ensure_npu_imports()
+    _ensure_ffi_trace()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dev = _device_obj_fast(a)
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    out_shape = ()
+    out_stride = ()
+    cdef int isize = c_dtype_itemsize(a_dtype)
+    cdef int64_t alloc_size_trace = isize
+    if dev_idx == 0:
+        _ensure_allocator_dev0()
+        out_ptr = _fast_allocator_dev0.malloc(alloc_size_trace, stream=stream.stream)
+    else:
+        out_ptr = _get_allocator_fn_ref(dev_idx).malloc(alloc_size_trace, stream=stream.stream)
+
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr, o_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    o_ptr = out_ptr
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _trace_getws_ptr, _trace_exec_ptr,
+        a.shape, a.stride,
+        out_shape, out_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, o_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _trace_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnTrace execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return _cy_make_npu_tensor(out_ptr, 1, a_dtype, a_dev, out_shape, out_stride)

--- a/src/candle/_backends/npu/ops/linalg.py
+++ b/src/candle/_backends/npu/ops/linalg.py
@@ -20,6 +20,15 @@ from .math import add, cos, div, exp, mul, sin, sqrt, sub
 from .reduce import sum_
 from .shape import contiguous, diag, diagonal_op, expand, index_select, split, tril, triu
 
+try:
+    from candle._C._npu_ops import (
+        fast_trace as _fast_trace_impl,
+    )  # pylint: disable=import-error,no-name-in-module
+    _HAS_FAST_TRACE = True
+except ImportError:
+    _fast_trace_impl = None  # type: ignore[assignment]
+    _HAS_FAST_TRACE = False
+
 
 def matmul(a, b, out=None):
     user_out = out
@@ -1427,21 +1436,9 @@ def tensordot_op(a, b, dims=2):
 
 def trace_op(a):
     """Sum of diagonal elements of a 2D matrix."""
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
-    a_storage = _unwrap_storage(a)
-    out_shape = ()
-    out_stride = ()
-    out_size = max(1, _numel(out_shape)) * _dtype_itemsize(a.dtype)
-    out_ptr = npu_runtime._alloc_device(out_size, runtime=runtime)
-    aclnn.strace(
-        a_storage.data_ptr(), out_ptr,
-        a.shape, a.stride, a.dtype,
-        out_shape, out_stride,
-        runtime, stream=stream.stream,
-    )
-    out_storage = npu_typed_storage_from_ptr(out_ptr, max(1, _numel(out_shape)), a.dtype, device=a.device)
-    return _wrap_tensor(out_storage, out_shape, out_stride)
+    if _HAS_FAST_TRACE:
+        return _fast_trace_impl(a)
+    raise RuntimeError("Cython NPU trace implementation is unavailable")
 
 
 def cross_op(a, b, dim=-1):

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -737,6 +737,19 @@ def test_npu_adam_step_delegates_through_cython_fast_adam_step():
     )
 
 
+def test_npu_trace_delegates_through_cython_fast_trace():
+    """`linalg.py::trace_op` must delegate to the Cython `fast_trace` helper.
+    The Python shim should not reference `aclnn.strace` directly — the
+    aclnnTrace orchestration belongs in `_C/_npu_ops.pyx`.
+    """
+    linalg_src = _source("src/candle/_backends/npu/ops/linalg.py")
+    body = _function_source(linalg_src, "trace_op")
+    assert "aclnn.strace" not in body, (
+        "linalg.py::trace_op still calls aclnn.strace directly; "
+        "should delegate to the Cython fast_trace helper"
+    )
+
+
 def test_npu_std_sqrt_delegates_through_cython_sqrt_shim():
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
     body = _function_source(reduce_src, "std_")


### PR DESCRIPTION
## Summary

- Add a new Cython entry point ``fast_trace`` in ``src/candle/_C/_npu_ops.pyx`` that owns the aclnnTrace orchestration: runtime/stream lookup, 0-d scalar output allocation, FFI ``unary_op`` call with cached Trace getws/exec pointers, and workspace deferred-free.
- Rewrite ``_backends/npu/ops/linalg.py::trace_op`` to import ``fast_trace`` and delegate to it. If the Cython module is unavailable, the shim raises ``RuntimeError`` instead of running a Python fallback.
- Add audit ``test_npu_trace_delegates_through_cython_fast_trace`` to lock down that the Python shim does not re-introduce direct ``aclnn.strace`` calls.

This continues the Python-shim-to-Cython migration: the Python side stays a thin PyTorch-aligned wrapper, the aclnn orchestration lives in ``_C``.

## Test Plan

- [x] ``conda run -n candle311 python -m pytest tests/contract/test_npu_mechanism_audit.py -v --tb=short`` (39 passed)
- [x] ``conda run -n candle311 python -m pytest tests/cpu/ tests/contract/ --tb=short -q`` (3346 passed, 30 skipped)
- [x] ``conda run -n candle311 pylint src/candle/ tools/autograd/ --rcfile=.github/pylint.conf`` (10.00/10)