### PR TITLE
refactor(npu): drop dead dtype constant imports across 9 ops modules (batch 59)

### DIFF
--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -1,8 +1,6 @@
 from ._helpers import (
     _unwrap_storage, _wrap_tensor, _dtype_itemsize,
     _npu_linear_index,
-    # Re-export commonly used imports so op functions can use them
-    bool_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr,
 )
 

--- a/src/candle/_backends/npu/ops/activation.py
+++ b/src/candle/_backends/npu/ops/activation.py
@@ -130,7 +130,7 @@ from ._helpers import (
     _scalar_to_npu_tensor,
     _npu_arange_1d,
     _cast_tensor_dtype,
-    bool_dtype, int64_dtype, float_dtype,
+    bool_dtype, float_dtype,
     reshape,
 )
 from .comparison import gt, lt

--- a/src/candle/_backends/npu/ops/conv.py
+++ b/src/candle/_backends/npu/ops/conv.py
@@ -6,7 +6,7 @@ from ._helpers import (
     _npu_broadcast_to,
     npu_index_put_impl,
     _cast_tensor_dtype,
-    bool_dtype, int64_dtype, float_dtype,
+    int64_dtype,
     npu_typed_storage_from_ptr, reshape,
     aclnn, npu_runtime, npu_state,
 )

--- a/src/candle/_backends/npu/ops/linalg.py
+++ b/src/candle/_backends/npu/ops/linalg.py
@@ -8,7 +8,7 @@ from ._helpers import (
     _cast_tensor_dtype,
     _matmul_out_shape,
     _iter_indices, _broadcast_index, _batch_offset,
-    bool_dtype, int64_dtype, float_dtype,
+    int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,
     aclnn, npu_runtime, npu_state,
 )

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -3,7 +3,6 @@
 from ._helpers import (
     _scalar_to_npu_tensor,
     _use_soc_fallback,
-    bool_dtype, int64_dtype, float_dtype,
 )
 
 

--- a/src/candle/_backends/npu/ops/norm.py
+++ b/src/candle/_backends/npu/ops/norm.py
@@ -4,7 +4,6 @@ from ._helpers import (
     _numel, _dtype_itemsize, _use_soc_fallback,
     _scalar_to_npu_tensor,
     _cast_tensor_dtype,
-    bool_dtype, int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,
     aclnn, npu_runtime, npu_state,
 )

--- a/src/candle/_backends/npu/ops/optim.py
+++ b/src/candle/_backends/npu/ops/optim.py
@@ -1,7 +1,6 @@
 """Optimizer step operations for NPU."""
 from ._helpers import (
     _scalar_to_npu_tensor,
-    bool_dtype, int64_dtype, float_dtype,
 )
 from .comparison import gt, lt
 from .elementwise import where

--- a/src/candle/_backends/npu/ops/random.py
+++ b/src/candle/_backends/npu/ops/random.py
@@ -6,7 +6,7 @@ from ._helpers import (
     _npu_arange_1d,
     _npu_add_scalar_,
     _cast_tensor_dtype,
-    bool_dtype, int64_dtype, float_dtype,
+    float_dtype,
     npu_typed_storage_from_ptr, reshape,
     aclnn, npu_runtime, npu_state,
 )

--- a/src/candle/_backends/npu/ops/shape.py
+++ b/src/candle/_backends/npu/ops/shape.py
@@ -7,7 +7,7 @@ from ._helpers import (
     _npu_broadcast_to, _npu_arange_1d,
     _normalize_tensor_sequence_args,
     _normalize_dim,
-    bool_dtype, int64_dtype, float_dtype,
+    bool_dtype, int64_dtype,
     npu_typed_storage_from_ptr, reshape,
     aclnn, npu_runtime, npu_state, ops_soc,
 )

--- a/src/candle/_backends/npu/ops/special.py
+++ b/src/candle/_backends/npu/ops/special.py
@@ -24,7 +24,7 @@ from ._helpers import (
     _wrap_tensor,
     _scalar_to_npu_tensor,
     _cast_tensor_dtype,
-    bool_dtype, int64_dtype, float_dtype,
+    int64_dtype, float_dtype,
     npu_typed_storage_from_ptr, reshape,
     npu_runtime,
 )

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1424,6 +1424,65 @@ def test_npu_ops_modules_do_not_import_unused_tensor_plumbing_helpers():
     )
 
 
+def test_npu_ops_modules_do_not_import_unused_dtype_constants():
+    """`bool_dtype`, `int64_dtype`, and `float_dtype` are re-exported from
+    `_helpers` for code that needs the candle dtype singletons. Several ops
+    modules — and the package `__init__.py` re-export itself — list them
+    without ever using them. No external code in `src/` or `tests/` consumes
+    these via `from .npu.ops import` or `npu_ops.X` either, so the
+    `__init__.py` re-export is also dead.
+
+    Drop the unused listings so the dtype surface stays honest.
+    """
+    cases = (
+        (
+            "bool_dtype",
+            (
+                "src/candle/_backends/npu/ops/__init__.py",
+                "src/candle/_backends/npu/ops/conv.py",
+                "src/candle/_backends/npu/ops/linalg.py",
+                "src/candle/_backends/npu/ops/math.py",
+                "src/candle/_backends/npu/ops/norm.py",
+                "src/candle/_backends/npu/ops/optim.py",
+                "src/candle/_backends/npu/ops/random.py",
+                "src/candle/_backends/npu/ops/special.py",
+            ),
+        ),
+        (
+            "int64_dtype",
+            (
+                "src/candle/_backends/npu/ops/__init__.py",
+                "src/candle/_backends/npu/ops/activation.py",
+                "src/candle/_backends/npu/ops/math.py",
+                "src/candle/_backends/npu/ops/norm.py",
+                "src/candle/_backends/npu/ops/optim.py",
+                "src/candle/_backends/npu/ops/random.py",
+            ),
+        ),
+        (
+            "float_dtype",
+            (
+                "src/candle/_backends/npu/ops/__init__.py",
+                "src/candle/_backends/npu/ops/conv.py",
+                "src/candle/_backends/npu/ops/math.py",
+                "src/candle/_backends/npu/ops/norm.py",
+                "src/candle/_backends/npu/ops/optim.py",
+                "src/candle/_backends/npu/ops/shape.py",
+            ),
+        ),
+    )
+    offenders = []
+    for name, consumer_modules in cases:
+        for path in consumer_modules:
+            src = _source(path)
+            if re.search(rf"\b{name}\b", src):
+                offenders.append(f"{path}: {name}")
+    assert not offenders, (
+        "These NPU ops modules still reference unused dtype constants — "
+        "drop the unused imports:\n  " + "\n  ".join(offenders)
+    )
+
+
 def test_npu_std_sqrt_delegates_through_cython_sqrt_shim():
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
     body = _function_source(reduce_src, "std_")


### PR DESCRIPTION
## Summary

- `bool_dtype`, `int64_dtype`, and `float_dtype` re-exports flow from `_helpers` through the package `__init__.py`. No external code consumes them via `from .npu.ops import` or `npu_ops.X`, and many per-module ops files list the trio in `from ._helpers import (...)` blocks without ever referencing the names they list.
- Drop **20 dead listings across 9 modules** (incl. the wholly-dead `__init__.py` re-export line). Keep only the dtype constants each module actually uses.
- Audit `test_npu_ops_modules_do_not_import_unused_dtype_constants` locks in the new state.

## Test Plan

- [x] \`pylint src/candle/\` — **10.00/10**
- [x] \`pytest tests/cpu/ tests/contract/\` — **3370 passed (+1 audit), 30 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)