### PR TITLE
feat(npu): register in-place unary ops (intake tranche 2)

### DIFF
--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -92,6 +92,12 @@ from .ops import (
     erfinv_,
     sub_,
     div_,
+    neg_,
+    exp_,
+    log_,
+    tan_,
+    floor_,
+    ceil_,
     contiguous,
     getitem,
     setitem,
@@ -507,6 +513,12 @@ registry.register("fill_", "npu", fill_, meta=meta_infer.infer_unary)
 registry.register("clamp_", "npu", clamp_, meta=meta_infer.infer_unary)
 registry.register("copy_", "npu", copy_, meta=meta_infer.infer_unary)
 registry.register("erfinv_", "npu", erfinv_, meta=meta_infer.infer_unary)
+registry.register("neg_", "npu", neg_, meta=meta_infer.infer_unary)
+registry.register("exp_", "npu", exp_, meta=meta_infer.infer_unary)
+registry.register("log_", "npu", log_, meta=meta_infer.infer_unary)
+registry.register("tan_", "npu", tan_, meta=meta_infer.infer_unary)
+registry.register("floor_", "npu", floor_, meta=meta_infer.infer_unary)
+registry.register("ceil_", "npu", ceil_, meta=meta_infer.infer_unary)
 registry.register("sub_", "npu", sub_, meta=meta_infer.infer_binary)
 registry.register("sub", "npu", sub, meta=meta_infer.infer_binary)
 registry.register("div", "npu", div, meta=meta_infer.infer_binary)

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -1,6 +1,7 @@
 from .math import (
     add, sub, mul, div,
     add_, sub_, mul_, div_,
+    neg_, exp_, log_, tan_, floor_, ceil_,
     abs, neg, sign, signbit, square,
     isfinite, isinf, isnan, isposinf, isneginf,
     exp, log, sqrt, rsqrt, sin, cos, tan, tanh, sigmoid,

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -23,6 +23,7 @@ try:
         fast_atan2 as _fast_atan2_impl,
         fast_atanh as _fast_atanh_impl,
         fast_ceil as _fast_ceil_impl,
+        fast_ceil_inplace as _fast_ceil_inplace_impl,
         fast_cos as _fast_cos_impl,
         fast_cosh as _fast_cosh_impl,
         fast_erf as _fast_erf_impl,
@@ -30,9 +31,11 @@ try:
         fast_div_inplace as _fast_div_inplace_impl,
         fast_erfc as _fast_erfc_impl,
         fast_exp as _fast_exp_impl,
+        fast_exp_inplace as _fast_exp_inplace_impl,
         fast_exp2 as _fast_exp2_impl,
         fast_expm1 as _fast_expm1_impl,
         fast_floor as _fast_floor_impl,
+        fast_floor_inplace as _fast_floor_inplace_impl,
         fast_frac as _fast_frac_impl,
         fast_isfinite as _fast_isfinite_impl,
         fast_isinf as _fast_isinf_impl,
@@ -40,6 +43,7 @@ try:
         fast_isneginf as _fast_isneginf_impl,
         fast_isposinf as _fast_isposinf_impl,
         fast_log as _fast_log_impl,
+        fast_log_inplace as _fast_log_inplace_impl,
         fast_log1p as _fast_log1p_impl,
         fast_log10 as _fast_log10_impl,
         fast_log2 as _fast_log2_impl,
@@ -47,6 +51,7 @@ try:
         fast_mul as _fast_mul_impl,
         fast_mul_inplace as _fast_mul_inplace_impl,
         fast_neg as _fast_neg_impl,
+        fast_neg_inplace as _fast_neg_inplace_impl,
         fast_pow as _fast_pow_impl,
         fast_pow_tensor_scalar as _fast_pow_tensor_scalar_impl,
         fast_reciprocal as _fast_reciprocal_impl,
@@ -62,6 +67,7 @@ try:
         fast_sub as _fast_sub_impl,
         fast_sub_inplace as _fast_sub_inplace_impl,
         fast_tan as _fast_tan_impl,
+        fast_tan_inplace as _fast_tan_inplace_impl,
         fast_tanh as _fast_tanh_impl,
         fast_trunc as _fast_trunc_impl,
     )  # pylint: disable=import-error,no-name-in-module
@@ -222,6 +228,12 @@ except ImportError:
     _fast_sub_inplace_impl = None  # type: ignore[assignment]
     _fast_mul_inplace_impl = None  # type: ignore[assignment]
     _fast_div_inplace_impl = None  # type: ignore[assignment]
+    _fast_neg_inplace_impl = None  # type: ignore[assignment]
+    _fast_exp_inplace_impl = None  # type: ignore[assignment]
+    _fast_log_inplace_impl = None  # type: ignore[assignment]
+    _fast_tan_inplace_impl = None  # type: ignore[assignment]
+    _fast_floor_inplace_impl = None  # type: ignore[assignment]
+    _fast_ceil_inplace_impl = None  # type: ignore[assignment]
 
 
 def add(a, b):
@@ -290,6 +302,17 @@ def div_(a, b):
     if _HAS_FAST_DIV_INPLACE:
         return _fast_div_inplace_impl(a, b)
     raise RuntimeError("Cython NPU div_ implementation is unavailable")
+
+
+# In-place unary aliases (operator intake tranche 2). Same pattern as
+# `erfinv_ = _fast_erfinv_inplace_impl` from PR #508 — direct Cython aliases
+# avoid pure-Python call frames on the dispatch hot path.
+neg_ = _fast_neg_inplace_impl
+exp_ = _fast_exp_inplace_impl
+log_ = _fast_log_inplace_impl
+tan_ = _fast_tan_inplace_impl
+floor_ = _fast_floor_inplace_impl
+ceil_ = _fast_ceil_inplace_impl
 
 
 # ---------------------------------------------------------------------------

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1730,13 +1730,16 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "bitwise_xor",
         "bucketize",
         "cartesian_prod",
+        "ceil_",
         "empty",
         "empty_like",
         "equal",
         "erfinv_",
+        "exp_",
         "expand_copy",
         "eye",
         "flatten",
+        "floor_",
         "full",
         "full_like",
         "histogram",
@@ -1748,6 +1751,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "isposinf",
         "isreal",
         "linspace",
+        "log_",
         "logical_and",
         "logical_not",
         "logical_or",
@@ -1755,6 +1759,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "logspace",
         "movedim",
         "narrow",
+        "neg_",
         "ones",
         "ones_like",
         "rand",
@@ -1770,6 +1775,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "searchsorted",
         "slice_copy",
         "squeeze",
+        "tan_",
         "tensor",
         "tril_indices",
         "triu_indices",
@@ -1779,7 +1785,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
     }
 
     assert missing_autograd == expected_missing
-    assert len(forward_ops) == 399
+    assert len(forward_ops) == 405
     assert len(autograd_ops & forward_ops) == 327
 
 
@@ -2478,3 +2484,36 @@ def test_npu_constant_pad_nd_routes_to_existing_constant_pad_path():
     )
     assert "constant_pad_nd" in ops_init_src, "NPU ops package must export `constant_pad_nd`."
     assert 'registry.register("constant_pad_nd", "npu", constant_pad_nd' in backend_init_src
+
+
+def test_npu_operator_intake_tranche2_registers_inplace_unary_ops():
+    """The second NPU operator intake tranche exposes 6 native in-place unary
+    ops that already have ACLNN-backed Cython fast helpers
+    (`fast_*_inplace`). Each is wired to its helper through a module-level
+    alias in `math.py` (the same pattern PR #508 established for `erfinv_`).
+    """
+    math_src = _source("src/candle/_backends/npu/ops/math.py")
+    backend_init_src = _source("src/candle/_backends/npu/__init__.py")
+
+    aliases = {
+        "neg_": "_fast_neg_inplace_impl",
+        "exp_": "_fast_exp_inplace_impl",
+        "log_": "_fast_log_inplace_impl",
+        "tan_": "_fast_tan_inplace_impl",
+        "floor_": "_fast_floor_inplace_impl",
+        "ceil_": "_fast_ceil_inplace_impl",
+    }
+    for op_name, fast_name in aliases.items():
+        assert f"def {op_name}(" not in math_src, (
+            f"`{op_name}` must be a module-level alias to `{fast_name}`, "
+            "not a `def` wrapper."
+        )
+        assert f"{op_name} = {fast_name}" in math_src, (
+            f"`math.py` must bind `{op_name}` to `{fast_name}` via a "
+            "module-level alias so the registration import surface in "
+            "`_backends/npu/__init__.py` resolves correctly."
+        )
+        assert f'registry.register("{op_name}", "npu", {op_name}' in backend_init_src, (
+            f"NPU backend must register `{op_name}` directly to the "
+            "Cython-aliased function as part of operator intake tranche 2."
+        )


### PR DESCRIPTION
## Summary
- Register 6 native in-place unary ops for NPU dispatch: `neg_`, `exp_`, `log_`, `tan_`, `floor_`, `ceil_`.
- Each is wired as a module-level Cython alias to its existing `fast_*_inplace` helper, following the pattern PR #508 established for `erfinv_`. No new kernels — `_npu_ops.pyx` already exposes all 6.
- Add mechanism audit `test_npu_operator_intake_tranche2_registers_inplace_unary_ops`.
- Bump explicit inventory: `forward_ops` 399 → 405. All 6 new ops join the `expected_missing` autograd set (forward-only, no autograd registered), so `autograd_ops & forward_ops` stays at 327.

## Test Plan
- [x] `python -m pytest tests/contract/test_npu_mechanism_audit.py -v --tb=short` — 84 passed
- [x] `python -m pytest tests/cpu/ tests/contract/ --tb=short -q` — 3391 passed, 30 skipped
- [x] `pylint --jobs=1 src/candle --rcfile=.github/pylint.conf` — 10.00/10
- [ ] `python -m pytest tests/npu/ -v --tb=short` — local CANN runtime unavailable (`OSError: libunified_dlog.so`), exercise on NPU-equipped CI runner.