### PR TITLE
refactor(npu): migrate linalg_inv orchestration to Cython fast_inverse

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -1640,6 +1640,8 @@ cdef object _addcdiv_getws_ptr = None    # cached Addcdiv getws pointer
 cdef object _addcdiv_exec_ptr = None     # cached Addcdiv exec pointer
 cdef object _trace_getws_ptr = None      # cached Trace getws pointer
 cdef object _trace_exec_ptr = None       # cached Trace exec pointer
+cdef object _inverse_getws_ptr = None    # cached Inverse getws pointer
+cdef object _inverse_exec_ptr = None     # cached Inverse exec pointer
 
 
 cdef object _scalar_bytes_fn = None      # aclnn._scalar_bytes
@@ -1686,6 +1688,15 @@ cdef inline void _ensure_ffi_trace() except *:
     if _ffi_ref is None:
         _ensure_ffi_binary()
     _trace_getws_ptr, _trace_exec_ptr = _ffi_ref.resolve_op("Trace")
+
+
+cdef inline void _ensure_ffi_inverse() except *:
+    global _ffi_ref, _inverse_getws_ptr, _inverse_exec_ptr
+    if _inverse_getws_ptr is not None:
+        return
+    if _ffi_ref is None:
+        _ensure_ffi_binary()
+    _inverse_getws_ptr, _inverse_exec_ptr = _ffi_ref.resolve_op("Inverse")
 
 
 
@@ -6974,3 +6985,66 @@ def fast_trace(a):
 
     _defer_executor_fn(executor)
     return _cy_make_npu_tensor(out_ptr, 1, a_dtype, a_dev, out_shape, out_stride)
+
+
+def fast_inverse(a):
+    """Cython entry point for aclnnInverse. Replaces the Python orchestration
+    that lived in `_backends/npu/ops/linalg.py::linalg_inv`. Output shares
+    the input's shape and stride; uses the contiguous shape/stride for the
+    output FFI argument.
+    """
+    _ensure_npu_imports()
+    _ensure_ffi_inverse()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dev = _device_obj_fast(a)
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    out_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    out_stride = a.stride
+    cdef int64_t n = 1
+    for dim in out_shape:
+        n *= dim
+
+    cdef int isize = c_dtype_itemsize(a_dtype)
+    cdef int64_t alloc_size_inv = n * isize
+    if dev_idx == 0:
+        _ensure_allocator_dev0()
+        out_ptr = _fast_allocator_dev0.malloc(alloc_size_inv, stream=stream.stream)
+    else:
+        out_ptr = _get_allocator_fn_ref(dev_idx).malloc(alloc_size_inv, stream=stream.stream)
+
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr, o_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    o_ptr = out_ptr
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _inverse_getws_ptr, _inverse_exec_ptr,
+        a.shape, a.stride,
+        out_shape, out_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, o_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _inverse_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnInverse execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return _cy_make_npu_tensor(out_ptr, n, a_dtype, a_dev, out_shape, out_stride)

--- a/src/candle/_backends/npu/ops/linalg.py
+++ b/src/candle/_backends/npu/ops/linalg.py
@@ -23,11 +23,15 @@ from .shape import contiguous, diag, diagonal_op, expand, index_select, split, t
 try:
     from candle._C._npu_ops import (
         fast_trace as _fast_trace_impl,
+        fast_inverse as _fast_inverse_impl,
     )  # pylint: disable=import-error,no-name-in-module
     _HAS_FAST_TRACE = True
+    _HAS_FAST_INVERSE = True
 except ImportError:
     _fast_trace_impl = None  # type: ignore[assignment]
+    _fast_inverse_impl = None  # type: ignore[assignment]
     _HAS_FAST_TRACE = False
+    _HAS_FAST_INVERSE = False
 
 
 def matmul(a, b, out=None):
@@ -568,13 +572,9 @@ def linalg_qr(a, mode='reduced'):
 
 
 def linalg_inv(a):
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
-    s = _unwrap_storage(a)
-    out_ptr = npu_runtime._alloc_device(s.nbytes, runtime=runtime)
-    out_storage = npu_typed_storage_from_ptr(out_ptr, _numel(a.shape), a.dtype, device=a.device)
-    aclnn.inverse(s.data_ptr(), out_ptr, a.shape, a.stride, a.dtype, runtime, stream=stream.stream)
-    return _wrap_tensor(out_storage, a.shape, a.stride)
+    if _HAS_FAST_INVERSE:
+        return _fast_inverse_impl(a)
+    raise RuntimeError("Cython NPU inverse implementation is unavailable")
 
 
 def linalg_vector_norm_op(a, ord=2, dim=None, keepdim=False):

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -750,6 +750,19 @@ def test_npu_trace_delegates_through_cython_fast_trace():
     )
 
 
+def test_npu_linalg_inv_delegates_through_cython_fast_inverse():
+    """`linalg.py::linalg_inv` must delegate to the Cython `fast_inverse`
+    helper. The Python shim should not reference `aclnn.inverse` directly —
+    the aclnnInverse orchestration belongs in `_C/_npu_ops.pyx`.
+    """
+    linalg_src = _source("src/candle/_backends/npu/ops/linalg.py")
+    body = _function_source(linalg_src, "linalg_inv")
+    assert "aclnn.inverse" not in body, (
+        "linalg.py::linalg_inv still calls aclnn.inverse directly; "
+        "should delegate to the Cython fast_inverse helper"
+    )
+
+
 def test_npu_std_sqrt_delegates_through_cython_sqrt_shim():
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
     body = _function_source(reduce_src, "std_")


### PR DESCRIPTION
## Summary

- Add a new Cython entry point ``fast_inverse`` in ``src/candle/_C/_npu_ops.pyx`` that owns the aclnnInverse orchestration: runtime/stream lookup, output allocation (same shape/stride as input), FFI ``unary_op`` call with cached Inverse getws/exec pointers, and workspace deferred-free.
- Rewrite ``_backends/npu/ops/linalg.py::linalg_inv`` to import ``fast_inverse`` and delegate to it. If the Cython module is unavailable, the shim raises ``RuntimeError`` instead of running a Python fallback.
- Add audit ``test_npu_linalg_inv_delegates_through_cython_fast_inverse`` to lock down that the Python shim does not re-introduce direct ``aclnn.inverse`` calls.

This continues the Python-shim-to-Cython migration: the Python side stays a thin PyTorch-aligned wrapper, the aclnn orchestration lives in ``_C``.

## Test Plan

- [x] ``conda run -n candle311 python -m pytest tests/contract/test_npu_mechanism_audit.py -v --tb=short`` (40 passed)
- [x] ``conda run -n candle311 python -m pytest tests/cpu/ tests/contract/ --tb=short -q`` (3347 passed, 30 skipped)
- [x] ``conda run -n candle311 pylint src/candle/ tools/autograd/ --rcfile=.github/pylint.conf`` (10.00/10)