### PR TITLE
refactor(npu): drop dead _binary_op imports from 10 ops modules

### DIFF
--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -4,7 +4,6 @@ from ._helpers import (
     _npu_broadcast_to, _npu_arange_1d, _use_soc_fallback,
     _npu_add_scalar_, _npu_linear_index, npu_index_put_impl,
     _normalize_tensor_sequence_args,
-    _binary_op,
     _normalize_reduction_dims, _reduce_out_shape,
     _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add, _nan_like,
     # Re-export commonly used imports so op functions can use them

--- a/src/candle/_backends/npu/ops/activation.py
+++ b/src/candle/_backends/npu/ops/activation.py
@@ -126,7 +126,7 @@ except ImportError:
     _HAS_FAST_ACTIVATION_COMPOSITES = False
 
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor, _binary_op,
+    _unwrap_storage, _wrap_tensor,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,

--- a/src/candle/_backends/npu/ops/conv.py
+++ b/src/candle/_backends/npu/ops/conv.py
@@ -1,6 +1,6 @@
 """Convolution, pooling, upsampling, and padding operations for NPU."""
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor, _binary_op,
+    _unwrap_storage, _wrap_tensor,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,

--- a/src/candle/_backends/npu/ops/elementwise.py
+++ b/src/candle/_backends/npu/ops/elementwise.py
@@ -57,7 +57,7 @@ except ImportError:
     _HAS_FAST_CLAMP_MAX = False
 
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor, _binary_op,
+    _unwrap_storage, _wrap_tensor,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,

--- a/src/candle/_backends/npu/ops/linalg.py
+++ b/src/candle/_backends/npu/ops/linalg.py
@@ -1,6 +1,6 @@
 """Linear algebra operations for NPU."""
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor, _binary_op,
+    _unwrap_storage, _wrap_tensor,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,

--- a/src/candle/_backends/npu/ops/norm.py
+++ b/src/candle/_backends/npu/ops/norm.py
@@ -1,6 +1,6 @@
 """Normalization operations for NPU."""
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor, _binary_op,
+    _unwrap_storage, _wrap_tensor,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,

--- a/src/candle/_backends/npu/ops/optim.py
+++ b/src/candle/_backends/npu/ops/optim.py
@@ -1,6 +1,6 @@
 """Optimizer step operations for NPU."""
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor, _binary_op,
+    _unwrap_storage, _wrap_tensor,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,

--- a/src/candle/_backends/npu/ops/random.py
+++ b/src/candle/_backends/npu/ops/random.py
@@ -1,6 +1,6 @@
 """Random number generation and in-place initialization for NPU."""
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor, _binary_op,
+    _unwrap_storage, _wrap_tensor,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,

--- a/src/candle/_backends/npu/ops/shape.py
+++ b/src/candle/_backends/npu/ops/shape.py
@@ -1,7 +1,7 @@
 """Shape manipulation, view, and indexing operations for NPU."""
 import ctypes
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor, _binary_op,
+    _unwrap_storage, _wrap_tensor,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,

--- a/src/candle/_backends/npu/ops/special.py
+++ b/src/candle/_backends/npu/ops/special.py
@@ -21,7 +21,7 @@ except ImportError:
     _HAS_FAST_SPECIAL_COMPOSITES = False
 
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor, _binary_op,
+    _unwrap_storage, _wrap_tensor,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -838,6 +838,36 @@ def test_npu_ops_modules_do_not_import_linalg_only_helpers():
 
 
 
+def test_npu_ops_modules_do_not_import_unused_binary_op_helper():
+    """`_binary_op` is a thin wrapper around the Cython `fast_binary_op`
+    that exists only for the helper's own internal use (and one fallback
+    shim in `_C/_npu_ops_fallback.py`). The ops modules import the name
+    but never call it — drop the dead imports so the helper surface stays
+    honest.
+    """
+    consumer_modules = (
+        "src/candle/_backends/npu/ops/__init__.py",
+        "src/candle/_backends/npu/ops/activation.py",
+        "src/candle/_backends/npu/ops/conv.py",
+        "src/candle/_backends/npu/ops/elementwise.py",
+        "src/candle/_backends/npu/ops/linalg.py",
+        "src/candle/_backends/npu/ops/norm.py",
+        "src/candle/_backends/npu/ops/optim.py",
+        "src/candle/_backends/npu/ops/random.py",
+        "src/candle/_backends/npu/ops/shape.py",
+        "src/candle/_backends/npu/ops/special.py",
+    )
+    offenders = []
+    for path in consumer_modules:
+        src = _source(path)
+        if re.search(r"\b_binary_op\b", src):
+            offenders.append(path)
+    assert not offenders, (
+        "These NPU ops modules still reference _binary_op but never call it — "
+        "drop the unused import:\n  " + "\n  ".join(offenders)
+    )
+
+
 def test_npu_std_sqrt_delegates_through_cython_sqrt_shim():
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
     body = _function_source(reduce_src, "std_")


### PR DESCRIPTION
## Summary

- \`_binary_op\` is a thin wrapper around the Cython \`fast_binary_op\` helper. It is used internally by \`_helpers.py\` (for scalar/index helpers) and re-exported through \`_C/_npu_ops_fallback.py\`, but the 9 ops modules that import it never call it.
- Drop the dead import from \`activation.py\`, \`conv.py\`, \`elementwise.py\`, \`linalg.py\`, \`norm.py\`, \`optim.py\`, \`random.py\`, \`shape.py\`, \`special.py\`, and the \`ops/__init__.py\` re-export block.
- Add a mechanism audit (\`test_npu_ops_modules_do_not_import_unused_binary_op_helper\`) so the import cannot drift back in.

## Test Plan

- [x] \`pytest tests/contract/test_npu_mechanism_audit.py\` — 45 passed
- [x] \`pytest tests/cpu/ tests/contract/\` — 3352 passed, 30 skipped
- [x] \`pylint src/candle/ tools/autograd/\` — 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)