### PR TITLE
refactor(npu): drop dead _binary_op import from math.py and stale ctypes import (batch 54)

### DIFF
--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -6,7 +6,6 @@ from ._helpers import (
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr,
 )
-import ctypes
 
 from .math import (
     add, sub, mul, div,

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -1,7 +1,7 @@
 """Arithmetic and unary math operations for NPU."""
 
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor, _binary_op,
+    _unwrap_storage, _wrap_tensor,
     _scalar_to_npu_tensor,
     _numel, _dtype_itemsize, _use_soc_fallback,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -851,6 +851,7 @@ def test_npu_ops_modules_do_not_import_unused_binary_op_helper():
         "src/candle/_backends/npu/ops/conv.py",
         "src/candle/_backends/npu/ops/elementwise.py",
         "src/candle/_backends/npu/ops/linalg.py",
+        "src/candle/_backends/npu/ops/math.py",
         "src/candle/_backends/npu/ops/norm.py",
         "src/candle/_backends/npu/ops/optim.py",
         "src/candle/_backends/npu/ops/random.py",
@@ -1246,6 +1247,19 @@ def test_npu_ops_modules_do_not_import_unused_backend_infrastructure():
     assert not offenders, (
         "These NPU ops modules still reference unused backend infrastructure — "
         "drop the unused imports:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_npu_ops_package_init_does_not_import_unused_ctypes():
+    """`src/candle/_backends/npu/ops/__init__.py` carries a bare
+    `import ctypes` from older code paths that have all moved to the
+    Cython helpers. Nothing in the file references `ctypes.*` anymore —
+    drop the dead import so the package surface stays honest.
+    """
+    src = _source("src/candle/_backends/npu/ops/__init__.py")
+    assert not re.search(r"\bctypes\b", src), (
+        "src/candle/_backends/npu/ops/__init__.py still references `ctypes` "
+        "but never calls it — drop the dead `import ctypes`."
     )
 
 


### PR DESCRIPTION
## Summary

Two leftover dead listings remained after the multi-module sweeps in batches 40-53:

- \`math.py\` imports \`_binary_op\` from \`._helpers\` but never calls it (the previous batch-43 audit excluded \`math.py\` from its consumer list).
- \`__init__.py\` carries a bare \`import ctypes\` from older code paths that have all moved to the Cython helpers; nothing in the file references \`ctypes.*\`.

Extend the existing \`_binary_op\` audit to cover \`math.py\` and add a new audit that locks the \`ctypes\` import out of the package init. Drop both dead imports — no behavior change.

## Test plan

- [x] \`pylint src/candle/ --rcfile=.github/pylint.conf\` → 10.00/10
- [x] \`pytest tests/cpu/ tests/contract/\` → 3364 passed (+1 audit), 30 skipped
- [x] Targeted RED/GREEN cycle on both audits

🤖 Generated with [Claude Code](https://claude.com/claude-code)