### PR TITLE
refactor(npu): drop dead _npu_add_scalar_ imports from 9 non-random modules

### DIFF
--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -2,7 +2,7 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor, _numel, _dtype_itemsize,
     _cast_tensor_dtype, _broadcast_shape, _broadcast_shape_checked,
     _npu_broadcast_to, _npu_arange_1d, _use_soc_fallback,
-    _npu_add_scalar_, _npu_linear_index,
+    _npu_linear_index,
     _scalar_to_npu_tensor, _nan_like,
     # Re-export commonly used imports so op functions can use them
     bool_dtype, int32_dtype, int64_dtype, float_dtype,

--- a/src/candle/_backends/npu/ops/activation.py
+++ b/src/candle/_backends/npu/ops/activation.py
@@ -131,7 +131,6 @@ from ._helpers import (
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
-    _npu_add_scalar_,
     _cast_tensor_dtype,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/src/candle/_backends/npu/ops/conv.py
+++ b/src/candle/_backends/npu/ops/conv.py
@@ -5,7 +5,7 @@ from ._helpers import (
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
-    _npu_add_scalar_, npu_index_put_impl,
+    npu_index_put_impl,
     _cast_tensor_dtype,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/src/candle/_backends/npu/ops/elementwise.py
+++ b/src/candle/_backends/npu/ops/elementwise.py
@@ -62,7 +62,6 @@ from ._helpers import (
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
-    _npu_add_scalar_,
     _cast_tensor_dtype,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/src/candle/_backends/npu/ops/linalg.py
+++ b/src/candle/_backends/npu/ops/linalg.py
@@ -5,7 +5,6 @@ from ._helpers import (
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
-    _npu_add_scalar_,
     _cast_tensor_dtype,
     _matmul_out_shape,
     _iter_indices, _broadcast_index, _batch_offset,

--- a/src/candle/_backends/npu/ops/norm.py
+++ b/src/candle/_backends/npu/ops/norm.py
@@ -5,7 +5,6 @@ from ._helpers import (
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
-    _npu_add_scalar_,
     _cast_tensor_dtype,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/src/candle/_backends/npu/ops/optim.py
+++ b/src/candle/_backends/npu/ops/optim.py
@@ -5,7 +5,6 @@ from ._helpers import (
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
-    _npu_add_scalar_,
     _cast_tensor_dtype,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/src/candle/_backends/npu/ops/shape.py
+++ b/src/candle/_backends/npu/ops/shape.py
@@ -6,7 +6,6 @@ from ._helpers import (
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
-    _npu_add_scalar_,
     _cast_tensor_dtype, _normalize_tensor_sequence_args,
     _normalize_dim,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,

--- a/src/candle/_backends/npu/ops/special.py
+++ b/src/candle/_backends/npu/ops/special.py
@@ -26,7 +26,6 @@ from ._helpers import (
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
-    _npu_add_scalar_,
     _cast_tensor_dtype,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -960,6 +960,33 @@ def test_npu_ops_modules_do_not_import_unused_index_put_or_tensor_seq_helpers():
     )
 
 
+def test_npu_ops_modules_do_not_import_unused_npu_add_scalar_helper():
+    """`_npu_add_scalar_` is only called from `_backends/npu/ops/random.py`.
+    Other ops modules should not list it in their `_helpers` import block —
+    the unused name just clutters the import surface.
+    """
+    consumer_modules = (
+        "src/candle/_backends/npu/ops/__init__.py",
+        "src/candle/_backends/npu/ops/activation.py",
+        "src/candle/_backends/npu/ops/conv.py",
+        "src/candle/_backends/npu/ops/elementwise.py",
+        "src/candle/_backends/npu/ops/linalg.py",
+        "src/candle/_backends/npu/ops/norm.py",
+        "src/candle/_backends/npu/ops/optim.py",
+        "src/candle/_backends/npu/ops/shape.py",
+        "src/candle/_backends/npu/ops/special.py",
+    )
+    offenders = []
+    for path in consumer_modules:
+        src = _source(path)
+        if re.search(r"\b_npu_add_scalar_\b", src):
+            offenders.append(path)
+    assert not offenders, (
+        "These NPU ops modules still reference `_npu_add_scalar_` — "
+        "drop the unused import:\n  " + "\n  ".join(offenders)
+    )
+
+
 def test_npu_std_sqrt_delegates_through_cython_sqrt_shim():
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
     body = _function_source(reduce_src, "std_")


### PR DESCRIPTION
## Summary

- `_npu_add_scalar_` is only called from `_backends/npu/ops/random.py` (deterministic 310B fallbacks for `uniform_`/`normal_`).
- The other nine ops modules (`__init__`, `activation`, `conv`, `elementwise`, `linalg`, `norm`, `optim`, `shape`, `special`) listed it in their `_helpers` import block but never referenced it.
- Drops the unused name from every consumer module that doesn't actually call it, leaving `random.py` (still uses it) untouched.
- Adds `test_npu_ops_modules_do_not_import_unused_npu_add_scalar_helper` to lock the cleanup in.

## Test plan

- [x] \`pytest tests/contract/test_npu_mechanism_audit.py\` — 49 passed
- [x] \`pytest tests/cpu/ tests/contract/\` — 3356 passed, 30 skipped
- [x] \`pylint src/candle/ --rcfile=.github/pylint.conf\` — 10.00/10