### PR TITLE
feat(npu): register functional masked_scatter (intake tranche 3a)

### DIFF
--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -206,6 +206,7 @@ from .ops import (
     scatter_,
     scatter_add_,
     masked_scatter_,
+    masked_scatter,
     unfold,
     as_strided_npu, as_strided_copy_npu, as_strided_scatter_npu,
     expand_copy_npu, slice_op_npu, slice_copy_npu, slice_scatter_npu,
@@ -665,6 +666,7 @@ registry.register("index_add_", "npu", index_add_)
 registry.register("scatter_", "npu", scatter_)
 registry.register("scatter_add_", "npu", scatter_add_)
 registry.register("masked_scatter_", "npu", masked_scatter_)
+registry.register("masked_scatter", "npu", masked_scatter, meta=meta_infer.infer_unary)
 registry.register("unfold", "npu", unfold)
 
 # View/copy/slice ops

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -47,7 +47,7 @@ from .shape import (
     narrow, select, expand,
     masked_fill, masked_fill_,
     index_put_, index_put, index_copy_, index_fill_, index_add_,
-    scatter_, scatter_add_, masked_scatter_,
+    scatter_, scatter_add_, masked_scatter_, masked_scatter,
     unfold,
     as_strided_npu, as_strided_copy_npu, as_strided_scatter_npu,
     expand_copy_npu, slice_op_npu, slice_copy_npu, slice_scatter_npu,

--- a/src/candle/_backends/npu/ops/shape.py
+++ b/src/candle/_backends/npu/ops/shape.py
@@ -2753,6 +2753,13 @@ def masked_scatter_(a, mask, source):
     return a
 
 
+def masked_scatter(a, mask, source):
+    """Non-inplace masked_scatter — clone + in-place. Fully NPU-resident."""
+    result = a.clone()
+    masked_scatter_(result, mask, source)
+    return result
+
+
 def unfold(a, dimension, size, step):
     """Unfold along a dimension — returns a higher-dimensional view/copy."""
     d = dimension if dimension >= 0 else dimension + a.dim()

--- a/tests/contract/test_mechanism_audit_pr1.py
+++ b/tests/contract/test_mechanism_audit_pr1.py
@@ -175,8 +175,8 @@ def test_npu_forward_ops_autograd_coverage_categorization_snapshot():
     assert (generated_only & both) == set()
     assert (handwritten_only & both) == set()
 
-    assert len(forward) == 405
-    assert len(generated_only) == 239
+    assert len(forward) == 406
+    assert len(generated_only) == 240
     assert len(handwritten_only) == 33
     assert len(both) == 55
     assert len(missing) == 78

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1785,8 +1785,8 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
     }
 
     assert missing_autograd == expected_missing
-    assert len(forward_ops) == 405
-    assert len(autograd_ops & forward_ops) == 327
+    assert len(forward_ops) == 406
+    assert len(autograd_ops & forward_ops) == 328
 
 
 def test_npu_activation_module_consolidates_fast_helper_try_blocks():
@@ -2517,3 +2517,26 @@ def test_npu_operator_intake_tranche2_registers_inplace_unary_ops():
             f"NPU backend must register `{op_name}` directly to the "
             "Cython-aliased function as part of operator intake tranche 2."
         )
+
+
+def test_npu_operator_intake_tranche3a_registers_functional_masked_scatter():
+    """The functional (out-of-place) `masked_scatter` is wired as a composite
+    of `clone()` + `masked_scatter_` on NPU. All ops stay on the device — no
+    CPU fallback. The op already has a generated autograd derivative
+    (`grad.masked_fill(mask, 0)` for self, `masked_scatter_backward` for
+    source), so requires_grad flows route through AutogradNPU correctly.
+    """
+    shape_src = _source("src/candle/_backends/npu/ops/shape.py")
+    backend_init_src = _source("src/candle/_backends/npu/__init__.py")
+    ops_init_src = _source("src/candle/_backends/npu/ops/__init__.py")
+
+    assert "def masked_scatter(a, mask, source):" in shape_src
+    assert "result = a.clone()" in shape_src
+    assert "masked_scatter_(result, mask, source)" in shape_src
+
+    assert "masked_scatter," in ops_init_src
+    assert "masked_scatter,\n" in backend_init_src
+    assert (
+        'registry.register("masked_scatter", "npu", masked_scatter'
+        in backend_init_src
+    )


### PR DESCRIPTION
## Summary

First operator of PR 3 in the mechanism-first NPU enablement plan. `masked_scatter` (out-of-place) had a schema and a generated autograd derivative but lacked an NPU forward kernel.

Implementation follows the existing `masked_fill` / `index_put` composite pattern: `result = a.clone(); masked_scatter_(result, mask, source); return result`. All ops stay on the NPU device — no CPU fallback. The in-place ACLNN-backed `masked_scatter_` is unchanged.

Generated autograd derivative (`grad.masked_fill(mask, 0)` for self, `masked_scatter_backward` for source) already routes through AutogradNPU.

## Test plan
- [x] `python -m pytest tests/contract/test_npu_mechanism_audit.py tests/contract/test_mechanism_audit_pr1.py -q` — 94 passed
- [x] `python -m pytest tests/contract/ tests/cpu/ -q` — 3401 passed, 30 skipped
- [x] `pylint src/candle/_backends/npu/ops/shape.py src/candle/_backends/npu/ops/__init__.py src/candle/_backends/npu/__init__.py` — 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)