### PR TITLE
feat(npu): register elu_/leaky_relu_ in-place on NPU (intake tranche 3n)

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -4928,6 +4928,112 @@ def fast_elu(a, alpha):
     return _cy_make_npu_tensor(out_ptr, n, a_dtype, a_dev, out_shape, out_stride)
 
 
+def fast_leaky_relu_inplace(a, negative_slope):
+    """In-place leaky_relu_(a, negative_slope) using aclnnLeakyRelu with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_leaky_relu()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+
+    scalar_handle = _create_scalar_fn(_scalar_bytes_fn(negative_slope, a_dtype), dtype_code)
+    cdef uintptr_t stream_raw = int(stream.stream)
+    try:
+        ws_size, executor = _ffi_ref.leaky_relu_op(
+            _leaky_relu_getws_ptr, _leaky_relu_exec_ptr,
+            a_shape, a_stride,
+            a_shape, a_stride,
+            dtype_code, 2,
+            a_ptr, a_ptr,
+            scalar_handle,
+            stream_raw)
+
+        if ws_size:
+            workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+            if ret != 0:
+                raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+            try:
+                ret = _ffi_ref.execute(
+                    _leaky_relu_exec_ptr, int(workspace_ptr), ws_size,
+                    executor, stream_raw)
+                if ret != 0:
+                    raise RuntimeError(f"aclnnLeakyRelu execute failed: {ret}")
+            finally:
+                runtime.defer_raw_free(workspace_ptr)
+
+        _defer_executor_fn(executor)
+    finally:
+        _destroy_scalar_fn(int(scalar_handle))
+
+    return a
+
+
+def fast_elu_inplace(a, alpha):
+    """In-place elu_(a, alpha) using aclnnElu with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_elu()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+
+    alpha_scalar = _create_scalar_fn(_scalar_bytes_fn(alpha, a_dtype), dtype_code)
+    scale_scalar = _create_scalar_fn(_scalar_bytes_fn(1.0, a_dtype), dtype_code)
+    input_scale_scalar = _create_scalar_fn(_scalar_bytes_fn(1.0, a_dtype), dtype_code)
+    cdef uintptr_t stream_raw = int(stream.stream)
+    try:
+        ws_size, executor = _ffi_ref.tensor_three_scalars_op(
+            _elu_getws_ptr, _elu_exec_ptr,
+            a_shape, a_stride,
+            a_shape, a_stride,
+            dtype_code, dtype_code, 2,
+            a_ptr, a_ptr,
+            alpha_scalar, scale_scalar, input_scale_scalar,
+            stream_raw)
+
+        if ws_size:
+            workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+            if ret != 0:
+                raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+            try:
+                ret = _ffi_ref.execute(
+                    _elu_exec_ptr, int(workspace_ptr), ws_size,
+                    executor, stream_raw)
+                if ret != 0:
+                    raise RuntimeError(f"aclnnElu execute failed: {ret}")
+            finally:
+                runtime.defer_raw_free(workspace_ptr)
+
+        _defer_executor_fn(executor)
+    finally:
+        _destroy_scalar_fn(int(alpha_scalar))
+        _destroy_scalar_fn(int(scale_scalar))
+        _destroy_scalar_fn(int(input_scale_scalar))
+
+    return a
+
+
 def fast_clamp(a, min_val=None, max_val=None):
     """Optimized clamp(a, min_val, max_val) that calls _ffi.clamp_optional_scalars_op directly."""
     _ensure_npu_imports()

--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -207,7 +207,9 @@ from .ops import (
     silu,
     silu_,
     leaky_relu,
+    leaky_relu_,
     elu,
+    elu_,
     mish,
     mish_,
     prelu,
@@ -706,7 +708,9 @@ registry.register("embedding", "npu", embedding, meta=meta_infer.infer_binary)
 registry.register("silu", "npu", silu, meta=meta_infer.infer_unary)
 registry.register("silu_", "npu", silu_, meta=meta_infer.infer_unary)
 registry.register("leaky_relu", "npu", leaky_relu, meta=meta_infer.infer_unary)
+registry.register("leaky_relu_", "npu", leaky_relu_, meta=meta_infer.infer_unary)
 registry.register("elu", "npu", elu, meta=meta_infer.infer_unary)
+registry.register("elu_", "npu", elu_, meta=meta_infer.infer_unary)
 registry.register("mish", "npu", mish, meta=meta_infer.infer_unary)
 registry.register("mish_", "npu", mish_, meta=meta_infer.infer_unary)
 registry.register("prelu", "npu", prelu, meta=meta_infer.infer_binary)

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -62,7 +62,7 @@ from .shape import (
 
 from .activation import (
     relu, relu_, relu6, relu6_, softplus, hardtanh, hardtanh_,
-    silu, silu_, gelu, leaky_relu, elu, mish, mish_, prelu,
+    silu, silu_, gelu, leaky_relu, leaky_relu_, elu, elu_, mish, mish_, prelu,
     selu_op, celu_op, threshold_op,
     hardshrink_op, softshrink_op, hardswish_op, hardsigmoid_op,
     softsign_op, rrelu_op,

--- a/src/candle/_backends/npu/ops/activation.py
+++ b/src/candle/_backends/npu/ops/activation.py
@@ -12,7 +12,9 @@ try:
         fast_softmax as _fast_softmax_impl,
         fast_log_softmax as _fast_log_softmax_impl,
         fast_leaky_relu as _fast_leaky_relu_impl,
+        fast_leaky_relu_inplace as _fast_leaky_relu_inplace_impl,
         fast_elu as _fast_elu_impl,
+        fast_elu_inplace as _fast_elu_inplace_impl,
         fast_silu as _fast_silu_impl,
         fast_silu_inplace as _fast_silu_inplace_impl,
         fast_gelu as _fast_gelu_impl,
@@ -40,6 +42,8 @@ try:
     _HAS_FAST_LOG_SOFTMAX = True
     _HAS_FAST_LEAKY_RELU = True
     _HAS_FAST_ELU = True
+    _HAS_FAST_LEAKY_RELU_INPLACE = True
+    _HAS_FAST_ELU_INPLACE = True
     _HAS_FAST_SILU = True
     _HAS_FAST_SILU_INPLACE = True
     _HAS_FAST_GELU = True
@@ -57,7 +61,9 @@ except ImportError:
     _fast_softmax_impl = None  # type: ignore[assignment]
     _fast_log_softmax_impl = None  # type: ignore[assignment]
     _fast_leaky_relu_impl = None  # type: ignore[assignment]
+    _fast_leaky_relu_inplace_impl = None  # type: ignore[assignment]
     _fast_elu_impl = None  # type: ignore[assignment]
+    _fast_elu_inplace_impl = None  # type: ignore[assignment]
     _fast_silu_impl = None  # type: ignore[assignment]
     _fast_silu_inplace_impl = None  # type: ignore[assignment]
     _fast_gelu_impl = None  # type: ignore[assignment]
@@ -84,6 +90,8 @@ except ImportError:
     _HAS_FAST_LOG_SOFTMAX = False
     _HAS_FAST_LEAKY_RELU = False
     _HAS_FAST_ELU = False
+    _HAS_FAST_LEAKY_RELU_INPLACE = False
+    _HAS_FAST_ELU_INPLACE = False
     _HAS_FAST_SILU = False
     _HAS_FAST_SILU_INPLACE = False
     _HAS_FAST_GELU = False
@@ -184,10 +192,22 @@ def leaky_relu(a, negative_slope=0.01):
     raise RuntimeError("Cython NPU leaky_relu implementation is unavailable")
 
 
+def leaky_relu_(a, negative_slope=0.01):
+    if _HAS_FAST_LEAKY_RELU_INPLACE:
+        return _fast_leaky_relu_inplace_impl(a, negative_slope)
+    raise RuntimeError("Cython NPU leaky_relu_ implementation is unavailable")
+
+
 def elu(a, alpha=1.0):
     if _HAS_FAST_ELU:
         return _fast_elu_impl(a, alpha)
     raise RuntimeError("Cython NPU elu implementation is unavailable")
+
+
+def elu_(a, alpha=1.0):
+    if _HAS_FAST_ELU_INPLACE:
+        return _fast_elu_inplace_impl(a, alpha)
+    raise RuntimeError("Cython NPU elu_ implementation is unavailable")
 
 
 def mish(a):

--- a/src/candle/_dispatch/schemas.py
+++ b/src/candle/_dispatch/schemas.py
@@ -330,6 +330,14 @@ def register_schemas():
         "hardtanh_",
         "hardtanh_(Tensor(a!) self, Scalar min_val=-1.0, Scalar max_val=1.0) -> Tensor(a)",
     )
+    registry.register_schema(
+        "elu_",
+        "elu_(Tensor(a!) self, Scalar alpha=1.0) -> Tensor(a)",
+    )
+    registry.register_schema(
+        "leaky_relu_",
+        "leaky_relu_(Tensor(a!) self, Scalar negative_slope=0.01) -> Tensor(a)",
+    )
     registry.register_schema("reciprocal_", "reciprocal_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("pow_", "pow_(Tensor(a!) self, Any exponent) -> Tensor(a)")
     registry.register_schema("bitwise_and_", "bitwise_and_(Tensor(a!) self, Any other) -> Tensor(a)")

--- a/tests/contract/test_autograd_audit_inventory.py
+++ b/tests/contract/test_autograd_audit_inventory.py
@@ -68,6 +68,7 @@ INPLACE_OR_MUTATION_OPS = {
     "cos_",
     "cosh_",
     "digamma_",
+    "elu_",
     "erf_",
     "erfc_",
     "erfinv_",
@@ -76,6 +77,7 @@ INPLACE_OR_MUTATION_OPS = {
     "expm1_",
     "floor_",
     "hardtanh_",
+    "leaky_relu_",
     "log10_",
     "log1p_",
     "log2_",
@@ -242,7 +244,7 @@ def test_schema_ops_without_autograd_registration_are_categorized():
     actual_missing = _schema_ops() - _autograd_registered_ops()
     assert sorted(actual_missing - expected_missing) == []
     assert sorted(expected_missing - actual_missing) == []
-    assert len(actual_missing) == 108
+    assert len(actual_missing) == 110
 
 
 def test_derivatives_not_implemented_inventory_is_classified():

--- a/tests/contract/test_mechanism_audit_pr1.py
+++ b/tests/contract/test_mechanism_audit_pr1.py
@@ -175,11 +175,11 @@ def test_npu_forward_ops_autograd_coverage_categorization_snapshot():
     assert (generated_only & both) == set()
     assert (handwritten_only & both) == set()
 
-    assert len(forward) == 442
+    assert len(forward) == 444
     assert len(generated_only) == 241
     assert len(handwritten_only) == 33
     assert len(both) == 55
-    assert len(missing) == 113
+    assert len(missing) == 115
 
 
 # ---------------------------------------------------------------------------

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1744,6 +1744,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "cos_",
         "cosh_",
         "digamma_",
+        "elu_",
         "empty",
         "empty_like",
         "equal",
@@ -1768,6 +1769,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "isneginf",
         "isposinf",
         "isreal",
+        "leaky_relu_",
         "linspace",
         "log10_",
         "log1p_",
@@ -1820,7 +1822,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
     }
 
     assert missing_autograd == expected_missing
-    assert len(forward_ops) == 442
+    assert len(forward_ops) == 444
     assert len(autograd_ops & forward_ops) == 329
 
 
@@ -2922,3 +2924,33 @@ def test_npu_operator_intake_tranche3m_registers_inplace_pow():
     assert 'register_schema("pow_",' in schemas_src
     assert "def fast_pow_inplace(a, b):" in pyx_src
     assert "_ensure_ffi_pow()" in pyx_src
+
+
+def test_npu_operator_intake_tranche3n_registers_inplace_elu_leaky_relu():
+    """Operator intake tranche 3n extends the in-place activation surface with
+    `elu_` and `leaky_relu_`. Each reuses the existing `aclnnElu` /
+    `aclnnLeakyRelu` bindings via new `fast_elu_inplace` /
+    `fast_leaky_relu_inplace` Cython helpers that alias the output ptr to
+    the `a` ptr — fully NPU-resident. New schemas are added in
+    `_dispatch/schemas.py`. Both ops live in `ops/activation.py` and use
+    the def-with-guard pattern (`def elu_(a, alpha=1.0): if
+    _HAS_FAST_ELU_INPLACE: ...`) since they take scalar parameters.
+    """
+    activation_src = _source("src/candle/_backends/npu/ops/activation.py")
+    backend_init_src = _source("src/candle/_backends/npu/__init__.py")
+    pyx_src = _source("src/candle/_C/_npu_ops.pyx")
+    schemas_src = _source("src/candle/_dispatch/schemas.py")
+
+    for op_name, fast_name, guard in (
+        ("elu_", "_fast_elu_inplace_impl", "_HAS_FAST_ELU_INPLACE"),
+        ("leaky_relu_", "_fast_leaky_relu_inplace_impl",
+         "_HAS_FAST_LEAKY_RELU_INPLACE"),
+    ):
+        assert f"def {op_name}(" in activation_src
+        assert fast_name in activation_src
+        assert guard in activation_src
+        assert f'registry.register("{op_name}", "npu", {op_name}' in backend_init_src
+        assert f'register_schema(\n        "{op_name}",' in schemas_src
+
+    assert "def fast_elu_inplace(a, alpha):" in pyx_src
+    assert "def fast_leaky_relu_inplace(a, negative_slope):" in pyx_src


### PR DESCRIPTION
## Summary

- Adds `elu_` and `leaky_relu_` to the NPU op registry via new `fast_elu_inplace` / `fast_leaky_relu_inplace` Cython helpers that alias the output ptr to `a` and reuse the existing `aclnnElu` / `aclnnLeakyRelu` bindings.
- New schemas added in `_dispatch/schemas.py` (these in-place variants were absent). Both ops live in `ops/activation.py` and use the def-with-guard pattern since they take scalar parameters (`alpha`, `negative_slope`).
- PR1 audit counts bump: forward 442→444, missing 113→115. Adds `elu_`/`leaky_relu_` to `INPLACE_OR_MUTATION_OPS` audit set (count 108→110). Adds a tranche 3n audit test asserting the def-with-guard pattern plus Cython entry points.

## Test plan

- [x] `pylint src/candle/ --rcfile=.github/pylint.conf` — 10.00/10
- [x] `pytest tests/contract/ -v --tb=short` — 1048 passed, 5 skipped
- [x] Cython rebuild + `from candle._C._npu_ops import fast_elu_inplace, fast_leaky_relu_inplace` import verified