### PR TITLE
feat(npu): register expm1_, log1p_, exp2_, erf_, erfc_ in-place on NPU (intake tranche 3f)

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -6470,6 +6470,231 @@ def fast_log10_inplace(a):
     return a
 
 
+def fast_expm1_inplace(a):
+    """In-place expm1_(a) using aclnnExpm1 with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_expm1()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _expm1_getws_ptr, _expm1_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _expm1_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnExpm1 execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
+def fast_log1p_inplace(a):
+    """In-place log1p_(a) using aclnnLog1p with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_log1p()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _log1p_getws_ptr, _log1p_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _log1p_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnLog1p execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
+def fast_exp2_inplace(a):
+    """In-place exp2_(a) using aclnnExp2 with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_exp2()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _exp2_getws_ptr, _exp2_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _exp2_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnExp2 execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
+def fast_erf_inplace(a):
+    """In-place erf_(a) using aclnnErf with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_erf()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _erf_getws_ptr, _erf_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _erf_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnErf execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
+def fast_erfc_inplace(a):
+    """In-place erfc_(a) using aclnnErfc with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_erfc()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _erfc_getws_ptr, _erfc_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _erfc_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnErfc execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
 def fast_exp2(a):
     """Optimized out-of-place exp2(a) that calls _ffi.unary_op directly."""
     _ensure_npu_imports()

--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -108,6 +108,11 @@ from .ops import (
     trunc_,
     log2_,
     log10_,
+    expm1_,
+    log1p_,
+    exp2_,
+    erf_,
+    erfc_,
     contiguous,
     getitem,
     setitem,
@@ -541,6 +546,11 @@ registry.register("round_", "npu", round_, meta=meta_infer.infer_unary)
 registry.register("trunc_", "npu", trunc_, meta=meta_infer.infer_unary)
 registry.register("log2_", "npu", log2_, meta=meta_infer.infer_unary)
 registry.register("log10_", "npu", log10_, meta=meta_infer.infer_unary)
+registry.register("expm1_", "npu", expm1_, meta=meta_infer.infer_unary)
+registry.register("log1p_", "npu", log1p_, meta=meta_infer.infer_unary)
+registry.register("exp2_", "npu", exp2_, meta=meta_infer.infer_unary)
+registry.register("erf_", "npu", erf_, meta=meta_infer.infer_unary)
+registry.register("erfc_", "npu", erfc_, meta=meta_infer.infer_unary)
 registry.register("sub_", "npu", sub_, meta=meta_infer.infer_binary)
 registry.register("sub", "npu", sub, meta=meta_infer.infer_binary)
 registry.register("div", "npu", div, meta=meta_infer.infer_binary)

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -4,6 +4,7 @@ from .math import (
     neg_, exp_, log_, tan_, floor_, ceil_,
     sin_, cos_, sqrt_, sigmoid_, tanh_,
     abs_, round_, trunc_, log2_, log10_,
+    expm1_, log1p_, exp2_, erf_, erfc_,
     abs, neg, sign, signbit, square,
     isfinite, isinf, isnan, isposinf, isneginf,
     exp, log, sqrt, rsqrt, sin, cos, tan, tanh, sigmoid,

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -29,13 +29,17 @@ try:
         fast_cos_inplace as _fast_cos_inplace_impl,
         fast_cosh as _fast_cosh_impl,
         fast_erf as _fast_erf_impl,
+        fast_erf_inplace as _fast_erf_inplace_impl,
         fast_div as _fast_div_impl,
         fast_div_inplace as _fast_div_inplace_impl,
         fast_erfc as _fast_erfc_impl,
+        fast_erfc_inplace as _fast_erfc_inplace_impl,
         fast_exp as _fast_exp_impl,
         fast_exp_inplace as _fast_exp_inplace_impl,
         fast_exp2 as _fast_exp2_impl,
+        fast_exp2_inplace as _fast_exp2_inplace_impl,
         fast_expm1 as _fast_expm1_impl,
+        fast_expm1_inplace as _fast_expm1_inplace_impl,
         fast_floor as _fast_floor_impl,
         fast_floor_inplace as _fast_floor_inplace_impl,
         fast_frac as _fast_frac_impl,
@@ -47,6 +51,7 @@ try:
         fast_log as _fast_log_impl,
         fast_log_inplace as _fast_log_inplace_impl,
         fast_log1p as _fast_log1p_impl,
+        fast_log1p_inplace as _fast_log1p_inplace_impl,
         fast_log10 as _fast_log10_impl,
         fast_log10_inplace as _fast_log10_inplace_impl,
         fast_log2 as _fast_log2_impl,
@@ -254,6 +259,11 @@ except ImportError:
     _fast_trunc_inplace_impl = None  # type: ignore[assignment]
     _fast_log2_inplace_impl = None  # type: ignore[assignment]
     _fast_log10_inplace_impl = None  # type: ignore[assignment]
+    _fast_expm1_inplace_impl = None  # type: ignore[assignment]
+    _fast_log1p_inplace_impl = None  # type: ignore[assignment]
+    _fast_exp2_inplace_impl = None  # type: ignore[assignment]
+    _fast_erf_inplace_impl = None  # type: ignore[assignment]
+    _fast_erfc_inplace_impl = None  # type: ignore[assignment]
 
 
 def add(a, b):
@@ -343,6 +353,11 @@ round_ = _fast_round_inplace_impl
 trunc_ = _fast_trunc_inplace_impl
 log2_ = _fast_log2_inplace_impl
 log10_ = _fast_log10_inplace_impl
+expm1_ = _fast_expm1_inplace_impl
+log1p_ = _fast_log1p_inplace_impl
+exp2_ = _fast_exp2_inplace_impl
+erf_ = _fast_erf_inplace_impl
+erfc_ = _fast_erfc_inplace_impl
 
 
 # ---------------------------------------------------------------------------

--- a/src/candle/_dispatch/schemas.py
+++ b/src/candle/_dispatch/schemas.py
@@ -59,6 +59,11 @@ CORE_SCHEMA_OPS = (
     "ceil_",
     "round_",
     "trunc_",
+    "expm1_",
+    "log1p_",
+    "exp2_",
+    "erf_",
+    "erfc_",
     "reciprocal_",
     "pow_",
     "bitwise_and_",
@@ -285,6 +290,11 @@ def register_schemas():
     registry.register_schema("ceil_", "ceil_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("round_", "round_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("trunc_", "trunc_(Tensor(a!) self) -> Tensor(a)")
+    registry.register_schema("expm1_", "expm1_(Tensor(a!) self) -> Tensor(a)")
+    registry.register_schema("log1p_", "log1p_(Tensor(a!) self) -> Tensor(a)")
+    registry.register_schema("exp2_", "exp2_(Tensor(a!) self) -> Tensor(a)")
+    registry.register_schema("erf_", "erf_(Tensor(a!) self) -> Tensor(a)")
+    registry.register_schema("erfc_", "erfc_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("reciprocal_", "reciprocal_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("pow_", "pow_(Tensor(a!) self, Any exponent) -> Tensor(a)")
     registry.register_schema("bitwise_and_", "bitwise_and_(Tensor(a!) self, Any other) -> Tensor(a)")

--- a/tests/contract/test_autograd_audit_inventory.py
+++ b/tests/contract/test_autograd_audit_inventory.py
@@ -60,10 +60,15 @@ INPLACE_OR_MUTATION_OPS = {
     "bitwise_xor_",
     "ceil_",
     "cos_",
+    "erf_",
+    "erfc_",
     "erfinv_",
+    "exp2_",
     "exp_",
+    "expm1_",
     "floor_",
     "log10_",
+    "log1p_",
     "log2_",
     "log_",
     "neg_",
@@ -221,7 +226,7 @@ def test_schema_ops_without_autograd_registration_are_categorized():
     actual_missing = _schema_ops() - _autograd_registered_ops()
     assert sorted(actual_missing - expected_missing) == []
     assert sorted(expected_missing - actual_missing) == []
-    assert len(actual_missing) == 87
+    assert len(actual_missing) == 92
 
 
 def test_derivatives_not_implemented_inventory_is_classified():

--- a/tests/contract/test_mechanism_audit_pr1.py
+++ b/tests/contract/test_mechanism_audit_pr1.py
@@ -175,11 +175,11 @@ def test_npu_forward_ops_autograd_coverage_categorization_snapshot():
     assert (generated_only & both) == set()
     assert (handwritten_only & both) == set()
 
-    assert len(forward) == 417
+    assert len(forward) == 422
     assert len(generated_only) == 241
     assert len(handwritten_only) == 33
     assert len(both) == 55
-    assert len(missing) == 88
+    assert len(missing) == 93
 
 
 # ---------------------------------------------------------------------------

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1736,9 +1736,13 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "empty",
         "empty_like",
         "equal",
+        "erf_",
+        "erfc_",
         "erfinv_",
+        "exp2_",
         "exp_",
         "expand_copy",
+        "expm1_",
         "eye",
         "flatten",
         "floor_",
@@ -1754,6 +1758,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "isreal",
         "linspace",
         "log10_",
+        "log1p_",
         "log2_",
         "log_",
         "logical_and",
@@ -1795,7 +1800,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
     }
 
     assert missing_autograd == expected_missing
-    assert len(forward_ops) == 417
+    assert len(forward_ops) == 422
     assert len(autograd_ops & forward_ops) == 329
 
 
@@ -2658,3 +2663,36 @@ def test_npu_operator_intake_tranche3e_registers_inplace_abs_round_trunc_log2_lo
     assert "def fast_trunc_inplace(a):" in pyx_src
     assert "def fast_log2_inplace(a):" in pyx_src
     assert "def fast_log10_inplace(a):" in pyx_src
+
+
+def test_npu_operator_intake_tranche3f_registers_inplace_expm1_log1p_exp2_erf_erfc():
+    """Operator intake tranche 3f extends the in-place unary surface with
+    `expm1_`, `log1p_`, `exp2_`, `erf_`, and `erfc_`. Each reuses the
+    existing `aclnnExpm1` / `aclnnLog1p` / `aclnnExp2` / `aclnnErf` /
+    `aclnnErfc` bindings via a new `fast_*_inplace` Cython helper that
+    aliases output to input — fully NPU-resident. New schemas are
+    registered in `_dispatch/schemas.py`.
+    """
+    math_src = _source("src/candle/_backends/npu/ops/math.py")
+    backend_init_src = _source("src/candle/_backends/npu/__init__.py")
+    pyx_src = _source("src/candle/_C/_npu_ops.pyx")
+    schemas_src = _source("src/candle/_dispatch/schemas.py")
+
+    aliases = {
+        "expm1_": "_fast_expm1_inplace_impl",
+        "log1p_": "_fast_log1p_inplace_impl",
+        "exp2_": "_fast_exp2_inplace_impl",
+        "erf_": "_fast_erf_inplace_impl",
+        "erfc_": "_fast_erfc_inplace_impl",
+    }
+    for op_name, fast_name in aliases.items():
+        assert f"def {op_name}(" not in math_src
+        assert f"{op_name} = {fast_name}" in math_src
+        assert f'registry.register("{op_name}", "npu", {op_name}' in backend_init_src
+        assert f'register_schema("{op_name}",' in schemas_src
+
+    assert "def fast_expm1_inplace(a):" in pyx_src
+    assert "def fast_log1p_inplace(a):" in pyx_src
+    assert "def fast_exp2_inplace(a):" in pyx_src
+    assert "def fast_erf_inplace(a):" in pyx_src
+    assert "def fast_erfc_inplace(a):" in pyx_src


### PR DESCRIPTION
## Summary

- Add five new Cython fast helpers in `_C/_npu_ops.pyx`: `fast_expm1_inplace`, `fast_log1p_inplace`, `fast_exp2_inplace`, `fast_erf_inplace`, `fast_erfc_inplace`. Each reuses the existing out-of-place ACLNN kernel binding with output pointer aliased to input — fully NPU-resident.
- Add matching schemas in `_dispatch/schemas.py`, module-level aliases in `_backends/npu/ops/math.py`, and register the new ops in the NPU dispatch registry.
- Bump audit counts: NPU forward ops 417 → 422, missing-autograd inventory 88 → 93, autograd schema inventory 87 → 92. Add tranche 3f audit test.

## Test plan

- [x] \`pytest tests/contract/ tests/cpu/ -x --tb=short\` — 3406 passed
- [x] \`pylint src/candle/ --rcfile=.github/pylint.conf\` — 10.00/10
- [x] Tranche 3f audit verifies all 5 ops registered + schemas + Cython helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)