### PR TITLE
refactor(npu): register linalg_det directly to det_op (batch 74)

### DIFF
--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -364,7 +364,6 @@ from .ops import (
     linalg_vander_op,
     linalg_cholesky_op,
     linalg_cond_op,
-    linalg_det_op,
     linalg_eig_op,
     linalg_eigh_op,
     linalg_eigvals_op,
@@ -825,7 +824,7 @@ registry.register("linalg_matrix_power", "npu", linalg_matrix_power_op)
 registry.register("linalg_vander", "npu", linalg_vander_op)
 registry.register("linalg_cholesky", "npu", linalg_cholesky_op)
 registry.register("linalg_cond", "npu", linalg_cond_op)
-registry.register("linalg_det", "npu", linalg_det_op)
+registry.register("linalg_det", "npu", det_op)
 registry.register("linalg_eig", "npu", linalg_eig_op)
 registry.register("linalg_eigh", "npu", linalg_eigh_op)
 registry.register("linalg_eigvals", "npu", linalg_eigvals_op)

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -74,7 +74,7 @@ from .linalg import (
     linalg_qr, linalg_inv, linalg_vector_norm_op,
     linalg_norm_op, linalg_matrix_norm_op,
     linalg_multi_dot_op, linalg_matrix_power_op, linalg_vander_op,
-    linalg_cholesky_op, linalg_cond_op, linalg_det_op, linalg_slogdet_op,
+    linalg_cholesky_op, linalg_cond_op, linalg_slogdet_op,
     linalg_eig_op, linalg_eigh_op, linalg_eigvals_op, linalg_eigvalsh_op,
     linalg_householder_product_op, linalg_lstsq_op,
     linalg_lu_op, linalg_lu_factor_op, linalg_lu_solve_op,

--- a/src/candle/_backends/npu/ops/linalg.py
+++ b/src/candle/_backends/npu/ops/linalg.py
@@ -775,11 +775,6 @@ def linalg_cond_op(a, p=None):
     return mul(a_norm, a_inv_norm)
 
 
-def linalg_det_op(a):
-    """Determinant — delegate to existing det_op (QR-based)."""
-    return det_op(a)
-
-
 def linalg_slogdet_op(a):
     """Sign and log absolute value of determinant via QR."""
     from collections import namedtuple

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -2239,3 +2239,58 @@ def test_npu_mm_and_bmm_register_matmul_directly_without_alias_wrappers():
         f"`mm_op` / `bmm_op` still referenced from: {offenders}. Drop "
         "all remaining references."
     )
+
+
+def test_npu_linalg_det_registers_det_op_directly_without_alias_wrapper():
+    """Audit: `linalg_det_op` in `_backends/npu/ops/linalg.py` was a
+    3-line pure-delegation wrapper that just returned `det_op(a)`.
+    The `linalg_det` schema `(Tensor input) -> Tensor` matches `det_op`'s
+    signature exactly, so the intermediate name added a hop without
+    changing behavior.
+
+    Registering `linalg_det` directly to `det_op` removes one indirection
+    and drops `linalg_det_op` from the package `__init__.py` re-export
+    surface.
+    """
+    linalg_src = _source("src/candle/_backends/npu/ops/linalg.py")
+    backend_init_src = _source("src/candle/_backends/npu/__init__.py")
+    ops_init_src = _source("src/candle/_backends/npu/ops/__init__.py")
+
+    # The wrapper definition must be gone.
+    assert "def linalg_det_op" not in linalg_src, (
+        "`linalg_det_op` wrapper still defined in `linalg.py`. Register "
+        "`linalg_det` directly with `det_op`."
+    )
+
+    # `linalg_det` must register `det_op` directly.
+    assert (
+        'registry.register("linalg_det", "npu", det_op)' in backend_init_src
+    ), (
+        "`linalg_det` must register `det_op` directly, not the removed "
+        "`linalg_det_op` wrapper."
+    )
+
+    # Neither `__init__.py` should import or re-export the wrapper.
+    assert "linalg_det_op" not in backend_init_src, (
+        "`_backends/npu/__init__.py` still references `linalg_det_op`."
+    )
+    assert "linalg_det_op" not in ops_init_src, (
+        "`_backends/npu/ops/__init__.py` still re-exports `linalg_det_op`."
+    )
+
+    # Cross-codebase consumer-scan: nothing else in `src/candle/` or
+    # `tests/` should reference the removed wrapper.
+    consumer_roots = ["src/candle", "tests"]
+    audit_path = Path(__file__).resolve()
+    offenders = []
+    for root in consumer_roots:
+        for path in (_REPO_ROOT / root).rglob("*.py"):
+            if path.resolve() == audit_path:
+                continue
+            text = path.read_text(encoding="utf-8")
+            if "linalg_det_op" in text:
+                offenders.append(str(path.relative_to(_REPO_ROOT)))
+    assert not offenders, (
+        f"`linalg_det_op` still referenced from: {offenders}. Drop all "
+        "remaining references."
+    )


### PR DESCRIPTION
## Summary

- Drop `linalg_det_op` 3-line pure-delegation wrapper in `_backends/npu/ops/linalg.py`; it just returned `det_op(a)`.
- Register `linalg_det` directly to `det_op` in `_backends/npu/__init__.py` — signatures match the schema `linalg_det(Tensor input) -> Tensor`.
- Drop the now-dead `linalg_det_op` re-export from `_backends/npu/ops/__init__.py` and import in `_backends/npu/__init__.py`.
- Add audit `test_npu_linalg_det_registers_det_op_directly_without_alias_wrapper` that:
  - asserts the wrapper definition is gone
  - asserts `linalg_det` registers `det_op` directly
  - scans `src/candle/` and `tests/` (excluding the audit file) for any remaining `linalg_det_op` references

## Test plan

- [x] `pylint --jobs=1 src/candle --rcfile=.github/pylint.conf` → 10.00/10
- [x] `pytest tests/cpu/ tests/contract/ -v --tb=short` → 3385 passed, 30 skipped
- [x] New audit: RED before edit, GREEN after

🤖 Generated with [Claude Code](https://claude.com/claude-code)