### PR TITLE
feat(npu): register bitwise_and_/bitwise_or_/bitwise_xor_ in-place on NPU (intake tranche 3l)

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -617,6 +617,12 @@ cdef object _sub_getws_ptr = None        # cached Sub getws pointer
 cdef object _sub_exec_ptr = None         # cached Sub exec pointer
 cdef object _div_getws_ptr = None        # cached Div getws pointer
 cdef object _div_exec_ptr = None         # cached Div exec pointer
+cdef object _bitwise_and_getws_ptr = None  # cached BitwiseAndTensor getws pointer
+cdef object _bitwise_and_exec_ptr = None   # cached BitwiseAndTensor exec pointer
+cdef object _bitwise_or_getws_ptr = None   # cached BitwiseOrTensor getws pointer
+cdef object _bitwise_or_exec_ptr = None    # cached BitwiseOrTensor exec pointer
+cdef object _bitwise_xor_getws_ptr = None  # cached BitwiseXorTensor getws pointer
+cdef object _bitwise_xor_exec_ptr = None   # cached BitwiseXorTensor exec pointer
 cdef object _defer_executor_fn = None    # aclnn._defer_executor
 cdef object _acl_rt_malloc_fn = None     # acl.rt.malloc
 cdef object _acl_rt_free_fn = None       # acl.rt.free (for workspace)
@@ -655,6 +661,19 @@ cdef inline void _ensure_ffi_binary() except *:
     if _f.is_pta_cache_available():
         _pta_cache_begin_fn = _f.pta_begin_add_cache_lookup
         _pta_cache_end_fn = _f.pta_end_cache_lookup
+
+
+cdef inline void _ensure_ffi_bitwise() except *:
+    """Resolve and cache BitwiseAnd/Or/Xor getws/exec ptrs (lazy)."""
+    global _bitwise_and_getws_ptr, _bitwise_and_exec_ptr
+    global _bitwise_or_getws_ptr, _bitwise_or_exec_ptr
+    global _bitwise_xor_getws_ptr, _bitwise_xor_exec_ptr
+    if _bitwise_and_getws_ptr is not None:
+        return
+    _ensure_ffi_binary()
+    _bitwise_and_getws_ptr, _bitwise_and_exec_ptr = _ffi_ref.resolve_op("BitwiseAndTensor")
+    _bitwise_or_getws_ptr, _bitwise_or_exec_ptr = _ffi_ref.resolve_op("BitwiseOrTensor")
+    _bitwise_xor_getws_ptr, _bitwise_xor_exec_ptr = _ffi_ref.resolve_op("BitwiseXorTensor")
 
 
 cdef uintptr_t _get_alpha_one(int dtype_code) except? 0:
@@ -1459,6 +1478,109 @@ def fast_div_inplace(a, b):
                 executor, stream_raw)
             if ret != 0:
                 raise RuntimeError(f"aclnnDiv execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
+def fast_bitwise_and_inplace(a, b):
+    """In-place bitwise_and_(a, b) — aliases output ptr to a via aclnnBitwiseAndTensor."""
+    return _fast_bitwise_inplace_dispatch(a, b, "bitwise_and_",
+                                          _bitwise_and_getws_ptr,
+                                          _bitwise_and_exec_ptr,
+                                          "aclnnBitwiseAndTensor")
+
+
+def fast_bitwise_or_inplace(a, b):
+    """In-place bitwise_or_(a, b) — aliases output ptr to a via aclnnBitwiseOrTensor."""
+    return _fast_bitwise_inplace_dispatch(a, b, "bitwise_or_",
+                                          _bitwise_or_getws_ptr,
+                                          _bitwise_or_exec_ptr,
+                                          "aclnnBitwiseOrTensor")
+
+
+def fast_bitwise_xor_inplace(a, b):
+    """In-place bitwise_xor_(a, b) — aliases output ptr to a via aclnnBitwiseXorTensor."""
+    return _fast_bitwise_inplace_dispatch(a, b, "bitwise_xor_",
+                                          _bitwise_xor_getws_ptr,
+                                          _bitwise_xor_exec_ptr,
+                                          "aclnnBitwiseXorTensor")
+
+
+cdef object _fast_bitwise_inplace_dispatch(object a, object b, str name,
+                                            object getws_ptr_unused,
+                                            object exec_ptr_unused,
+                                            str pretty):
+    """Common in-place bitwise tensor op (a = a op b) reusing the existing
+    out-of-place aclnnBitwise<And|Or|Xor>Tensor with output ptr aliased to a."""
+    _ensure_npu_imports()
+    _ensure_ffi_bitwise()
+
+    cdef int dev_idx
+    _validate_npu_binary(a, b, name, &dev_idx)
+
+    a_dtype = a.dtype
+    stream = _get_stream_fast(dev_idx)
+
+    py_a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    py_b_shape = (<TensorImpl>b)._shape_tuple if isinstance(b, TensorImpl) else b.shape
+    cdef int a_ndim = len(py_a_shape)
+    cdef int b_ndim = len(py_b_shape)
+    if a_ndim > MAX_NDIM or b_ndim > MAX_NDIM:
+        raise ValueError(f"ndim exceeds MAX_NDIM ({MAX_NDIM})")
+
+    cdef int64_t[MAX_NDIM] a_shape_buf, b_shape_buf, out_shape_buf
+    _fill_shape(py_a_shape, a_shape_buf, a_ndim)
+    _fill_shape(py_b_shape, b_shape_buf, b_ndim)
+    cdef int out_ndim
+    with nogil:
+        out_ndim = c_broadcast_shape(
+            a_shape_buf, a_ndim, b_shape_buf, b_ndim, out_shape_buf)
+    if out_ndim != a_ndim:
+        raise ValueError(f"NPU {name} requires broadcastable to self shape")
+    cdef int i
+    for i in range(out_ndim):
+        if out_shape_buf[i] != a_shape_buf[i]:
+            raise ValueError(f"NPU {name} requires broadcastable to self shape")
+
+    runtime = _get_runtime_fast(dev_idx)
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr = a._storage._untyped._device_ptr
+    cdef uintptr_t b_ptr = b._storage._untyped._device_ptr
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    if name == "bitwise_and_":
+        getws_ptr = _bitwise_and_getws_ptr
+        exec_ptr = _bitwise_and_exec_ptr
+    elif name == "bitwise_or_":
+        getws_ptr = _bitwise_or_getws_ptr
+        exec_ptr = _bitwise_or_exec_ptr
+    else:
+        getws_ptr = _bitwise_xor_getws_ptr
+        exec_ptr = _bitwise_xor_exec_ptr
+
+    ws_size, executor = _ffi_ref.binary_two_inputs_op(
+        getws_ptr, exec_ptr,
+        py_a_shape, a.stride,
+        py_b_shape, b.stride,
+        py_a_shape, a.stride,
+        dtype_code, dtype_code, dtype_code,
+        2,
+        int(a_ptr), int(b_ptr), int(a_ptr),
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"{pretty} execute failed: {ret}")
         finally:
             runtime.defer_raw_free(workspace_ptr)
 

--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -274,6 +274,9 @@ from .ops import (
     bitwise_and,
     bitwise_or,
     bitwise_xor,
+    bitwise_and_,
+    bitwise_or_,
+    bitwise_xor_,
     # Math ops
     expm1,
     log1p,
@@ -601,6 +604,9 @@ registry.register("bitwise_not", "npu", bitwise_not, meta=meta_infer.infer_unary
 registry.register("bitwise_and", "npu", bitwise_and, meta=meta_infer.infer_binary)
 registry.register("bitwise_or", "npu", bitwise_or, meta=meta_infer.infer_binary)
 registry.register("bitwise_xor", "npu", bitwise_xor, meta=meta_infer.infer_binary)
+registry.register("bitwise_and_", "npu", bitwise_and_, meta=meta_infer.infer_binary)
+registry.register("bitwise_or_", "npu", bitwise_or_, meta=meta_infer.infer_binary)
+registry.register("bitwise_xor_", "npu", bitwise_xor_, meta=meta_infer.infer_binary)
 # Math ops
 registry.register("expm1", "npu", expm1, meta=meta_infer.infer_unary)
 registry.register("log1p", "npu", log1p, meta=meta_infer.infer_unary)

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -21,6 +21,7 @@ from .comparison import (
     eq, ne, le, lt, gt, ge,
     logical_and, logical_or, logical_not, logical_xor,
     bitwise_not, bitwise_and, bitwise_or, bitwise_xor,
+    bitwise_and_, bitwise_or_, bitwise_xor_,
     equal, allclose, isclose,
 )
 

--- a/src/candle/_backends/npu/ops/comparison.py
+++ b/src/candle/_backends/npu/ops/comparison.py
@@ -17,6 +17,9 @@ try:
         fast_bitwise_and as _fast_bitwise_and_impl,
         fast_bitwise_or as _fast_bitwise_or_impl,
         fast_bitwise_xor as _fast_bitwise_xor_impl,
+        fast_bitwise_and_inplace as _fast_bitwise_and_inplace_impl,
+        fast_bitwise_or_inplace as _fast_bitwise_or_inplace_impl,
+        fast_bitwise_xor_inplace as _fast_bitwise_xor_inplace_impl,
     )  # pylint: disable=import-error,no-name-in-module
     _HAS_FAST_LOGICAL_NOT = True
     _HAS_FAST_BITWISE_NOT = True
@@ -33,6 +36,9 @@ try:
     _HAS_FAST_BITWISE_AND = True
     _HAS_FAST_BITWISE_OR = True
     _HAS_FAST_BITWISE_XOR = True
+    _HAS_FAST_BITWISE_AND_INPLACE = True
+    _HAS_FAST_BITWISE_OR_INPLACE = True
+    _HAS_FAST_BITWISE_XOR_INPLACE = True
 except ImportError:
     _fast_logical_not_impl = None  # type: ignore[assignment]
     _fast_bitwise_not_impl = None  # type: ignore[assignment]
@@ -49,6 +55,9 @@ except ImportError:
     _fast_bitwise_and_impl = None  # type: ignore[assignment]
     _fast_bitwise_or_impl = None  # type: ignore[assignment]
     _fast_bitwise_xor_impl = None  # type: ignore[assignment]
+    _fast_bitwise_and_inplace_impl = None  # type: ignore[assignment]
+    _fast_bitwise_or_inplace_impl = None  # type: ignore[assignment]
+    _fast_bitwise_xor_inplace_impl = None  # type: ignore[assignment]
     _HAS_FAST_LOGICAL_NOT = False
     _HAS_FAST_BITWISE_NOT = False
     _HAS_FAST_ISCLOSE = False
@@ -64,6 +73,9 @@ except ImportError:
     _HAS_FAST_BITWISE_AND = False
     _HAS_FAST_BITWISE_OR = False
     _HAS_FAST_BITWISE_XOR = False
+    _HAS_FAST_BITWISE_AND_INPLACE = False
+    _HAS_FAST_BITWISE_OR_INPLACE = False
+    _HAS_FAST_BITWISE_XOR_INPLACE = False
 
 from ._helpers import (
     _unwrap_storage, _wrap_tensor,
@@ -172,6 +184,11 @@ def bitwise_xor(a, b):
     if _HAS_FAST_BITWISE_XOR:
         return _fast_bitwise_xor_impl(a, b)
     raise RuntimeError("Cython NPU bitwise_xor implementation is unavailable")
+
+
+bitwise_and_ = _fast_bitwise_and_inplace_impl
+bitwise_or_ = _fast_bitwise_or_inplace_impl
+bitwise_xor_ = _fast_bitwise_xor_inplace_impl
 
 
 def equal(a, b):

--- a/tests/contract/test_mechanism_audit_pr1.py
+++ b/tests/contract/test_mechanism_audit_pr1.py
@@ -175,11 +175,11 @@ def test_npu_forward_ops_autograd_coverage_categorization_snapshot():
     assert (generated_only & both) == set()
     assert (handwritten_only & both) == set()
 
-    assert len(forward) == 438
+    assert len(forward) == 441
     assert len(generated_only) == 241
     assert len(handwritten_only) == 33
     assert len(both) == 55
-    assert len(missing) == 109
+    assert len(missing) == 112
 
 
 # ---------------------------------------------------------------------------

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1732,9 +1732,12 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "atanh_",
         "bincount",
         "bitwise_and",
+        "bitwise_and_",
         "bitwise_not",
         "bitwise_or",
+        "bitwise_or_",
         "bitwise_xor",
+        "bitwise_xor_",
         "bucketize",
         "cartesian_prod",
         "ceil_",
@@ -1816,7 +1819,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
     }
 
     assert missing_autograd == expected_missing
-    assert len(forward_ops) == 438
+    assert len(forward_ops) == 441
     assert len(autograd_ops & forward_ops) == 329
 
 
@@ -2864,3 +2867,33 @@ def test_npu_operator_intake_tranche3k_registers_inplace_relu6_hardtanh():
         assert f'registry.register("{op_name}", "npu", {op_name}' in backend_init_src
         assert f'register_schema(\n        "{op_name}",' in schemas_src or \
             f'register_schema("{op_name}",' in schemas_src
+
+
+def test_npu_operator_intake_tranche3l_registers_inplace_bitwise_ops():
+    """Operator intake tranche 3l extends the in-place binary surface with
+    `bitwise_and_`, `bitwise_or_`, and `bitwise_xor_`. Each reuses the existing
+    `aclnnBitwiseAndTensor` / `aclnnBitwiseOrTensor` / `aclnnBitwiseXorTensor`
+    bindings via new `fast_bitwise_<op>_inplace` Cython helpers that alias the
+    output ptr to the `a` ptr through `_ffi_ref.binary_two_inputs_op` —
+    fully NPU-resident. Schemas already exist in `_dispatch/schemas.py`.
+    Both ops live in `ops/comparison.py` and use the module-level alias
+    pattern (`bitwise_and_ = _fast_bitwise_and_inplace_impl`).
+    """
+    comparison_src = _source("src/candle/_backends/npu/ops/comparison.py")
+    backend_init_src = _source("src/candle/_backends/npu/__init__.py")
+    pyx_src = _source("src/candle/_C/_npu_ops.pyx")
+    schemas_src = _source("src/candle/_dispatch/schemas.py")
+
+    for op_name, fast_name in (
+        ("bitwise_and_", "_fast_bitwise_and_inplace_impl"),
+        ("bitwise_or_", "_fast_bitwise_or_inplace_impl"),
+        ("bitwise_xor_", "_fast_bitwise_xor_inplace_impl"),
+    ):
+        assert f"{op_name} = {fast_name}" in comparison_src
+        assert f'registry.register("{op_name}", "npu", {op_name}' in backend_init_src
+        assert f'register_schema("{op_name}",' in schemas_src
+
+    assert "def fast_bitwise_and_inplace(a, b):" in pyx_src
+    assert "def fast_bitwise_or_inplace(a, b):" in pyx_src
+    assert "def fast_bitwise_xor_inplace(a, b):" in pyx_src
+    assert "_ensure_ffi_bitwise()" in pyx_src


### PR DESCRIPTION
## Summary

- Adds three new Cython in-place helpers (`fast_bitwise_and_inplace`, `fast_bitwise_or_inplace`, `fast_bitwise_xor_inplace`) that reuse the existing `aclnnBitwise<And|Or|Xor>Tensor` bindings via `_ffi_ref.binary_two_inputs_op` with the output ptr aliased to the `a` ptr — fully NPU-resident.
- Wires `bitwise_and_`, `bitwise_or_`, `bitwise_xor_` into `_backends/npu/ops/comparison.py` using the module-level alias pattern and registers them on the NPU forward dispatch.
- Schemas for these ops already exist in `_dispatch/schemas.py`; no schema additions needed.
- Audit count anchors bumped: forward 438→441, missing 109→112 in `test_npu_mechanism_audit.py` and `test_mechanism_audit_pr1.py`. (No change in `test_autograd_audit_inventory.py` since schemas were already present.)
- Adds a tranche 3l audit test asserting the alias pattern and Cython entry points.

## Test plan

- [x] `pylint src/candle/ --rcfile=.github/pylint.conf` → 10.00/10 (existing R0915 warning unchanged at 408/400, exit 0)
- [x] `pytest tests/contract/test_npu_mechanism_audit.py tests/contract/test_autograd_audit_inventory.py -v` → 101 passed
- [x] `pytest tests/cpu/ tests/contract/ -q` → 3412 passed, 30 skipped (PR1 snapshot count assertion bumped)
- [x] Cython rebuilt, symbols import OK, dispatcher routes all three `aten::bitwise_<op>_` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)