### PR TITLE
feat(npu): register silu_/mish_ in-place (intake tranche 3j)

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -7235,6 +7235,96 @@ def fast_sign_inplace(a):
     return a
 
 
+def fast_silu_inplace(a):
+    """In-place silu_(a) using aclnnSilu with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_silu()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _silu_getws_ptr, _silu_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _silu_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnSilu execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
+def fast_mish_inplace(a):
+    """In-place mish_(a) using aclnnMish with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_mish()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _mish_getws_ptr, _mish_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _mish_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnMish execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
 def fast_exp2(a):
     """Optimized out-of-place exp2(a) that calls _ffi.unary_op directly."""
     _ensure_npu_imports()

--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -202,9 +202,11 @@ from .ops import (
     layer_norm,
     embedding,
     silu,
+    silu_,
     leaky_relu,
     elu,
     mish,
+    mish_,
     prelu,
     batch_norm,
     instance_norm,
@@ -690,9 +692,11 @@ registry.register("embedding", "npu", embedding, meta=meta_infer.infer_binary)
 
 # Activation functions (composite ops)
 registry.register("silu", "npu", silu, meta=meta_infer.infer_unary)
+registry.register("silu_", "npu", silu_, meta=meta_infer.infer_unary)
 registry.register("leaky_relu", "npu", leaky_relu, meta=meta_infer.infer_unary)
 registry.register("elu", "npu", elu, meta=meta_infer.infer_unary)
 registry.register("mish", "npu", mish, meta=meta_infer.infer_unary)
+registry.register("mish_", "npu", mish_, meta=meta_infer.infer_unary)
 registry.register("prelu", "npu", prelu, meta=meta_infer.infer_binary)
 
 # Normalization (composite ops)

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -61,7 +61,7 @@ from .shape import (
 
 from .activation import (
     relu, relu_, relu6, softplus, hardtanh,
-    silu, gelu, leaky_relu, elu, mish, prelu,
+    silu, silu_, gelu, leaky_relu, elu, mish, mish_, prelu,
     selu_op, celu_op, threshold_op,
     hardshrink_op, softshrink_op, hardswish_op, hardsigmoid_op,
     softsign_op, rrelu_op,

--- a/src/candle/_backends/npu/ops/activation.py
+++ b/src/candle/_backends/npu/ops/activation.py
@@ -14,8 +14,10 @@ try:
         fast_leaky_relu as _fast_leaky_relu_impl,
         fast_elu as _fast_elu_impl,
         fast_silu as _fast_silu_impl,
+        fast_silu_inplace as _fast_silu_inplace_impl,
         fast_gelu as _fast_gelu_impl,
         fast_mish as _fast_mish_impl,
+        fast_mish_inplace as _fast_mish_inplace_impl,
         fast_relu6 as _fast_relu6_impl,
         fast_selu as _fast_selu_impl,
         fast_celu as _fast_celu_impl,
@@ -39,8 +41,10 @@ try:
     _HAS_FAST_LEAKY_RELU = True
     _HAS_FAST_ELU = True
     _HAS_FAST_SILU = True
+    _HAS_FAST_SILU_INPLACE = True
     _HAS_FAST_GELU = True
     _HAS_FAST_MISH = True
+    _HAS_FAST_MISH_INPLACE = True
     _HAS_FAST_ACTIVATION_COMPOSITES = True
 except ImportError:
     _fast_relu_impl = None  # type: ignore[assignment]
@@ -55,8 +59,10 @@ except ImportError:
     _fast_leaky_relu_impl = None  # type: ignore[assignment]
     _fast_elu_impl = None  # type: ignore[assignment]
     _fast_silu_impl = None  # type: ignore[assignment]
+    _fast_silu_inplace_impl = None  # type: ignore[assignment]
     _fast_gelu_impl = None  # type: ignore[assignment]
     _fast_mish_impl = None  # type: ignore[assignment]
+    _fast_mish_inplace_impl = None  # type: ignore[assignment]
     _fast_relu6_impl = None  # type: ignore[assignment]
     _fast_selu_impl = None  # type: ignore[assignment]
     _fast_celu_impl = None  # type: ignore[assignment]
@@ -79,8 +85,10 @@ except ImportError:
     _HAS_FAST_LEAKY_RELU = False
     _HAS_FAST_ELU = False
     _HAS_FAST_SILU = False
+    _HAS_FAST_SILU_INPLACE = False
     _HAS_FAST_GELU = False
     _HAS_FAST_MISH = False
+    _HAS_FAST_MISH_INPLACE = False
     _HAS_FAST_ACTIVATION_COMPOSITES = False
 
 from ._helpers import (
@@ -149,6 +157,12 @@ def silu(a):
     raise RuntimeError("Cython NPU silu implementation is unavailable")
 
 
+def silu_(a):
+    if _HAS_FAST_SILU_INPLACE:
+        return _fast_silu_inplace_impl(a)
+    raise RuntimeError("Cython NPU silu_ implementation is unavailable")
+
+
 def gelu(a):
     if _HAS_FAST_GELU:
         return _fast_gelu_impl(a)
@@ -173,6 +187,12 @@ def mish(a):
     if _HAS_FAST_MISH:
         return _fast_mish_impl(a)
     raise RuntimeError("Cython NPU mish implementation is unavailable")
+
+
+def mish_(a):
+    if _HAS_FAST_MISH_INPLACE:
+        return _fast_mish_inplace_impl(a)
+    raise RuntimeError("Cython NPU mish_ implementation is unavailable")
 
 
 def prelu(a, weight):

--- a/src/candle/_dispatch/schemas.py
+++ b/src/candle/_dispatch/schemas.py
@@ -76,6 +76,8 @@ CORE_SCHEMA_OPS = (
     "square_",
     "digamma_",
     "sign_",
+    "silu_",
+    "mish_",
     "reciprocal_",
     "pow_",
     "bitwise_and_",
@@ -319,6 +321,8 @@ def register_schemas():
     registry.register_schema("square_", "square_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("digamma_", "digamma_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("sign_", "sign_(Tensor(a!) self) -> Tensor(a)")
+    registry.register_schema("silu_", "silu_(Tensor(a!) self) -> Tensor(a)")
+    registry.register_schema("mish_", "mish_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("reciprocal_", "reciprocal_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("pow_", "pow_(Tensor(a!) self, Any exponent) -> Tensor(a)")
     registry.register_schema("bitwise_and_", "bitwise_and_(Tensor(a!) self, Any other) -> Tensor(a)")

--- a/tests/contract/test_autograd_audit_inventory.py
+++ b/tests/contract/test_autograd_audit_inventory.py
@@ -79,6 +79,7 @@ INPLACE_OR_MUTATION_OPS = {
     "log1p_",
     "log2_",
     "log_",
+    "mish_",
     "neg_",
     "pow_",
     "randint_",
@@ -87,6 +88,7 @@ INPLACE_OR_MUTATION_OPS = {
     "rsqrt_",
     "sigmoid_",
     "sign_",
+    "silu_",
     "sin_",
     "sinh_",
     "sqrt_",
@@ -238,7 +240,7 @@ def test_schema_ops_without_autograd_registration_are_categorized():
     actual_missing = _schema_ops() - _autograd_registered_ops()
     assert sorted(actual_missing - expected_missing) == []
     assert sorted(expected_missing - actual_missing) == []
-    assert len(actual_missing) == 104
+    assert len(actual_missing) == 106
 
 
 def test_derivatives_not_implemented_inventory_is_classified():

--- a/tests/contract/test_mechanism_audit_pr1.py
+++ b/tests/contract/test_mechanism_audit_pr1.py
@@ -175,11 +175,11 @@ def test_npu_forward_ops_autograd_coverage_categorization_snapshot():
     assert (generated_only & both) == set()
     assert (handwritten_only & both) == set()
 
-    assert len(forward) == 434
+    assert len(forward) == 436
     assert len(generated_only) == 241
     assert len(handwritten_only) == 33
     assert len(both) == 55
-    assert len(missing) == 105
+    assert len(missing) == 107
 
 
 # ---------------------------------------------------------------------------

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1774,6 +1774,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "logical_or",
         "logical_xor",
         "logspace",
+        "mish_",
         "movedim",
         "narrow",
         "neg_",
@@ -1794,6 +1795,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "searchsorted",
         "sigmoid_",
         "sign_",
+        "silu_",
         "sin_",
         "sinh_",
         "slice_copy",
@@ -1812,7 +1814,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
     }
 
     assert missing_autograd == expected_missing
-    assert len(forward_ops) == 434
+    assert len(forward_ops) == 436
     assert len(autograd_ops & forward_ops) == 329
 
 
@@ -2808,3 +2810,32 @@ def test_npu_operator_intake_tranche3i_registers_inplace_digamma_sign():
 
     assert "def fast_digamma_inplace(a):" in pyx_src
     assert "def fast_sign_inplace(a):" in pyx_src
+
+
+def test_npu_operator_intake_tranche3j_registers_inplace_silu_mish():
+    """Operator intake tranche 3j extends the in-place unary surface with
+    `silu_` and `mish_`. Each reuses the existing `aclnnSilu` / `aclnnMish`
+    bindings via a new `fast_*_inplace` Cython helper that aliases output
+    to input — fully NPU-resident. New schemas are registered in
+    `_dispatch/schemas.py`. Unlike prior tranches, both ops live in
+    `ops/activation.py` and use the def-with-guard pattern
+    (`def silu_(a): if _HAS_FAST_SILU_INPLACE: return ...`), not the
+    module-level alias pattern.
+    """
+    activation_src = _source("src/candle/_backends/npu/ops/activation.py")
+    backend_init_src = _source("src/candle/_backends/npu/__init__.py")
+    pyx_src = _source("src/candle/_C/_npu_ops.pyx")
+    schemas_src = _source("src/candle/_dispatch/schemas.py")
+
+    for op_name, has_flag, fast_name in (
+        ("silu_", "_HAS_FAST_SILU_INPLACE", "_fast_silu_inplace_impl"),
+        ("mish_", "_HAS_FAST_MISH_INPLACE", "_fast_mish_inplace_impl"),
+    ):
+        assert f"def {op_name}(a):" in activation_src
+        assert f"if {has_flag}:" in activation_src
+        assert f"return {fast_name}(a)" in activation_src
+        assert f'registry.register("{op_name}", "npu", {op_name}' in backend_init_src
+        assert f'register_schema("{op_name}",' in schemas_src
+
+    assert "def fast_silu_inplace(a):" in pyx_src
+    assert "def fast_mish_inplace(a):" in pyx_src


### PR DESCRIPTION
## Summary

- Adds `silu_` and `mish_` in-place NPU registrations, reusing existing aclnnSilu/aclnnMish bindings via new `fast_silu_inplace` / `fast_mish_inplace` Cython helpers (output aliased to input).
- Both ops live in `ops/activation.py` and use the def-with-guard pattern (`def silu_(a): if _HAS_FAST_SILU_INPLACE: return ...`), not the module-level alias pattern used in prior tranches. The 3j audit test reflects this.
- Fully NPU-resident, no CPU fallback.

## Test plan

- [x] All 1044 contract tests pass
- [x] Pylint 10.00/10
- [x] `fast_silu_inplace` / `fast_mish_inplace` import cleanly
- [x] `aten::silu_` / `aten::mish_` registered with NPU kernel
- [x] Audit counts bumped: forward 434→436, missing 105→107 (mechanism_audit_pr1); 104→106 (autograd_audit_inventory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)