### PR TITLE
refactor(npu): drop duplicate registrations and dead composite ops

### DIFF
--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -277,7 +277,6 @@ from .ops import (
     unflatten_op,
     diagonal_op,
     # Missing forward ops — composites
-    aminmax_op,
     nanmean_op,
     argwhere_op,
     det_op,
@@ -290,7 +289,6 @@ from .ops import (
     uniform_op,
     isreal_op,
     isin_op,
-    bincount_op,
     bucketize_op,
     histc_op,
     histogram_op,
@@ -543,9 +541,7 @@ registry.register("mv", "npu", mv, meta=meta_infer.infer_matmul)
 registry.register("outer", "npu", outer, meta=meta_infer.infer_binary)
 registry.register("searchsorted", "npu", searchsorted, meta=meta_infer.infer_unary)
 registry.register("unique", "npu", unique)
-registry.register("randperm", "npu", randperm)
 registry.register("flatten", "npu", flatten_op, meta=meta_infer.infer_view)
-registry.register("where", "npu", where, meta=meta_infer.infer_binary)
 registry.register("lerp", "npu", lerp, meta=meta_infer.infer_binary)
 registry.register("addcmul", "npu", addcmul, meta=meta_infer.infer_binary)
 registry.register("addcdiv", "npu", addcdiv, meta=meta_infer.infer_binary)
@@ -734,7 +730,6 @@ registry.register("unflatten", "npu", unflatten_op, meta=meta_infer.infer_unflat
 registry.register("diagonal", "npu", diagonal_op, meta=meta_infer.infer_diagonal)
 
 # Missing forward ops — composites
-registry.register("aminmax", "npu", aminmax_op)
 registry.register("nanmean", "npu", nanmean_op, meta=meta_infer.infer_sum)
 registry.register("argwhere", "npu", argwhere_op)
 registry.register("det", "npu", det_op)
@@ -747,7 +742,6 @@ registry.register("cdist", "npu", cdist_op)
 registry.register("uniform", "npu", uniform_op)
 registry.register("isreal", "npu", isreal_op, meta=meta_infer.infer_unary)
 registry.register("isin", "npu", isin_op, meta=meta_infer.infer_binary)
-registry.register("bincount", "npu", bincount_op)
 registry.register("bucketize", "npu", bucketize_op)
 registry.register("histc", "npu", histc_op)
 registry.register("histogram", "npu", histogram_op)

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -42,7 +42,7 @@ from .reduce import (
     cumsum, cumprod, cummax, argsort, sort, topk,
     sum_, mean, var_, std_, norm_, prod_,
     cummin_op, logsumexp_op, renorm_op, nansum,
-    aminmax_op, nanmean_op, argwhere_op,
+    nanmean_op, argwhere_op,
     quantile_op, nanquantile_op, nanmedian_op,
     aminmax_aclnn,
     sum_to_size_npu,
@@ -131,7 +131,7 @@ from .elementwise import (
     clamp, clamp_min, clamp_max,
     heaviside_op, uniform_op, isreal_op,
     isin_op, bucketize_op, diff_op,
-    bincount_op, bincount_aclnn, histc_op, histogram_op,
+    bincount_aclnn, histc_op, histogram_op,
 )
 
 from .special import (

--- a/src/candle/_backends/npu/ops/elementwise.py
+++ b/src/candle/_backends/npu/ops/elementwise.py
@@ -307,37 +307,6 @@ def diff_op(a, n=1, dim=-1, prepend=None, append=None):
     return t
 
 
-def bincount_op(a, weights=None, minlength=0):
-    """Count occurrences of each value in a 1-D int tensor."""
-    from ...._dispatch.dispatcher import dispatch
-    from ...common import view as view_backend
-    flat = dispatch("flatten", "npu", a)
-    n = flat.shape[0]
-    if n == 0:
-        length = max(0, minlength)
-        return dispatch("zeros", "npu", (length,), dtype=float_dtype if weights is not None else int64_dtype, device=a.device)
-    max_val = dispatch("amax", "npu", flat)
-    # We need max_val as a Python int — sync to get value
-    max_val_c = contiguous(max_val)
-    import numpy as _np
-    runtime = npu_runtime.get_runtime((a.device.index or 0))
-    max_np = _np.zeros(1, dtype=_np.int64)
-    npu_runtime._memcpy_d2h(max_np.ctypes.data, max_np.nbytes, _unwrap_storage(max_val_c).data_ptr(), runtime=runtime)
-    length = max(int(max_np[0]) + 1, minlength)
-    out_dtype = weights.dtype if weights is not None else int64_dtype
-    out = dispatch("zeros", "npu", (length,), dtype=out_dtype, device=a.device)
-    if weights is not None:
-        w_flat = dispatch("flatten", "npu", weights)
-    else:
-        w_flat = dispatch("ones", "npu", (n,), dtype=out_dtype, device=a.device)
-    # Use scatter_add to accumulate
-    idx = _cast_tensor_dtype(flat, int64_dtype)
-    idx = view_backend.reshape(idx, (n,))
-    from ...._functional import scatter_add_ as _scatter_add
-    _scatter_add(out, 0, idx, w_flat)
-    return out
-
-
 def bincount_aclnn(a, weights=None, minlength=0):
     import numpy as _np
     from ...._dispatch.dispatcher import dispatch

--- a/src/candle/_backends/npu/ops/reduce.py
+++ b/src/candle/_backends/npu/ops/reduce.py
@@ -1284,14 +1284,6 @@ def nansum(a, dim=None, keepdim=False):
     return _wrap_tensor(out_storage, out_shape, out_stride)
 
 
-def aminmax_op(a, dim=None, keepdim=False):
-    """Simultaneous min and max reduction."""
-    from collections import namedtuple
-    AminmaxResult = namedtuple("aminmax", ["min", "max"])
-    return AminmaxResult(amin(a, dim=dim, keepdim=keepdim),
-                         amax(a, dim=dim, keepdim=keepdim))
-
-
 def aminmax_aclnn(a, dim=None, keepdim=False):
     from collections import namedtuple
     from ...._dispatch.dispatcher import dispatch

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -775,6 +775,24 @@ def test_npu_helpers_no_unused_unary_op_python_fallback():
     )
 
 
+def test_npu_init_has_no_duplicate_registry_register_calls():
+    """`src/candle/_backends/npu/__init__.py` must not register the same
+    op name twice — a later `registry.register(name, "npu", impl)` call
+    silently overrides the earlier one, leaving dead code and dead
+    imports behind. Pick exactly one implementation per op.
+    """
+    init_src = _source("src/candle/_backends/npu/__init__.py")
+    names = re.findall(r'registry\.register\(\s*"([^"]+)"\s*,\s*"npu"', init_src)
+    seen = {}
+    for name in names:
+        seen[name] = seen.get(name, 0) + 1
+    duplicates = sorted(n for n, c in seen.items() if c > 1)
+    assert not duplicates, (
+        f"duplicate NPU registry.register entries for: {duplicates}; "
+        "remove the dead earlier registration so each op has a single entry"
+    )
+
+
 def test_npu_std_sqrt_delegates_through_cython_sqrt_shim():
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
     body = _function_source(reduce_src, "std_")


### PR DESCRIPTION
## Summary

`src/candle/_backends/npu/__init__.py` registered four ops twice — the
later call silently overrode the earlier one, leaving dead code and
dead imports behind. Pick a single implementation per op and add an
audit so this can't regress.

- `aminmax_op` (composite) → overridden by `aminmax_aclnn`. Drop the
  composite definition and import.
- `bincount_op` (composite) → overridden by `bincount_aclnn`. Drop the
  composite definition and import.
- `where` → identical registration line repeated. Drop the duplicate.
- `randperm` → registered twice (the second registration switches the
  registry to `randperm_create`). Drop the first registration line.

## Audit

`test_npu_init_has_no_duplicate_registry_register_calls` scans
`_backends/npu/__init__.py` and fails if any op name appears more than
once in a `registry.register("name", "npu", ...)` call. Confirmed
RED before the source change and GREEN after.

## Test plan

- [x] `pytest tests/contract/test_npu_mechanism_audit.py` (42 passed)
- [x] `pytest tests/cpu/ tests/contract/` (3349 passed, 30 skipped)
- [x] `pylint src/candle/ tools/autograd/` (10.00/10)