### PR TITLE
feat(npu): register sqrt_, sigmoid_, tanh_ in-place on NPU (intake tranche 3d)

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -3700,6 +3700,51 @@ def fast_sqrt(a):
     return _cy_make_npu_tensor(out_ptr, n, a_dtype, a_dev, out_shape, out_stride)
 
 
+def fast_sqrt_inplace(a):
+    """In-place sqrt_(a) using aclnnSqrt with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_sqrt()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _sqrt_getws_ptr, _sqrt_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _sqrt_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnSqrt execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
 def fast_hypot(a, b):
     """NPU hypot(a, b) implemented as an on-device Cython composite."""
     return fast_sqrt(fast_add(fast_mul(a, a), fast_mul(b, b)))
@@ -4248,6 +4293,51 @@ def fast_tanh(a):
 
 
 
+def fast_tanh_inplace(a):
+    """In-place tanh_(a) using aclnnTanh with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_tanh()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _tanh_getws_ptr, _tanh_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _tanh_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnTanh execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
 def fast_sigmoid(a):
     """Optimized out-of-place sigmoid(a) that calls _ffi.unary_op directly."""
     _ensure_npu_imports()
@@ -4305,6 +4395,51 @@ def fast_sigmoid(a):
 
     _defer_executor_fn(executor)
     return _cy_make_npu_tensor(out_ptr, n, a_dtype, a_dev, out_shape, out_stride)
+
+
+def fast_sigmoid_inplace(a):
+    """In-place sigmoid_(a) using aclnnSigmoid with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_sigmoid()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _sigmoid_getws_ptr, _sigmoid_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _sigmoid_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnSigmoid execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
 
 
 def fast_relu(a):

--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -100,6 +100,9 @@ from .ops import (
     ceil_,
     sin_,
     cos_,
+    sqrt_,
+    sigmoid_,
+    tanh_,
     contiguous,
     getitem,
     setitem,
@@ -525,6 +528,9 @@ registry.register("floor_", "npu", floor_, meta=meta_infer.infer_unary)
 registry.register("ceil_", "npu", ceil_, meta=meta_infer.infer_unary)
 registry.register("sin_", "npu", sin_, meta=meta_infer.infer_unary)
 registry.register("cos_", "npu", cos_, meta=meta_infer.infer_unary)
+registry.register("sqrt_", "npu", sqrt_, meta=meta_infer.infer_unary)
+registry.register("sigmoid_", "npu", sigmoid_, meta=meta_infer.infer_unary)
+registry.register("tanh_", "npu", tanh_, meta=meta_infer.infer_unary)
 registry.register("sub_", "npu", sub_, meta=meta_infer.infer_binary)
 registry.register("sub", "npu", sub, meta=meta_infer.infer_binary)
 registry.register("div", "npu", div, meta=meta_infer.infer_binary)

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -2,7 +2,7 @@ from .math import (
     add, sub, mul, div,
     add_, sub_, mul_, div_,
     neg_, exp_, log_, tan_, floor_, ceil_,
-    sin_, cos_,
+    sin_, cos_, sqrt_, sigmoid_, tanh_,
     abs, neg, sign, signbit, square,
     isfinite, isinf, isnan, isposinf, isneginf,
     exp, log, sqrt, rsqrt, sin, cos, tan, tanh, sigmoid,

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -59,18 +59,21 @@ try:
         fast_round as _fast_round_impl,
         fast_rsqrt as _fast_rsqrt_impl,
         fast_sigmoid as _fast_sigmoid_impl,
+        fast_sigmoid_inplace as _fast_sigmoid_inplace_impl,
         fast_sign as _fast_sign_impl,
         fast_signbit as _fast_signbit_impl,
         fast_sin as _fast_sin_impl,
         fast_sin_inplace as _fast_sin_inplace_impl,
         fast_sinh as _fast_sinh_impl,
         fast_sqrt as _fast_sqrt_impl,
+        fast_sqrt_inplace as _fast_sqrt_inplace_impl,
         fast_square as _fast_square_impl,
         fast_sub as _fast_sub_impl,
         fast_sub_inplace as _fast_sub_inplace_impl,
         fast_tan as _fast_tan_impl,
         fast_tan_inplace as _fast_tan_inplace_impl,
         fast_tanh as _fast_tanh_impl,
+        fast_tanh_inplace as _fast_tanh_inplace_impl,
         fast_trunc as _fast_trunc_impl,
     )  # pylint: disable=import-error,no-name-in-module
     _HAS_FAST_ADD = True
@@ -238,6 +241,9 @@ except ImportError:
     _fast_ceil_inplace_impl = None  # type: ignore[assignment]
     _fast_sin_inplace_impl = None  # type: ignore[assignment]
     _fast_cos_inplace_impl = None  # type: ignore[assignment]
+    _fast_sqrt_inplace_impl = None  # type: ignore[assignment]
+    _fast_sigmoid_inplace_impl = None  # type: ignore[assignment]
+    _fast_tanh_inplace_impl = None  # type: ignore[assignment]
 
 
 def add(a, b):
@@ -319,6 +325,9 @@ floor_ = _fast_floor_inplace_impl
 ceil_ = _fast_ceil_inplace_impl
 sin_ = _fast_sin_inplace_impl
 cos_ = _fast_cos_inplace_impl
+sqrt_ = _fast_sqrt_inplace_impl
+sigmoid_ = _fast_sigmoid_inplace_impl
+tanh_ = _fast_tanh_inplace_impl
 
 
 # ---------------------------------------------------------------------------

--- a/tests/contract/test_mechanism_audit_pr1.py
+++ b/tests/contract/test_mechanism_audit_pr1.py
@@ -175,11 +175,11 @@ def test_npu_forward_ops_autograd_coverage_categorization_snapshot():
     assert (generated_only & both) == set()
     assert (handwritten_only & both) == set()
 
-    assert len(forward) == 409
+    assert len(forward) == 412
     assert len(generated_only) == 241
     assert len(handwritten_only) == 33
     assert len(both) == 55
-    assert len(missing) == 80
+    assert len(missing) == 83
 
 
 # ---------------------------------------------------------------------------

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1774,10 +1774,13 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "range",
         "reciprocal_",
         "searchsorted",
+        "sigmoid_",
         "sin_",
         "slice_copy",
+        "sqrt_",
         "squeeze",
         "tan_",
+        "tanh_",
         "tensor",
         "tril_indices",
         "triu_indices",
@@ -1787,7 +1790,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
     }
 
     assert missing_autograd == expected_missing
-    assert len(forward_ops) == 409
+    assert len(forward_ops) == 412
     assert len(autograd_ops & forward_ops) == 329
 
 
@@ -2594,3 +2597,29 @@ def test_npu_operator_intake_tranche3c_registers_inplace_sin_cos():
 
     assert "def fast_sin_inplace(a):" in pyx_src
     assert "def fast_cos_inplace(a):" in pyx_src
+
+
+def test_npu_operator_intake_tranche3d_registers_inplace_sqrt_sigmoid_tanh():
+    """Operator intake tranche 3d extends the in-place unary surface with
+    `sqrt_`, `sigmoid_`, and `tanh_`. Each reuses the existing
+    `aclnnSqrt` / `aclnnSigmoid` / `aclnnTanh` bindings via a new
+    `fast_*_inplace` Cython helper that aliases output to input — fully
+    NPU-resident.
+    """
+    math_src = _source("src/candle/_backends/npu/ops/math.py")
+    backend_init_src = _source("src/candle/_backends/npu/__init__.py")
+    pyx_src = _source("src/candle/_C/_npu_ops.pyx")
+
+    aliases = {
+        "sqrt_": "_fast_sqrt_inplace_impl",
+        "sigmoid_": "_fast_sigmoid_inplace_impl",
+        "tanh_": "_fast_tanh_inplace_impl",
+    }
+    for op_name, fast_name in aliases.items():
+        assert f"def {op_name}(" not in math_src
+        assert f"{op_name} = {fast_name}" in math_src
+        assert f'registry.register("{op_name}", "npu", {op_name}' in backend_init_src
+
+    assert "def fast_sqrt_inplace(a):" in pyx_src
+    assert "def fast_sigmoid_inplace(a):" in pyx_src
+    assert "def fast_tanh_inplace(a):" in pyx_src


### PR DESCRIPTION
## Summary
- Add `fast_sqrt_inplace` / `fast_sigmoid_inplace` / `fast_tanh_inplace` Cython helpers that reuse `aclnnSqrt` / `aclnnSigmoid` / `aclnnTanh` with output aliased to input — fully NPU-resident.
- Wire `sqrt_` / `sigmoid_` / `tanh_` as module-level Cython aliases in `math.py`, same pattern as tranche 3c.
- In-place unaries follow the established no-autograd convention, consistent with all sibling in-place ops.

## Test plan
- [x] `pytest tests/contract/test_npu_mechanism_audit.py tests/contract/test_mechanism_audit_pr1.py` — 97 passed
- [x] `pytest tests/contract/ tests/cpu/` — 3404 passed, 30 skipped
- [x] `pylint` on touched files — 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)