### PR TITLE
refactor(npu): collapse view_backend alias in _helpers.py to direct reshape import (batch 69)

### DIFF
--- a/src/candle/_backends/npu/ops/_helpers.py
+++ b/src/candle/_backends/npu/ops/_helpers.py
@@ -5,8 +5,7 @@ from ...._dtype import int32 as int32_dtype
 from ...._dtype import int64 as int64_dtype
 from ...._dtype import float32 as float_dtype
 from ...._C import npu_typed_storage_from_ptr
-from ...common import view as view_backend
-reshape = view_backend.reshape
+from ...common.view import reshape
 from .. import aclnn
 from .. import runtime as npu_runtime
 from .. import state as npu_state

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1926,3 +1926,55 @@ def test_npu_binary_op_inlines_native_fast_ops_guard():
         f"`_require_native_fast_ops` still referenced from: {offenders}. "
         "Remove all consumers before dropping the helper definition."
     )
+
+
+def test_npu_helpers_imports_reshape_directly_without_view_backend_alias():
+    """`_helpers.py` carries two adjacent lines whose only purpose is to
+    expose `reshape` as a public name for re-export to consumer modules:
+
+        from ...common import view as view_backend
+        reshape = view_backend.reshape
+
+    Inside `_helpers.py`, `view_backend` is never referenced anywhere
+    else — it exists solely to define the `reshape` alias on the next
+    line. No consumer module imports `view_backend` from `_helpers`
+    either; the few NPU files that need `view_backend.permute` etc.
+    import `view as view_backend` directly from `..._backends.common`
+    in their own function bodies.
+
+    Collapse the two lines into a single direct import:
+
+        from ...common.view import reshape
+
+    so `_helpers.py` does not carry an unused module-level alias.
+    """
+    helpers_src = _source("src/candle/_backends/npu/ops/_helpers.py")
+
+    # The module-level alias setup line must be gone.
+    assert "view as view_backend" not in helpers_src, (
+        "`_helpers.py` still imports `view as view_backend` at module "
+        "level. The alias has no other use in this file — collapse to "
+        "`from ...common.view import reshape`."
+    )
+    assert "reshape = view_backend.reshape" not in helpers_src, (
+        "`_helpers.py` still defines `reshape = view_backend.reshape`. "
+        "Replace with a direct `from ...common.view import reshape` to "
+        "drop the indirection through `view_backend`."
+    )
+
+    # The direct import must be present (so re-export of `reshape`
+    # continues to work for consumer modules).
+    assert "from ...common.view import reshape" in helpers_src, (
+        "`_helpers.py` must import `reshape` directly from "
+        "`...common.view` so its existing re-exports (activation.py / "
+        "random.py / special.py) keep working."
+    )
+
+    # No `view_backend` name at module-level scope of `_helpers.py`.
+    for line in helpers_src.splitlines():
+        if line.startswith((" ", "\t", "#")) or not line.strip():
+            continue
+        assert "view_backend" not in line, (
+            f"`_helpers.py` still references `view_backend` at module "
+            f"level: {line!r}. The alias should be dropped entirely."
+        )


### PR DESCRIPTION
## Summary

- Replace the two-line `view_backend` alias scaffold in `src/candle/_backends/npu/ops/_helpers.py` with a direct `from ...common.view import reshape`.
- `view_backend` was never used anywhere else in `_helpers.py` — it existed only so the next line could define `reshape = view_backend.reshape`. No consumer module imports `view_backend` from `_helpers` either.

## Audit

`tests/contract/test_npu_mechanism_audit.py::test_npu_helpers_imports_reshape_directly_without_view_backend_alias` asserts the file:

- no longer contains the alias `view as view_backend` at module level,
- no longer carries the `reshape = view_backend.reshape` rebind,
- imports `reshape` directly via `from ...common.view import reshape`,
- has no remaining \`view_backend\` reference at module-level scope.

## Test plan

- [x] \`pylint --jobs=1 src/candle --rcfile=.github/pylint.conf\` — 10.00/10
- [x] \`python -m pytest tests/cpu tests/contract -q\` — 3380 passed, 30 skipped
- [x] New audit fails before edit (RED) and passes after (GREEN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)