### PR TITLE
refactor(npu): drop dead reduce-only helper imports from non-reduce ops modules

### DIFF
--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -4,7 +4,6 @@ from ._helpers import (
     _npu_broadcast_to, _npu_arange_1d, _use_soc_fallback,
     _npu_add_scalar_, _npu_linear_index, npu_index_put_impl,
     _normalize_tensor_sequence_args,
-    _normalize_reduction_dims, _reduce_out_shape,
     _scalar_to_npu_tensor, _nan_like,
     # Re-export commonly used imports so op functions can use them
     bool_dtype, int32_dtype, int64_dtype, float_dtype,

--- a/src/candle/_backends/npu/ops/activation.py
+++ b/src/candle/_backends/npu/ops/activation.py
@@ -132,7 +132,6 @@ from ._helpers import (
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
     _npu_add_scalar_, npu_index_put_impl,
-    _normalize_reduction_dims, _reduce_out_shape,
     _cast_tensor_dtype, _normalize_tensor_sequence_args,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/src/candle/_backends/npu/ops/conv.py
+++ b/src/candle/_backends/npu/ops/conv.py
@@ -6,7 +6,6 @@ from ._helpers import (
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
     _npu_add_scalar_, npu_index_put_impl,
-    _normalize_reduction_dims, _reduce_out_shape,
     _cast_tensor_dtype, _normalize_tensor_sequence_args,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/src/candle/_backends/npu/ops/elementwise.py
+++ b/src/candle/_backends/npu/ops/elementwise.py
@@ -63,7 +63,6 @@ from ._helpers import (
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
     _npu_add_scalar_, npu_index_put_impl,
-    _normalize_reduction_dims, _reduce_out_shape,
     _cast_tensor_dtype, _normalize_tensor_sequence_args,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/src/candle/_backends/npu/ops/linalg.py
+++ b/src/candle/_backends/npu/ops/linalg.py
@@ -6,7 +6,6 @@ from ._helpers import (
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
     _npu_add_scalar_, npu_index_put_impl,
-    _normalize_reduction_dims, _reduce_out_shape,
     _cast_tensor_dtype, _normalize_tensor_sequence_args,
     _matmul_out_shape,
     _iter_indices, _broadcast_index, _batch_offset,

--- a/src/candle/_backends/npu/ops/norm.py
+++ b/src/candle/_backends/npu/ops/norm.py
@@ -6,7 +6,6 @@ from ._helpers import (
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
     _npu_add_scalar_, npu_index_put_impl,
-    _normalize_reduction_dims, _reduce_out_shape,
     _cast_tensor_dtype, _normalize_tensor_sequence_args,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/src/candle/_backends/npu/ops/optim.py
+++ b/src/candle/_backends/npu/ops/optim.py
@@ -6,7 +6,6 @@ from ._helpers import (
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
     _npu_add_scalar_, npu_index_put_impl,
-    _normalize_reduction_dims, _reduce_out_shape,
     _cast_tensor_dtype, _normalize_tensor_sequence_args,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/src/candle/_backends/npu/ops/random.py
+++ b/src/candle/_backends/npu/ops/random.py
@@ -6,7 +6,6 @@ from ._helpers import (
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
     _npu_add_scalar_, npu_index_put_impl,
-    _normalize_reduction_dims, _reduce_out_shape,
     _cast_tensor_dtype, _normalize_tensor_sequence_args,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/src/candle/_backends/npu/ops/shape.py
+++ b/src/candle/_backends/npu/ops/shape.py
@@ -7,7 +7,6 @@ from ._helpers import (
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
     _npu_add_scalar_, npu_index_put_impl,
-    _normalize_reduction_dims, _reduce_out_shape,
     _cast_tensor_dtype, _normalize_tensor_sequence_args,
     _normalize_dim,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,

--- a/src/candle/_backends/npu/ops/special.py
+++ b/src/candle/_backends/npu/ops/special.py
@@ -27,7 +27,6 @@ from ._helpers import (
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
     _npu_add_scalar_, npu_index_put_impl,
-    _normalize_reduction_dims, _reduce_out_shape,
     _cast_tensor_dtype, _normalize_tensor_sequence_args,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -880,6 +880,37 @@ def test_npu_helpers_no_unused_scalar_to_npu_tensor_no_add_helper():
     )
 
 
+def test_npu_ops_modules_do_not_import_reduce_only_helpers():
+    """`_normalize_reduction_dims` and `_reduce_out_shape` are only called
+    from `_backends/npu/ops/reduce.py` (and `_helpers.py` internal use).
+    Other ops modules should not list them in their `_helpers` import
+    block — the unused names just clutter the import surface.
+    """
+    dead_names = ("_normalize_reduction_dims", "_reduce_out_shape")
+    consumer_modules = (
+        "src/candle/_backends/npu/ops/__init__.py",
+        "src/candle/_backends/npu/ops/activation.py",
+        "src/candle/_backends/npu/ops/conv.py",
+        "src/candle/_backends/npu/ops/elementwise.py",
+        "src/candle/_backends/npu/ops/linalg.py",
+        "src/candle/_backends/npu/ops/norm.py",
+        "src/candle/_backends/npu/ops/optim.py",
+        "src/candle/_backends/npu/ops/random.py",
+        "src/candle/_backends/npu/ops/shape.py",
+        "src/candle/_backends/npu/ops/special.py",
+    )
+    offenders = []
+    for path in consumer_modules:
+        src = _source(path)
+        for name in dead_names:
+            if re.search(rf"\b{name}\b", src):
+                offenders.append(f"{path}: {name}")
+    assert not offenders, (
+        "These NPU ops modules still reference reduce-only helpers — "
+        "drop the unused names:\n  " + "\n  ".join(offenders)
+    )
+
+
 def test_npu_std_sqrt_delegates_through_cython_sqrt_shim():
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
     body = _function_source(reduce_src, "std_")


### PR DESCRIPTION
## Summary

- \`_normalize_reduction_dims\` and \`_reduce_out_shape\` are only called from \`_backends/npu/ops/reduce.py\` (and \`_helpers.py\` internal use). The other nine ops modules plus \`ops/__init__.py\` imported the names but never referenced them — same dead-import pattern cleaned up in batches 42–44.
- Drop the unused imports from \`activation.py\`, \`conv.py\`, \`elementwise.py\`, \`linalg.py\`, \`norm.py\`, \`optim.py\`, \`random.py\`, \`shape.py\`, \`special.py\`, and \`ops/__init__.py\`.
- Add a mechanism audit (\`test_npu_ops_modules_do_not_import_reduce_only_helpers\`) so the imports cannot drift back.

## Test Plan

- [x] \`pytest tests/contract/test_npu_mechanism_audit.py\` — 47 passed
- [x] \`pytest tests/cpu/ tests/contract/\` — 3354 passed, 30 skipped
- [x] \`pylint src/candle/ tools/autograd/\` — 10.00/10

�� Generated with [Claude Code](https://claude.com/claude-code)