### PR TITLE
feat(npu): register relu6_/hardtanh_ in-place (intake tranche 3k)

### DIFF
--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -38,6 +38,7 @@ from .ops import (
     floor,
     frac,
     hardtanh,
+    hardtanh_,
     isfinite,
     isinf,
     isnan,
@@ -50,6 +51,7 @@ from .ops import (
     mul,
     neg,
     relu6,
+    relu6_,
     sign,
     signbit,
     square,
@@ -512,7 +514,9 @@ registry.register("clamp", "npu", clamp, meta=meta_infer.infer_unary)
 registry.register("clamp_min", "npu", clamp_min, meta=meta_infer.infer_unary)
 registry.register("clamp_max", "npu", clamp_max, meta=meta_infer.infer_unary)
 registry.register("relu6", "npu", relu6, meta=meta_infer.infer_unary)
+registry.register("relu6_", "npu", relu6_, meta=meta_infer.infer_unary)
 registry.register("hardtanh", "npu", hardtanh, meta=meta_infer.infer_unary)
+registry.register("hardtanh_", "npu", hardtanh_, meta=meta_infer.infer_unary)
 registry.register("min", "npu", min_, meta=meta_infer.infer_binary)
 registry.register("max", "npu", max_, meta=meta_infer.infer_binary)
 registry.register("pow", "npu", pow, meta=meta_infer.infer_binary)

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -60,7 +60,7 @@ from .shape import (
 )
 
 from .activation import (
-    relu, relu_, relu6, softplus, hardtanh,
+    relu, relu_, relu6, relu6_, softplus, hardtanh, hardtanh_,
     silu, silu_, gelu, leaky_relu, elu, mish, mish_, prelu,
     selu_op, celu_op, threshold_op,
     hardshrink_op, softshrink_op, hardswish_op, hardsigmoid_op,

--- a/src/candle/_backends/npu/ops/activation.py
+++ b/src/candle/_backends/npu/ops/activation.py
@@ -102,6 +102,7 @@ from ._helpers import (
 from .comparison import gt, lt
 from .elementwise import clamp, where
 from .math import abs, add, div, exp, frac, log, mul, neg, sin, tanh
+from .random import clamp_
 
 
 def relu(a):
@@ -120,6 +121,10 @@ def relu6(a):
     if _HAS_FAST_ACTIVATION_COMPOSITES:
         return _fast_relu6_impl(a)
     raise RuntimeError("Cython NPU relu6 implementation is unavailable")
+
+
+def relu6_(a):
+    return clamp_(a, 0.0, 6.0)
 
 
 def softplus(a, beta=1.0, threshold=20.0):
@@ -149,6 +154,10 @@ def hardtanh(a, min_val=-1.0, max_val=1.0):
                 raise
             return clamp(a, min_val, max_val)
     raise RuntimeError("Cython NPU hardtanh implementation is unavailable")
+
+
+def hardtanh_(a, min_val=-1.0, max_val=1.0):
+    return clamp_(a, min_val, max_val)
 
 
 def silu(a):

--- a/src/candle/_dispatch/schemas.py
+++ b/src/candle/_dispatch/schemas.py
@@ -78,6 +78,8 @@ CORE_SCHEMA_OPS = (
     "sign_",
     "silu_",
     "mish_",
+    "relu6_",
+    "hardtanh_",
     "reciprocal_",
     "pow_",
     "bitwise_and_",
@@ -323,6 +325,11 @@ def register_schemas():
     registry.register_schema("sign_", "sign_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("silu_", "silu_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("mish_", "mish_(Tensor(a!) self) -> Tensor(a)")
+    registry.register_schema("relu6_", "relu6_(Tensor(a!) self) -> Tensor(a)")
+    registry.register_schema(
+        "hardtanh_",
+        "hardtanh_(Tensor(a!) self, Scalar min_val=-1.0, Scalar max_val=1.0) -> Tensor(a)",
+    )
     registry.register_schema("reciprocal_", "reciprocal_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("pow_", "pow_(Tensor(a!) self, Any exponent) -> Tensor(a)")
     registry.register_schema("bitwise_and_", "bitwise_and_(Tensor(a!) self, Any other) -> Tensor(a)")

--- a/tests/contract/test_autograd_audit_inventory.py
+++ b/tests/contract/test_autograd_audit_inventory.py
@@ -75,6 +75,7 @@ INPLACE_OR_MUTATION_OPS = {
     "exp_",
     "expm1_",
     "floor_",
+    "hardtanh_",
     "log10_",
     "log1p_",
     "log2_",
@@ -84,6 +85,7 @@ INPLACE_OR_MUTATION_OPS = {
     "pow_",
     "randint_",
     "reciprocal_",
+    "relu6_",
     "round_",
     "rsqrt_",
     "sigmoid_",
@@ -240,7 +242,7 @@ def test_schema_ops_without_autograd_registration_are_categorized():
     actual_missing = _schema_ops() - _autograd_registered_ops()
     assert sorted(actual_missing - expected_missing) == []
     assert sorted(expected_missing - actual_missing) == []
-    assert len(actual_missing) == 106
+    assert len(actual_missing) == 108
 
 
 def test_derivatives_not_implemented_inventory_is_classified():

--- a/tests/contract/test_mechanism_audit_pr1.py
+++ b/tests/contract/test_mechanism_audit_pr1.py
@@ -175,11 +175,11 @@ def test_npu_forward_ops_autograd_coverage_categorization_snapshot():
     assert (generated_only & both) == set()
     assert (handwritten_only & both) == set()
 
-    assert len(forward) == 436
+    assert len(forward) == 438
     assert len(generated_only) == 241
     assert len(handwritten_only) == 33
     assert len(both) == 55
-    assert len(missing) == 107
+    assert len(missing) == 109
 
 
 # ---------------------------------------------------------------------------

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1756,6 +1756,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "floor_",
         "full",
         "full_like",
+        "hardtanh_",
         "histogram",
         "isclose",
         "isfinite",
@@ -1790,6 +1791,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "randperm",
         "range",
         "reciprocal_",
+        "relu6_",
         "round_",
         "rsqrt_",
         "searchsorted",
@@ -1814,7 +1816,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
     }
 
     assert missing_autograd == expected_missing
-    assert len(forward_ops) == 436
+    assert len(forward_ops) == 438
     assert len(autograd_ops & forward_ops) == 329
 
 
@@ -2839,3 +2841,26 @@ def test_npu_operator_intake_tranche3j_registers_inplace_silu_mish():
 
     assert "def fast_silu_inplace(a):" in pyx_src
     assert "def fast_mish_inplace(a):" in pyx_src
+
+
+def test_npu_operator_intake_tranche3k_registers_inplace_relu6_hardtanh():
+    """Operator intake tranche 3k extends the in-place activation surface
+    with `relu6_` and `hardtanh_`. Unlike prior tranches, these are pure
+    Python composites delegating to the existing `clamp_` in-place op:
+    `relu6_(a) = clamp_(a, 0, 6)`, `hardtanh_(a, mn, mx) = clamp_(a, mn, mx)`.
+    No new Cython work; reuses existing `fast_clamp_inplace` indirectly.
+    """
+    activation_src = _source("src/candle/_backends/npu/ops/activation.py")
+    backend_init_src = _source("src/candle/_backends/npu/__init__.py")
+    schemas_src = _source("src/candle/_dispatch/schemas.py")
+
+    assert "from .random import clamp_" in activation_src
+    assert "def relu6_(a):" in activation_src
+    assert "return clamp_(a, 0.0, 6.0)" in activation_src
+    assert "def hardtanh_(a, min_val=-1.0, max_val=1.0):" in activation_src
+    assert "return clamp_(a, min_val, max_val)" in activation_src
+
+    for op_name in ("relu6_", "hardtanh_"):
+        assert f'registry.register("{op_name}", "npu", {op_name}' in backend_init_src
+        assert f'register_schema(\n        "{op_name}",' in schemas_src or \
+            f'register_schema("{op_name}",' in schemas_src


### PR DESCRIPTION
## Summary

- Adds `relu6_` and `hardtanh_` in-place NPU registrations as pure Python composites delegating to the existing `clamp_` in-place op (no new Cython work).
- `relu6_(a) = clamp_(a, 0.0, 6.0)`, `hardtanh_(a, mn, mx) = clamp_(a, mn, mx)`.
- New pattern in the intake series — earlier tranches used alias-pattern (math.py/special.py) or def-with-guard backed by `fast_*_inplace` Cython helpers. The composite pattern unlocks more in-place activations without adding aclnn bindings.

## Test plan

- [x] All 1045 contract tests pass
- [x] Pylint 10.00/10
- [x] `aten::relu6_` / `aten::hardtanh_` registered with NPU kernel
- [x] Audit counts bumped: forward 436→438, missing 107→109 (mechanism_audit_pr1); 106→108 (autograd_audit_inventory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)