### PR TITLE
refactor(npu): drop dead _numel and _npu_arange_1d listings from 7 ops modules (batch 57)

### DIFF
--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -1,6 +1,5 @@
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor, _numel, _dtype_itemsize,
-    _npu_arange_1d,
+    _unwrap_storage, _wrap_tensor, _dtype_itemsize,
     _npu_linear_index,
     # Re-export commonly used imports so op functions can use them
     bool_dtype, int64_dtype, float_dtype,

--- a/src/candle/_backends/npu/ops/conv.py
+++ b/src/candle/_backends/npu/ops/conv.py
@@ -3,7 +3,7 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
-    _npu_broadcast_to, _npu_arange_1d,
+    _npu_broadcast_to,
     npu_index_put_impl,
     _cast_tensor_dtype,
     bool_dtype, int64_dtype, float_dtype,

--- a/src/candle/_backends/npu/ops/elementwise.py
+++ b/src/candle/_backends/npu/ops/elementwise.py
@@ -59,9 +59,9 @@ except ImportError:
 from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _broadcast_shape,
-    _numel, _dtype_itemsize, _use_soc_fallback,
+    _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
-    _npu_broadcast_to, _npu_arange_1d,
+    _npu_broadcast_to,
     _cast_tensor_dtype,
     bool_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -3,7 +3,7 @@
 from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _scalar_to_npu_tensor,
-    _numel, _dtype_itemsize, _use_soc_fallback,
+    _dtype_itemsize, _use_soc_fallback,
     bool_dtype, int64_dtype, float_dtype,
 )
 

--- a/src/candle/_backends/npu/ops/norm.py
+++ b/src/candle/_backends/npu/ops/norm.py
@@ -3,7 +3,6 @@ from ._helpers import (
     _unwrap_storage, _wrap_tensor,
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
-    _npu_arange_1d,
     _cast_tensor_dtype,
     bool_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/src/candle/_backends/npu/ops/optim.py
+++ b/src/candle/_backends/npu/ops/optim.py
@@ -1,9 +1,8 @@
 """Optimizer step operations for NPU."""
 from ._helpers import (
     _unwrap_storage, _wrap_tensor,
-    _numel, _dtype_itemsize,
+    _dtype_itemsize,
     _scalar_to_npu_tensor,
-    _npu_arange_1d,
     bool_dtype, int64_dtype, float_dtype,
 )
 from .comparison import gt, lt

--- a/src/candle/_backends/npu/ops/special.py
+++ b/src/candle/_backends/npu/ops/special.py
@@ -22,9 +22,8 @@ except ImportError:
 
 from ._helpers import (
     _unwrap_storage, _wrap_tensor,
-    _numel, _dtype_itemsize,
+    _dtype_itemsize,
     _scalar_to_npu_tensor,
-    _npu_arange_1d,
     _cast_tensor_dtype,
     bool_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1334,6 +1334,47 @@ def test_npu_ops_modules_do_not_import_unused_int32_dtype():
     )
 
 
+def test_npu_ops_modules_do_not_import_unused_numel_or_arange_helpers():
+    """The `_numel` and `_npu_arange_1d` helpers are re-exported from
+    `_helpers` but only some ops modules use them. The rest list them
+    in `from ._helpers import (...)` blocks without ever calling them
+    — drop the dead listings so the helper surface stays honest.
+    """
+    cases = (
+        (
+            "_numel",
+            (
+                "src/candle/_backends/npu/ops/__init__.py",
+                "src/candle/_backends/npu/ops/elementwise.py",
+                "src/candle/_backends/npu/ops/math.py",
+                "src/candle/_backends/npu/ops/optim.py",
+                "src/candle/_backends/npu/ops/special.py",
+            ),
+        ),
+        (
+            "_npu_arange_1d",
+            (
+                "src/candle/_backends/npu/ops/__init__.py",
+                "src/candle/_backends/npu/ops/conv.py",
+                "src/candle/_backends/npu/ops/elementwise.py",
+                "src/candle/_backends/npu/ops/norm.py",
+                "src/candle/_backends/npu/ops/optim.py",
+                "src/candle/_backends/npu/ops/special.py",
+            ),
+        ),
+    )
+    offenders = []
+    for name, consumer_modules in cases:
+        for path in consumer_modules:
+            src = _source(path)
+            if re.search(rf"\b{name}\b", src):
+                offenders.append(f"{path}: {name}")
+    assert not offenders, (
+        "These NPU ops modules still reference unused helpers — "
+        "drop the unused imports:\n  " + "\n  ".join(offenders)
+    )
+
+
 def test_npu_std_sqrt_delegates_through_cython_sqrt_shim():
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
     body = _function_source(reduce_src, "std_")


### PR DESCRIPTION
## Summary

\`_numel\` and \`_npu_arange_1d\` are widely used helpers, but several ops modules list them in their \`from ._helpers import (...)\` blocks without ever calling them:

- \`_numel\` dead in \`__init__\`, \`elementwise\`, \`math\`, \`optim\`, \`special\` (5 modules)
- \`_npu_arange_1d\` dead in \`__init__\`, \`conv\`, \`elementwise\`, \`norm\`, \`optim\`, \`special\` (6 modules)

Verified other modules still use these helpers legitimately (reduce.py uses \`_numel\` 54 times, shape.py 44 times, etc.). No external consumers via \`from .npu.ops import ...\`.

Add a combined audit and drop the dead listings — no behavior change.

## Test plan

- [x] \`pylint src/candle/ --rcfile=.github/pylint.conf\` → 10.00/10
- [x] \`pytest tests/cpu/ tests/contract/\` → 3368 passed (+1 audit), 30 skipped
- [x] Targeted RED/GREEN cycle on the new audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)