### PR TITLE
feat(npu): register digamma_/sign_ in-place (intake tranche 3i)

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -7145,6 +7145,96 @@ def fast_square_inplace(a):
     return a
 
 
+def fast_digamma_inplace(a):
+    """In-place digamma_(a) using aclnnDigamma with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_digamma()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _digamma_getws_ptr, _digamma_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _digamma_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnDigamma execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
+def fast_sign_inplace(a):
+    """In-place sign_(a) using aclnnSign with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_sign()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _sign_getws_ptr, _sign_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _sign_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnSign execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
 def fast_exp2(a):
     """Optimized out-of-place exp2(a) that calls _ffi.unary_op directly."""
     _ensure_npu_imports()

--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -123,6 +123,7 @@ from .ops import (
     atanh_,
     rsqrt_,
     square_,
+    sign_,
     contiguous,
     getitem,
     setitem,
@@ -330,6 +331,7 @@ from .ops import (
     col2im_op,
     # Phase 1: ACLNN large kernel ops (910B confirmed)
     special_digamma,
+    digamma_,
     special_erfinv,
     special_gammaln,
     special_sinc,
@@ -571,6 +573,8 @@ registry.register("acosh_", "npu", acosh_, meta=meta_infer.infer_unary)
 registry.register("atanh_", "npu", atanh_, meta=meta_infer.infer_unary)
 registry.register("rsqrt_", "npu", rsqrt_, meta=meta_infer.infer_unary)
 registry.register("square_", "npu", square_, meta=meta_infer.infer_unary)
+registry.register("sign_", "npu", sign_, meta=meta_infer.infer_unary)
+registry.register("digamma_", "npu", digamma_, meta=meta_infer.infer_unary)
 registry.register("sub_", "npu", sub_, meta=meta_infer.infer_binary)
 registry.register("sub", "npu", sub, meta=meta_infer.infer_binary)
 registry.register("div", "npu", div, meta=meta_infer.infer_binary)

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -7,6 +7,7 @@ from .math import (
     expm1_, log1p_, exp2_, erf_, erfc_,
     asin_, acos_, atan_, sinh_, cosh_,
     asinh_, acosh_, atanh_, rsqrt_, square_,
+    sign_,
     abs, neg, sign, signbit, square,
     isfinite, isinf, isnan, isposinf, isneginf,
     exp, log, sqrt, rsqrt, sin, cos, tan, tanh, sigmoid,
@@ -124,6 +125,7 @@ from .elementwise import (
 
 from .special import (
     special_digamma, special_erfinv, special_gammaln, special_sinc,
+    digamma_,
     special_entr_op, special_erfcx_op, special_logit_op,
     special_ndtr_op, special_log_ndtr_op,
     special_xlogy_op, special_xlog1py_op, special_multigammaln_op,

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -78,6 +78,7 @@ try:
         fast_sigmoid as _fast_sigmoid_impl,
         fast_sigmoid_inplace as _fast_sigmoid_inplace_impl,
         fast_sign as _fast_sign_impl,
+        fast_sign_inplace as _fast_sign_inplace_impl,
         fast_signbit as _fast_signbit_impl,
         fast_sin as _fast_sin_impl,
         fast_sin_inplace as _fast_sin_inplace_impl,
@@ -284,6 +285,7 @@ except ImportError:
     _fast_atanh_inplace_impl = None  # type: ignore[assignment]
     _fast_rsqrt_inplace_impl = None  # type: ignore[assignment]
     _fast_square_inplace_impl = None  # type: ignore[assignment]
+    _fast_sign_inplace_impl = None  # type: ignore[assignment]
 
 
 def add(a, b):
@@ -388,6 +390,7 @@ acosh_ = _fast_acosh_inplace_impl
 atanh_ = _fast_atanh_inplace_impl
 rsqrt_ = _fast_rsqrt_inplace_impl
 square_ = _fast_square_inplace_impl
+sign_ = _fast_sign_inplace_impl
 
 
 # ---------------------------------------------------------------------------

--- a/src/candle/_backends/npu/ops/special.py
+++ b/src/candle/_backends/npu/ops/special.py
@@ -10,6 +10,7 @@ try:
         fast_special_xlogy as _fast_special_xlogy_impl,
         fast_sinc as _fast_sinc_impl,
         fast_digamma as _fast_digamma_impl,
+        fast_digamma_inplace as _fast_digamma_inplace_impl,
         fast_erfinv as _fast_erfinv_impl,
         fast_lgamma as _fast_lgamma_impl,
     )
@@ -25,6 +26,7 @@ except ImportError:
     _fast_special_xlogy_impl = None  # type: ignore[assignment]
     _fast_sinc_impl = None  # type: ignore[assignment]
     _fast_digamma_impl = None  # type: ignore[assignment]
+    _fast_digamma_inplace_impl = None  # type: ignore[assignment]
     _fast_erfinv_impl = None  # type: ignore[assignment]
     _fast_lgamma_impl = None  # type: ignore[assignment]
     _HAS_FAST_SPECIAL_COMPOSITES = False
@@ -47,6 +49,9 @@ from .shape import contiguous, index_select
 
 
 special_digamma = _fast_digamma_impl
+
+
+digamma_ = _fast_digamma_inplace_impl
 
 
 special_erfinv = _fast_erfinv_impl

--- a/src/candle/_dispatch/schemas.py
+++ b/src/candle/_dispatch/schemas.py
@@ -74,6 +74,8 @@ CORE_SCHEMA_OPS = (
     "atanh_",
     "rsqrt_",
     "square_",
+    "digamma_",
+    "sign_",
     "reciprocal_",
     "pow_",
     "bitwise_and_",
@@ -315,6 +317,8 @@ def register_schemas():
     registry.register_schema("atanh_", "atanh_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("rsqrt_", "rsqrt_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("square_", "square_(Tensor(a!) self) -> Tensor(a)")
+    registry.register_schema("digamma_", "digamma_(Tensor(a!) self) -> Tensor(a)")
+    registry.register_schema("sign_", "sign_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("reciprocal_", "reciprocal_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("pow_", "pow_(Tensor(a!) self, Any exponent) -> Tensor(a)")
     registry.register_schema("bitwise_and_", "bitwise_and_(Tensor(a!) self, Any other) -> Tensor(a)")

--- a/tests/contract/test_autograd_audit_inventory.py
+++ b/tests/contract/test_autograd_audit_inventory.py
@@ -67,6 +67,7 @@ INPLACE_OR_MUTATION_OPS = {
     "ceil_",
     "cos_",
     "cosh_",
+    "digamma_",
     "erf_",
     "erfc_",
     "erfinv_",
@@ -85,6 +86,7 @@ INPLACE_OR_MUTATION_OPS = {
     "round_",
     "rsqrt_",
     "sigmoid_",
+    "sign_",
     "sin_",
     "sinh_",
     "sqrt_",
@@ -236,7 +238,7 @@ def test_schema_ops_without_autograd_registration_are_categorized():
     actual_missing = _schema_ops() - _autograd_registered_ops()
     assert sorted(actual_missing - expected_missing) == []
     assert sorted(expected_missing - actual_missing) == []
-    assert len(actual_missing) == 102
+    assert len(actual_missing) == 104
 
 
 def test_derivatives_not_implemented_inventory_is_classified():

--- a/tests/contract/test_mechanism_audit_pr1.py
+++ b/tests/contract/test_mechanism_audit_pr1.py
@@ -175,11 +175,11 @@ def test_npu_forward_ops_autograd_coverage_categorization_snapshot():
     assert (generated_only & both) == set()
     assert (handwritten_only & both) == set()
 
-    assert len(forward) == 432
+    assert len(forward) == 434
     assert len(generated_only) == 241
     assert len(handwritten_only) == 33
     assert len(both) == 55
-    assert len(missing) == 103
+    assert len(missing) == 105
 
 
 # ---------------------------------------------------------------------------

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1740,6 +1740,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "ceil_",
         "cos_",
         "cosh_",
+        "digamma_",
         "empty",
         "empty_like",
         "equal",
@@ -1792,6 +1793,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "rsqrt_",
         "searchsorted",
         "sigmoid_",
+        "sign_",
         "sin_",
         "sinh_",
         "slice_copy",
@@ -1810,7 +1812,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
     }
 
     assert missing_autograd == expected_missing
-    assert len(forward_ops) == 432
+    assert len(forward_ops) == 434
     assert len(autograd_ops & forward_ops) == 329
 
 
@@ -2772,3 +2774,37 @@ def test_npu_operator_intake_tranche3h_registers_inplace_asinh_acosh_atanh_rsqrt
     assert "def fast_atanh_inplace(a):" in pyx_src
     assert "def fast_rsqrt_inplace(a):" in pyx_src
     assert "def fast_square_inplace(a):" in pyx_src
+
+
+def test_npu_operator_intake_tranche3i_registers_inplace_digamma_sign():
+    """Operator intake tranche 3i extends the in-place unary surface with
+    `digamma_` and `sign_`. Each reuses the existing `aclnnDigamma` /
+    `aclnnSign` bindings via a new `fast_*_inplace` Cython helper that
+    aliases output to input — fully NPU-resident. New schemas are
+    registered in `_dispatch/schemas.py`. Unlike prior tranches, the two
+    ops live in different modules: `sign_` in `ops/math.py`, `digamma_`
+    in `ops/special.py`.
+    """
+    math_src = _source("src/candle/_backends/npu/ops/math.py")
+    special_src = _source("src/candle/_backends/npu/ops/special.py")
+    backend_init_src = _source("src/candle/_backends/npu/__init__.py")
+    pyx_src = _source("src/candle/_C/_npu_ops.pyx")
+    schemas_src = _source("src/candle/_dispatch/schemas.py")
+
+    math_aliases = {"sign_": "_fast_sign_inplace_impl"}
+    special_aliases = {"digamma_": "_fast_digamma_inplace_impl"}
+
+    for op_name, fast_name in math_aliases.items():
+        assert f"def {op_name}(" not in math_src
+        assert f"{op_name} = {fast_name}" in math_src
+        assert f'registry.register("{op_name}", "npu", {op_name}' in backend_init_src
+        assert f'register_schema("{op_name}",' in schemas_src
+
+    for op_name, fast_name in special_aliases.items():
+        assert f"def {op_name}(" not in special_src
+        assert f"{op_name} = {fast_name}" in special_src
+        assert f'registry.register("{op_name}", "npu", {op_name}' in backend_init_src
+        assert f'register_schema("{op_name}",' in schemas_src
+
+    assert "def fast_digamma_inplace(a):" in pyx_src
+    assert "def fast_sign_inplace(a):" in pyx_src


### PR DESCRIPTION
## Summary

- Adds `digamma_` and `sign_` in-place NPU registrations, reusing existing aclnnDigamma/aclnnSign bindings via new `fast_digamma_inplace` / `fast_sign_inplace` Cython helpers (output aliased to input).
- Unlike prior intake tranches (3c–3h), the two ops live in different modules: `sign_` in `ops/math.py`, `digamma_` in `ops/special.py` — audit test reflects the cross-module split.
- Fully NPU-resident, no CPU fallback. Schemas registered in `_dispatch/schemas.py`.

## Test plan

- [x] All 1043 contract tests pass
- [x] Pylint 10.00/10
- [x] `fast_digamma_inplace` / `fast_sign_inplace` Cython symbols import cleanly
- [x] `aten::digamma_` / `aten::sign_` registered with NPU kernel
- [x] Audit counts bumped: forward 432→434, missing 103→105 (mechanism_audit_pr1); 102→104 (autograd_audit_inventory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)