### PR TITLE
refactor(npu): collapse special unary wrappers to Cython aliases (batch 77)

### DIFF
--- a/src/candle/_backends/npu/ops/special.py
+++ b/src/candle/_backends/npu/ops/special.py
@@ -8,6 +8,7 @@ try:
         fast_special_sinc as _fast_special_sinc_impl,
         fast_special_xlog1py as _fast_special_xlog1py_impl,
         fast_special_xlogy as _fast_special_xlogy_impl,
+        fast_sinc as _fast_sinc_impl,
         fast_digamma as _fast_digamma_impl,
         fast_erfinv as _fast_erfinv_impl,
         fast_lgamma as _fast_lgamma_impl,
@@ -22,6 +23,7 @@ except ImportError:
     _fast_special_sinc_impl = None  # type: ignore[assignment]
     _fast_special_xlog1py_impl = None  # type: ignore[assignment]
     _fast_special_xlogy_impl = None  # type: ignore[assignment]
+    _fast_sinc_impl = None  # type: ignore[assignment]
     _fast_digamma_impl = None  # type: ignore[assignment]
     _fast_erfinv_impl = None  # type: ignore[assignment]
     _fast_lgamma_impl = None  # type: ignore[assignment]
@@ -44,23 +46,20 @@ from .reduce import maximum
 from .shape import contiguous, index_select
 
 
-def special_digamma(a):
-    return _fast_digamma_impl(a)
+special_digamma = _fast_digamma_impl
 
 
-def special_erfinv(a):
-    return _fast_erfinv_impl(a)
+special_erfinv = _fast_erfinv_impl
 
 
-def special_gammaln(a):
-    return _fast_lgamma_impl(a)
+special_gammaln = _fast_lgamma_impl
 
 
 def special_sinc(a):
     if _HAS_FAST_SPECIAL_COMPOSITES:
         return _fast_special_sinc_impl(a)
-    from candle._C._npu_ops import fast_sinc as _fast_sinc_impl  # pylint: disable=import-error,no-name-in-module
     return _fast_sinc_impl(a)
+
 
 
 def special_entr_op(a):

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -175,27 +175,39 @@ def test_npu_bulk_fast_helpers_have_no_python_fallback_bodies():
             assert marker not in body
 
 
-def test_npu_special_gamma_and_erfinv_wrappers_delegate_to_cython():
+def test_npu_special_unary_wrappers_collapse_to_cython_aliases():
+    """Audit: `special_digamma`, `special_erfinv`, and `special_gammaln`
+    in `_backends/npu/ops/special.py` are 2-line `def` wrappers whose bodies
+    only return their module-level Cython helpers. Their schemas each take a
+    single tensor input, identical to the imported helper signatures, so the
+    wrappers add Python call frames without changing behavior.
+
+    Collapse them to module-level aliases:
+
+      special_digamma = _fast_digamma_impl
+      special_erfinv = _fast_erfinv_impl
+      special_gammaln = _fast_lgamma_impl
+
+    Keep the names intact so `_backends/npu/__init__.py` registrations and the
+    internal `special_multigammaln_op()` call site continue to work.
+    """
     special_src = _source("src/candle/_backends/npu/ops/special.py")
 
-    special_expectations = {
+    expectations = {
         "special_digamma": "_fast_digamma_impl",
         "special_erfinv": "_fast_erfinv_impl",
         "special_gammaln": "_fast_lgamma_impl",
     }
-    forbidden = [
-        "return _unary_op(",
-        "return _binary_op(",
-        "aclnn.",
-        "_wrap_tensor(",
-        "npu_runtime._alloc_device",
-        "_unwrap_storage(",
-    ]
-    for name, fast_name in special_expectations.items():
-        body = _function_source(special_src, name)
-        assert fast_name in body, f"{name} does not delegate to {fast_name}"
-        for marker in forbidden:
-            assert marker not in body
+    for name, fast_name in expectations.items():
+        assert f"def {name}(" not in special_src, (
+            f"`{name}` is still defined as a `def` wrapper in `special.py`. "
+            f"Replace it with the module-level alias `{name} = {fast_name}`."
+        )
+        assert f"{name} = {fast_name}" in special_src, (
+            f"`special.py` must bind `{name}` to `{fast_name}` via a "
+            "module-level alias so the registration/import surface stays "
+            "unchanged."
+        )
 
 
 def test_npu_comparison_thin_wrappers_delegate_to_cython():
@@ -1590,9 +1602,7 @@ def test_npu_ops_modules_lift_fast_helper_imports_to_module_level():
     """
     targets = {
         "src/candle/_backends/npu/ops/special.py": [
-            "special_digamma",
-            "special_erfinv",
-            "special_gammaln",
+            "special_sinc",
         ],
     }
     for rel, names in targets.items():


### PR DESCRIPTION
## Summary
- Collapse `special_digamma`, `special_erfinv`, and `special_gammaln` in `special.py` from single-return Python wrappers to module-level aliases of their Cython helpers.
- Lift `fast_sinc` into the existing consolidated special fast-helper import block so `special_sinc` no longer performs a function-body import.
- Update the NPU mechanism audit to require these special unary names to remain aliases while keeping the fast-helper import consolidation check on `special_sinc`.

## Test Plan
- [x] `python -m pytest tests/contract/test_npu_mechanism_audit.py -v --tb=short` — 80 passed
- [x] `python -m pytest tests/cpu/ tests/contract/ -v --tb=short` — 3387 passed, 30 skipped
- [x] `pylint --jobs=1 src/candle --rcfile=.github/pylint.conf` — 10.00/10
- [ ] `python -m pytest tests/npu/ -v --tb=short` — blocked during collection by environment missing `libunified_dlog.so`