### PR TITLE
refactor(npu): drop dead cross-module imports across 6 ops modules (batch 60)

### DIFF
--- a/src/candle/_backends/npu/ops/activation.py
+++ b/src/candle/_backends/npu/ops/activation.py
@@ -135,8 +135,7 @@ from ._helpers import (
 )
 from .comparison import gt, lt
 from .elementwise import clamp, where
-from .math import abs, add, div, exp, frac, log, mul, neg, sin, sub, tanh
-from .reduce import maximum, minimum
+from .math import abs, add, div, exp, frac, log, mul, neg, sin, tanh
 
 
 def relu(a):

--- a/src/candle/_backends/npu/ops/conv.py
+++ b/src/candle/_backends/npu/ops/conv.py
@@ -12,7 +12,7 @@ from ._helpers import (
 )
 from .elementwise import logaddexp, where
 from .linalg import matmul
-from .math import add, ceil, div, floor, isinf
+from .math import add, ceil, div, isinf
 from .reduce import maximum, mean, sum_
 from .shape import contiguous, expand, gather, index_select, repeat, split, stack, tile
 

--- a/src/candle/_backends/npu/ops/elementwise.py
+++ b/src/candle/_backends/npu/ops/elementwise.py
@@ -68,9 +68,9 @@ from ._helpers import (
     aclnn, npu_runtime, npu_state,
 )
 from .comparison import eq, gt, logical_and, logical_or, lt, ne
-from .math import add, div, mul, sqrt, sub
+from .math import add, div, mul, sub
 from .reduce import searchsorted
-from .shape import contiguous, index_put_, index_select, masked_select, nonzero, split
+from .shape import contiguous, index_select, split
 
 
 def where(cond, x, y):

--- a/src/candle/_backends/npu/ops/norm.py
+++ b/src/candle/_backends/npu/ops/norm.py
@@ -7,7 +7,6 @@ from ._helpers import (
     npu_typed_storage_from_ptr, reshape,
     aclnn, npu_runtime, npu_state,
 )
-from ...._dtype import float16 as float16_dtype
 from .math import add, div, mul, rsqrt, sqrt, sub
 from .random import copy_
 from .reduce import maximum, mean, norm_

--- a/src/candle/_backends/npu/ops/random.py
+++ b/src/candle/_backends/npu/ops/random.py
@@ -12,7 +12,7 @@ from ._helpers import (
 )
 from .comparison import lt
 from .elementwise import clamp
-from .math import abs, add, ceil, cos, div, exp, floor, frac, log, mul, neg, sin, sqrt, tan
+from .math import abs, add, ceil, cos, exp, floor, frac, log, mul, neg, sin, sqrt, tan
 
 try:
     from candle._C._npu_ops import (

--- a/src/candle/_backends/npu/ops/reduce.py
+++ b/src/candle/_backends/npu/ops/reduce.py
@@ -1354,7 +1354,6 @@ def argwhere_op(a):
     ndim = len(a.shape)
     if isinstance(indices, tuple):
         if len(indices) == 0:
-            from ...._tensor import Tensor
             runtime = npu_runtime.get_runtime((a.device.index or 0))
             out_shape = (0, ndim)
             out_stride = npu_runtime._contiguous_stride(out_shape)

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1483,6 +1483,39 @@ def test_npu_ops_modules_do_not_import_unused_dtype_constants():
     )
 
 
+def test_npu_ops_modules_do_not_carry_dead_cross_module_imports():
+    """A handful of NPU ops modules still list cross-module helpers in their
+    top-level (or function-local) `from X import Y` blocks that they never
+    actually call. Drop them so the per-file import surface is honest.
+
+    Each pair below is `(file, name)` — if `name` appears in `file`, it must
+    be referenced more than once (i.e. used somewhere beyond the import line).
+    A single occurrence means the import is dead.
+    """
+    cases = (
+        ("src/candle/_backends/npu/ops/activation.py", "sub"),
+        ("src/candle/_backends/npu/ops/activation.py", "maximum"),
+        ("src/candle/_backends/npu/ops/activation.py", "minimum"),
+        ("src/candle/_backends/npu/ops/conv.py", "floor"),
+        ("src/candle/_backends/npu/ops/elementwise.py", "sqrt"),
+        ("src/candle/_backends/npu/ops/elementwise.py", "index_put_"),
+        ("src/candle/_backends/npu/ops/elementwise.py", "masked_select"),
+        ("src/candle/_backends/npu/ops/elementwise.py", "nonzero"),
+        ("src/candle/_backends/npu/ops/norm.py", "float16_dtype"),
+        ("src/candle/_backends/npu/ops/random.py", "div"),
+        ("src/candle/_backends/npu/ops/reduce.py", "Tensor"),
+    )
+    offenders = []
+    for path, name in cases:
+        src = _source(path)
+        if re.search(rf"\b{name}\b", src):
+            offenders.append(f"{path}: {name}")
+    assert not offenders, (
+        "These NPU ops modules still carry dead cross-module imports — "
+        "drop them:\n  " + "\n  ".join(offenders)
+    )
+
+
 def test_npu_std_sqrt_delegates_through_cython_sqrt_shim():
     reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
     body = _function_source(reduce_src, "std_")


### PR DESCRIPTION
## Summary

Several NPU ops modules still list cross-module helpers in \`from X import Y\` blocks (or in a function-local lazy import) without ever calling them. Drop the dead listings so the per-file import surface is honest:

- \`activation.py\` — drop \`sub\` from math, \`maximum\`/\`minimum\` from reduce
- \`conv.py\` — drop \`floor\` from math
- \`elementwise.py\` — drop \`sqrt\` from math; \`index_put_\`/\`masked_select\`/\`nonzero\` from shape
- \`norm.py\` — drop unused \`float16 as float16_dtype\` alias
- \`random.py\` — drop \`div\` from math
- \`reduce.py\` — drop dead function-local \`Tensor\` import (zero-index branch)

Audit \`test_npu_ops_modules_do_not_carry_dead_cross_module_imports\` locks in the new state.

## Test Plan

- [x] \`pylint src/candle/\` — **10.00/10**
- [x] \`pytest tests/cpu/ tests/contract/\` — **3371 passed (+1 audit), 30 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)