### PR TITLE
refactor(npu): drop dead module-level ctypes import and unused reshape listing (batch 55)

### DIFF
--- a/src/candle/_backends/npu/ops/_helpers.py
+++ b/src/candle/_backends/npu/ops/_helpers.py
@@ -1,6 +1,5 @@
 """Shared helper utilities for NPU ops modules."""
 
-import ctypes
 from ...._dtype import bool as bool_dtype
 from ...._dtype import int32 as int32_dtype
 from ...._dtype import int64 as int64_dtype

--- a/src/candle/_backends/npu/ops/reduce.py
+++ b/src/candle/_backends/npu/ops/reduce.py
@@ -28,7 +28,7 @@ from ._helpers import (
     _cast_tensor_dtype,
     _normalize_dim,
     bool_dtype, int32_dtype, int64_dtype, float_dtype,
-    npu_typed_storage_from_ptr, reshape,
+    npu_typed_storage_from_ptr,
     aclnn, npu_runtime, npu_state,
 )
 

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1263,6 +1263,46 @@ def test_npu_ops_package_init_does_not_import_unused_ctypes():
     )
 
 
+def test_npu_helpers_does_not_carry_unused_module_level_aliases():
+    """`src/candle/_backends/npu/ops/_helpers.py` carries a bare
+    ``import ctypes`` at module scope from older code paths; the only
+    ``ctypes`` reference is inside ``_scalar_to_npu_tensor``, which
+    already does a function-local ``import ctypes``. Drop the dead
+    module-level import so the helper surface stays honest.
+    """
+    src = _source("src/candle/_backends/npu/ops/_helpers.py")
+    assert not re.search(r"^import ctypes\b", src, flags=re.MULTILINE), (
+        "src/candle/_backends/npu/ops/_helpers.py still carries a "
+        "module-level `import ctypes` but the only use is inside "
+        "_scalar_to_npu_tensor, which imports ctypes locally — drop "
+        "the dead module-level import."
+    )
+
+
+def test_npu_reduce_does_not_import_unused_reshape_alias():
+    """`src/candle/_backends/npu/ops/reduce.py` imports the ``reshape``
+    alias from ``._helpers`` but never calls it — every reshape site in
+    the file goes through the function-local
+    ``from ...common import view as view_backend`` followed by
+    ``view_backend.reshape(...)``. Drop the dead listing.
+    """
+    src = _source("src/candle/_backends/npu/ops/reduce.py")
+    in_helpers_block = False
+    helpers_block_imports = []
+    for line in src.splitlines():
+        if line.strip().startswith("from ._helpers import"):
+            in_helpers_block = True
+        if in_helpers_block:
+            helpers_block_imports.append(line)
+            if ")" in line:
+                in_helpers_block = False
+    block_src = "\n".join(helpers_block_imports)
+    assert not re.search(r"\breshape\b", block_src), (
+        "src/candle/_backends/npu/ops/reduce.py still imports `reshape` "
+        "from ._helpers but never calls it — drop the dead listing."
+    )
+
+
 def test_npu_std_sqrt_delegates_through_cython_sqrt_shim():
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
     body = _function_source(reduce_src, "std_")


### PR DESCRIPTION
## Summary

Two more leftover dead bindings after the multi-module sweeps in batches 40-54:

- \`_helpers.py\` carries a bare \`import ctypes\` at module scope from older code paths. The only \`ctypes\` reference is inside \`_scalar_to_npu_tensor\`, which already does a function-local \`import ctypes\`.
- \`reduce.py\` imports the \`reshape\` alias from \`._helpers\` but never calls it — every reshape site in the file goes through the function-local \`from ...common import view as view_backend\` followed by \`view_backend.reshape(...)\`.

Add two audits and drop both dead listings — no behavior change.

## Test plan

- [x] \`pylint src/candle/ --rcfile=.github/pylint.conf\` → 10.00/10
- [x] \`pytest tests/cpu/ tests/contract/\` → 3366 passed (+2 audits), 30 skipped
- [x] Targeted RED/GREEN cycle on both new audits

🤖 Generated with [Claude Code](https://claude.com/claude-code)