### PR TITLE
feat(npu): register var_mean composite on NPU (intake tranche 3b)

### DIFF
--- a/src/candle/_backends/meta/infer.py
+++ b/src/candle/_backends/meta/infer.py
@@ -115,6 +115,11 @@ def infer_sum(a, dim=None, keepdim=False):
     return TensorSpec(shape=shape, stride=_contiguous_stride(shape), dtype=a.dtype)
 
 
+def infer_var_mean(a, dim=None, unbiased=True, keepdim=False):  # pylint: disable=unused-argument
+    spec = infer_sum(a, dim=dim, keepdim=keepdim)
+    return (spec, spec)
+
+
 def infer_reduce_bool(a, dim=None, keepdim=False):
     spec = infer_sum(a, dim=dim, keepdim=keepdim)
     return TensorSpec(shape=spec.shape, stride=spec.stride, dtype=bool_dtype)

--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -212,6 +212,7 @@ from .ops import (
     expand_copy_npu, slice_op_npu, slice_copy_npu, slice_scatter_npu,
     sum_to_size_npu,
     var_,
+    var_mean,
     norm_,
     prod_,
     floor_divide,
@@ -681,6 +682,7 @@ registry.register("sum_to_size", "npu", sum_to_size_npu, meta=meta_infer.infer_s
 
 # Reduction ops (composite)
 registry.register("var", "npu", var_, meta=meta_infer.infer_sum)
+registry.register("var_mean", "npu", var_mean, meta=meta_infer.infer_var_mean)
 registry.register("norm", "npu", norm_, meta=meta_infer.infer_sum)
 registry.register("prod", "npu", prod_, meta=meta_infer.infer_sum)
 registry.register("floor_divide", "npu", floor_divide, meta=meta_infer.infer_binary)

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -23,7 +23,7 @@ from .reduce import (
     amax, amin, count_nonzero, all_, any_,
     min_, max_, maximum, minimum, fmin, fmax,
     cumsum, cumprod, cummax, argsort, sort, topk,
-    sum_, mean, var_, std_, norm_, prod_,
+    sum_, mean, var_, var_mean, std_, norm_, prod_,
     cummin_op, logsumexp_op, renorm_op, nansum,
     nanmean_op, argwhere_op,
     quantile_op, nanquantile_op, nanmedian_op,

--- a/src/candle/_backends/npu/ops/reduce.py
+++ b/src/candle/_backends/npu/ops/reduce.py
@@ -788,6 +788,17 @@ def var_(a, dim=None, unbiased=True, keepdim=False):
     return _wrap_tensor(out_storage, out_shape, out_stride)
 
 
+def var_mean(a, dim=None, unbiased=True, keepdim=False):
+    """Compute (variance, mean) tuple as a composite of `var_` + `mean`.
+
+    Both reductions stay on the NPU device; no CPU fallback.
+    """
+    return (
+        var_(a, dim=dim, unbiased=unbiased, keepdim=keepdim),
+        mean(a, dim=dim, keepdim=keepdim),
+    )
+
+
 def std_(a, dim=None, unbiased=True, keepdim=False):
     """Compute std as sqrt(var).
 

--- a/tests/contract/test_mechanism_audit_pr1.py
+++ b/tests/contract/test_mechanism_audit_pr1.py
@@ -175,8 +175,8 @@ def test_npu_forward_ops_autograd_coverage_categorization_snapshot():
     assert (generated_only & both) == set()
     assert (handwritten_only & both) == set()
 
-    assert len(forward) == 406
-    assert len(generated_only) == 240
+    assert len(forward) == 407
+    assert len(generated_only) == 241
     assert len(handwritten_only) == 33
     assert len(both) == 55
     assert len(missing) == 78

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1785,8 +1785,8 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
     }
 
     assert missing_autograd == expected_missing
-    assert len(forward_ops) == 406
-    assert len(autograd_ops & forward_ops) == 328
+    assert len(forward_ops) == 407
+    assert len(autograd_ops & forward_ops) == 329
 
 
 def test_npu_activation_module_consolidates_fast_helper_try_blocks():
@@ -2540,3 +2540,29 @@ def test_npu_operator_intake_tranche3a_registers_functional_masked_scatter():
         'registry.register("masked_scatter", "npu", masked_scatter'
         in backend_init_src
     )
+
+
+def test_npu_operator_intake_tranche3b_registers_var_mean_composite():
+    """`var_mean` returns `(variance, mean)` and is wired on NPU as a composite
+    of the existing `var_` + `mean` kernels. Both reductions stay on the NPU
+    device — no CPU fallback. The op already has a generated autograd
+    derivative (`var_mean_backward`), so requires_grad flows route through
+    AutogradNPU correctly. Meta inference returns a `(spec, spec)` tuple
+    matching the schema's `-> (Tensor, Tensor)` return type.
+    """
+    reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
+    backend_init_src = _source("src/candle/_backends/npu/__init__.py")
+    ops_init_src = _source("src/candle/_backends/npu/ops/__init__.py")
+    meta_src = _source("src/candle/_backends/meta/infer.py")
+
+    assert "def var_mean(a, dim=None, unbiased=True, keepdim=False):" in reduce_src
+    assert "var_(a, dim=dim, unbiased=unbiased, keepdim=keepdim)" in reduce_src
+    assert "mean(a, dim=dim, keepdim=keepdim)" in reduce_src
+
+    assert "var_mean," in ops_init_src
+    assert "var_mean," in backend_init_src
+    assert (
+        'registry.register("var_mean", "npu", var_mean, meta=meta_infer.infer_var_mean)'
+        in backend_init_src
+    )
+    assert "def infer_var_mean(a, dim=None, unbiased=True, keepdim=False)" in meta_src


### PR DESCRIPTION
## Summary
- Register `var_mean` on NPU as a composite of existing `var_` + `mean` kernels, returning `(variance, mean)` tuple. Both reductions stay device-resident — no CPU fallback.
- Meta inference returns the `(spec, spec)` tuple matching the schema's `-> (Tensor, Tensor)` signature.
- Generated autograd derivative for `var_mean` already exists.
- Bumps the mechanism-audit categorization snapshot from 406 → 407 NPU forward ops (generated_only 240 → 241).

## Test plan
- [x] `pytest tests/contract/test_npu_mechanism_audit.py tests/contract/test_mechanism_audit_pr1.py` — 95 passed
- [x] `pytest tests/contract/ tests/cpu/` — 3402 passed, 30 skipped
- [x] `pylint` on touched files — 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)