### PR TITLE
feat(npu): register pow_ in-place on NPU (intake tranche 3m)

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -623,6 +623,8 @@ cdef object _bitwise_or_getws_ptr = None   # cached BitwiseOrTensor getws pointe
 cdef object _bitwise_or_exec_ptr = None    # cached BitwiseOrTensor exec pointer
 cdef object _bitwise_xor_getws_ptr = None  # cached BitwiseXorTensor getws pointer
 cdef object _bitwise_xor_exec_ptr = None   # cached BitwiseXorTensor exec pointer
+cdef object _pow_getws_ptr = None          # cached PowTensorTensor getws pointer
+cdef object _pow_exec_ptr = None           # cached PowTensorTensor exec pointer
 cdef object _defer_executor_fn = None    # aclnn._defer_executor
 cdef object _acl_rt_malloc_fn = None     # acl.rt.malloc
 cdef object _acl_rt_free_fn = None       # acl.rt.free (for workspace)
@@ -674,6 +676,15 @@ cdef inline void _ensure_ffi_bitwise() except *:
     _bitwise_and_getws_ptr, _bitwise_and_exec_ptr = _ffi_ref.resolve_op("BitwiseAndTensor")
     _bitwise_or_getws_ptr, _bitwise_or_exec_ptr = _ffi_ref.resolve_op("BitwiseOrTensor")
     _bitwise_xor_getws_ptr, _bitwise_xor_exec_ptr = _ffi_ref.resolve_op("BitwiseXorTensor")
+
+
+cdef inline void _ensure_ffi_pow() except *:
+    """Resolve and cache PowTensorTensor getws/exec ptrs (lazy)."""
+    global _pow_getws_ptr, _pow_exec_ptr
+    if _pow_getws_ptr is not None:
+        return
+    _ensure_ffi_binary()
+    _pow_getws_ptr, _pow_exec_ptr = _ffi_ref.resolve_op("PowTensorTensor")
 
 
 cdef uintptr_t _get_alpha_one(int dtype_code) except? 0:
@@ -1594,6 +1605,76 @@ def fast_pow(a, b):
 
 def fast_pow_tensor_scalar(a, exponent):
     return fast_pow(a, _npu_scalar_like(exponent, a))
+
+
+def fast_pow_inplace(a, b):
+    """In-place pow_(a, b) — aliases output ptr to a via aclnnPowTensorTensor.
+
+    Reuses the existing out-of-place aclnnPowTensorTensor with the output
+    pointer aliased to the `a` pointer. Caller must ensure b is broadcastable
+    to a's shape.
+    """
+    _ensure_npu_imports()
+    _ensure_ffi_pow()
+
+    cdef int dev_idx
+    _validate_npu_binary(a, b, "pow_", &dev_idx)
+
+    a_dtype = a.dtype
+    stream = _get_stream_fast(dev_idx)
+
+    py_a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    py_b_shape = (<TensorImpl>b)._shape_tuple if isinstance(b, TensorImpl) else b.shape
+    cdef int a_ndim = len(py_a_shape)
+    cdef int b_ndim = len(py_b_shape)
+    if a_ndim > MAX_NDIM or b_ndim > MAX_NDIM:
+        raise ValueError(f"ndim exceeds MAX_NDIM ({MAX_NDIM})")
+
+    cdef int64_t[MAX_NDIM] a_shape_buf, b_shape_buf, out_shape_buf
+    _fill_shape(py_a_shape, a_shape_buf, a_ndim)
+    _fill_shape(py_b_shape, b_shape_buf, b_ndim)
+    cdef int out_ndim
+    with nogil:
+        out_ndim = c_broadcast_shape(
+            a_shape_buf, a_ndim, b_shape_buf, b_ndim, out_shape_buf)
+    if out_ndim != a_ndim:
+        raise ValueError("NPU pow_ requires broadcastable to self shape")
+    cdef int i
+    for i in range(out_ndim):
+        if out_shape_buf[i] != a_shape_buf[i]:
+            raise ValueError("NPU pow_ requires broadcastable to self shape")
+
+    runtime = _get_runtime_fast(dev_idx)
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr = a._storage._untyped._device_ptr
+    cdef uintptr_t b_ptr = b._storage._untyped._device_ptr
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.binary_two_inputs_op(
+        _pow_getws_ptr, _pow_exec_ptr,
+        py_a_shape, a.stride,
+        py_b_shape, b.stride,
+        py_a_shape, a.stride,
+        dtype_code, dtype_code, dtype_code,
+        2,
+        int(a_ptr), int(b_ptr), int(a_ptr),
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _pow_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnPowTensorTensor execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
 
 
 def fast_floor_divide(a, b):

--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -56,6 +56,7 @@ from .ops import (
     signbit,
     square,
     pow,
+    pow_,
     relu,
     round,
     rsqrt,
@@ -523,6 +524,7 @@ registry.register("hardtanh_", "npu", hardtanh_, meta=meta_infer.infer_unary)
 registry.register("min", "npu", min_, meta=meta_infer.infer_binary)
 registry.register("max", "npu", max_, meta=meta_infer.infer_binary)
 registry.register("pow", "npu", pow, meta=meta_infer.infer_binary)
+registry.register("pow_", "npu", pow_, meta=meta_infer.infer_binary)
 # Element-wise min/max
 registry.register("maximum", "npu", maximum, meta=meta_infer.infer_binary)
 registry.register("minimum", "npu", minimum, meta=meta_infer.infer_binary)

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -14,7 +14,7 @@ from .math import (
     sinh, cosh, erf, erfc, floor, ceil, round, trunc, frac,
     log2, log10, exp2, expm1, log1p,
     asin, acos, atan, asinh, acosh, atanh,
-    atan2, pow, floor_divide, reciprocal,
+    atan2, pow, pow_, floor_divide, reciprocal,
 )
 
 from .comparison import (

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -70,6 +70,7 @@ try:
         fast_neg_inplace as _fast_neg_inplace_impl,
         fast_pow as _fast_pow_impl,
         fast_pow_tensor_scalar as _fast_pow_tensor_scalar_impl,
+        fast_pow_inplace as _fast_pow_inplace_impl,
         fast_reciprocal as _fast_reciprocal_impl,
         fast_round as _fast_round_impl,
         fast_round_inplace as _fast_round_inplace_impl,
@@ -144,6 +145,7 @@ try:
     _HAS_FAST_MUL = True
     _HAS_FAST_POW = True
     _HAS_FAST_POW_TENSOR_SCALAR = True
+    _HAS_FAST_POW_INPLACE = True
     _HAS_FAST_SUB = True
     _HAS_FAST_ADD_INPLACE = True
     _HAS_FAST_SUB_INPLACE = True
@@ -155,6 +157,7 @@ except ImportError:
     _fast_neg_impl = None  # type: ignore[assignment]
     _fast_pow_impl = None  # type: ignore[assignment]
     _fast_pow_tensor_scalar_impl = None  # type: ignore[assignment]
+    _fast_pow_inplace_impl = None  # type: ignore[assignment]
     _fast_sign_impl = None  # type: ignore[assignment]
     _fast_signbit_impl = None  # type: ignore[assignment]
     _fast_isfinite_impl = None  # type: ignore[assignment]
@@ -245,6 +248,7 @@ except ImportError:
     _HAS_FAST_MUL = False
     _HAS_FAST_POW = False
     _HAS_FAST_POW_TENSOR_SCALAR = False
+    _HAS_FAST_POW_INPLACE = False
     _HAS_FAST_SUB = False
     _HAS_FAST_ADD_INPLACE = False
     _HAS_FAST_SUB_INPLACE = False
@@ -696,6 +700,14 @@ def pow(a, b):
     if _HAS_FAST_POW_TENSOR_SCALAR:
         return _fast_pow_tensor_scalar_impl(a, b)
     raise RuntimeError("Cython NPU pow tensor-scalar implementation is unavailable")
+
+
+def pow_(a, b):
+    if isinstance(b, (int, float)):
+        b = _scalar_to_npu_tensor(b, a)
+    if _HAS_FAST_POW_INPLACE:
+        return _fast_pow_inplace_impl(a, b)
+    raise RuntimeError("Cython NPU pow_ implementation is unavailable")
 
 
 def floor_divide(a, b):

--- a/tests/contract/test_mechanism_audit_pr1.py
+++ b/tests/contract/test_mechanism_audit_pr1.py
@@ -175,11 +175,11 @@ def test_npu_forward_ops_autograd_coverage_categorization_snapshot():
     assert (generated_only & both) == set()
     assert (handwritten_only & both) == set()
 
-    assert len(forward) == 441
+    assert len(forward) == 442
     assert len(generated_only) == 241
     assert len(handwritten_only) == 33
     assert len(both) == 55
-    assert len(missing) == 112
+    assert len(missing) == 113
 
 
 # ---------------------------------------------------------------------------

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1784,6 +1784,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "neg_",
         "ones",
         "ones_like",
+        "pow_",
         "rand",
         "rand_like",
         "randint",
@@ -1819,7 +1820,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
     }
 
     assert missing_autograd == expected_missing
-    assert len(forward_ops) == 441
+    assert len(forward_ops) == 442
     assert len(autograd_ops & forward_ops) == 329
 
 
@@ -2897,3 +2898,27 @@ def test_npu_operator_intake_tranche3l_registers_inplace_bitwise_ops():
     assert "def fast_bitwise_or_inplace(a, b):" in pyx_src
     assert "def fast_bitwise_xor_inplace(a, b):" in pyx_src
     assert "_ensure_ffi_bitwise()" in pyx_src
+
+
+def test_npu_operator_intake_tranche3m_registers_inplace_pow():
+    """Operator intake tranche 3m extends the in-place binary surface with
+    `pow_`. It reuses the existing `aclnnPowTensorTensor` binding via a new
+    `fast_pow_inplace` Cython helper that aliases the output ptr to the `a`
+    ptr through `_ffi_ref.binary_two_inputs_op` — fully NPU-resident.
+    Schema already exists in `_dispatch/schemas.py`. `pow_` lives in
+    `ops/math.py` and uses the def-with-guard pattern (not the module-level
+    alias) so it can promote scalar exponents to NPU tensors before
+    delegating to the fast helper.
+    """
+    math_src = _source("src/candle/_backends/npu/ops/math.py")
+    backend_init_src = _source("src/candle/_backends/npu/__init__.py")
+    pyx_src = _source("src/candle/_C/_npu_ops.pyx")
+    schemas_src = _source("src/candle/_dispatch/schemas.py")
+
+    assert "def pow_(a, b):" in math_src
+    assert "_fast_pow_inplace_impl" in math_src
+    assert "_HAS_FAST_POW_INPLACE" in math_src
+    assert 'registry.register("pow_", "npu", pow_' in backend_init_src
+    assert 'register_schema("pow_",' in schemas_src
+    assert "def fast_pow_inplace(a, b):" in pyx_src
+    assert "_ensure_ffi_pow()" in pyx_src


### PR DESCRIPTION
## Summary

- Adds `pow_` in-place to the NPU op registry via a new `fast_pow_inplace` Cython helper that aliases the output ptr to `a` through `_ffi_ref.binary_two_inputs_op` and reuses the existing `aclnnPowTensorTensor` binding.
- `pow_` lives in `ops/math.py` and uses the def-with-guard pattern so it can promote scalar exponents to NPU tensors via `_scalar_to_npu_tensor` before delegating to the fast helper (mirrors the functional `pow` scalar branch).
- Schema already exists in `_dispatch/schemas.py`. PR1 audit counts bump: forward 441→442, missing 112→113. Adds a tranche 3m audit test asserting the def-with-guard pattern plus Cython entry points.

## Test plan

- [x] `pylint src/candle/ --rcfile=.github/pylint.conf` — 10.00/10
- [x] `pytest tests/cpu/ tests/contract/ -v --tb=short` — 3413 passed, 30 skipped
- [x] Cython rebuild and `from candle._C._npu_ops import fast_pow_inplace` import verified