### PR TITLE
refactor(npu): drop dead _broadcast_shape and _broadcast_shape_checked imports

### DIFF
--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -1,6 +1,6 @@
 from ._helpers import (
     _unwrap_storage, _wrap_tensor, _numel, _dtype_itemsize,
-    _cast_tensor_dtype, _broadcast_shape, _broadcast_shape_checked,
+    _cast_tensor_dtype,
     _npu_broadcast_to, _npu_arange_1d, _use_soc_fallback,
     _npu_linear_index,
     _scalar_to_npu_tensor, _nan_like,

--- a/src/candle/_backends/npu/ops/activation.py
+++ b/src/candle/_backends/npu/ops/activation.py
@@ -127,7 +127,6 @@ except ImportError:
 
 from ._helpers import (
     _unwrap_storage, _wrap_tensor,
-    _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,

--- a/src/candle/_backends/npu/ops/conv.py
+++ b/src/candle/_backends/npu/ops/conv.py
@@ -1,7 +1,6 @@
 """Convolution, pooling, upsampling, and padding operations for NPU."""
 from ._helpers import (
     _unwrap_storage, _wrap_tensor,
-    _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,

--- a/src/candle/_backends/npu/ops/elementwise.py
+++ b/src/candle/_backends/npu/ops/elementwise.py
@@ -58,7 +58,7 @@ except ImportError:
 
 from ._helpers import (
     _unwrap_storage, _wrap_tensor,
-    _broadcast_shape, _broadcast_shape_checked,
+    _broadcast_shape,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,

--- a/src/candle/_backends/npu/ops/linalg.py
+++ b/src/candle/_backends/npu/ops/linalg.py
@@ -1,7 +1,7 @@
 """Linear algebra operations for NPU."""
 from ._helpers import (
     _unwrap_storage, _wrap_tensor,
-    _broadcast_shape, _broadcast_shape_checked,
+    _broadcast_shape,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -2,7 +2,7 @@
 
 from ._helpers import (
     _unwrap_storage, _wrap_tensor, _binary_op,
-    _cast_tensor_dtype, _broadcast_shape, _broadcast_shape_checked,
+    _cast_tensor_dtype,
     _npu_broadcast_to,
     _scalar_to_npu_tensor,
     _numel, _dtype_itemsize, _use_soc_fallback,

--- a/src/candle/_backends/npu/ops/norm.py
+++ b/src/candle/_backends/npu/ops/norm.py
@@ -1,7 +1,6 @@
 """Normalization operations for NPU."""
 from ._helpers import (
     _unwrap_storage, _wrap_tensor,
-    _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,

--- a/src/candle/_backends/npu/ops/optim.py
+++ b/src/candle/_backends/npu/ops/optim.py
@@ -1,7 +1,6 @@
 """Optimizer step operations for NPU."""
 from ._helpers import (
     _unwrap_storage, _wrap_tensor,
-    _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,

--- a/src/candle/_backends/npu/ops/random.py
+++ b/src/candle/_backends/npu/ops/random.py
@@ -1,7 +1,6 @@
 """Random number generation and in-place initialization for NPU."""
 from ._helpers import (
     _unwrap_storage, _wrap_tensor,
-    _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,

--- a/src/candle/_backends/npu/ops/reduce.py
+++ b/src/candle/_backends/npu/ops/reduce.py
@@ -22,7 +22,6 @@ except ImportError:
 
 from ._helpers import (
     _unwrap_storage, _wrap_tensor,
-    _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
     _normalize_reduction_dims, _reduce_out_shape,

--- a/src/candle/_backends/npu/ops/shape.py
+++ b/src/candle/_backends/npu/ops/shape.py
@@ -2,7 +2,6 @@
 import ctypes
 from ._helpers import (
     _unwrap_storage, _wrap_tensor,
-    _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,

--- a/src/candle/_backends/npu/ops/special.py
+++ b/src/candle/_backends/npu/ops/special.py
@@ -22,7 +22,6 @@ except ImportError:
 
 from ._helpers import (
     _unwrap_storage, _wrap_tensor,
-    _broadcast_shape, _broadcast_shape_checked,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -987,6 +987,60 @@ def test_npu_ops_modules_do_not_import_unused_npu_add_scalar_helper():
     )
 
 
+def test_npu_ops_modules_do_not_import_unused_broadcast_shape_helpers():
+    """`_broadcast_shape_checked` is only used inside `_helpers.py` itself
+    and is not called by any op module. `_broadcast_shape` is only called
+    from `comparison.py`, `elementwise.py`, and `linalg.py`. Other ops
+    modules should not list these names in their `_helpers` import block —
+    the unused names just clutter the import surface.
+    """
+    cases = (
+        (
+            "_broadcast_shape_checked",
+            (
+                "src/candle/_backends/npu/ops/__init__.py",
+                "src/candle/_backends/npu/ops/activation.py",
+                "src/candle/_backends/npu/ops/conv.py",
+                "src/candle/_backends/npu/ops/elementwise.py",
+                "src/candle/_backends/npu/ops/linalg.py",
+                "src/candle/_backends/npu/ops/math.py",
+                "src/candle/_backends/npu/ops/norm.py",
+                "src/candle/_backends/npu/ops/optim.py",
+                "src/candle/_backends/npu/ops/random.py",
+                "src/candle/_backends/npu/ops/reduce.py",
+                "src/candle/_backends/npu/ops/shape.py",
+                "src/candle/_backends/npu/ops/special.py",
+            ),
+        ),
+        (
+            "_broadcast_shape",
+            (
+                "src/candle/_backends/npu/ops/__init__.py",
+                "src/candle/_backends/npu/ops/activation.py",
+                "src/candle/_backends/npu/ops/conv.py",
+                "src/candle/_backends/npu/ops/math.py",
+                "src/candle/_backends/npu/ops/norm.py",
+                "src/candle/_backends/npu/ops/optim.py",
+                "src/candle/_backends/npu/ops/random.py",
+                "src/candle/_backends/npu/ops/reduce.py",
+                "src/candle/_backends/npu/ops/shape.py",
+                "src/candle/_backends/npu/ops/special.py",
+            ),
+        ),
+    )
+    offenders = []
+    for name, consumer_modules in cases:
+        for path in consumer_modules:
+            src = _source(path)
+            if re.search(rf"\b{name}\b", src):
+                offenders.append(f"{path}: {name}")
+    assert not offenders, (
+        "These NPU ops modules still reference broadcast-shape helpers "
+        "that they don't call — drop the unused names:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
 def test_npu_std_sqrt_delegates_through_cython_sqrt_shim():
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
     body = _function_source(reduce_src, "std_")


### PR DESCRIPTION
## Summary

- `_broadcast_shape_checked` is only used inside `_helpers.py` itself (one internal call). Every op module that imported it never referenced it — dead in 12 modules.
- `_broadcast_shape` is only called from `comparison.py`, `elementwise.py`, and `linalg.py`. The other ten ops modules imported it but never referenced it.
- Drops both names from the import surface of every consumer module that doesn't call them; leaves `comparison.py`, `elementwise.py`, and `linalg.py` on `_broadcast_shape`.
- Adds \`test_npu_ops_modules_do_not_import_unused_broadcast_shape_helpers\` to lock the cleanup in.

## Test plan

- [x] \`pytest tests/contract/test_npu_mechanism_audit.py\` — 50 passed
- [x] \`pytest tests/cpu/ tests/contract/\` — 3357 passed, 30 skipped
- [x] \`pylint src/candle/ --rcfile=.github/pylint.conf\` — 10.00/10