### PR TITLE
refactor(npu): drop dead ops_soc imports from 11 non-shape modules (batch 52)

### DIFF
--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -5,7 +5,7 @@ from ._helpers import (
     # Re-export commonly used imports so op functions can use them
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,
-    aclnn, npu_runtime, npu_state, ops_soc,
+    aclnn, npu_runtime, npu_state,
 )
 import ctypes
 

--- a/src/candle/_backends/npu/ops/activation.py
+++ b/src/candle/_backends/npu/ops/activation.py
@@ -133,7 +133,7 @@ from ._helpers import (
     _cast_tensor_dtype,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,
-    aclnn, npu_runtime, npu_state, ops_soc,
+    aclnn, npu_runtime, npu_state,
 )
 from .comparison import gt, lt
 from .elementwise import clamp, where

--- a/src/candle/_backends/npu/ops/conv.py
+++ b/src/candle/_backends/npu/ops/conv.py
@@ -8,7 +8,7 @@ from ._helpers import (
     _cast_tensor_dtype,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,
-    aclnn, npu_runtime, npu_state, ops_soc,
+    aclnn, npu_runtime, npu_state,
 )
 from .elementwise import logaddexp, where
 from .linalg import matmul

--- a/src/candle/_backends/npu/ops/elementwise.py
+++ b/src/candle/_backends/npu/ops/elementwise.py
@@ -65,7 +65,7 @@ from ._helpers import (
     _cast_tensor_dtype,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,
-    aclnn, npu_runtime, npu_state, ops_soc,
+    aclnn, npu_runtime, npu_state,
 )
 from .comparison import eq, gt, logical_and, logical_or, lt, ne
 from .math import add, div, mul, sqrt, sub

--- a/src/candle/_backends/npu/ops/linalg.py
+++ b/src/candle/_backends/npu/ops/linalg.py
@@ -10,7 +10,7 @@ from ._helpers import (
     _iter_indices, _broadcast_index, _batch_offset,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,
-    aclnn, npu_runtime, npu_state, ops_soc,
+    aclnn, npu_runtime, npu_state,
 )
 from .comparison import eq, gt
 from .elementwise import where

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -6,7 +6,7 @@ from ._helpers import (
     _numel, _dtype_itemsize, _use_soc_fallback,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr,
-    aclnn, npu_runtime, npu_state, ops_soc,
+    aclnn, npu_runtime, npu_state,
 )
 
 

--- a/src/candle/_backends/npu/ops/norm.py
+++ b/src/candle/_backends/npu/ops/norm.py
@@ -7,7 +7,7 @@ from ._helpers import (
     _cast_tensor_dtype,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,
-    aclnn, npu_runtime, npu_state, ops_soc,
+    aclnn, npu_runtime, npu_state,
 )
 from ...._dtype import float16 as float16_dtype
 from .math import add, div, mul, rsqrt, sqrt, sub

--- a/src/candle/_backends/npu/ops/optim.py
+++ b/src/candle/_backends/npu/ops/optim.py
@@ -6,7 +6,7 @@ from ._helpers import (
     _npu_arange_1d,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,
-    aclnn, npu_runtime, npu_state, ops_soc,
+    aclnn, npu_runtime, npu_state,
 )
 from .comparison import gt, lt
 from .elementwise import where

--- a/src/candle/_backends/npu/ops/random.py
+++ b/src/candle/_backends/npu/ops/random.py
@@ -8,7 +8,7 @@ from ._helpers import (
     _cast_tensor_dtype,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,
-    aclnn, npu_runtime, npu_state, ops_soc,
+    aclnn, npu_runtime, npu_state,
 )
 from .comparison import lt
 from .elementwise import clamp

--- a/src/candle/_backends/npu/ops/reduce.py
+++ b/src/candle/_backends/npu/ops/reduce.py
@@ -29,7 +29,7 @@ from ._helpers import (
     _normalize_dim,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,
-    aclnn, npu_runtime, npu_state, ops_soc,
+    aclnn, npu_runtime, npu_state,
 )
 
 

--- a/src/candle/_backends/npu/ops/special.py
+++ b/src/candle/_backends/npu/ops/special.py
@@ -28,7 +28,7 @@ from ._helpers import (
     _cast_tensor_dtype,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,
-    aclnn, npu_runtime, npu_state, ops_soc,
+    aclnn, npu_runtime, npu_state,
 )
 from .comparison import eq, gt
 from .elementwise import clamp, where

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1154,6 +1154,36 @@ def test_npu_ops_modules_do_not_import_unused_cast_soc_or_scalar_helpers():
     )
 
 
+def test_npu_ops_modules_do_not_import_unused_ops_soc_helper():
+    """`ops_soc` is only used from `_backends/npu/ops/shape.py` (and inside
+    `_helpers.py` itself). Other ops modules and the package `__init__`
+    list it in their `_helpers` import block but never call it — drop the
+    unused listings so the import surface stays in sync with what is used.
+    """
+    consumer_modules = (
+        "src/candle/_backends/npu/ops/__init__.py",
+        "src/candle/_backends/npu/ops/activation.py",
+        "src/candle/_backends/npu/ops/conv.py",
+        "src/candle/_backends/npu/ops/elementwise.py",
+        "src/candle/_backends/npu/ops/linalg.py",
+        "src/candle/_backends/npu/ops/math.py",
+        "src/candle/_backends/npu/ops/norm.py",
+        "src/candle/_backends/npu/ops/optim.py",
+        "src/candle/_backends/npu/ops/random.py",
+        "src/candle/_backends/npu/ops/reduce.py",
+        "src/candle/_backends/npu/ops/special.py",
+    )
+    offenders = []
+    for path in consumer_modules:
+        src = _source(path)
+        if re.search(r"\bops_soc\b", src):
+            offenders.append(path)
+    assert not offenders, (
+        "These NPU ops modules still reference `ops_soc` — "
+        "drop the unused import:\n  " + "\n  ".join(offenders)
+    )
+
+
 def test_npu_std_sqrt_delegates_through_cython_sqrt_shim():
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
     body = _function_source(reduce_src, "std_")


### PR DESCRIPTION
## Summary

\`ops_soc\` is only used from \`_backends/npu/ops/shape.py\` (and inside
\`_helpers.py\` itself for \`_npu_arange_1d\` and \`_use_soc_fallback\`). The
other 11 ops modules (\`__init__\`, \`activation\`, \`conv\`, \`elementwise\`,
\`linalg\`, \`math\`, \`norm\`, \`optim\`, \`random\`, \`reduce\`, \`special\`)
listed it in their \`_helpers\` import block but never called it — drop
the unused listings so the import surface stays in sync with what is
used.

## Audit

- \`test_npu_ops_modules_do_not_import_unused_ops_soc_helper\`

## Test plan

- [x] pylint: 10.00/10
- [x] CPU + contract: 3362 passed, 30 skipped