### PR TITLE
refactor(npu): register mm and bmm directly to matmul (batch 73)

### DIFF
--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -303,8 +303,6 @@ from .ops import (
     special_gammaln,
     special_sinc,
     linalg_inv,
-    mm_op,
-    bmm_op,
     linalg_vector_norm_op,
     aminmax_aclnn,
     bincount_aclnn,
@@ -751,8 +749,8 @@ registry.register("matrix_power", "npu", matrix_power_op, meta=meta_infer.infer_
 registry.register("col2im", "npu", col2im_op)
 
 # Phase 1: ACLNN large kernel ops (910B confirmed working)
-registry.register("mm", "npu", mm_op, meta=meta_infer.infer_matmul)
-registry.register("bmm", "npu", bmm_op, meta=meta_infer.infer_matmul)
+registry.register("mm", "npu", matmul, meta=meta_infer.infer_matmul)
+registry.register("bmm", "npu", matmul, meta=meta_infer.infer_matmul)
 registry.register("special_digamma", "npu", special_digamma, meta=meta_infer.infer_unary)
 registry.register("special_erfinv", "npu", special_erfinv, meta=meta_infer.infer_unary)
 registry.register("special_gammaln", "npu", special_gammaln, meta=meta_infer.infer_unary)

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -69,7 +69,7 @@ from .norm import (
 )
 
 from .linalg import (
-    matmul, dot, mv, outer, mm_op, bmm_op,
+    matmul, dot, mv, outer,
     addmm, baddbmm, einsum_,
     linalg_qr, linalg_inv, linalg_vector_norm_op,
     linalg_norm_op, linalg_matrix_norm_op,

--- a/src/candle/_backends/npu/ops/linalg.py
+++ b/src/candle/_backends/npu/ops/linalg.py
@@ -282,14 +282,6 @@ def outer(a, b):
     return _wrap_tensor(storage, out_shape, out_stride)
 
 
-def mm_op(a, b):
-    return matmul(a, b)
-
-
-def bmm_op(a, b):
-    return matmul(a, b)
-
-
 def addmm(input, mat1, mat2, beta=1, alpha=1):
     runtime = npu_runtime.get_runtime((input.device.index or 0))
     stream = npu_state.current_stream((input.device.index or 0))

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -2172,3 +2172,70 @@ def test_npu_adamw_step_registers_adam_step_op_directly_without_rename_wrapper()
         f"`_adamw_step_op` still referenced from: {offenders}. Drop all "
         "remaining references."
     )
+
+
+def test_npu_mm_and_bmm_register_matmul_directly_without_alias_wrappers():
+    """Audit: `mm_op` and `bmm_op` in `_backends/npu/ops/linalg.py` were
+    2-line pure-delegation wrappers that just returned `matmul(a, b)`.
+    The `mm` and `bmm` schemas take exactly two tensors, so the
+    intermediate names added a hop without changing behavior.
+
+    Registering `mm` and `bmm` directly to `matmul` removes one
+    indirection per op and drops both names from the package
+    `__init__.py` re-export surface.
+    """
+    linalg_src = _source("src/candle/_backends/npu/ops/linalg.py")
+    backend_init_src = _source("src/candle/_backends/npu/__init__.py")
+    ops_init_src = _source("src/candle/_backends/npu/ops/__init__.py")
+
+    # The wrapper definitions must be gone.
+    assert "def mm_op" not in linalg_src, (
+        "`mm_op` wrapper still defined in `linalg.py`. Register `mm` "
+        "directly with `matmul`."
+    )
+    assert "def bmm_op" not in linalg_src, (
+        "`bmm_op` wrapper still defined in `linalg.py`. Register `bmm` "
+        "directly with `matmul`."
+    )
+
+    # `mm` / `bmm` must register `matmul` directly.
+    assert (
+        'registry.register("mm", "npu", matmul, meta=meta_infer.infer_matmul)'
+        in backend_init_src
+    ), (
+        "`mm` must register `matmul` directly, not the removed `mm_op` "
+        "wrapper."
+    )
+    assert (
+        'registry.register("bmm", "npu", matmul, meta=meta_infer.infer_matmul)'
+        in backend_init_src
+    ), (
+        "`bmm` must register `matmul` directly, not the removed `bmm_op` "
+        "wrapper."
+    )
+
+    # Neither `__init__.py` should import or re-export the wrappers.
+    for name in ("mm_op", "bmm_op"):
+        assert name not in backend_init_src, (
+            f"`_backends/npu/__init__.py` still references `{name}`."
+        )
+        assert name not in ops_init_src, (
+            f"`_backends/npu/ops/__init__.py` still re-exports `{name}`."
+        )
+
+    # Cross-codebase consumer-scan: nothing else in `src/candle/` or
+    # `tests/` should reference the removed wrappers.
+    consumer_roots = ["src/candle", "tests"]
+    audit_path = Path(__file__).resolve()
+    offenders = []
+    for root in consumer_roots:
+        for path in (_REPO_ROOT / root).rglob("*.py"):
+            if path.resolve() == audit_path:
+                continue
+            text = path.read_text(encoding="utf-8")
+            if "mm_op" in text or "bmm_op" in text:
+                offenders.append(str(path.relative_to(_REPO_ROOT)))
+    assert not offenders, (
+        f"`mm_op` / `bmm_op` still referenced from: {offenders}. Drop "
+        "all remaining references."
+    )


### PR DESCRIPTION
## Summary

- `mm_op` and `bmm_op` in `_backends/npu/ops/linalg.py` were 2-line pure-delegation wrappers that just returned `matmul(a, b)`. The `mm` and `bmm` schemas take exactly two tensors, so the intermediate names added a hop without changing behavior.
- Drop both wrappers and register `mm` and `bmm` directly to `matmul`, removing one indirection per op plus the two names from both `__init__.py` import surfaces.
- New audit `test_npu_mm_and_bmm_register_matmul_directly_without_alias_wrappers` locks in the deletion: it asserts both wrapper definitions are gone, `mm` and `bmm` are registered against `matmul`, neither `__init__.py` still mentions the wrappers, and a cross-codebase consumer scan (excluding the audit file itself) finds no remaining references.

Continues the NPU Python-shim-to-Cython migration after PR #504.

## Test plan

- [x] New audit RED before change, GREEN after.
- [x] `pytest tests/cpu tests/contract -q` — 3384 passed, 30 skipped.
- [x] `pylint --jobs=1 src/candle --rcfile=.github/pylint.conf` — 10.00/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)