### PR TITLE
refactor(npu): inline _pow_tensor_scalar_op into pow (batch 71)

### DIFF
--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -581,12 +581,6 @@ def atan2(a, b):
     raise RuntimeError("Cython NPU atan2 implementation is unavailable")
 
 
-def _pow_tensor_scalar_op(a, exponent):
-    if _HAS_FAST_POW_TENSOR_SCALAR:
-        return _fast_pow_tensor_scalar_impl(a, exponent)
-    raise RuntimeError("Cython NPU pow tensor-scalar implementation is unavailable")
-
-
 def reciprocal(a):
     if _HAS_FAST_RECIPROCAL:
         return _fast_reciprocal_impl(a)
@@ -598,7 +592,9 @@ def pow(a, b):
         if _HAS_FAST_POW:
             return _fast_pow_impl(a, b)
         raise RuntimeError("Cython NPU pow implementation is unavailable")
-    return _pow_tensor_scalar_op(a, b)
+    if _HAS_FAST_POW_TENSOR_SCALAR:
+        return _fast_pow_tensor_scalar_impl(a, b)
+    raise RuntimeError("Cython NPU pow tensor-scalar implementation is unavailable")
 
 
 def floor_divide(a, b):

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -236,7 +236,6 @@ def test_npu_thin_binary_wrappers_delegate_to_cython():
         math_src: {
             "sub": "_fast_sub_impl",
             "div": "_fast_div_impl",
-            "_pow_tensor_scalar_op": "_fast_pow_tensor_scalar_impl",
             "pow": "_fast_pow_impl",
             "floor_divide": "_fast_floor_divide_impl",
         },
@@ -2063,4 +2062,55 @@ def test_npu_linear_index_routed_directly_in_functionalize_not_via_ops_package()
         f"Unexpected direct importers of `_npu_linear_index` from "
         f"`_helpers`: {direct_consumers}. Only `_dispatch/functionalize.py` "
         "should import it directly."
+    )
+
+
+def test_npu_pow_tensor_scalar_branch_inlined_into_pow_without_wrapper_helper():
+    """Audit: `_pow_tensor_scalar_op` was a 4-line single-use helper in
+    `_backends/npu/ops/math.py` that wrapped the
+    `_fast_pow_tensor_scalar_impl` call for the scalar-exponent path of
+    `pow`. Its only caller was `pow` itself.
+
+    Inlining the scalar branch directly into `pow` removes the indirection
+    and reduces the function from a two-hop dispatch (`pow` ->
+    `_pow_tensor_scalar_op` -> `_fast_pow_tensor_scalar_impl`) to a single
+    direct call.
+    """
+    math_path = _REPO_ROOT / "src/candle/_backends/npu/ops/math.py"
+    math_src = math_path.read_text(encoding="utf-8")
+
+    # The wrapper helper itself must be gone.
+    assert "def _pow_tensor_scalar_op" not in math_src, (
+        "`_pow_tensor_scalar_op` helper still defined in math.py. "
+        "Inline its body into `pow` so the scalar-exponent path calls "
+        "`_fast_pow_tensor_scalar_impl` directly."
+    )
+
+    # `pow` must reference the fast helper directly.
+    pow_body = _function_source(math_src, "pow")
+    assert "_fast_pow_tensor_scalar_impl" in pow_body, (
+        "`pow` body must call `_fast_pow_tensor_scalar_impl` directly "
+        "after the wrapper helper is removed."
+    )
+    assert "_pow_tensor_scalar_op" not in pow_body, (
+        "`pow` still references the removed `_pow_tensor_scalar_op` "
+        "wrapper helper."
+    )
+
+    # Cross-codebase consumer-scan: the wrapper name must not appear
+    # anywhere else in `src/candle/` or `tests/` (excluding this audit
+    # file's own references to it).
+    consumer_roots = ["src/candle", "tests"]
+    audit_path = Path(__file__).resolve()
+    offenders = []
+    for root in consumer_roots:
+        for path in (_REPO_ROOT / root).rglob("*.py"):
+            if path.resolve() == audit_path:
+                continue
+            text = path.read_text(encoding="utf-8")
+            if "_pow_tensor_scalar_op" in text:
+                offenders.append(str(path.relative_to(_REPO_ROOT)))
+    assert not offenders, (
+        f"`_pow_tensor_scalar_op` still referenced from: {offenders}. "
+        "Drop all remaining references."
     )


### PR DESCRIPTION
## Summary

- Inline the 4-line `_pow_tensor_scalar_op` helper directly into its sole caller `pow` in `_backends/npu/ops/math.py`. The wrapper just dispatched to `_fast_pow_tensor_scalar_impl`, so removing it collapses a two-hop call into a single direct call.
- New audit `test_npu_pow_tensor_scalar_branch_inlined_into_pow_without_wrapper_helper` locks in the deletion: it asserts the helper definition is gone, `pow` references `_fast_pow_tensor_scalar_impl` directly, and a cross-codebase consumer scan (excluding the audit file itself) finds no remaining references.
- Existing `test_npu_thin_binary_wrappers_delegate_to_cython` audit drops its `_pow_tensor_scalar_op` expectation entry to match the new state.

Continues the NPU Python-shim-to-Cython migration after PRs #500, #501, and #502.

## Test plan

- [x] New audit RED before change, GREEN after.
- [x] `pytest tests/cpu tests/contract -q` — 3382 passed, 30 skipped.
- [x] `pylint --jobs=1 src/candle --rcfile=.github/pylint.conf` — 10.00/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)