### PR TITLE
refactor(npu): drop dead tensor-plumbing helper imports from 4 ops modules (batch 58)

### DIFF
--- a/src/candle/_backends/npu/ops/activation.py
+++ b/src/candle/_backends/npu/ops/activation.py
@@ -126,8 +126,7 @@ except ImportError:
     _HAS_FAST_ACTIVATION_COMPOSITES = False
 
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor,
-    _numel, _dtype_itemsize, _use_soc_fallback,
+    _numel, _use_soc_fallback,
     _scalar_to_npu_tensor,
     _npu_arange_1d,
     _cast_tensor_dtype,

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -1,9 +1,8 @@
 """Arithmetic and unary math operations for NPU."""
 
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor,
     _scalar_to_npu_tensor,
-    _dtype_itemsize, _use_soc_fallback,
+    _use_soc_fallback,
     bool_dtype, int64_dtype, float_dtype,
 )
 

--- a/src/candle/_backends/npu/ops/optim.py
+++ b/src/candle/_backends/npu/ops/optim.py
@@ -1,7 +1,5 @@
 """Optimizer step operations for NPU."""
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor,
-    _dtype_itemsize,
     _scalar_to_npu_tensor,
     bool_dtype, int64_dtype, float_dtype,
 )

--- a/src/candle/_backends/npu/ops/special.py
+++ b/src/candle/_backends/npu/ops/special.py
@@ -21,8 +21,7 @@ except ImportError:
     _HAS_FAST_SPECIAL_COMPOSITES = False
 
 from ._helpers import (
-    _unwrap_storage, _wrap_tensor,
-    _dtype_itemsize,
+    _wrap_tensor,
     _scalar_to_npu_tensor,
     _cast_tensor_dtype,
     bool_dtype, int64_dtype, float_dtype,

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1375,6 +1375,55 @@ def test_npu_ops_modules_do_not_import_unused_numel_or_arange_helpers():
     )
 
 
+def test_npu_ops_modules_do_not_import_unused_tensor_plumbing_helpers():
+    """`_dtype_itemsize`, `_wrap_tensor`, and `_unwrap_storage` are core
+    tensor-plumbing helpers re-exported from `_helpers`. Several ops modules
+    list them in `from ._helpers import (...)` blocks without ever calling
+    them — drop the dead listings so the helper surface stays honest.
+
+    The package `__init__.py` re-export is excluded because `_backends/autograd.py`
+    consumes these helpers via `from .npu.ops import ...`.
+    """
+    cases = (
+        (
+            "_dtype_itemsize",
+            (
+                "src/candle/_backends/npu/ops/activation.py",
+                "src/candle/_backends/npu/ops/math.py",
+                "src/candle/_backends/npu/ops/optim.py",
+                "src/candle/_backends/npu/ops/special.py",
+            ),
+        ),
+        (
+            "_wrap_tensor",
+            (
+                "src/candle/_backends/npu/ops/activation.py",
+                "src/candle/_backends/npu/ops/math.py",
+                "src/candle/_backends/npu/ops/optim.py",
+            ),
+        ),
+        (
+            "_unwrap_storage",
+            (
+                "src/candle/_backends/npu/ops/activation.py",
+                "src/candle/_backends/npu/ops/math.py",
+                "src/candle/_backends/npu/ops/optim.py",
+                "src/candle/_backends/npu/ops/special.py",
+            ),
+        ),
+    )
+    offenders = []
+    for name, consumer_modules in cases:
+        for path in consumer_modules:
+            src = _source(path)
+            if re.search(rf"\b{name}\b", src):
+                offenders.append(f"{path}: {name}")
+    assert not offenders, (
+        "These NPU ops modules still reference unused tensor-plumbing helpers — "
+        "drop the unused imports:\n  " + "\n  ".join(offenders)
+    )
+
+
 def test_npu_std_sqrt_delegates_through_cython_sqrt_shim():
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
     body = _function_source(reduce_src, "std_")


### PR DESCRIPTION
## Summary

- `_dtype_itemsize`, `_wrap_tensor`, and `_unwrap_storage` are re-exported from `_helpers` because `_backends/autograd.py` consumes them via `from .npu.ops import ...`. Several per-module ops files list them in `from ._helpers import (...)` blocks without calling them.
- 11 dead listings dropped across 4 modules (activation, math, optim, special).
- Audit `test_npu_ops_modules_do_not_import_unused_tensor_plumbing_helpers` locks in the new state.
- Package `__init__.py` re-export preserved for external consumers in `_backends/autograd.py`.

## Test Plan

- [x] `pylint src/candle/` — **10.00/10**
- [x] `pytest tests/cpu/ tests/contract/` — **3369 passed (+1 audit), 30 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)