### PR TITLE
refactor(npu): drop dead int32_dtype imports from 11 non-reduce modules (batch 56)

### DIFF
--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -3,7 +3,7 @@ from ._helpers import (
     _npu_arange_1d,
     _npu_linear_index,
     # Re-export commonly used imports so op functions can use them
-    bool_dtype, int32_dtype, int64_dtype, float_dtype,
+    bool_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr,
 )
 

--- a/src/candle/_backends/npu/ops/activation.py
+++ b/src/candle/_backends/npu/ops/activation.py
@@ -131,7 +131,7 @@ from ._helpers import (
     _scalar_to_npu_tensor,
     _npu_arange_1d,
     _cast_tensor_dtype,
-    bool_dtype, int32_dtype, int64_dtype, float_dtype,
+    bool_dtype, int64_dtype, float_dtype,
     reshape,
 )
 from .comparison import gt, lt

--- a/src/candle/_backends/npu/ops/conv.py
+++ b/src/candle/_backends/npu/ops/conv.py
@@ -6,7 +6,7 @@ from ._helpers import (
     _npu_broadcast_to, _npu_arange_1d,
     npu_index_put_impl,
     _cast_tensor_dtype,
-    bool_dtype, int32_dtype, int64_dtype, float_dtype,
+    bool_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,
     aclnn, npu_runtime, npu_state,
 )

--- a/src/candle/_backends/npu/ops/elementwise.py
+++ b/src/candle/_backends/npu/ops/elementwise.py
@@ -63,7 +63,7 @@ from ._helpers import (
     _scalar_to_npu_tensor,
     _npu_broadcast_to, _npu_arange_1d,
     _cast_tensor_dtype,
-    bool_dtype, int32_dtype, int64_dtype, float_dtype,
+    bool_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,
     aclnn, npu_runtime, npu_state,
 )

--- a/src/candle/_backends/npu/ops/linalg.py
+++ b/src/candle/_backends/npu/ops/linalg.py
@@ -8,7 +8,7 @@ from ._helpers import (
     _cast_tensor_dtype,
     _matmul_out_shape,
     _iter_indices, _broadcast_index, _batch_offset,
-    bool_dtype, int32_dtype, int64_dtype, float_dtype,
+    bool_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,
     aclnn, npu_runtime, npu_state,
 )

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -4,7 +4,7 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _scalar_to_npu_tensor,
     _numel, _dtype_itemsize, _use_soc_fallback,
-    bool_dtype, int32_dtype, int64_dtype, float_dtype,
+    bool_dtype, int64_dtype, float_dtype,
 )
 
 

--- a/src/candle/_backends/npu/ops/norm.py
+++ b/src/candle/_backends/npu/ops/norm.py
@@ -5,7 +5,7 @@ from ._helpers import (
     _scalar_to_npu_tensor,
     _npu_arange_1d,
     _cast_tensor_dtype,
-    bool_dtype, int32_dtype, int64_dtype, float_dtype,
+    bool_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,
     aclnn, npu_runtime, npu_state,
 )

--- a/src/candle/_backends/npu/ops/optim.py
+++ b/src/candle/_backends/npu/ops/optim.py
@@ -4,7 +4,7 @@ from ._helpers import (
     _numel, _dtype_itemsize,
     _scalar_to_npu_tensor,
     _npu_arange_1d,
-    bool_dtype, int32_dtype, int64_dtype, float_dtype,
+    bool_dtype, int64_dtype, float_dtype,
 )
 from .comparison import gt, lt
 from .elementwise import where

--- a/src/candle/_backends/npu/ops/random.py
+++ b/src/candle/_backends/npu/ops/random.py
@@ -6,7 +6,7 @@ from ._helpers import (
     _npu_arange_1d,
     _npu_add_scalar_,
     _cast_tensor_dtype,
-    bool_dtype, int32_dtype, int64_dtype, float_dtype,
+    bool_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,
     aclnn, npu_runtime, npu_state,
 )

--- a/src/candle/_backends/npu/ops/shape.py
+++ b/src/candle/_backends/npu/ops/shape.py
@@ -7,7 +7,7 @@ from ._helpers import (
     _npu_broadcast_to, _npu_arange_1d,
     _normalize_tensor_sequence_args,
     _normalize_dim,
-    bool_dtype, int32_dtype, int64_dtype, float_dtype,
+    bool_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,
     aclnn, npu_runtime, npu_state, ops_soc,
 )

--- a/src/candle/_backends/npu/ops/special.py
+++ b/src/candle/_backends/npu/ops/special.py
@@ -26,7 +26,7 @@ from ._helpers import (
     _scalar_to_npu_tensor,
     _npu_arange_1d,
     _cast_tensor_dtype,
-    bool_dtype, int32_dtype, int64_dtype, float_dtype,
+    bool_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,
     npu_runtime,
 )

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1303,6 +1303,37 @@ def test_npu_reduce_does_not_import_unused_reshape_alias():
     )
 
 
+def test_npu_ops_modules_do_not_import_unused_int32_dtype():
+    """`int32_dtype` is re-exported by `_helpers` so reduce ops (which
+    legitimately use it 13 times) can pick it up. Every other ops
+    module lists it in the `from ._helpers import (...)` block but
+    never references it — drop the dead listings so the import surface
+    stays in sync with what is used.
+    """
+    consumer_modules = (
+        "src/candle/_backends/npu/ops/__init__.py",
+        "src/candle/_backends/npu/ops/activation.py",
+        "src/candle/_backends/npu/ops/conv.py",
+        "src/candle/_backends/npu/ops/elementwise.py",
+        "src/candle/_backends/npu/ops/linalg.py",
+        "src/candle/_backends/npu/ops/math.py",
+        "src/candle/_backends/npu/ops/norm.py",
+        "src/candle/_backends/npu/ops/optim.py",
+        "src/candle/_backends/npu/ops/random.py",
+        "src/candle/_backends/npu/ops/shape.py",
+        "src/candle/_backends/npu/ops/special.py",
+    )
+    offenders = []
+    for path in consumer_modules:
+        src = _source(path)
+        if re.search(r"\bint32_dtype\b", src):
+            offenders.append(path)
+    assert not offenders, (
+        "These NPU ops modules still reference `int32_dtype` but never "
+        "use it — drop the unused import:\n  " + "\n  ".join(offenders)
+    )
+
+
 def test_npu_std_sqrt_delegates_through_cython_sqrt_shim():
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
     body = _function_source(reduce_src, "std_")


### PR DESCRIPTION
## Summary

\`int32_dtype\` is re-exported by \`_helpers\` so reduce ops (which legitimately use it 13 times for index tensor dtype matching) can pick it up. Every other ops module lists it in the \`from ._helpers import (...)\` block but never references it.

Add an audit covering 11 modules and drop the dead listings: \`__init__\`, \`activation\`, \`conv\`, \`elementwise\`, \`linalg\`, \`math\`, \`norm\`, \`optim\`, \`random\`, \`shape\`, \`special\`. No behavior change.

## Test plan

- [x] \`pylint src/candle/ --rcfile=.github/pylint.conf\` → 10.00/10
- [x] \`pytest tests/cpu/ tests/contract/\` → 3367 passed (+1 audit), 30 skipped
- [x] Targeted RED/GREEN cycle on the new audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)