### PR TITLE
feat(npu): register asinh_/acosh_/atanh_/rsqrt_/square_ in-place on NPU (intake tranche 3h)

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -6920,6 +6920,231 @@ def fast_cosh_inplace(a):
     return a
 
 
+def fast_asinh_inplace(a):
+    """In-place asinh_(a) using aclnnAsinh with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_asinh()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _asinh_getws_ptr, _asinh_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _asinh_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnAsinh execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
+def fast_acosh_inplace(a):
+    """In-place acosh_(a) using aclnnAcosh with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_acosh()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _acosh_getws_ptr, _acosh_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _acosh_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnAcosh execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
+def fast_atanh_inplace(a):
+    """In-place atanh_(a) using aclnnAtanh with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_atanh()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _atanh_getws_ptr, _atanh_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _atanh_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnAtanh execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
+def fast_rsqrt_inplace(a):
+    """In-place rsqrt_(a) using aclnnRsqrt with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_rsqrt()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _rsqrt_getws_ptr, _rsqrt_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _rsqrt_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnRsqrt execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
+def fast_square_inplace(a):
+    """In-place square_(a) using aclnnSquare with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_square()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _square_getws_ptr, _square_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _square_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnSquare execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
 def fast_exp2(a):
     """Optimized out-of-place exp2(a) that calls _ffi.unary_op directly."""
     _ensure_npu_imports()

--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -118,6 +118,11 @@ from .ops import (
     atan_,
     sinh_,
     cosh_,
+    asinh_,
+    acosh_,
+    atanh_,
+    rsqrt_,
+    square_,
     contiguous,
     getitem,
     setitem,
@@ -561,6 +566,11 @@ registry.register("acos_", "npu", acos_, meta=meta_infer.infer_unary)
 registry.register("atan_", "npu", atan_, meta=meta_infer.infer_unary)
 registry.register("sinh_", "npu", sinh_, meta=meta_infer.infer_unary)
 registry.register("cosh_", "npu", cosh_, meta=meta_infer.infer_unary)
+registry.register("asinh_", "npu", asinh_, meta=meta_infer.infer_unary)
+registry.register("acosh_", "npu", acosh_, meta=meta_infer.infer_unary)
+registry.register("atanh_", "npu", atanh_, meta=meta_infer.infer_unary)
+registry.register("rsqrt_", "npu", rsqrt_, meta=meta_infer.infer_unary)
+registry.register("square_", "npu", square_, meta=meta_infer.infer_unary)
 registry.register("sub_", "npu", sub_, meta=meta_infer.infer_binary)
 registry.register("sub", "npu", sub, meta=meta_infer.infer_binary)
 registry.register("div", "npu", div, meta=meta_infer.infer_binary)

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -6,6 +6,7 @@ from .math import (
     abs_, round_, trunc_, log2_, log10_,
     expm1_, log1p_, exp2_, erf_, erfc_,
     asin_, acos_, atan_, sinh_, cosh_,
+    asinh_, acosh_, atanh_, rsqrt_, square_,
     abs, neg, sign, signbit, square,
     isfinite, isinf, isnan, isposinf, isneginf,
     exp, log, sqrt, rsqrt, sin, cos, tan, tanh, sigmoid,

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -17,15 +17,18 @@ try:
         fast_acos as _fast_acos_impl,
         fast_acos_inplace as _fast_acos_inplace_impl,
         fast_acosh as _fast_acosh_impl,
+        fast_acosh_inplace as _fast_acosh_inplace_impl,
         fast_add as _fast_add_impl,
         fast_add_inplace as _fast_add_inplace_impl,
         fast_asin as _fast_asin_impl,
         fast_asin_inplace as _fast_asin_inplace_impl,
         fast_asinh as _fast_asinh_impl,
+        fast_asinh_inplace as _fast_asinh_inplace_impl,
         fast_atan as _fast_atan_impl,
         fast_atan_inplace as _fast_atan_inplace_impl,
         fast_atan2 as _fast_atan2_impl,
         fast_atanh as _fast_atanh_impl,
+        fast_atanh_inplace as _fast_atanh_inplace_impl,
         fast_ceil as _fast_ceil_impl,
         fast_ceil_inplace as _fast_ceil_inplace_impl,
         fast_cos as _fast_cos_impl,
@@ -71,6 +74,7 @@ try:
         fast_round as _fast_round_impl,
         fast_round_inplace as _fast_round_inplace_impl,
         fast_rsqrt as _fast_rsqrt_impl,
+        fast_rsqrt_inplace as _fast_rsqrt_inplace_impl,
         fast_sigmoid as _fast_sigmoid_impl,
         fast_sigmoid_inplace as _fast_sigmoid_inplace_impl,
         fast_sign as _fast_sign_impl,
@@ -82,6 +86,7 @@ try:
         fast_sqrt as _fast_sqrt_impl,
         fast_sqrt_inplace as _fast_sqrt_inplace_impl,
         fast_square as _fast_square_impl,
+        fast_square_inplace as _fast_square_inplace_impl,
         fast_sub as _fast_sub_impl,
         fast_sub_inplace as _fast_sub_inplace_impl,
         fast_tan as _fast_tan_impl,
@@ -274,6 +279,11 @@ except ImportError:
     _fast_atan_inplace_impl = None  # type: ignore[assignment]
     _fast_sinh_inplace_impl = None  # type: ignore[assignment]
     _fast_cosh_inplace_impl = None  # type: ignore[assignment]
+    _fast_asinh_inplace_impl = None  # type: ignore[assignment]
+    _fast_acosh_inplace_impl = None  # type: ignore[assignment]
+    _fast_atanh_inplace_impl = None  # type: ignore[assignment]
+    _fast_rsqrt_inplace_impl = None  # type: ignore[assignment]
+    _fast_square_inplace_impl = None  # type: ignore[assignment]
 
 
 def add(a, b):
@@ -373,6 +383,11 @@ acos_ = _fast_acos_inplace_impl
 atan_ = _fast_atan_inplace_impl
 sinh_ = _fast_sinh_inplace_impl
 cosh_ = _fast_cosh_inplace_impl
+asinh_ = _fast_asinh_inplace_impl
+acosh_ = _fast_acosh_inplace_impl
+atanh_ = _fast_atanh_inplace_impl
+rsqrt_ = _fast_rsqrt_inplace_impl
+square_ = _fast_square_inplace_impl
 
 
 # ---------------------------------------------------------------------------

--- a/src/candle/_dispatch/schemas.py
+++ b/src/candle/_dispatch/schemas.py
@@ -69,6 +69,11 @@ CORE_SCHEMA_OPS = (
     "atan_",
     "sinh_",
     "cosh_",
+    "asinh_",
+    "acosh_",
+    "atanh_",
+    "rsqrt_",
+    "square_",
     "reciprocal_",
     "pow_",
     "bitwise_and_",
@@ -305,6 +310,11 @@ def register_schemas():
     registry.register_schema("atan_", "atan_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("sinh_", "sinh_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("cosh_", "cosh_(Tensor(a!) self) -> Tensor(a)")
+    registry.register_schema("asinh_", "asinh_(Tensor(a!) self) -> Tensor(a)")
+    registry.register_schema("acosh_", "acosh_(Tensor(a!) self) -> Tensor(a)")
+    registry.register_schema("atanh_", "atanh_(Tensor(a!) self) -> Tensor(a)")
+    registry.register_schema("rsqrt_", "rsqrt_(Tensor(a!) self) -> Tensor(a)")
+    registry.register_schema("square_", "square_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("reciprocal_", "reciprocal_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("pow_", "pow_(Tensor(a!) self, Any exponent) -> Tensor(a)")
     registry.register_schema("bitwise_and_", "bitwise_and_(Tensor(a!) self, Any other) -> Tensor(a)")

--- a/tests/contract/test_autograd_audit_inventory.py
+++ b/tests/contract/test_autograd_audit_inventory.py
@@ -56,8 +56,11 @@ CREATION_RANDOM_OPS = {
 INPLACE_OR_MUTATION_OPS = {
     "abs_",
     "acos_",
+    "acosh_",
     "asin_",
+    "asinh_",
     "atan_",
+    "atanh_",
     "bitwise_and_",
     "bitwise_or_",
     "bitwise_xor_",
@@ -80,10 +83,12 @@ INPLACE_OR_MUTATION_OPS = {
     "randint_",
     "reciprocal_",
     "round_",
+    "rsqrt_",
     "sigmoid_",
     "sin_",
     "sinh_",
     "sqrt_",
+    "square_",
     "tan_",
     "tanh_",
     "trunc_",
@@ -231,7 +236,7 @@ def test_schema_ops_without_autograd_registration_are_categorized():
     actual_missing = _schema_ops() - _autograd_registered_ops()
     assert sorted(actual_missing - expected_missing) == []
     assert sorted(expected_missing - actual_missing) == []
-    assert len(actual_missing) == 97
+    assert len(actual_missing) == 102
 
 
 def test_derivatives_not_implemented_inventory_is_classified():

--- a/tests/contract/test_mechanism_audit_pr1.py
+++ b/tests/contract/test_mechanism_audit_pr1.py
@@ -175,11 +175,11 @@ def test_npu_forward_ops_autograd_coverage_categorization_snapshot():
     assert (generated_only & both) == set()
     assert (handwritten_only & both) == set()
 
-    assert len(forward) == 427
+    assert len(forward) == 432
     assert len(generated_only) == 241
     assert len(handwritten_only) == 33
     assert len(both) == 55
-    assert len(missing) == 98
+    assert len(missing) == 103
 
 
 # ---------------------------------------------------------------------------

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1718,6 +1718,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "_sparse_adam_step",
         "abs_",
         "acos_",
+        "acosh_",
         "allclose",
         "arange",
         "argmax",
@@ -1726,7 +1727,9 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "argwhere",
         "as_strided_copy",
         "asin_",
+        "asinh_",
         "atan_",
+        "atanh_",
         "bincount",
         "bitwise_and",
         "bitwise_not",
@@ -1786,12 +1789,14 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "range",
         "reciprocal_",
         "round_",
+        "rsqrt_",
         "searchsorted",
         "sigmoid_",
         "sin_",
         "sinh_",
         "slice_copy",
         "sqrt_",
+        "square_",
         "squeeze",
         "tan_",
         "tanh_",
@@ -1805,7 +1810,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
     }
 
     assert missing_autograd == expected_missing
-    assert len(forward_ops) == 427
+    assert len(forward_ops) == 432
     assert len(autograd_ops & forward_ops) == 329
 
 
@@ -2734,3 +2739,36 @@ def test_npu_operator_intake_tranche3g_registers_inplace_asin_acos_atan_sinh_cos
     assert "def fast_atan_inplace(a):" in pyx_src
     assert "def fast_sinh_inplace(a):" in pyx_src
     assert "def fast_cosh_inplace(a):" in pyx_src
+
+
+def test_npu_operator_intake_tranche3h_registers_inplace_asinh_acosh_atanh_rsqrt_square():
+    """Operator intake tranche 3h extends the in-place unary surface with
+    `asinh_`, `acosh_`, `atanh_`, `rsqrt_`, and `square_`. Each reuses the
+    existing `aclnnAsinh` / `aclnnAcosh` / `aclnnAtanh` / `aclnnRsqrt` /
+    `aclnnSquare` bindings via a new `fast_*_inplace` Cython helper that
+    aliases output to input — fully NPU-resident. New schemas are
+    registered in `_dispatch/schemas.py`.
+    """
+    math_src = _source("src/candle/_backends/npu/ops/math.py")
+    backend_init_src = _source("src/candle/_backends/npu/__init__.py")
+    pyx_src = _source("src/candle/_C/_npu_ops.pyx")
+    schemas_src = _source("src/candle/_dispatch/schemas.py")
+
+    aliases = {
+        "asinh_": "_fast_asinh_inplace_impl",
+        "acosh_": "_fast_acosh_inplace_impl",
+        "atanh_": "_fast_atanh_inplace_impl",
+        "rsqrt_": "_fast_rsqrt_inplace_impl",
+        "square_": "_fast_square_inplace_impl",
+    }
+    for op_name, fast_name in aliases.items():
+        assert f"def {op_name}(" not in math_src
+        assert f"{op_name} = {fast_name}" in math_src
+        assert f'registry.register("{op_name}", "npu", {op_name}' in backend_init_src
+        assert f'register_schema("{op_name}",' in schemas_src
+
+    assert "def fast_asinh_inplace(a):" in pyx_src
+    assert "def fast_acosh_inplace(a):" in pyx_src
+    assert "def fast_atanh_inplace(a):" in pyx_src
+    assert "def fast_rsqrt_inplace(a):" in pyx_src
+    assert "def fast_square_inplace(a):" in pyx_src


### PR DESCRIPTION
## Summary
- Extends in-place unary surface with `asinh_`, `acosh_`, `atanh_`, `rsqrt_`, `square_`.
- Each new op reuses existing out-of-place `aclnn{Asinh,Acosh,Atanh,Rsqrt,Square}` bindings via new `fast_*_inplace` Cython helpers that alias output to input — fully NPU-resident.
- New schemas registered in `_dispatch/schemas.py`.
- Audit counts: forward 427→432, missing autograd 98→103, expected schema-only 97→102.

## Test plan
- [x] `pytest tests/contract/ -x --tb=short` — 1042 passed (includes new tranche 3h audit)
- [x] `pylint src/candle/` — 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)