### PR TITLE
feat(npu): register asin_/acos_/atan_/sinh_/cosh_ in-place on NPU (intake tranche 3g)

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -6695,6 +6695,231 @@ def fast_erfc_inplace(a):
     return a
 
 
+def fast_asin_inplace(a):
+    """In-place asin_(a) using aclnnAsin with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_asin()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _asin_getws_ptr, _asin_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _asin_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnAsin execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
+def fast_acos_inplace(a):
+    """In-place acos_(a) using aclnnAcos with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_acos()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _acos_getws_ptr, _acos_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _acos_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnAcos execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
+def fast_atan_inplace(a):
+    """In-place atan_(a) using aclnnAtan with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_atan()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _atan_getws_ptr, _atan_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _atan_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnAtan execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
+def fast_sinh_inplace(a):
+    """In-place sinh_(a) using aclnnSinh with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_sinh()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _sinh_getws_ptr, _sinh_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _sinh_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnSinh execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
+def fast_cosh_inplace(a):
+    """In-place cosh_(a) using aclnnCosh with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_cosh()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _cosh_getws_ptr, _cosh_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _cosh_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnCosh execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
 def fast_exp2(a):
     """Optimized out-of-place exp2(a) that calls _ffi.unary_op directly."""
     _ensure_npu_imports()

--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -113,6 +113,11 @@ from .ops import (
     exp2_,
     erf_,
     erfc_,
+    asin_,
+    acos_,
+    atan_,
+    sinh_,
+    cosh_,
     contiguous,
     getitem,
     setitem,
@@ -551,6 +556,11 @@ registry.register("log1p_", "npu", log1p_, meta=meta_infer.infer_unary)
 registry.register("exp2_", "npu", exp2_, meta=meta_infer.infer_unary)
 registry.register("erf_", "npu", erf_, meta=meta_infer.infer_unary)
 registry.register("erfc_", "npu", erfc_, meta=meta_infer.infer_unary)
+registry.register("asin_", "npu", asin_, meta=meta_infer.infer_unary)
+registry.register("acos_", "npu", acos_, meta=meta_infer.infer_unary)
+registry.register("atan_", "npu", atan_, meta=meta_infer.infer_unary)
+registry.register("sinh_", "npu", sinh_, meta=meta_infer.infer_unary)
+registry.register("cosh_", "npu", cosh_, meta=meta_infer.infer_unary)
 registry.register("sub_", "npu", sub_, meta=meta_infer.infer_binary)
 registry.register("sub", "npu", sub, meta=meta_infer.infer_binary)
 registry.register("div", "npu", div, meta=meta_infer.infer_binary)

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -5,6 +5,7 @@ from .math import (
     sin_, cos_, sqrt_, sigmoid_, tanh_,
     abs_, round_, trunc_, log2_, log10_,
     expm1_, log1p_, exp2_, erf_, erfc_,
+    asin_, acos_, atan_, sinh_, cosh_,
     abs, neg, sign, signbit, square,
     isfinite, isinf, isnan, isposinf, isneginf,
     exp, log, sqrt, rsqrt, sin, cos, tan, tanh, sigmoid,

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -15,12 +15,15 @@ try:
         fast_abs as _fast_abs_impl,
         fast_abs_inplace as _fast_abs_inplace_impl,
         fast_acos as _fast_acos_impl,
+        fast_acos_inplace as _fast_acos_inplace_impl,
         fast_acosh as _fast_acosh_impl,
         fast_add as _fast_add_impl,
         fast_add_inplace as _fast_add_inplace_impl,
         fast_asin as _fast_asin_impl,
+        fast_asin_inplace as _fast_asin_inplace_impl,
         fast_asinh as _fast_asinh_impl,
         fast_atan as _fast_atan_impl,
+        fast_atan_inplace as _fast_atan_inplace_impl,
         fast_atan2 as _fast_atan2_impl,
         fast_atanh as _fast_atanh_impl,
         fast_ceil as _fast_ceil_impl,
@@ -28,6 +31,7 @@ try:
         fast_cos as _fast_cos_impl,
         fast_cos_inplace as _fast_cos_inplace_impl,
         fast_cosh as _fast_cosh_impl,
+        fast_cosh_inplace as _fast_cosh_inplace_impl,
         fast_erf as _fast_erf_impl,
         fast_erf_inplace as _fast_erf_inplace_impl,
         fast_div as _fast_div_impl,
@@ -74,6 +78,7 @@ try:
         fast_sin as _fast_sin_impl,
         fast_sin_inplace as _fast_sin_inplace_impl,
         fast_sinh as _fast_sinh_impl,
+        fast_sinh_inplace as _fast_sinh_inplace_impl,
         fast_sqrt as _fast_sqrt_impl,
         fast_sqrt_inplace as _fast_sqrt_inplace_impl,
         fast_square as _fast_square_impl,
@@ -264,6 +269,11 @@ except ImportError:
     _fast_exp2_inplace_impl = None  # type: ignore[assignment]
     _fast_erf_inplace_impl = None  # type: ignore[assignment]
     _fast_erfc_inplace_impl = None  # type: ignore[assignment]
+    _fast_asin_inplace_impl = None  # type: ignore[assignment]
+    _fast_acos_inplace_impl = None  # type: ignore[assignment]
+    _fast_atan_inplace_impl = None  # type: ignore[assignment]
+    _fast_sinh_inplace_impl = None  # type: ignore[assignment]
+    _fast_cosh_inplace_impl = None  # type: ignore[assignment]
 
 
 def add(a, b):
@@ -358,6 +368,11 @@ log1p_ = _fast_log1p_inplace_impl
 exp2_ = _fast_exp2_inplace_impl
 erf_ = _fast_erf_inplace_impl
 erfc_ = _fast_erfc_inplace_impl
+asin_ = _fast_asin_inplace_impl
+acos_ = _fast_acos_inplace_impl
+atan_ = _fast_atan_inplace_impl
+sinh_ = _fast_sinh_inplace_impl
+cosh_ = _fast_cosh_inplace_impl
 
 
 # ---------------------------------------------------------------------------

--- a/src/candle/_dispatch/schemas.py
+++ b/src/candle/_dispatch/schemas.py
@@ -64,6 +64,11 @@ CORE_SCHEMA_OPS = (
     "exp2_",
     "erf_",
     "erfc_",
+    "asin_",
+    "acos_",
+    "atan_",
+    "sinh_",
+    "cosh_",
     "reciprocal_",
     "pow_",
     "bitwise_and_",
@@ -295,6 +300,11 @@ def register_schemas():
     registry.register_schema("exp2_", "exp2_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("erf_", "erf_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("erfc_", "erfc_(Tensor(a!) self) -> Tensor(a)")
+    registry.register_schema("asin_", "asin_(Tensor(a!) self) -> Tensor(a)")
+    registry.register_schema("acos_", "acos_(Tensor(a!) self) -> Tensor(a)")
+    registry.register_schema("atan_", "atan_(Tensor(a!) self) -> Tensor(a)")
+    registry.register_schema("sinh_", "sinh_(Tensor(a!) self) -> Tensor(a)")
+    registry.register_schema("cosh_", "cosh_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("reciprocal_", "reciprocal_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("pow_", "pow_(Tensor(a!) self, Any exponent) -> Tensor(a)")
     registry.register_schema("bitwise_and_", "bitwise_and_(Tensor(a!) self, Any other) -> Tensor(a)")

--- a/tests/contract/test_autograd_audit_inventory.py
+++ b/tests/contract/test_autograd_audit_inventory.py
@@ -55,11 +55,15 @@ CREATION_RANDOM_OPS = {
 
 INPLACE_OR_MUTATION_OPS = {
     "abs_",
+    "acos_",
+    "asin_",
+    "atan_",
     "bitwise_and_",
     "bitwise_or_",
     "bitwise_xor_",
     "ceil_",
     "cos_",
+    "cosh_",
     "erf_",
     "erfc_",
     "erfinv_",
@@ -78,6 +82,7 @@ INPLACE_OR_MUTATION_OPS = {
     "round_",
     "sigmoid_",
     "sin_",
+    "sinh_",
     "sqrt_",
     "tan_",
     "tanh_",
@@ -226,7 +231,7 @@ def test_schema_ops_without_autograd_registration_are_categorized():
     actual_missing = _schema_ops() - _autograd_registered_ops()
     assert sorted(actual_missing - expected_missing) == []
     assert sorted(expected_missing - actual_missing) == []
-    assert len(actual_missing) == 92
+    assert len(actual_missing) == 97
 
 
 def test_derivatives_not_implemented_inventory_is_classified():

--- a/tests/contract/test_mechanism_audit_pr1.py
+++ b/tests/contract/test_mechanism_audit_pr1.py
@@ -175,11 +175,11 @@ def test_npu_forward_ops_autograd_coverage_categorization_snapshot():
     assert (generated_only & both) == set()
     assert (handwritten_only & both) == set()
 
-    assert len(forward) == 422
+    assert len(forward) == 427
     assert len(generated_only) == 241
     assert len(handwritten_only) == 33
     assert len(both) == 55
-    assert len(missing) == 93
+    assert len(missing) == 98
 
 
 # ---------------------------------------------------------------------------

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1717,6 +1717,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "_sgd_step",
         "_sparse_adam_step",
         "abs_",
+        "acos_",
         "allclose",
         "arange",
         "argmax",
@@ -1724,6 +1725,8 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "argsort",
         "argwhere",
         "as_strided_copy",
+        "asin_",
+        "atan_",
         "bincount",
         "bitwise_and",
         "bitwise_not",
@@ -1733,6 +1736,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "cartesian_prod",
         "ceil_",
         "cos_",
+        "cosh_",
         "empty",
         "empty_like",
         "equal",
@@ -1785,6 +1789,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "searchsorted",
         "sigmoid_",
         "sin_",
+        "sinh_",
         "slice_copy",
         "sqrt_",
         "squeeze",
@@ -1800,7 +1805,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
     }
 
     assert missing_autograd == expected_missing
-    assert len(forward_ops) == 422
+    assert len(forward_ops) == 427
     assert len(autograd_ops & forward_ops) == 329
 
 
@@ -2696,3 +2701,36 @@ def test_npu_operator_intake_tranche3f_registers_inplace_expm1_log1p_exp2_erf_er
     assert "def fast_exp2_inplace(a):" in pyx_src
     assert "def fast_erf_inplace(a):" in pyx_src
     assert "def fast_erfc_inplace(a):" in pyx_src
+
+
+def test_npu_operator_intake_tranche3g_registers_inplace_asin_acos_atan_sinh_cosh():
+    """Operator intake tranche 3g extends the in-place unary surface with
+    `asin_`, `acos_`, `atan_`, `sinh_`, and `cosh_`. Each reuses the
+    existing `aclnnAsin` / `aclnnAcos` / `aclnnAtan` / `aclnnSinh` /
+    `aclnnCosh` bindings via a new `fast_*_inplace` Cython helper that
+    aliases output to input — fully NPU-resident. New schemas are
+    registered in `_dispatch/schemas.py`.
+    """
+    math_src = _source("src/candle/_backends/npu/ops/math.py")
+    backend_init_src = _source("src/candle/_backends/npu/__init__.py")
+    pyx_src = _source("src/candle/_C/_npu_ops.pyx")
+    schemas_src = _source("src/candle/_dispatch/schemas.py")
+
+    aliases = {
+        "asin_": "_fast_asin_inplace_impl",
+        "acos_": "_fast_acos_inplace_impl",
+        "atan_": "_fast_atan_inplace_impl",
+        "sinh_": "_fast_sinh_inplace_impl",
+        "cosh_": "_fast_cosh_inplace_impl",
+    }
+    for op_name, fast_name in aliases.items():
+        assert f"def {op_name}(" not in math_src
+        assert f"{op_name} = {fast_name}" in math_src
+        assert f'registry.register("{op_name}", "npu", {op_name}' in backend_init_src
+        assert f'register_schema("{op_name}",' in schemas_src
+
+    assert "def fast_asin_inplace(a):" in pyx_src
+    assert "def fast_acos_inplace(a):" in pyx_src
+    assert "def fast_atan_inplace(a):" in pyx_src
+    assert "def fast_sinh_inplace(a):" in pyx_src
+    assert "def fast_cosh_inplace(a):" in pyx_src


### PR DESCRIPTION
## Summary
- Extends in-place unary surface with `asin_`, `acos_`, `atan_`, `sinh_`, `cosh_`.
- Each new op reuses existing out-of-place `aclnn{Asin,Acos,Atan,Sinh,Cosh}` bindings via new `fast_*_inplace` Cython helpers that alias output to input — fully NPU-resident.
- New schemas registered in `_dispatch/schemas.py`.
- Audit counts: forward 422→427, missing autograd 93→98, expected schema-only 92→97.

## Test plan
- [x] `pytest tests/contract/ -x --tb=short` — 105 passed (includes new tranche 3g audit)
- [x] `pytest tests/cpu/ -x --tb=short` — 2366 passed, 25 skipped
- [x] `pylint src/candle/` — 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)