### PR TITLE
refactor(npu): lift fast_* helper imports to module level (batch 63)

### DIFF
--- a/src/candle/_backends/npu/ops/random.py
+++ b/src/candle/_backends/npu/ops/random.py
@@ -21,6 +21,7 @@ try:
         fast_clamp_inplace as _fast_clamp_inplace_impl,
         fast_copy_inplace as _fast_copy_inplace_impl,
         fast_div_inplace as _fast_div_inplace_impl,
+        fast_erfinv_ as _fast_erfinv_inplace_impl,
         fast_exp_inplace as _fast_exp_inplace_impl,
         fast_fill_inplace as _fast_fill_inplace_impl,
         fast_floor_inplace as _fast_floor_inplace_impl,
@@ -35,6 +36,7 @@ try:
     _HAS_FAST_CLAMP_INPLACE = True
     _HAS_FAST_COPY_INPLACE = True
     _HAS_FAST_DIV_INPLACE = True
+    _HAS_FAST_ERFINV_INPLACE = True
     _HAS_FAST_EXP_INPLACE = True
     _HAS_FAST_FILL_INPLACE = True
     _HAS_FAST_FLOOR_INPLACE = True
@@ -49,6 +51,7 @@ except ImportError:
     _fast_clamp_inplace_impl = None  # type: ignore[assignment]
     _fast_copy_inplace_impl = None  # type: ignore[assignment]
     _fast_div_inplace_impl = None  # type: ignore[assignment]
+    _fast_erfinv_inplace_impl = None  # type: ignore[assignment]
     _fast_exp_inplace_impl = None  # type: ignore[assignment]
     _fast_fill_inplace_impl = None  # type: ignore[assignment]
     _fast_floor_inplace_impl = None  # type: ignore[assignment]
@@ -62,6 +65,7 @@ except ImportError:
     _HAS_FAST_CLAMP_INPLACE = False
     _HAS_FAST_COPY_INPLACE = False
     _HAS_FAST_DIV_INPLACE = False
+    _HAS_FAST_ERFINV_INPLACE = False
     _HAS_FAST_EXP_INPLACE = False
     _HAS_FAST_FILL_INPLACE = False
     _HAS_FAST_FLOOR_INPLACE = False
@@ -335,8 +339,7 @@ def copy_(a, src):
 
 def erfinv_(a):
     """In-place erfinv using aclnnErfinv."""
-    from candle._C._npu_ops import fast_erfinv_ as _fast_erfinv_impl  # pylint: disable=import-error,no-name-in-module
-    return _fast_erfinv_impl(a)
+    return _fast_erfinv_inplace_impl(a)
 
 
 def reciprocal_(a):

--- a/src/candle/_backends/npu/ops/special.py
+++ b/src/candle/_backends/npu/ops/special.py
@@ -20,6 +20,19 @@ except ImportError:
     _fast_special_xlogy_impl = None  # type: ignore[assignment]
     _HAS_FAST_SPECIAL_COMPOSITES = False
 
+try:
+    from candle._C._npu_ops import (  # pylint: disable=import-error,no-name-in-module
+        fast_digamma as _fast_digamma_impl,
+        fast_erfinv as _fast_erfinv_impl,
+        fast_lgamma as _fast_lgamma_impl,
+    )
+    _HAS_FAST_SPECIAL_UNARY = True
+except ImportError:
+    _fast_digamma_impl = None  # type: ignore[assignment]
+    _fast_erfinv_impl = None  # type: ignore[assignment]
+    _fast_lgamma_impl = None  # type: ignore[assignment]
+    _HAS_FAST_SPECIAL_UNARY = False
+
 from ._helpers import (
     _wrap_tensor,
     _scalar_to_npu_tensor,
@@ -37,17 +50,14 @@ from .shape import contiguous, index_select
 
 
 def special_digamma(a):
-    from candle._C._npu_ops import fast_digamma as _fast_digamma_impl  # pylint: disable=import-error,no-name-in-module
     return _fast_digamma_impl(a)
 
 
 def special_erfinv(a):
-    from candle._C._npu_ops import fast_erfinv as _fast_erfinv_impl  # pylint: disable=import-error,no-name-in-module
     return _fast_erfinv_impl(a)
 
 
 def special_gammaln(a):
-    from candle._C._npu_ops import fast_lgamma as _fast_lgamma_impl  # pylint: disable=import-error,no-name-in-module
     return _fast_lgamma_impl(a)
 
 

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -199,7 +199,7 @@ def test_npu_special_gamma_and_erfinv_wrappers_delegate_to_cython():
             assert marker not in body
 
     erfinv_body = _function_source(random_src, "erfinv_")
-    assert "_fast_erfinv_impl" in erfinv_body
+    assert "_fast_erfinv_inplace_impl" in erfinv_body
     for marker in forbidden:
         assert marker not in erfinv_body
 
@@ -1529,6 +1529,32 @@ def test_npu_shape_does_not_duplicate_storage_meta_helper():
         "`_npu_storage_meta` — replace with `_storage_meta` from `._helpers` "
         "so the duplicate function body is removed."
     )
+
+
+def test_npu_ops_modules_lift_fast_helper_imports_to_module_level():
+    """Four ops-module functions still load their Cython `fast_*` helper via a
+    function-body `from candle._C._npu_ops import ...` line. Every other NPU
+    op resolves its Cython helper through a module-level try/except block.
+    The four laggards pay a Python import lookup on every call and obscure
+    the module's dependency surface — lift them to module level so the
+    pattern is consistent across the package.
+    """
+    targets = {
+        "src/candle/_backends/npu/ops/random.py": ["erfinv_"],
+        "src/candle/_backends/npu/ops/special.py": [
+            "special_digamma",
+            "special_erfinv",
+            "special_gammaln",
+        ],
+    }
+    for rel, names in targets.items():
+        src = _source(rel)
+        for name in names:
+            body = _function_source(src, name)
+            assert "from candle._C._npu_ops import fast_" not in body, (
+                f"{rel}::{name} still has a function-body "
+                f"`from candle._C._npu_ops import fast_*` — lift to module level."
+            )
 
 
 def test_npu_ops_modules_do_not_carry_wholly_dead_helper_defs():


### PR DESCRIPTION
## Summary

- Four ops-module functions (\`erfinv_\`, \`special_digamma\`, \`special_erfinv\`, \`special_gammaln\`) still loaded their Cython \`fast_*\` helper via a function-body \`from candle._C._npu_ops import ...\` line.
- Lift them to module level alongside the existing try/except blocks. Each function body collapses to a single \`return _fast_*_impl(a)\`.
- Pin the consolidation with \`tests/contract/test_npu_mechanism_audit.py::test_npu_ops_modules_lift_fast_helper_imports_to_module_level\`.

## Test Plan

- [x] Focused audit PASS
- [x] \`pytest tests/cpu/ tests/contract/\` — 3374 passed, 30 skipped
- [x] \`pylint src/candle/ --rcfile=.github/pylint.conf\` — 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)