### PR TITLE
refactor(npu): drop wholly-dead _nan_like helper and dead _npu_linear_index imports (batch 50)

### DIFF
--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -3,7 +3,7 @@ from ._helpers import (
     _cast_tensor_dtype,
     _npu_arange_1d, _use_soc_fallback,
     _npu_linear_index,
-    _scalar_to_npu_tensor, _nan_like,
+    _scalar_to_npu_tensor,
     # Re-export commonly used imports so op functions can use them
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/src/candle/_backends/npu/ops/_helpers.py
+++ b/src/candle/_backends/npu/ops/_helpers.py
@@ -415,10 +415,6 @@ def _scalar_to_npu_tensor(scalar, ref_tensor):
 
 
 
-def _nan_like(a):
-    return _scalar_to_npu_tensor(float("nan"), a)
-
-
 def _normalize_dim(dim, ndim):
     if dim < 0:
         dim += ndim

--- a/src/candle/_backends/npu/ops/activation.py
+++ b/src/candle/_backends/npu/ops/activation.py
@@ -129,7 +129,7 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
-    _npu_arange_1d, _npu_linear_index,
+    _npu_arange_1d,
     _cast_tensor_dtype,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/src/candle/_backends/npu/ops/conv.py
+++ b/src/candle/_backends/npu/ops/conv.py
@@ -3,7 +3,7 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
-    _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
+    _npu_broadcast_to, _npu_arange_1d,
     npu_index_put_impl,
     _cast_tensor_dtype,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,

--- a/src/candle/_backends/npu/ops/elementwise.py
+++ b/src/candle/_backends/npu/ops/elementwise.py
@@ -61,7 +61,7 @@ from ._helpers import (
     _broadcast_shape,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
-    _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
+    _npu_broadcast_to, _npu_arange_1d,
     _cast_tensor_dtype,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/src/candle/_backends/npu/ops/linalg.py
+++ b/src/candle/_backends/npu/ops/linalg.py
@@ -4,7 +4,7 @@ from ._helpers import (
     _broadcast_shape,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
-    _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
+    _npu_broadcast_to, _npu_arange_1d,
     _cast_tensor_dtype,
     _matmul_out_shape,
     _iter_indices, _broadcast_index, _batch_offset,

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -5,7 +5,6 @@ from ._helpers import (
     _cast_tensor_dtype,
     _scalar_to_npu_tensor,
     _numel, _dtype_itemsize, _use_soc_fallback,
-    _nan_like,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr,
     aclnn, npu_runtime, npu_state, ops_soc,

--- a/src/candle/_backends/npu/ops/norm.py
+++ b/src/candle/_backends/npu/ops/norm.py
@@ -3,7 +3,7 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
-    _npu_arange_1d, _npu_linear_index,
+    _npu_arange_1d,
     _cast_tensor_dtype,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/src/candle/_backends/npu/ops/optim.py
+++ b/src/candle/_backends/npu/ops/optim.py
@@ -3,7 +3,7 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
-    _npu_arange_1d, _npu_linear_index,
+    _npu_arange_1d,
     _cast_tensor_dtype,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/src/candle/_backends/npu/ops/random.py
+++ b/src/candle/_backends/npu/ops/random.py
@@ -3,7 +3,7 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
-    _npu_arange_1d, _npu_linear_index,
+    _npu_arange_1d,
     _npu_add_scalar_,
     _cast_tensor_dtype,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,

--- a/src/candle/_backends/npu/ops/reduce.py
+++ b/src/candle/_backends/npu/ops/reduce.py
@@ -25,7 +25,7 @@ from ._helpers import (
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
     _normalize_reduction_dims, _reduce_out_shape,
-    _cast_tensor_dtype, _nan_like,
+    _cast_tensor_dtype,
     _normalize_dim,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/src/candle/_backends/npu/ops/shape.py
+++ b/src/candle/_backends/npu/ops/shape.py
@@ -4,7 +4,7 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
-    _npu_broadcast_to, _npu_arange_1d, _npu_linear_index,
+    _npu_broadcast_to, _npu_arange_1d,
     _cast_tensor_dtype, _normalize_tensor_sequence_args,
     _normalize_dim,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,

--- a/src/candle/_backends/npu/ops/special.py
+++ b/src/candle/_backends/npu/ops/special.py
@@ -24,7 +24,7 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
-    _npu_arange_1d, _npu_linear_index,
+    _npu_arange_1d,
     _cast_tensor_dtype,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1068,6 +1068,46 @@ def test_npu_ops_modules_do_not_import_unused_npu_broadcast_to_helper():
     )
 
 
+def test_npu_helpers_no_unused_nan_like_helper():
+    """`_nan_like` lives in `_helpers.py` and is imported by a few ops
+    modules, but nothing actually calls it. Drop the helper entirely so
+    the import surface stays in sync with what is used.
+    """
+    helpers_src = _source("src/candle/_backends/npu/ops/_helpers.py")
+    assert "def _nan_like" not in helpers_src, (
+        "_helpers.py still defines _nan_like; it has no live callers"
+    )
+
+
+def test_npu_ops_modules_do_not_import_unused_npu_linear_index_helper():
+    """`_npu_linear_index` is only called from `_dispatch/functionalize.py`
+    via `npu_ops._npu_linear_index`, so it stays exported from
+    `_backends/npu/ops/__init__.py`. Other ops modules should not list it
+    in their `_helpers` import block — the unused name just clutters the
+    import surface.
+    """
+    consumer_modules = (
+        "src/candle/_backends/npu/ops/activation.py",
+        "src/candle/_backends/npu/ops/conv.py",
+        "src/candle/_backends/npu/ops/elementwise.py",
+        "src/candle/_backends/npu/ops/linalg.py",
+        "src/candle/_backends/npu/ops/norm.py",
+        "src/candle/_backends/npu/ops/optim.py",
+        "src/candle/_backends/npu/ops/random.py",
+        "src/candle/_backends/npu/ops/shape.py",
+        "src/candle/_backends/npu/ops/special.py",
+    )
+    offenders = []
+    for path in consumer_modules:
+        src = _source(path)
+        if re.search(r"\b_npu_linear_index\b", src):
+            offenders.append(path)
+    assert not offenders, (
+        "These NPU ops modules still reference `_npu_linear_index` — "
+        "drop the unused import:\n  " + "\n  ".join(offenders)
+    )
+
+
 def test_npu_std_sqrt_delegates_through_cython_sqrt_shim():
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
     body = _function_source(reduce_src, "std_")


### PR DESCRIPTION
## Summary

- `_nan_like` lives in `_helpers.py` and is imported by `__init__.py`,
  `math.py`, and `reduce.py`, but nothing actually calls it — drop the
  helper entirely so the import surface stays in sync with what is used.
- `_npu_linear_index` has a real caller in `_dispatch/functionalize.py`
  (via `npu_ops._npu_linear_index(...)`), so the def and the
  `__init__.py` re-export stay. Each of the 9 ops modules
  (`activation`, `conv`, `elementwise`, `linalg`, `norm`, `optim`,
  `random`, `shape`, `special`) imports the name from `_helpers` but
  never calls it locally — drop those dead local imports.

## Audit

New contract tests lock down the cleanup:

- `test_npu_helpers_no_unused_nan_like_helper`
- `test_npu_ops_modules_do_not_import_unused_npu_linear_index_helper`

## Test plan

- [x] pylint: 10.00/10
- [x] CPU + contract: 3360 passed, 30 skipped