### PR TITLE
refactor(npu): drop dead _cast_tensor_dtype/_use_soc_fallback/_scalar_to_npu_tensor imports (batch 51)

### DIFF
--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -1,9 +1,7 @@
 from ._helpers import (
     _unwrap_storage, _wrap_tensor, _numel, _dtype_itemsize,
-    _cast_tensor_dtype,
-    _npu_arange_1d, _use_soc_fallback,
+    _npu_arange_1d,
     _npu_linear_index,
-    _scalar_to_npu_tensor,
     # Re-export commonly used imports so op functions can use them
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -2,7 +2,6 @@
 
 from ._helpers import (
     _unwrap_storage, _wrap_tensor, _binary_op,
-    _cast_tensor_dtype,
     _scalar_to_npu_tensor,
     _numel, _dtype_itemsize, _use_soc_fallback,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,

--- a/src/candle/_backends/npu/ops/optim.py
+++ b/src/candle/_backends/npu/ops/optim.py
@@ -1,10 +1,9 @@
 """Optimizer step operations for NPU."""
 from ._helpers import (
     _unwrap_storage, _wrap_tensor,
-    _numel, _dtype_itemsize, _use_soc_fallback,
+    _numel, _dtype_itemsize,
     _scalar_to_npu_tensor,
     _npu_arange_1d,
-    _cast_tensor_dtype,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,
     aclnn, npu_runtime, npu_state, ops_soc,

--- a/src/candle/_backends/npu/ops/shape.py
+++ b/src/candle/_backends/npu/ops/shape.py
@@ -5,7 +5,7 @@ from ._helpers import (
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d,
-    _cast_tensor_dtype, _normalize_tensor_sequence_args,
+    _normalize_tensor_sequence_args,
     _normalize_dim,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/src/candle/_backends/npu/ops/special.py
+++ b/src/candle/_backends/npu/ops/special.py
@@ -22,7 +22,7 @@ except ImportError:
 
 from ._helpers import (
     _unwrap_storage, _wrap_tensor,
-    _numel, _dtype_itemsize, _use_soc_fallback,
+    _numel, _dtype_itemsize,
     _scalar_to_npu_tensor,
     _npu_arange_1d,
     _cast_tensor_dtype,

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1108,6 +1108,52 @@ def test_npu_ops_modules_do_not_import_unused_npu_linear_index_helper():
     )
 
 
+def test_npu_ops_modules_do_not_import_unused_cast_soc_or_scalar_helpers():
+    """`_cast_tensor_dtype`, `_use_soc_fallback`, and `_scalar_to_npu_tensor`
+    are all heavily used helpers — but a few ops modules list them in their
+    `_helpers` import block without ever calling them locally. The
+    `_backends/npu/ops/__init__.py` re-exports them as well, but no external
+    consumer reaches them via `npu_ops.<name>` (Cython hot paths and tests
+    import directly from `_helpers`). Drop the dead listings so the import
+    surface stays in sync with what is used.
+    """
+    cases = (
+        (
+            "_cast_tensor_dtype",
+            (
+                "src/candle/_backends/npu/ops/__init__.py",
+                "src/candle/_backends/npu/ops/math.py",
+                "src/candle/_backends/npu/ops/optim.py",
+                "src/candle/_backends/npu/ops/shape.py",
+            ),
+        ),
+        (
+            "_use_soc_fallback",
+            (
+                "src/candle/_backends/npu/ops/__init__.py",
+                "src/candle/_backends/npu/ops/optim.py",
+                "src/candle/_backends/npu/ops/special.py",
+            ),
+        ),
+        (
+            "_scalar_to_npu_tensor",
+            (
+                "src/candle/_backends/npu/ops/__init__.py",
+            ),
+        ),
+    )
+    offenders = []
+    for name, consumer_modules in cases:
+        for path in consumer_modules:
+            src = _source(path)
+            if re.search(rf"\b{name}\b", src):
+                offenders.append(f"{path}: {name}")
+    assert not offenders, (
+        "These NPU ops modules still reference unused helpers — "
+        "drop the unused imports:\n  " + "\n  ".join(offenders)
+    )
+
+
 def test_npu_std_sqrt_delegates_through_cython_sqrt_shim():
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
     body = _function_source(reduce_src, "std_")


### PR DESCRIPTION
## Summary

- `_cast_tensor_dtype` (8 real callers), `_use_soc_fallback` (11 real
  callers), and `_scalar_to_npu_tensor` (heavily used) all stay in
  \`_helpers.py\`. But a handful of ops modules list them in their
  \`_helpers\` import block without ever calling them locally, and the
  \`_backends/npu/ops/__init__.py\` re-exports them with no external
  consumer reaching for \`npu_ops.<name>\` (Cython hot paths and tests
  import directly from \`_helpers\`). Drop the dead listings:
  - \`_cast_tensor_dtype\`: \`__init__.py\`, \`math.py\`, \`optim.py\`, \`shape.py\`
  - \`_use_soc_fallback\`: \`__init__.py\`, \`optim.py\`, \`special.py\`
  - \`_scalar_to_npu_tensor\`: \`__init__.py\`

## Audit

New contract test locks down the cleanup:

- \`test_npu_ops_modules_do_not_import_unused_cast_soc_or_scalar_helpers\`

## Test plan

- [x] pylint: 10.00/10
- [x] CPU + contract: 3361 passed, 30 skipped