### PR TITLE
refactor(npu): consolidate activation.py fast_* try blocks (batch 65)

### DIFF
--- a/src/candle/_backends/npu/ops/activation.py
+++ b/src/candle/_backends/npu/ops/activation.py
@@ -1,105 +1,21 @@
 """Activation functions and embedding for NPU."""
 
 try:
-    from candle._C._npu_ops import fast_relu as _fast_relu_impl  # pylint: disable=import-error,no-name-in-module
-    _HAS_FAST_RELU = True
-except ImportError:
-    _fast_relu_impl = None  # type: ignore[assignment]
-    _HAS_FAST_RELU = False
-
-try:
-    from candle._C._npu_ops import fast_relu_inplace as _fast_relu_inplace_impl  # pylint: disable=import-error,no-name-in-module
-    _HAS_FAST_RELU_INPLACE = True
-except ImportError:
-    _fast_relu_inplace_impl = None  # type: ignore[assignment]
-    _HAS_FAST_RELU_INPLACE = False
-
-try:
-    from candle._C._npu_ops import fast_hardtanh as _fast_hardtanh_impl  # pylint: disable=import-error,no-name-in-module
-    _HAS_FAST_HARDTANH = True
-except ImportError:
-    _fast_hardtanh_impl = None  # type: ignore[assignment]
-    _HAS_FAST_HARDTANH = False
-
-try:
-    from candle._C._npu_ops import fast_dropout as _fast_dropout_impl  # pylint: disable=import-error,no-name-in-module
-    _HAS_FAST_DROPOUT = True
-except ImportError:
-    _fast_dropout_impl = None  # type: ignore[assignment]
-    _HAS_FAST_DROPOUT = False
-
-try:
-    from candle._C._npu_ops import fast_embedding as _fast_embedding_impl  # pylint: disable=import-error,no-name-in-module
-    _HAS_FAST_EMBEDDING = True
-except ImportError:
-    _fast_embedding_impl = None  # type: ignore[assignment]
-    _HAS_FAST_EMBEDDING = False
-
-try:
-    from candle._C._npu_ops import fast_prelu as _fast_prelu_impl  # pylint: disable=import-error,no-name-in-module
-    _HAS_FAST_PRELU = True
-except ImportError:
-    _fast_prelu_impl = None  # type: ignore[assignment]
-    _HAS_FAST_PRELU = False
-
-try:
-    from candle._C._npu_ops import fast_softplus as _fast_softplus_impl  # pylint: disable=import-error,no-name-in-module
-    _HAS_FAST_SOFTPLUS = True
-except ImportError:
-    _fast_softplus_impl = None  # type: ignore[assignment]
-    _HAS_FAST_SOFTPLUS = False
-
-try:
-    from candle._C._npu_ops import fast_softmax as _fast_softmax_impl  # pylint: disable=import-error,no-name-in-module
-    _HAS_FAST_SOFTMAX = True
-except ImportError:
-    _fast_softmax_impl = None  # type: ignore[assignment]
-    _HAS_FAST_SOFTMAX = False
-
-try:
-    from candle._C._npu_ops import fast_log_softmax as _fast_log_softmax_impl  # pylint: disable=import-error,no-name-in-module
-    _HAS_FAST_LOG_SOFTMAX = True
-except ImportError:
-    _fast_log_softmax_impl = None  # type: ignore[assignment]
-    _HAS_FAST_LOG_SOFTMAX = False
-
-try:
-    from candle._C._npu_ops import fast_leaky_relu as _fast_leaky_relu_impl  # pylint: disable=import-error,no-name-in-module
-    _HAS_FAST_LEAKY_RELU = True
-except ImportError:
-    _fast_leaky_relu_impl = None  # type: ignore[assignment]
-    _HAS_FAST_LEAKY_RELU = False
-
-try:
-    from candle._C._npu_ops import fast_elu as _fast_elu_impl  # pylint: disable=import-error,no-name-in-module
-    _HAS_FAST_ELU = True
-except ImportError:
-    _fast_elu_impl = None  # type: ignore[assignment]
-    _HAS_FAST_ELU = False
-
-try:
-    from candle._C._npu_ops import fast_silu as _fast_silu_impl  # pylint: disable=import-error,no-name-in-module
-    _HAS_FAST_SILU = True
-except ImportError:
-    _fast_silu_impl = None  # type: ignore[assignment]
-    _HAS_FAST_SILU = False
-
-try:
-    from candle._C._npu_ops import fast_gelu as _fast_gelu_impl  # pylint: disable=import-error,no-name-in-module
-    _HAS_FAST_GELU = True
-except ImportError:
-    _fast_gelu_impl = None  # type: ignore[assignment]
-    _HAS_FAST_GELU = False
-
-try:
-    from candle._C._npu_ops import fast_mish as _fast_mish_impl  # pylint: disable=import-error,no-name-in-module
-    _HAS_FAST_MISH = True
-except ImportError:
-    _fast_mish_impl = None  # type: ignore[assignment]
-    _HAS_FAST_MISH = False
-
-try:
     from candle._C._npu_ops import (  # pylint: disable=import-error,no-name-in-module
+        fast_relu as _fast_relu_impl,
+        fast_relu_inplace as _fast_relu_inplace_impl,
+        fast_hardtanh as _fast_hardtanh_impl,
+        fast_dropout as _fast_dropout_impl,
+        fast_embedding as _fast_embedding_impl,
+        fast_prelu as _fast_prelu_impl,
+        fast_softplus as _fast_softplus_impl,
+        fast_softmax as _fast_softmax_impl,
+        fast_log_softmax as _fast_log_softmax_impl,
+        fast_leaky_relu as _fast_leaky_relu_impl,
+        fast_elu as _fast_elu_impl,
+        fast_silu as _fast_silu_impl,
+        fast_gelu as _fast_gelu_impl,
+        fast_mish as _fast_mish_impl,
         fast_relu6 as _fast_relu6_impl,
         fast_selu as _fast_selu_impl,
         fast_celu as _fast_celu_impl,
@@ -111,8 +27,36 @@ try:
         fast_softsign as _fast_softsign_impl,
         fast_rrelu as _fast_rrelu_impl,
     )
+    _HAS_FAST_RELU = True
+    _HAS_FAST_RELU_INPLACE = True
+    _HAS_FAST_HARDTANH = True
+    _HAS_FAST_DROPOUT = True
+    _HAS_FAST_EMBEDDING = True
+    _HAS_FAST_PRELU = True
+    _HAS_FAST_SOFTPLUS = True
+    _HAS_FAST_SOFTMAX = True
+    _HAS_FAST_LOG_SOFTMAX = True
+    _HAS_FAST_LEAKY_RELU = True
+    _HAS_FAST_ELU = True
+    _HAS_FAST_SILU = True
+    _HAS_FAST_GELU = True
+    _HAS_FAST_MISH = True
     _HAS_FAST_ACTIVATION_COMPOSITES = True
 except ImportError:
+    _fast_relu_impl = None  # type: ignore[assignment]
+    _fast_relu_inplace_impl = None  # type: ignore[assignment]
+    _fast_hardtanh_impl = None  # type: ignore[assignment]
+    _fast_dropout_impl = None  # type: ignore[assignment]
+    _fast_embedding_impl = None  # type: ignore[assignment]
+    _fast_prelu_impl = None  # type: ignore[assignment]
+    _fast_softplus_impl = None  # type: ignore[assignment]
+    _fast_softmax_impl = None  # type: ignore[assignment]
+    _fast_log_softmax_impl = None  # type: ignore[assignment]
+    _fast_leaky_relu_impl = None  # type: ignore[assignment]
+    _fast_elu_impl = None  # type: ignore[assignment]
+    _fast_silu_impl = None  # type: ignore[assignment]
+    _fast_gelu_impl = None  # type: ignore[assignment]
+    _fast_mish_impl = None  # type: ignore[assignment]
     _fast_relu6_impl = None  # type: ignore[assignment]
     _fast_selu_impl = None  # type: ignore[assignment]
     _fast_celu_impl = None  # type: ignore[assignment]
@@ -123,6 +67,20 @@ except ImportError:
     _fast_hardsigmoid_impl = None  # type: ignore[assignment]
     _fast_softsign_impl = None  # type: ignore[assignment]
     _fast_rrelu_impl = None  # type: ignore[assignment]
+    _HAS_FAST_RELU = False
+    _HAS_FAST_RELU_INPLACE = False
+    _HAS_FAST_HARDTANH = False
+    _HAS_FAST_DROPOUT = False
+    _HAS_FAST_EMBEDDING = False
+    _HAS_FAST_PRELU = False
+    _HAS_FAST_SOFTPLUS = False
+    _HAS_FAST_SOFTMAX = False
+    _HAS_FAST_LOG_SOFTMAX = False
+    _HAS_FAST_LEAKY_RELU = False
+    _HAS_FAST_ELU = False
+    _HAS_FAST_SILU = False
+    _HAS_FAST_GELU = False
+    _HAS_FAST_MISH = False
     _HAS_FAST_ACTIVATION_COMPOSITES = False
 
 from ._helpers import (

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1782,3 +1782,32 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
     assert missing_autograd == expected_missing
     assert len(forward_ops) == 396
     assert len(autograd_ops & forward_ops) == 324
+
+
+def test_npu_activation_module_consolidates_fast_helper_try_blocks():
+    """`activation.py` historically grew one `try/except ImportError` block
+    per `fast_*` helper — currently 15 separate blocks (14 individual
+    primaries + 1 composites). Every other ops module that mirrors this
+    pattern (`math.py`, `comparison.py`, `reduce.py`, `elementwise.py`,
+    `linalg.py`, `random.py`, `optim.py`) uses a *single* consolidated
+    try/except block at module top, importing every `fast_*` helper inside
+    a tuple and setting each `_HAS_FAST_X` flag in the success branch /
+    `None` + `False` in the failure branch.
+
+    All `fast_*` helpers come from the same Cython extension module
+    (`candle._C._npu_ops`) — they either all exist or none do — so
+    splitting the import into 15 blocks adds clutter without changing
+    runtime semantics. Consolidate them so `activation.py` matches the
+    rest of the package and pays one ImportError check instead of 15.
+    """
+    activation_src = _source("src/candle/_backends/npu/ops/activation.py")
+    try_count = len(
+        [line for line in activation_src.splitlines() if line.startswith("try:")]
+    )
+    assert try_count <= 1, (
+        "`src/candle/_backends/npu/ops/activation.py` still has "
+        f"{try_count} top-level `try:` blocks for importing `fast_*` "
+        "helpers. Consolidate them into a single try/except block so the "
+        "module matches `math.py`, `comparison.py`, and the rest of the "
+        "ops package."
+    )


### PR DESCRIPTION
## Summary

- Collapse 15 separate top-level `try/except ImportError` blocks in `src/candle/_backends/npu/ops/activation.py` into a single consolidated block, matching the convention already used by `math.py`, `comparison.py`, `reduce.py`, `elementwise.py`, `linalg.py`, `random.py`, and `optim.py`.
- Add a new audit test in `tests/contract/test_npu_mechanism_audit.py` that locks the single-block invariant in place so the module cannot regress to per-helper try/except clutter.

All 24 `fast_*` helpers come from `candle._C._npu_ops`; they either all exist or none do, so the consolidation does not change runtime semantics — only the import surface and the count of `ImportError` checks (15 → 1).

## Test plan

- [x] `pylint --jobs=1 src/candle --rcfile=.github/pylint.conf` → 10.00/10
- [x] `pytest tests/cpu/ tests/contract/ -q` → 3376 passed, 30 skipped
- [x] new audit test `test_npu_activation_module_consolidates_fast_helper_try_blocks` verified RED before the source edit and GREEN after

🤖 Generated with [Claude Code](https://claude.com/claude-code)