### PR TITLE
refactor(npu): consolidate special.py fast_* try blocks (batch 67)

### DIFF
--- a/src/candle/_backends/npu/ops/special.py
+++ b/src/candle/_backends/npu/ops/special.py
@@ -8,8 +8,12 @@ try:
         fast_special_sinc as _fast_special_sinc_impl,
         fast_special_xlog1py as _fast_special_xlog1py_impl,
         fast_special_xlogy as _fast_special_xlogy_impl,
+        fast_digamma as _fast_digamma_impl,
+        fast_erfinv as _fast_erfinv_impl,
+        fast_lgamma as _fast_lgamma_impl,
     )
     _HAS_FAST_SPECIAL_COMPOSITES = True
+    _HAS_FAST_SPECIAL_UNARY = True
 except ImportError:
     _fast_special_erfcx_impl = None  # type: ignore[assignment]
     _fast_special_log_ndtr_impl = None  # type: ignore[assignment]
@@ -18,19 +22,10 @@ except ImportError:
     _fast_special_sinc_impl = None  # type: ignore[assignment]
     _fast_special_xlog1py_impl = None  # type: ignore[assignment]
     _fast_special_xlogy_impl = None  # type: ignore[assignment]
-    _HAS_FAST_SPECIAL_COMPOSITES = False
-
-try:
-    from candle._C._npu_ops import (  # pylint: disable=import-error,no-name-in-module
-        fast_digamma as _fast_digamma_impl,
-        fast_erfinv as _fast_erfinv_impl,
-        fast_lgamma as _fast_lgamma_impl,
-    )
-    _HAS_FAST_SPECIAL_UNARY = True
-except ImportError:
     _fast_digamma_impl = None  # type: ignore[assignment]
     _fast_erfinv_impl = None  # type: ignore[assignment]
     _fast_lgamma_impl = None  # type: ignore[assignment]
+    _HAS_FAST_SPECIAL_COMPOSITES = False
     _HAS_FAST_SPECIAL_UNARY = False
 
 from ._helpers import (

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1848,3 +1848,29 @@ def test_npu_linalg_module_has_no_dead_cross_module_imports():
                     f"`{name}` from `.shape`, but no function body calls it — "
                     "drop the dead import."
                 )
+
+
+def test_npu_special_module_consolidates_fast_helper_try_blocks():
+    """`special.py` carries 2 top-level `try/except ImportError` blocks
+    that import distinct `fast_*` helpers from `candle._C._npu_ops` —
+    one for `_HAS_FAST_SPECIAL_COMPOSITES` (sinc / xlogy / ndtr etc.)
+    and one for `_HAS_FAST_SPECIAL_UNARY` (digamma / erfinv / lgamma).
+    The two blocks load from the same Cython module, so they either
+    both succeed or both fail at import time; splitting them adds an
+    extra `ImportError` check without changing runtime semantics.
+
+    Merge them into one consolidated block — matching the pattern in
+    `math.py`, `comparison.py`, `activation.py`, and the rest of the
+    ops package — so the module pays a single ImportError check.
+    """
+    special_src = _source("src/candle/_backends/npu/ops/special.py")
+    try_count = len(
+        [line for line in special_src.splitlines() if line.startswith("try:")]
+    )
+    assert try_count <= 1, (
+        "`src/candle/_backends/npu/ops/special.py` still has "
+        f"{try_count} top-level `try:` blocks for importing `fast_*` "
+        "helpers. Consolidate them into a single try/except block so the "
+        "module matches `math.py`, `comparison.py`, `activation.py`, and "
+        "the rest of the ops package."
+    )


### PR DESCRIPTION
## Summary

- Merge \`special.py\`'s 2 top-level \`try/except ImportError\` blocks (one for \`_HAS_FAST_SPECIAL_COMPOSITES\`, one for \`_HAS_FAST_SPECIAL_UNARY\`) into a single consolidated block, matching the pattern used by \`math.py\`, \`comparison.py\`, \`activation.py\`, and the rest of the ops package.
- Add an audit test in \`tests/contract/test_npu_mechanism_audit.py\` that locks the single-block invariant in place.

Both blocks load from the same Cython extension (\`candle._C._npu_ops\`); they either both succeed or both fail at import time, so the consolidation does not change runtime semantics — only the count of ImportError checks (2 → 1).

## Test plan

- [x] \`pylint --jobs=1 src/candle --rcfile=.github/pylint.conf\` → 10.00/10
- [x] \`pytest tests/cpu/ tests/contract/ -q\` → 3378 passed, 30 skipped
- [x] new audit \`test_npu_special_module_consolidates_fast_helper_try_blocks\` verified RED before edit and GREEN after

🤖 Generated with [Claude Code](https://claude.com/claude-code)