### PR TITLE
refactor(npu): drop unused _unary_op helper and clean up imports

### DIFF
--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -5,7 +5,7 @@ from ._helpers import (
     _npu_add_scalar_, _npu_linear_index, npu_index_put_impl,
     _matmul_out_shape, _normalize_tensor_sequence_args,
     _iter_indices, _broadcast_index, _batch_offset,
-    _unary_op, _binary_op,
+    _binary_op,
     _normalize_reduction_dims, _reduce_out_shape,
     _reduce_dim_sizes, _broadcast_dims_to_out,
     _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add, _nan_like,

--- a/src/candle/_backends/npu/ops/_helpers.py
+++ b/src/candle/_backends/npu/ops/_helpers.py
@@ -303,19 +303,6 @@ def _batch_offset(index, stride):
     return sum(i * s for i, s in zip(index, stride))
 
 
-def _unary_op(a, fn, name, out_dtype=None):
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    stream = npu_state.current_stream((a.device.index or 0))
-    if out_dtype is None:
-        out_dtype = a.dtype
-    out_size = _numel(a.shape) * _dtype_itemsize(out_dtype)
-    out_ptr = npu_runtime._alloc_device(out_size, runtime=runtime)
-    storage = _unwrap_storage(a)
-    fn(storage.data_ptr(), out_ptr, a.shape, a.stride, a.dtype, runtime, stream=stream.stream)
-    out_storage = npu_typed_storage_from_ptr(out_ptr, _numel(a.shape), out_dtype, device=a.device)
-    return _wrap_tensor(out_storage, a.shape, a.stride)
-
-
 def _binary_op_slow(a, b, fn, name):
     runtime = npu_runtime.get_runtime((a.device.index or 0))
     stream = npu_state.current_stream((a.device.index or 0))

--- a/src/candle/_backends/npu/ops/activation.py
+++ b/src/candle/_backends/npu/ops/activation.py
@@ -126,7 +126,7 @@ except ImportError:
     _HAS_FAST_ACTIVATION_COMPOSITES = False
 
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor, _unary_op, _binary_op,
+    _unwrap_storage, _wrap_tensor, _binary_op,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,

--- a/src/candle/_backends/npu/ops/comparison.py
+++ b/src/candle/_backends/npu/ops/comparison.py
@@ -66,7 +66,7 @@ except ImportError:
     _HAS_FAST_BITWISE_XOR = False
 
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor, _unary_op,
+    _unwrap_storage, _wrap_tensor,
     _broadcast_shape, _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
     bool_dtype,

--- a/src/candle/_backends/npu/ops/conv.py
+++ b/src/candle/_backends/npu/ops/conv.py
@@ -1,6 +1,6 @@
 """Convolution, pooling, upsampling, and padding operations for NPU."""
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor, _unary_op, _binary_op,
+    _unwrap_storage, _wrap_tensor, _binary_op,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,

--- a/src/candle/_backends/npu/ops/elementwise.py
+++ b/src/candle/_backends/npu/ops/elementwise.py
@@ -57,7 +57,7 @@ except ImportError:
     _HAS_FAST_CLAMP_MAX = False
 
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor, _unary_op, _binary_op,
+    _unwrap_storage, _wrap_tensor, _binary_op,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,

--- a/src/candle/_backends/npu/ops/linalg.py
+++ b/src/candle/_backends/npu/ops/linalg.py
@@ -1,6 +1,6 @@
 """Linear algebra operations for NPU."""
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor, _unary_op, _binary_op,
+    _unwrap_storage, _wrap_tensor, _binary_op,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -1,7 +1,7 @@
 """Arithmetic and unary math operations for NPU."""
 
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor, _unary_op, _binary_op,
+    _unwrap_storage, _wrap_tensor, _binary_op,
     _cast_tensor_dtype, _broadcast_shape, _broadcast_shape_checked,
     _npu_broadcast_to,
     _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,

--- a/src/candle/_backends/npu/ops/norm.py
+++ b/src/candle/_backends/npu/ops/norm.py
@@ -1,6 +1,6 @@
 """Normalization operations for NPU."""
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor, _unary_op, _binary_op,
+    _unwrap_storage, _wrap_tensor, _binary_op,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,

--- a/src/candle/_backends/npu/ops/optim.py
+++ b/src/candle/_backends/npu/ops/optim.py
@@ -1,6 +1,6 @@
 """Optimizer step operations for NPU."""
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor, _unary_op, _binary_op,
+    _unwrap_storage, _wrap_tensor, _binary_op,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,

--- a/src/candle/_backends/npu/ops/random.py
+++ b/src/candle/_backends/npu/ops/random.py
@@ -1,6 +1,6 @@
 """Random number generation and in-place initialization for NPU."""
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor, _unary_op, _binary_op,
+    _unwrap_storage, _wrap_tensor, _binary_op,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,

--- a/src/candle/_backends/npu/ops/shape.py
+++ b/src/candle/_backends/npu/ops/shape.py
@@ -1,7 +1,7 @@
 """Shape manipulation, view, and indexing operations for NPU."""
 import ctypes
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor, _unary_op, _binary_op,
+    _unwrap_storage, _wrap_tensor, _binary_op,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,

--- a/src/candle/_backends/npu/ops/special.py
+++ b/src/candle/_backends/npu/ops/special.py
@@ -21,7 +21,7 @@ except ImportError:
     _HAS_FAST_SPECIAL_COMPOSITES = False
 
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor, _unary_op, _binary_op,
+    _unwrap_storage, _wrap_tensor, _binary_op,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -572,7 +572,6 @@ def test_npu_single_tensor_unary_shims_have_no_dispatch_redundant_device_guard()
         ("src/candle/_backends/npu/ops/elementwise.py", "clamp"),
         ("src/candle/_backends/npu/ops/elementwise.py", "clamp_min"),
         ("src/candle/_backends/npu/ops/elementwise.py", "clamp_max"),
-        ("src/candle/_backends/npu/ops/_helpers.py", "_unary_op"),
     ]
     for path, name in targets:
         src = _source(path)
@@ -760,6 +759,19 @@ def test_npu_linalg_inv_delegates_through_cython_fast_inverse():
     assert "aclnn.inverse" not in body, (
         "linalg.py::linalg_inv still calls aclnn.inverse directly; "
         "should delegate to the Cython fast_inverse helper"
+    )
+
+
+def test_npu_helpers_no_unused_unary_op_python_fallback():
+    """The Python-side `_unary_op` orchestration helper in
+    `_backends/npu/ops/_helpers.py` is dead code — every unary op was
+    migrated to a Cython `fast_*` helper. Remove the helper and its
+    import sites so the surface area matches what is actually in use.
+    """
+    helpers_src = _source("src/candle/_backends/npu/ops/_helpers.py")
+    assert "def _unary_op(" not in helpers_src, (
+        "_helpers.py still defines the unused _unary_op Python helper; "
+        "all NPU unary orchestration now flows through Cython fast_* helpers"
     )
 
 


### PR DESCRIPTION
## Summary

The Python-side `_unary_op` orchestration helper in
`src/candle/_backends/npu/ops/_helpers.py` is dead code — every NPU
single-tensor unary op has been migrated to a Cython `fast_*` helper in
`src/candle/_C/_npu_ops.pyx`. Drop the helper and clean up the now-stale
`_unary_op` entry from the shared `_helpers` import list across all 12
consumer modules.

## Changes

- Remove `_unary_op` from `src/candle/_backends/npu/ops/_helpers.py`
- Drop the symbol from the import list in `__init__.py`, `activation.py`,
  `comparison.py`, `conv.py`, `elementwise.py`, `linalg.py`, `math.py`,
  `norm.py`, `optim.py`, `random.py`, `shape.py`, `special.py`
- Add `test_npu_helpers_no_unused_unary_op_python_fallback` audit so the
  helper cannot return without an updated consumer
- Drop the now-defunct `_unary_op` entry from
  `test_npu_single_tensor_unary_shims_have_no_dispatch_redundant_device_guard`

## Test plan

- [x] `pytest tests/contract/test_npu_mechanism_audit.py` (41 passed)
- [x] `pytest tests/cpu/ tests/contract/` (3348 passed, 30 skipped)
- [x] `pylint src/candle/ tools/autograd/` (10.00/10)