### PR TITLE
refactor(npu): register _adamw_step directly to _adam_step_op (batch 72)

### DIFF
--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -312,7 +312,6 @@ from .ops import (
     upsample_bicubic2d_op,
     upsample_linear1d_op,
     _adam_step_op,
-    _adamw_step_op,
     # Phase 2: activation composites
     selu_op,
     celu_op,
@@ -764,7 +763,7 @@ registry.register("adaptive_avg_pool3d", "npu", adaptive_avg_pool3d_op)
 registry.register("upsample_bicubic2d", "npu", upsample_bicubic2d_op)
 registry.register("upsample_linear1d", "npu", upsample_linear1d_op)
 registry.register("_adam_step", "npu", _adam_step_op)
-registry.register("_adamw_step", "npu", _adamw_step_op)
+registry.register("_adamw_step", "npu", _adam_step_op)
 
 # Upgrade composites to ACLNN large kernels
 registry.register("aminmax", "npu", aminmax_aclnn)

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -132,7 +132,7 @@ from .special import (
 )
 
 from .optim import (
-    _adam_step_op, _adamw_step_op, _sgd_step_op,
+    _adam_step_op, _sgd_step_op,
     _adagrad_step_op, _rmsprop_step_op, _adadelta_step_op,
     _adamax_step_op, _asgd_step_op, _nadam_step_op,
     _radam_step_op, _rprop_step_op, _sparse_adam_step_op,

--- a/src/candle/_backends/npu/ops/optim.py
+++ b/src/candle/_backends/npu/ops/optim.py
@@ -30,12 +30,6 @@ def _adam_step_op(param, grad, exp_avg, exp_avg_sq, max_exp_avg_sq,
     raise RuntimeError("Cython NPU adam_step implementation is unavailable")
 
 
-def _adamw_step_op(param, grad, exp_avg, exp_avg_sq, max_exp_avg_sq,
-                   step, lr, beta1, beta2, eps, weight_decay, amsgrad, maximize):
-    return _adam_step_op(param, grad, exp_avg, exp_avg_sq, max_exp_avg_sq,
-                         step, lr, beta1, beta2, eps, weight_decay, amsgrad, maximize)
-
-
 # ===========================================================================
 # Phase 2: Activation function composites
 # ===========================================================================

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -2114,3 +2114,61 @@ def test_npu_pow_tensor_scalar_branch_inlined_into_pow_without_wrapper_helper():
         f"`_pow_tensor_scalar_op` still referenced from: {offenders}. "
         "Drop all remaining references."
     )
+
+
+def test_npu_adamw_step_registers_adam_step_op_directly_without_rename_wrapper():
+    """Audit: `_adamw_step_op` in `_backends/npu/ops/optim.py` was a
+    4-line pure-delegation wrapper that called `_adam_step_op` with the
+    exact same argument list. Both ops dispatch to the same Cython
+    `_fast_adam_step_impl` kernel, so the wrapper added a hop without
+    changing behavior.
+
+    Dropping the wrapper registers `_adamw_step` directly to
+    `_adam_step_op`, removing one indirection and one symbol from the
+    package `__init__.py` re-export surface.
+    """
+    optim_src = _source("src/candle/_backends/npu/ops/optim.py")
+    backend_init_src = _source("src/candle/_backends/npu/__init__.py")
+    ops_init_src = _source("src/candle/_backends/npu/ops/__init__.py")
+
+    # The wrapper function definition must be gone.
+    assert "def _adamw_step_op" not in optim_src, (
+        "`_adamw_step_op` wrapper still defined in `optim.py`. Remove "
+        "it and register `_adamw_step` directly with `_adam_step_op`."
+    )
+
+    # `_adamw_step` registration must point at `_adam_step_op` directly.
+    assert 'registry.register("_adamw_step", "npu", _adam_step_op)' in backend_init_src, (
+        "`_adamw_step` must register `_adam_step_op` directly, not the "
+        "removed `_adamw_step_op` rename wrapper."
+    )
+    assert 'registry.register("_adamw_step", "npu", _adamw_step_op)' not in backend_init_src, (
+        "`_adamw_step` still registered against the removed "
+        "`_adamw_step_op` wrapper in `_backends/npu/__init__.py`."
+    )
+
+    # Neither `__init__.py` should still import or re-export the wrapper.
+    assert "_adamw_step_op" not in backend_init_src, (
+        "`_backends/npu/__init__.py` still references `_adamw_step_op`."
+    )
+    assert "_adamw_step_op" not in ops_init_src, (
+        "`_backends/npu/ops/__init__.py` still re-exports "
+        "`_adamw_step_op`."
+    )
+
+    # Cross-codebase consumer-scan: nothing else in `src/candle/` or
+    # `tests/` should reference the removed wrapper.
+    consumer_roots = ["src/candle", "tests"]
+    audit_path = Path(__file__).resolve()
+    offenders = []
+    for root in consumer_roots:
+        for path in (_REPO_ROOT / root).rglob("*.py"):
+            if path.resolve() == audit_path:
+                continue
+            text = path.read_text(encoding="utf-8")
+            if "_adamw_step_op" in text:
+                offenders.append(str(path.relative_to(_REPO_ROOT)))
+    assert not offenders, (
+        f"`_adamw_step_op` still referenced from: {offenders}. Drop all "
+        "remaining references."
+    )


### PR DESCRIPTION
## Summary

- `_adamw_step_op` in `_backends/npu/ops/optim.py` was a 4-line pure-delegation wrapper that called `_adam_step_op` with the exact same argument list. Both ops dispatch to the same Cython `_fast_adam_step_impl` kernel, so the wrapper added a hop without changing behavior.
- Drop the wrapper and register \`_adamw_step\` directly to \`_adam_step_op\`, removing one indirection plus the symbol from both \`__init__.py\` import lists.
- New audit \`test_npu_adamw_step_registers_adam_step_op_directly_without_rename_wrapper\` locks in the deletion: it asserts the wrapper definition is gone, \`_adamw_step\` is registered against \`_adam_step_op\`, both \`__init__.py\` files no longer mention the wrapper, and a cross-codebase consumer scan (excluding the audit file itself) finds no remaining references.

Continues the NPU Python-shim-to-Cython migration after PR #503.

## Test plan

- [x] New audit RED before change, GREEN after.
- [x] \`pytest tests/cpu tests/contract -q\` — 3383 passed, 30 skipped.
- [x] \`pylint --jobs=1 src/candle --rcfile=.github/pylint.conf\` — 10.00/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)