### PR TITLE
feat(npu): register abs_, round_, trunc_, log2_, log10_ in-place on NPU (intake tranche 3e)

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -2675,6 +2675,51 @@ def fast_abs(a):
     return _cy_make_npu_tensor(out_ptr, n, a_dtype, a_dev, out_shape, out_stride)
 
 
+def fast_abs_inplace(a):
+    """In-place abs_(a) using aclnnAbs with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_abs()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _abs_getws_ptr, _abs_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _abs_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnAbs execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
 def fast_neg(a):
     """Optimized out-of-place neg(a) that calls _ffi.unary_op directly."""
     _ensure_npu_imports()
@@ -6068,6 +6113,51 @@ def fast_round(a):
 
 
 
+def fast_round_inplace(a):
+    """In-place round_(a) using aclnnRound with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_round()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _round_getws_ptr, _round_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _round_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnRound execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
 def fast_trunc(a):
     """Optimized out-of-place trunc(a) that calls _ffi.unary_op directly."""
     _ensure_npu_imports()
@@ -6125,6 +6215,51 @@ def fast_trunc(a):
 
     _defer_executor_fn(executor)
     return _cy_make_npu_tensor(out_ptr, n, a_dtype, a_dev, out_shape, out_stride)
+
+
+def fast_trunc_inplace(a):
+    """In-place trunc_(a) using aclnnTrunc with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_trunc()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _trunc_getws_ptr, _trunc_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _trunc_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnTrunc execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
 
 
 def fast_log2(a):
@@ -6186,6 +6321,51 @@ def fast_log2(a):
     return _cy_make_npu_tensor(out_ptr, n, a_dtype, a_dev, out_shape, out_stride)
 
 
+def fast_log2_inplace(a):
+    """In-place log2_(a) using aclnnLog2 with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_log2()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _log2_getws_ptr, _log2_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _log2_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnLog2 execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
 def fast_log10(a):
     """Optimized out-of-place log10(a) that calls _ffi.unary_op directly."""
     _ensure_npu_imports()
@@ -6243,6 +6423,51 @@ def fast_log10(a):
 
     _defer_executor_fn(executor)
     return _cy_make_npu_tensor(out_ptr, n, a_dtype, a_dev, out_shape, out_stride)
+
+
+def fast_log10_inplace(a):
+    """In-place log10_(a) using aclnnLog10 with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_log10()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _log10_getws_ptr, _log10_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _log10_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnLog10 execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
 
 
 def fast_exp2(a):

--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -103,6 +103,11 @@ from .ops import (
     sqrt_,
     sigmoid_,
     tanh_,
+    abs_,
+    round_,
+    trunc_,
+    log2_,
+    log10_,
     contiguous,
     getitem,
     setitem,
@@ -531,6 +536,11 @@ registry.register("cos_", "npu", cos_, meta=meta_infer.infer_unary)
 registry.register("sqrt_", "npu", sqrt_, meta=meta_infer.infer_unary)
 registry.register("sigmoid_", "npu", sigmoid_, meta=meta_infer.infer_unary)
 registry.register("tanh_", "npu", tanh_, meta=meta_infer.infer_unary)
+registry.register("abs_", "npu", abs_, meta=meta_infer.infer_unary)
+registry.register("round_", "npu", round_, meta=meta_infer.infer_unary)
+registry.register("trunc_", "npu", trunc_, meta=meta_infer.infer_unary)
+registry.register("log2_", "npu", log2_, meta=meta_infer.infer_unary)
+registry.register("log10_", "npu", log10_, meta=meta_infer.infer_unary)
 registry.register("sub_", "npu", sub_, meta=meta_infer.infer_binary)
 registry.register("sub", "npu", sub, meta=meta_infer.infer_binary)
 registry.register("div", "npu", div, meta=meta_infer.infer_binary)

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -3,6 +3,7 @@ from .math import (
     add_, sub_, mul_, div_,
     neg_, exp_, log_, tan_, floor_, ceil_,
     sin_, cos_, sqrt_, sigmoid_, tanh_,
+    abs_, round_, trunc_, log2_, log10_,
     abs, neg, sign, signbit, square,
     isfinite, isinf, isnan, isposinf, isneginf,
     exp, log, sqrt, rsqrt, sin, cos, tan, tanh, sigmoid,

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -13,6 +13,7 @@ from ._helpers import (
 try:
     from candle._C._npu_ops import (
         fast_abs as _fast_abs_impl,
+        fast_abs_inplace as _fast_abs_inplace_impl,
         fast_acos as _fast_acos_impl,
         fast_acosh as _fast_acosh_impl,
         fast_add as _fast_add_impl,
@@ -47,7 +48,9 @@ try:
         fast_log_inplace as _fast_log_inplace_impl,
         fast_log1p as _fast_log1p_impl,
         fast_log10 as _fast_log10_impl,
+        fast_log10_inplace as _fast_log10_inplace_impl,
         fast_log2 as _fast_log2_impl,
+        fast_log2_inplace as _fast_log2_inplace_impl,
         fast_floor_divide as _fast_floor_divide_impl,
         fast_mul as _fast_mul_impl,
         fast_mul_inplace as _fast_mul_inplace_impl,
@@ -57,6 +60,7 @@ try:
         fast_pow_tensor_scalar as _fast_pow_tensor_scalar_impl,
         fast_reciprocal as _fast_reciprocal_impl,
         fast_round as _fast_round_impl,
+        fast_round_inplace as _fast_round_inplace_impl,
         fast_rsqrt as _fast_rsqrt_impl,
         fast_sigmoid as _fast_sigmoid_impl,
         fast_sigmoid_inplace as _fast_sigmoid_inplace_impl,
@@ -75,6 +79,7 @@ try:
         fast_tanh as _fast_tanh_impl,
         fast_tanh_inplace as _fast_tanh_inplace_impl,
         fast_trunc as _fast_trunc_impl,
+        fast_trunc_inplace as _fast_trunc_inplace_impl,
     )  # pylint: disable=import-error,no-name-in-module
     _HAS_FAST_ADD = True
     _HAS_FAST_ABS = True
@@ -244,6 +249,11 @@ except ImportError:
     _fast_sqrt_inplace_impl = None  # type: ignore[assignment]
     _fast_sigmoid_inplace_impl = None  # type: ignore[assignment]
     _fast_tanh_inplace_impl = None  # type: ignore[assignment]
+    _fast_abs_inplace_impl = None  # type: ignore[assignment]
+    _fast_round_inplace_impl = None  # type: ignore[assignment]
+    _fast_trunc_inplace_impl = None  # type: ignore[assignment]
+    _fast_log2_inplace_impl = None  # type: ignore[assignment]
+    _fast_log10_inplace_impl = None  # type: ignore[assignment]
 
 
 def add(a, b):
@@ -328,6 +338,11 @@ cos_ = _fast_cos_inplace_impl
 sqrt_ = _fast_sqrt_inplace_impl
 sigmoid_ = _fast_sigmoid_inplace_impl
 tanh_ = _fast_tanh_inplace_impl
+abs_ = _fast_abs_inplace_impl
+round_ = _fast_round_inplace_impl
+trunc_ = _fast_trunc_inplace_impl
+log2_ = _fast_log2_inplace_impl
+log10_ = _fast_log10_inplace_impl
 
 
 # ---------------------------------------------------------------------------

--- a/tests/contract/test_mechanism_audit_pr1.py
+++ b/tests/contract/test_mechanism_audit_pr1.py
@@ -175,11 +175,11 @@ def test_npu_forward_ops_autograd_coverage_categorization_snapshot():
     assert (generated_only & both) == set()
     assert (handwritten_only & both) == set()
 
-    assert len(forward) == 412
+    assert len(forward) == 417
     assert len(generated_only) == 241
     assert len(handwritten_only) == 33
     assert len(both) == 55
-    assert len(missing) == 83
+    assert len(missing) == 88
 
 
 # ---------------------------------------------------------------------------

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1716,6 +1716,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "_rprop_step",
         "_sgd_step",
         "_sparse_adam_step",
+        "abs_",
         "allclose",
         "arange",
         "argmax",
@@ -1752,6 +1753,8 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "isposinf",
         "isreal",
         "linspace",
+        "log10_",
+        "log2_",
         "log_",
         "logical_and",
         "logical_not",
@@ -1773,6 +1776,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "randperm",
         "range",
         "reciprocal_",
+        "round_",
         "searchsorted",
         "sigmoid_",
         "sin_",
@@ -1784,13 +1788,14 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "tensor",
         "tril_indices",
         "triu_indices",
+        "trunc_",
         "unflatten",
         "zeros",
         "zeros_like",
     }
 
     assert missing_autograd == expected_missing
-    assert len(forward_ops) == 412
+    assert len(forward_ops) == 417
     assert len(autograd_ops & forward_ops) == 329
 
 
@@ -2623,3 +2628,33 @@ def test_npu_operator_intake_tranche3d_registers_inplace_sqrt_sigmoid_tanh():
     assert "def fast_sqrt_inplace(a):" in pyx_src
     assert "def fast_sigmoid_inplace(a):" in pyx_src
     assert "def fast_tanh_inplace(a):" in pyx_src
+
+
+def test_npu_operator_intake_tranche3e_registers_inplace_abs_round_trunc_log2_log10():
+    """Operator intake tranche 3e extends the in-place unary surface with
+    `abs_`, `round_`, `trunc_`, `log2_`, and `log10_`. Each reuses the
+    existing `aclnnAbs` / `aclnnRound` / `aclnnTrunc` / `aclnnLog2` /
+    `aclnnLog10` bindings via a new `fast_*_inplace` Cython helper that
+    aliases output to input — fully NPU-resident.
+    """
+    math_src = _source("src/candle/_backends/npu/ops/math.py")
+    backend_init_src = _source("src/candle/_backends/npu/__init__.py")
+    pyx_src = _source("src/candle/_C/_npu_ops.pyx")
+
+    aliases = {
+        "abs_": "_fast_abs_inplace_impl",
+        "round_": "_fast_round_inplace_impl",
+        "trunc_": "_fast_trunc_inplace_impl",
+        "log2_": "_fast_log2_inplace_impl",
+        "log10_": "_fast_log10_inplace_impl",
+    }
+    for op_name, fast_name in aliases.items():
+        assert f"def {op_name}(" not in math_src
+        assert f"{op_name} = {fast_name}" in math_src
+        assert f'registry.register("{op_name}", "npu", {op_name}' in backend_init_src
+
+    assert "def fast_abs_inplace(a):" in pyx_src
+    assert "def fast_round_inplace(a):" in pyx_src
+    assert "def fast_trunc_inplace(a):" in pyx_src
+    assert "def fast_log2_inplace(a):" in pyx_src
+    assert "def fast_log10_inplace(a):" in pyx_src


### PR DESCRIPTION
## Summary

- Add five new Cython fast helpers in `_C/_npu_ops.pyx`: `fast_abs_inplace`, `fast_round_inplace`, `fast_trunc_inplace`, `fast_log2_inplace`, `fast_log10_inplace`. Each reuses the existing out-of-place ACLNN kernel binding with output pointer aliased to input — fully NPU-resident.
- Register `abs_`, `round_`, `trunc_`, `log2_`, `log10_` as module-level aliases in `_backends/npu/ops/math.py` and wire them into the dispatch registry in `_backends/npu/__init__.py`.
- Bump audit counts: NPU forward ops 412 → 417, missing-autograd inventory 83 → 88. Add tranche 3e audit test.

## Test plan

- [x] `pytest tests/contract/ tests/cpu/ -x --tb=short` — 3405 passed
- [x] `pylint src/candle/ --rcfile=.github/pylint.conf` — 10.00/10
- [x] Tranche 3e audit verifies all 5 ops registered + Cython helpers exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)