### PR TITLE
refactor(npu): drop unused _scalar_to_npu_tensor_no_add helper

### DIFF
--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -5,7 +5,7 @@ from ._helpers import (
     _npu_add_scalar_, _npu_linear_index, npu_index_put_impl,
     _normalize_tensor_sequence_args,
     _normalize_reduction_dims, _reduce_out_shape,
-    _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add, _nan_like,
+    _scalar_to_npu_tensor, _nan_like,
     # Re-export commonly used imports so op functions can use them
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/src/candle/_backends/npu/ops/_helpers.py
+++ b/src/candle/_backends/npu/ops/_helpers.py
@@ -413,34 +413,6 @@ def _scalar_to_npu_tensor(scalar, ref_tensor):
     return _wrap_tensor(out_storage, out_shape, out_stride)
 
 
-def _scalar_to_npu_tensor_no_add(scalar, ref_tensor):
-    """Helper to avoid recursion: create scalar using add_scalar without add()."""
-    runtime = npu_runtime.get_runtime((ref_tensor.device.index or 0))
-    stream = npu_state.current_stream((ref_tensor.device.index or 0))
-    out_shape = ref_tensor.shape
-    out_stride = npu_runtime._contiguous_stride(out_shape)
-    out_size = _numel(out_shape) * _dtype_itemsize(ref_tensor.dtype)
-    out_ptr = npu_runtime._alloc_device(out_size, runtime=runtime)
-    aclnn.inplace_zero(
-        out_ptr,
-        out_shape,
-        out_stride,
-        ref_tensor.dtype,
-        runtime,
-        stream=stream.stream,
-    )
-    aclnn.add_scalar(
-        out_ptr,
-        scalar,
-        out_ptr,
-        out_shape,
-        out_stride,
-        ref_tensor.dtype,
-        runtime,
-        stream=stream.stream,
-    )
-    out_storage = npu_typed_storage_from_ptr(out_ptr, _numel(out_shape), ref_tensor.dtype, device=ref_tensor.device)
-    return _wrap_tensor(out_storage, out_shape, out_stride)
 
 
 def _nan_like(a):

--- a/src/candle/_backends/npu/ops/activation.py
+++ b/src/candle/_backends/npu/ops/activation.py
@@ -129,7 +129,7 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
-    _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,
+    _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
     _npu_add_scalar_, npu_index_put_impl,
     _normalize_reduction_dims, _reduce_out_shape,

--- a/src/candle/_backends/npu/ops/conv.py
+++ b/src/candle/_backends/npu/ops/conv.py
@@ -3,7 +3,7 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
-    _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,
+    _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
     _npu_add_scalar_, npu_index_put_impl,
     _normalize_reduction_dims, _reduce_out_shape,

--- a/src/candle/_backends/npu/ops/elementwise.py
+++ b/src/candle/_backends/npu/ops/elementwise.py
@@ -60,7 +60,7 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
-    _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,
+    _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
     _npu_add_scalar_, npu_index_put_impl,
     _normalize_reduction_dims, _reduce_out_shape,

--- a/src/candle/_backends/npu/ops/linalg.py
+++ b/src/candle/_backends/npu/ops/linalg.py
@@ -3,7 +3,7 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
-    _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,
+    _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
     _npu_add_scalar_, npu_index_put_impl,
     _normalize_reduction_dims, _reduce_out_shape,

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -4,7 +4,7 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor, _binary_op,
     _cast_tensor_dtype, _broadcast_shape, _broadcast_shape_checked,
     _npu_broadcast_to,
-    _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,
+    _scalar_to_npu_tensor,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _nan_like,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,

--- a/src/candle/_backends/npu/ops/norm.py
+++ b/src/candle/_backends/npu/ops/norm.py
@@ -3,7 +3,7 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
-    _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,
+    _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
     _npu_add_scalar_, npu_index_put_impl,
     _normalize_reduction_dims, _reduce_out_shape,

--- a/src/candle/_backends/npu/ops/optim.py
+++ b/src/candle/_backends/npu/ops/optim.py
@@ -3,7 +3,7 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
-    _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,
+    _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
     _npu_add_scalar_, npu_index_put_impl,
     _normalize_reduction_dims, _reduce_out_shape,

--- a/src/candle/_backends/npu/ops/random.py
+++ b/src/candle/_backends/npu/ops/random.py
@@ -3,7 +3,7 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
-    _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,
+    _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
     _npu_add_scalar_, npu_index_put_impl,
     _normalize_reduction_dims, _reduce_out_shape,

--- a/src/candle/_backends/npu/ops/reduce.py
+++ b/src/candle/_backends/npu/ops/reduce.py
@@ -24,7 +24,7 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
-    _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,
+    _scalar_to_npu_tensor,
     _normalize_reduction_dims, _reduce_out_shape,
     _cast_tensor_dtype, _npu_broadcast_to, _nan_like,
     _normalize_dim,

--- a/src/candle/_backends/npu/ops/shape.py
+++ b/src/candle/_backends/npu/ops/shape.py
@@ -4,7 +4,7 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
-    _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,
+    _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
     _npu_add_scalar_, npu_index_put_impl,
     _normalize_reduction_dims, _reduce_out_shape,

--- a/src/candle/_backends/npu/ops/special.py
+++ b/src/candle/_backends/npu/ops/special.py
@@ -24,7 +24,7 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
-    _scalar_to_npu_tensor, _scalar_to_npu_tensor_no_add,
+    _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
     _npu_add_scalar_, npu_index_put_impl,
     _normalize_reduction_dims, _reduce_out_shape,

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -868,6 +868,18 @@ def test_npu_ops_modules_do_not_import_unused_binary_op_helper():
     )
 
 
+def test_npu_helpers_no_unused_scalar_to_npu_tensor_no_add_helper():
+    """`_scalar_to_npu_tensor_no_add` lives in `_helpers.py` and is
+    imported by every ops module, but nothing actually calls it. Drop
+    the helper entirely so the import surface stays in sync with what
+    is used.
+    """
+    helpers_src = _source("src/candle/_backends/npu/ops/_helpers.py")
+    assert "def _scalar_to_npu_tensor_no_add" not in helpers_src, (
+        "_helpers.py still defines _scalar_to_npu_tensor_no_add; it has no live callers"
+    )
+
+
 def test_npu_std_sqrt_delegates_through_cython_sqrt_shim():
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
     body = _function_source(reduce_src, "std_")


### PR DESCRIPTION
## Summary

- \`_scalar_to_npu_tensor_no_add\` was introduced as an anti-recursion shortcut for scalar broadcasting, but no NPU op ever ended up calling it. The helper was still imported by every ops module (11 modules plus \`ops/__init__.py\`), inflating the shared import surface without purpose.
- Drop the definition from \`_helpers.py\` and the dead imports across all 12 consumers.
- Add a mechanism audit (\`test_npu_helpers_no_unused_scalar_to_npu_tensor_no_add_helper\`) so the helper cannot drift back.

## Test Plan

- [x] \`pytest tests/contract/test_npu_mechanism_audit.py\` — 46 passed
- [x] \`pytest tests/cpu/ tests/contract/\` — 3353 passed, 30 skipped
- [x] \`pylint src/candle/ tools/autograd/\` — 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)