### PR TITLE
refactor(npu): drop dead _npu_broadcast_to imports from 8 non-caller modules

### DIFF
--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -1,7 +1,7 @@
 from ._helpers import (
     _unwrap_storage, _wrap_tensor, _numel, _dtype_itemsize,
     _cast_tensor_dtype,
-    _npu_broadcast_to, _npu_arange_1d, _use_soc_fallback,
+    _npu_arange_1d, _use_soc_fallback,
     _npu_linear_index,
     _scalar_to_npu_tensor, _nan_like,
     # Re-export commonly used imports so op functions can use them

--- a/src/candle/_backends/npu/ops/activation.py
+++ b/src/candle/_backends/npu/ops/activation.py
@@ -129,7 +129,7 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
-    _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
+    _npu_arange_1d, _npu_linear_index,
     _cast_tensor_dtype,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -3,7 +3,6 @@
 from ._helpers import (
     _unwrap_storage, _wrap_tensor, _binary_op,
     _cast_tensor_dtype,
-    _npu_broadcast_to,
     _scalar_to_npu_tensor,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _nan_like,

--- a/src/candle/_backends/npu/ops/norm.py
+++ b/src/candle/_backends/npu/ops/norm.py
@@ -3,7 +3,7 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
-    _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
+    _npu_arange_1d, _npu_linear_index,
     _cast_tensor_dtype,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/src/candle/_backends/npu/ops/optim.py
+++ b/src/candle/_backends/npu/ops/optim.py
@@ -3,7 +3,7 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
-    _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
+    _npu_arange_1d, _npu_linear_index,
     _cast_tensor_dtype,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/src/candle/_backends/npu/ops/random.py
+++ b/src/candle/_backends/npu/ops/random.py
@@ -3,7 +3,7 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
-    _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
+    _npu_arange_1d, _npu_linear_index,
     _npu_add_scalar_,
     _cast_tensor_dtype,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,

--- a/src/candle/_backends/npu/ops/reduce.py
+++ b/src/candle/_backends/npu/ops/reduce.py
@@ -25,7 +25,7 @@ from ._helpers import (
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
     _normalize_reduction_dims, _reduce_out_shape,
-    _cast_tensor_dtype, _npu_broadcast_to, _nan_like,
+    _cast_tensor_dtype, _nan_like,
     _normalize_dim,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/src/candle/_backends/npu/ops/special.py
+++ b/src/candle/_backends/npu/ops/special.py
@@ -24,7 +24,7 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
-    _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
+    _npu_arange_1d, _npu_linear_index,
     _cast_tensor_dtype,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1041,6 +1041,33 @@ def test_npu_ops_modules_do_not_import_unused_broadcast_shape_helpers():
     )
 
 
+def test_npu_ops_modules_do_not_import_unused_npu_broadcast_to_helper():
+    """`_npu_broadcast_to` is only called from `_backends/npu/ops/conv.py`,
+    `elementwise.py`, `linalg.py`, and `shape.py`. Other ops modules
+    should not list it in their `_helpers` import block — the unused name
+    just clutters the import surface.
+    """
+    consumer_modules = (
+        "src/candle/_backends/npu/ops/__init__.py",
+        "src/candle/_backends/npu/ops/activation.py",
+        "src/candle/_backends/npu/ops/math.py",
+        "src/candle/_backends/npu/ops/norm.py",
+        "src/candle/_backends/npu/ops/optim.py",
+        "src/candle/_backends/npu/ops/random.py",
+        "src/candle/_backends/npu/ops/reduce.py",
+        "src/candle/_backends/npu/ops/special.py",
+    )
+    offenders = []
+    for path in consumer_modules:
+        src = _source(path)
+        if re.search(r"\b_npu_broadcast_to\b", src):
+            offenders.append(path)
+    assert not offenders, (
+        "These NPU ops modules still reference `_npu_broadcast_to` — "
+        "drop the unused import:\n  " + "\n  ".join(offenders)
+    )
+
+
 def test_npu_std_sqrt_delegates_through_cython_sqrt_shim():
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
     body = _function_source(reduce_src, "std_")


### PR DESCRIPTION
## Summary

- `_npu_broadcast_to` is only called from `_backends/npu/ops/conv.py`, `elementwise.py`, `linalg.py`, and `shape.py` (plus internal `_helpers.py` use).
- The other eight ops modules (`__init__`, `activation`, `math`, `norm`, `optim`, `random`, `reduce`, `special`) listed it in their `_helpers` import block but never referenced it.
- Drops the unused name from every consumer module that doesn't call it.
- Adds \`test_npu_ops_modules_do_not_import_unused_npu_broadcast_to_helper\` to lock the cleanup in.

## Test plan

- [x] \`pytest tests/contract/test_npu_mechanism_audit.py\` — 51 passed
- [x] \`pytest tests/cpu/ tests/contract/\` — 3358 passed, 30 skipped
- [x] \`pylint src/candle/ --rcfile=.github/pylint.conf\` — 10.00/10