### PR TITLE
refactor(npu): drop unused _reduce_dim_sizes/_broadcast_dims_to_out helpers

### DIFF
--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -7,7 +7,6 @@ from ._helpers import (
     _iter_indices, _broadcast_index, _batch_offset,
     _binary_op,
     _normalize_reduction_dims, _reduce_out_shape,
-    _reduce_dim_sizes, _broadcast_dims_to_out,
     _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add, _nan_like,
     # Re-export commonly used imports so op functions can use them
     bool_dtype, int32_dtype, int64_dtype, float_dtype,

--- a/src/candle/_backends/npu/ops/_helpers.py
+++ b/src/candle/_backends/npu/ops/_helpers.py
@@ -356,24 +356,6 @@ def _reduce_out_shape(shape, dims, keepdim):
     return tuple(out_shape)
 
 
-def _reduce_dim_sizes(shape, dims, keepdim):
-    dims = sorted(dims)
-    sizes = []
-    for d in dims:
-        sizes.append(shape[d])
-    if keepdim:
-        out_sizes = [1] * len(shape)
-        for d, size in zip(dims, sizes):
-            out_sizes[d] = size
-        return tuple(out_sizes)
-    return tuple(sizes)
-
-
-def _broadcast_dims_to_out(dims, out_shape, keepdim):
-    if keepdim:
-        return dims
-    offset = len(out_shape) - len(dims)
-    return tuple(range(offset, offset + len(dims)))
 
 
 def _scalar_to_npu_tensor(scalar, ref_tensor):

--- a/src/candle/_backends/npu/ops/reduce.py
+++ b/src/candle/_backends/npu/ops/reduce.py
@@ -26,7 +26,6 @@ from ._helpers import (
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,
     _normalize_reduction_dims, _reduce_out_shape,
-    _reduce_dim_sizes, _broadcast_dims_to_out,
     _cast_tensor_dtype, _npu_broadcast_to, _nan_like,
     _normalize_dim,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -793,6 +793,20 @@ def test_npu_init_has_no_duplicate_registry_register_calls():
     )
 
 
+def test_npu_helpers_no_unused_reduction_dim_helpers():
+    """`_reduce_dim_sizes` and `_broadcast_dims_to_out` in
+    `_backends/npu/ops/_helpers.py` are dead code — only imported by
+    `reduce.py` and `ops/__init__.py`, never actually called. Remove
+    them and their imports to keep the shared helper surface honest.
+    """
+    helpers_src = _source("src/candle/_backends/npu/ops/_helpers.py")
+    for fn in ("_reduce_dim_sizes", "_broadcast_dims_to_out"):
+        assert f"def {fn}(" not in helpers_src, (
+            f"_helpers.py still defines unused {fn}; it has no live callers"
+        )
+
+
+
 def test_npu_std_sqrt_delegates_through_cython_sqrt_shim():
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
     body = _function_source(reduce_src, "std_")


### PR DESCRIPTION
## Summary

`_reduce_dim_sizes` and `_broadcast_dims_to_out` in
`src/candle/_backends/npu/ops/_helpers.py` are dead code — both are
imported by `reduce.py` and `ops/__init__.py` but never invoked.
Drop them and their imports.

## Audit

`test_npu_helpers_no_unused_reduction_dim_helpers` fails if either
helper definition reappears. Confirmed RED before the source change
and GREEN after.

## Test plan

- [x] `pytest tests/contract/test_npu_mechanism_audit.py` (43 passed)
- [x] `pytest tests/cpu/ tests/contract/` (3350 passed, 30 skipped)
- [x] `pylint src/candle/ tools/autograd/` (10.00/10)