### PR TITLE
feat(npu): register sin_ and cos_ in-place on NPU (intake tranche 3c)

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -3935,6 +3935,51 @@ def fast_sin(a):
     return _cy_make_npu_tensor(out_ptr, n, a_dtype, a_dev, out_shape, out_stride)
 
 
+def fast_sin_inplace(a):
+    """In-place sin_(a) using aclnnSin with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_sin()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _sin_getws_ptr, _sin_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _sin_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnSin execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
 def fast_cos(a):
     """Optimized out-of-place cos(a) that calls _ffi.unary_op directly."""
     _ensure_npu_imports()
@@ -3992,6 +4037,51 @@ def fast_cos(a):
 
     _defer_executor_fn(executor)
     return _cy_make_npu_tensor(out_ptr, n, a_dtype, a_dev, out_shape, out_stride)
+
+
+def fast_cos_inplace(a):
+    """In-place cos_(a) using aclnnCos with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_cos()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _cos_getws_ptr, _cos_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _cos_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnCos execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
 
 
 def fast_tan(a):

--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -98,6 +98,8 @@ from .ops import (
     tan_,
     floor_,
     ceil_,
+    sin_,
+    cos_,
     contiguous,
     getitem,
     setitem,
@@ -521,6 +523,8 @@ registry.register("log_", "npu", log_, meta=meta_infer.infer_unary)
 registry.register("tan_", "npu", tan_, meta=meta_infer.infer_unary)
 registry.register("floor_", "npu", floor_, meta=meta_infer.infer_unary)
 registry.register("ceil_", "npu", ceil_, meta=meta_infer.infer_unary)
+registry.register("sin_", "npu", sin_, meta=meta_infer.infer_unary)
+registry.register("cos_", "npu", cos_, meta=meta_infer.infer_unary)
 registry.register("sub_", "npu", sub_, meta=meta_infer.infer_binary)
 registry.register("sub", "npu", sub, meta=meta_infer.infer_binary)
 registry.register("div", "npu", div, meta=meta_infer.infer_binary)

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -2,6 +2,7 @@ from .math import (
     add, sub, mul, div,
     add_, sub_, mul_, div_,
     neg_, exp_, log_, tan_, floor_, ceil_,
+    sin_, cos_,
     abs, neg, sign, signbit, square,
     isfinite, isinf, isnan, isposinf, isneginf,
     exp, log, sqrt, rsqrt, sin, cos, tan, tanh, sigmoid,

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -25,6 +25,7 @@ try:
         fast_ceil as _fast_ceil_impl,
         fast_ceil_inplace as _fast_ceil_inplace_impl,
         fast_cos as _fast_cos_impl,
+        fast_cos_inplace as _fast_cos_inplace_impl,
         fast_cosh as _fast_cosh_impl,
         fast_erf as _fast_erf_impl,
         fast_div as _fast_div_impl,
@@ -61,6 +62,7 @@ try:
         fast_sign as _fast_sign_impl,
         fast_signbit as _fast_signbit_impl,
         fast_sin as _fast_sin_impl,
+        fast_sin_inplace as _fast_sin_inplace_impl,
         fast_sinh as _fast_sinh_impl,
         fast_sqrt as _fast_sqrt_impl,
         fast_square as _fast_square_impl,
@@ -234,6 +236,8 @@ except ImportError:
     _fast_tan_inplace_impl = None  # type: ignore[assignment]
     _fast_floor_inplace_impl = None  # type: ignore[assignment]
     _fast_ceil_inplace_impl = None  # type: ignore[assignment]
+    _fast_sin_inplace_impl = None  # type: ignore[assignment]
+    _fast_cos_inplace_impl = None  # type: ignore[assignment]
 
 
 def add(a, b):
@@ -313,6 +317,8 @@ log_ = _fast_log_inplace_impl
 tan_ = _fast_tan_inplace_impl
 floor_ = _fast_floor_inplace_impl
 ceil_ = _fast_ceil_inplace_impl
+sin_ = _fast_sin_inplace_impl
+cos_ = _fast_cos_inplace_impl
 
 
 # ---------------------------------------------------------------------------

--- a/tests/contract/test_mechanism_audit_pr1.py
+++ b/tests/contract/test_mechanism_audit_pr1.py
@@ -175,11 +175,11 @@ def test_npu_forward_ops_autograd_coverage_categorization_snapshot():
     assert (generated_only & both) == set()
     assert (handwritten_only & both) == set()
 
-    assert len(forward) == 407
+    assert len(forward) == 409
     assert len(generated_only) == 241
     assert len(handwritten_only) == 33
     assert len(both) == 55
-    assert len(missing) == 78
+    assert len(missing) == 80
 
 
 # ---------------------------------------------------------------------------

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1731,6 +1731,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "bucketize",
         "cartesian_prod",
         "ceil_",
+        "cos_",
         "empty",
         "empty_like",
         "equal",
@@ -1773,6 +1774,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "range",
         "reciprocal_",
         "searchsorted",
+        "sin_",
         "slice_copy",
         "squeeze",
         "tan_",
@@ -1785,7 +1787,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
     }
 
     assert missing_autograd == expected_missing
-    assert len(forward_ops) == 407
+    assert len(forward_ops) == 409
     assert len(autograd_ops & forward_ops) == 329
 
 
@@ -2566,3 +2568,29 @@ def test_npu_operator_intake_tranche3b_registers_var_mean_composite():
         in backend_init_src
     )
     assert "def infer_var_mean(a, dim=None, unbiased=True, keepdim=False)" in meta_src
+
+
+def test_npu_operator_intake_tranche3c_registers_inplace_sin_cos():
+    """Operator intake tranche 3c extends the in-place unary surface (PR #508,
+    tranche 2) with `sin_` and `cos_`. Both are wired through new
+    `fast_sin_inplace` / `fast_cos_inplace` Cython helpers that reuse the
+    existing `aclnnSin` / `aclnnCos` bindings with output aliased to input —
+    so all computation stays on NPU.
+    """
+    math_src = _source("src/candle/_backends/npu/ops/math.py")
+    backend_init_src = _source("src/candle/_backends/npu/__init__.py")
+    pyx_src = _source("src/candle/_C/_npu_ops.pyx")
+
+    aliases = {
+        "sin_": "_fast_sin_inplace_impl",
+        "cos_": "_fast_cos_inplace_impl",
+    }
+    for op_name, fast_name in aliases.items():
+        assert f"def {op_name}(" not in math_src, (
+            f"`{op_name}` must be a module-level alias to `{fast_name}`."
+        )
+        assert f"{op_name} = {fast_name}" in math_src
+        assert f'registry.register("{op_name}", "npu", {op_name}' in backend_init_src
+
+    assert "def fast_sin_inplace(a):" in pyx_src
+    assert "def fast_cos_inplace(a):" in pyx_src


### PR DESCRIPTION
## Summary
- Add `fast_sin_inplace` / `fast_cos_inplace` Cython helpers that reuse `aclnnSin` / `aclnnCos` with output aliased to input — fully NPU-resident.
- Wire `sin_` / `cos_` as module-level Cython aliases in `math.py` (same pattern as `erfinv_` from PR #508 and tranche-2 in-place unaries).
- In-place unaries follow the established no-autograd convention, consistent with `neg_`/`exp_`/`log_`/`tan_`/`floor_`/`ceil_`.

## Test plan
- [x] `pytest tests/contract/test_npu_mechanism_audit.py tests/contract/test_mechanism_audit_pr1.py` — 96 passed
- [x] `pytest tests/contract/ tests/cpu/` — 3403 passed, 30 skipped
- [x] `pylint` on touched files — 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)