### PR TITLE
feat(npu): register addcmul_/addcdiv_/lerp_ in-place (batch 78)

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -8451,6 +8451,267 @@ def fast_addcdiv(a, b, c, value):
 
 
 
+def fast_addcmul_inplace(a, b, c, value):
+    """In-place addcmul_(a, b, c, value) — aliases output ptr to a via aclnnAddcmul."""
+    _ensure_npu_imports()
+    _ensure_ffi_addcmul()
+
+    cdef int dev_idx
+    _validate_npu_binary(a, b, "addcmul_", &dev_idx)
+    if c.device.type != "npu":
+        raise ValueError("NPU addcmul_ expects NPU tensors")
+    if c.dtype != a.dtype:
+        raise ValueError("NPU addcmul_ requires matching dtypes")
+
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    py_a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    py_b_shape = (<TensorImpl>b)._shape_tuple if isinstance(b, TensorImpl) else b.shape
+    py_c_shape = (<TensorImpl>c)._shape_tuple if isinstance(c, TensorImpl) else c.shape
+
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr, b_ptr, c_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    if isinstance(b, TensorImpl):
+        b_ptr = <uintptr_t>(<TensorImpl>b)._storage._untyped._device_ptr
+    else:
+        b_ptr = <uintptr_t>b.storage().data_ptr()
+    if isinstance(c, TensorImpl):
+        c_ptr = <uintptr_t>(<TensorImpl>c)._storage._untyped._device_ptr
+    else:
+        c_ptr = <uintptr_t>c.storage().data_ptr()
+
+    scalar_handle = _create_scalar_fn(_scalar_bytes_fn(value, a_dtype), dtype_code)
+    cdef uintptr_t stream_raw = int(stream.stream)
+    try:
+        ws_size, executor = _ffi_ref.three_tensor_scalar_op(
+            _addcmul_getws_ptr, _addcmul_exec_ptr,
+            py_a_shape, a.stride,
+            py_b_shape, b.stride,
+            py_c_shape, c.stride,
+            py_a_shape, a.stride,
+            dtype_code, dtype_code, dtype_code, dtype_code, 2,
+            a_ptr, b_ptr, c_ptr, a_ptr,
+            scalar_handle,
+            stream_raw)
+
+        if ws_size:
+            workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+            if ret != 0:
+                raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+            try:
+                ret = _ffi_ref.execute(
+                    _addcmul_exec_ptr, int(workspace_ptr), ws_size,
+                    executor, stream_raw)
+                if ret != 0:
+                    raise RuntimeError(f"aclnnAddcmul execute failed: {ret}")
+            finally:
+                runtime.defer_raw_free(workspace_ptr)
+
+        _defer_executor_fn(executor)
+    finally:
+        _destroy_scalar_fn(int(scalar_handle))
+
+    return a
+
+
+def fast_addcdiv_inplace(a, b, c, value):
+    """In-place addcdiv_(a, b, c, value) — aliases output ptr to a via aclnnAddcdiv."""
+    _ensure_npu_imports()
+    _ensure_ffi_addcdiv()
+
+    cdef int dev_idx
+    _validate_npu_binary(a, b, "addcdiv_", &dev_idx)
+    if c.device.type != "npu":
+        raise ValueError("NPU addcdiv_ expects NPU tensors")
+    if c.dtype != a.dtype:
+        raise ValueError("NPU addcdiv_ requires matching dtypes")
+
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    py_a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    py_b_shape = (<TensorImpl>b)._shape_tuple if isinstance(b, TensorImpl) else b.shape
+    py_c_shape = (<TensorImpl>c)._shape_tuple if isinstance(c, TensorImpl) else c.shape
+
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr, b_ptr, c_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    if isinstance(b, TensorImpl):
+        b_ptr = <uintptr_t>(<TensorImpl>b)._storage._untyped._device_ptr
+    else:
+        b_ptr = <uintptr_t>b.storage().data_ptr()
+    if isinstance(c, TensorImpl):
+        c_ptr = <uintptr_t>(<TensorImpl>c)._storage._untyped._device_ptr
+    else:
+        c_ptr = <uintptr_t>c.storage().data_ptr()
+
+    scalar_handle = _create_scalar_fn(_scalar_bytes_fn(value, a_dtype), dtype_code)
+    cdef uintptr_t stream_raw = int(stream.stream)
+    try:
+        ws_size, executor = _ffi_ref.three_tensor_scalar_op(
+            _addcdiv_getws_ptr, _addcdiv_exec_ptr,
+            py_a_shape, a.stride,
+            py_b_shape, b.stride,
+            py_c_shape, c.stride,
+            py_a_shape, a.stride,
+            dtype_code, dtype_code, dtype_code, dtype_code, 2,
+            a_ptr, b_ptr, c_ptr, a_ptr,
+            scalar_handle,
+            stream_raw)
+
+        if ws_size:
+            workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+            if ret != 0:
+                raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+            try:
+                ret = _ffi_ref.execute(
+                    _addcdiv_exec_ptr, int(workspace_ptr), ws_size,
+                    executor, stream_raw)
+                if ret != 0:
+                    raise RuntimeError(f"aclnnAddcdiv execute failed: {ret}")
+            finally:
+                runtime.defer_raw_free(workspace_ptr)
+
+        _defer_executor_fn(executor)
+    finally:
+        _destroy_scalar_fn(int(scalar_handle))
+
+    return a
+
+
+def fast_lerp_tensor_inplace(a, b, weight):
+    """In-place lerp_(a, b, weight_tensor) — aliases output ptr to a via aclnnLerp."""
+    _ensure_npu_imports()
+    _ensure_ffi_lerp()
+
+    cdef int dev_idx
+    _validate_npu_binary(a, b, "lerp_", &dev_idx)
+    if weight.device.type != "npu":
+        raise ValueError("NPU lerp_ expects NPU tensors")
+    if weight.dtype != a.dtype:
+        raise ValueError("NPU lerp_ requires matching dtypes")
+
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    py_a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    py_b_shape = (<TensorImpl>b)._shape_tuple if isinstance(b, TensorImpl) else b.shape
+    py_w_shape = (<TensorImpl>weight)._shape_tuple if isinstance(weight, TensorImpl) else weight.shape
+
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr, b_ptr, w_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    if isinstance(b, TensorImpl):
+        b_ptr = <uintptr_t>(<TensorImpl>b)._storage._untyped._device_ptr
+    else:
+        b_ptr = <uintptr_t>b.storage().data_ptr()
+    if isinstance(weight, TensorImpl):
+        w_ptr = <uintptr_t>(<TensorImpl>weight)._storage._untyped._device_ptr
+    else:
+        w_ptr = <uintptr_t>weight.storage().data_ptr()
+
+    cdef uintptr_t stream_raw = int(stream.stream)
+    ws_size, executor = _ffi_ref.four_tensor_op(
+        _lerp_getws_ptr, _lerp_exec_ptr,
+        py_a_shape, a.stride,
+        py_b_shape, b.stride,
+        py_w_shape, weight.stride,
+        py_a_shape, a.stride,
+        dtype_code, dtype_code, dtype_code, dtype_code, 2,
+        a_ptr, b_ptr, w_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _lerp_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnLerp execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
+def fast_lerp_scalar_inplace(a, b, value):
+    """In-place lerp_(a, b, scalar) — aliases output ptr to a via aclnnLerps."""
+    _ensure_npu_imports()
+    _ensure_ffi_lerps()
+
+    cdef int dev_idx
+    _validate_npu_binary(a, b, "lerp_", &dev_idx)
+
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    py_a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    py_b_shape = (<TensorImpl>b)._shape_tuple if isinstance(b, TensorImpl) else b.shape
+
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr, b_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    if isinstance(b, TensorImpl):
+        b_ptr = <uintptr_t>(<TensorImpl>b)._storage._untyped._device_ptr
+    else:
+        b_ptr = <uintptr_t>b.storage().data_ptr()
+
+    scalar_handle = _create_scalar_fn(_scalar_bytes_fn(value, a_dtype), dtype_code)
+    cdef uintptr_t stream_raw = int(stream.stream)
+    try:
+        ws_size, executor = _ffi_ref.two_tensor_scalar_op(
+            _lerps_getws_ptr, _lerps_exec_ptr,
+            py_a_shape, a.stride,
+            py_b_shape, b.stride,
+            py_a_shape, a.stride,
+            dtype_code, dtype_code, dtype_code, 2,
+            a_ptr, b_ptr, a_ptr,
+            scalar_handle,
+            stream_raw)
+
+        if ws_size:
+            workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+            if ret != 0:
+                raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+            try:
+                ret = _ffi_ref.execute(
+                    _lerps_exec_ptr, int(workspace_ptr), ws_size,
+                    executor, stream_raw)
+                if ret != 0:
+                    raise RuntimeError(f"aclnnLerps execute failed: {ret}")
+            finally:
+                runtime.defer_raw_free(workspace_ptr)
+
+        _defer_executor_fn(executor)
+    finally:
+        _destroy_scalar_fn(int(scalar_handle))
+
+    return a
+
+
+
 def cy_npu_synchronize(int device_id=0):
     """Fast NPU synchronize: skip Python imports, Device construction, activate().
 

--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -171,7 +171,9 @@ from .ops import (
     div,
     acosh,
     addcdiv,
+    addcdiv_,
     addcmul,
+    addcmul_,
     allclose,
     asin,
     asinh,
@@ -191,6 +193,7 @@ from .ops import (
     hypot,
     isclose,
     lerp,
+    lerp_,
     logaddexp,
     logaddexp2,
     max_,
@@ -621,8 +624,11 @@ registry.register("searchsorted", "npu", searchsorted, meta=meta_infer.infer_una
 registry.register("unique", "npu", unique)
 registry.register("flatten", "npu", flatten_op, meta=meta_infer.infer_view)
 registry.register("lerp", "npu", lerp, meta=meta_infer.infer_binary)
+registry.register("lerp_", "npu", lerp_, meta=meta_infer.infer_binary)
 registry.register("addcmul", "npu", addcmul, meta=meta_infer.infer_binary)
+registry.register("addcmul_", "npu", addcmul_, meta=meta_infer.infer_binary)
 registry.register("addcdiv", "npu", addcdiv, meta=meta_infer.infer_binary)
+registry.register("addcdiv_", "npu", addcdiv_, meta=meta_infer.infer_binary)
 registry.register("logaddexp", "npu", logaddexp, meta=meta_infer.infer_binary)
 registry.register("logaddexp2", "npu", logaddexp2, meta=meta_infer.infer_binary)
 registry.register("hypot", "npu", hypot, meta=meta_infer.infer_binary)

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -115,7 +115,7 @@ from .random import (
 )
 
 from .elementwise import (
-    where, lerp, addcmul, addcdiv,
+    where, lerp, lerp_, addcmul, addcmul_, addcdiv, addcdiv_,
     logaddexp, logaddexp2, hypot,
     remainder, fmod,
     clamp, clamp_min, clamp_max,

--- a/src/candle/_backends/npu/ops/elementwise.py
+++ b/src/candle/_backends/npu/ops/elementwise.py
@@ -4,8 +4,12 @@ try:
         fast_where as _fast_where_impl,
         fast_lerp_tensor as _fast_lerp_tensor_impl,
         fast_lerp_scalar as _fast_lerp_scalar_impl,
+        fast_lerp_tensor_inplace as _fast_lerp_tensor_inplace_impl,
+        fast_lerp_scalar_inplace as _fast_lerp_scalar_inplace_impl,
         fast_addcmul as _fast_addcmul_impl,
         fast_addcdiv as _fast_addcdiv_impl,
+        fast_addcmul_inplace as _fast_addcmul_inplace_impl,
+        fast_addcdiv_inplace as _fast_addcdiv_inplace_impl,
         fast_fmod as _fast_fmod_impl,
         fast_hypot as _fast_hypot_impl,
         fast_logaddexp as _fast_logaddexp_impl,
@@ -18,8 +22,12 @@ try:
     _HAS_FAST_WHERE = True
     _HAS_FAST_LERP_TENSOR = True
     _HAS_FAST_LERP_SCALAR = True
+    _HAS_FAST_LERP_TENSOR_INPLACE = True
+    _HAS_FAST_LERP_SCALAR_INPLACE = True
     _HAS_FAST_ADDCMUL = True
     _HAS_FAST_ADDCDIV = True
+    _HAS_FAST_ADDCMUL_INPLACE = True
+    _HAS_FAST_ADDCDIV_INPLACE = True
     _HAS_FAST_FMOD = True
     _HAS_FAST_HYPOT = True
     _HAS_FAST_LOGADDEXP = True
@@ -32,8 +40,12 @@ except ImportError:
     _fast_where_impl = None  # type: ignore[assignment]
     _fast_lerp_tensor_impl = None  # type: ignore[assignment]
     _fast_lerp_scalar_impl = None  # type: ignore[assignment]
+    _fast_lerp_tensor_inplace_impl = None  # type: ignore[assignment]
+    _fast_lerp_scalar_inplace_impl = None  # type: ignore[assignment]
     _fast_addcmul_impl = None  # type: ignore[assignment]
     _fast_addcdiv_impl = None  # type: ignore[assignment]
+    _fast_addcmul_inplace_impl = None  # type: ignore[assignment]
+    _fast_addcdiv_inplace_impl = None  # type: ignore[assignment]
     _fast_fmod_impl = None  # type: ignore[assignment]
     _fast_hypot_impl = None  # type: ignore[assignment]
     _fast_logaddexp_impl = None  # type: ignore[assignment]
@@ -45,8 +57,12 @@ except ImportError:
     _HAS_FAST_WHERE = False
     _HAS_FAST_LERP_TENSOR = False
     _HAS_FAST_LERP_SCALAR = False
+    _HAS_FAST_LERP_TENSOR_INPLACE = False
+    _HAS_FAST_LERP_SCALAR_INPLACE = False
     _HAS_FAST_ADDCMUL = False
     _HAS_FAST_ADDCDIV = False
+    _HAS_FAST_ADDCMUL_INPLACE = False
+    _HAS_FAST_ADDCDIV_INPLACE = False
     _HAS_FAST_FMOD = False
     _HAS_FAST_HYPOT = False
     _HAS_FAST_LOGADDEXP = False
@@ -118,16 +134,36 @@ def lerp(a, b, weight):
     raise RuntimeError("Cython NPU lerp implementation is unavailable")
 
 
+def lerp_(a, b, weight):
+    if hasattr(weight, "shape") and _HAS_FAST_LERP_TENSOR_INPLACE:
+        return _fast_lerp_tensor_inplace_impl(a, b, weight)
+    if not hasattr(weight, "shape") and _HAS_FAST_LERP_SCALAR_INPLACE:
+        return _fast_lerp_scalar_inplace_impl(a, b, float(weight))
+    raise RuntimeError("Cython NPU lerp_ implementation is unavailable")
+
+
 def addcmul(a, b, c, value=1.0):
     if _HAS_FAST_ADDCMUL:
         return _fast_addcmul_impl(a, b, c, float(value))
     raise RuntimeError("Cython NPU addcmul implementation is unavailable")
 
 
+def addcmul_(a, b, c, value=1.0):
+    if _HAS_FAST_ADDCMUL_INPLACE:
+        return _fast_addcmul_inplace_impl(a, b, c, float(value))
+    raise RuntimeError("Cython NPU addcmul_ implementation is unavailable")
+
+
 def addcdiv(a, b, c, value=1.0):
     if _HAS_FAST_ADDCDIV:
         return _fast_addcdiv_impl(a, b, c, float(value))
     raise RuntimeError("Cython NPU addcdiv implementation is unavailable")
+
+
+def addcdiv_(a, b, c, value=1.0):
+    if _HAS_FAST_ADDCDIV_INPLACE:
+        return _fast_addcdiv_inplace_impl(a, b, c, float(value))
+    raise RuntimeError("Cython NPU addcdiv_ implementation is unavailable")
 
 
 def logaddexp(a, b):

--- a/src/candle/_dispatch/schemas.py
+++ b/src/candle/_dispatch/schemas.py
@@ -338,6 +338,18 @@ def register_schemas():
         "leaky_relu_",
         "leaky_relu_(Tensor(a!) self, Scalar negative_slope=0.01) -> Tensor(a)",
     )
+    registry.register_schema(
+        "addcmul_",
+        "addcmul_(Tensor(a!) self, Tensor tensor1, Tensor tensor2, *, Scalar value=1.0) -> Tensor(a)",
+    )
+    registry.register_schema(
+        "addcdiv_",
+        "addcdiv_(Tensor(a!) self, Tensor tensor1, Tensor tensor2, *, Scalar value=1.0) -> Tensor(a)",
+    )
+    registry.register_schema(
+        "lerp_",
+        "lerp_(Tensor(a!) self, Tensor end, Any weight) -> Tensor(a)",
+    )
     registry.register_schema("reciprocal_", "reciprocal_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("pow_", "pow_(Tensor(a!) self, Any exponent) -> Tensor(a)")
     registry.register_schema("bitwise_and_", "bitwise_and_(Tensor(a!) self, Any other) -> Tensor(a)")

--- a/tests/contract/test_autograd_audit_inventory.py
+++ b/tests/contract/test_autograd_audit_inventory.py
@@ -57,6 +57,8 @@ INPLACE_OR_MUTATION_OPS = {
     "abs_",
     "acos_",
     "acosh_",
+    "addcdiv_",
+    "addcmul_",
     "asin_",
     "asinh_",
     "atan_",
@@ -78,6 +80,7 @@ INPLACE_OR_MUTATION_OPS = {
     "floor_",
     "hardtanh_",
     "leaky_relu_",
+    "lerp_",
     "log10_",
     "log1p_",
     "log2_",
@@ -244,7 +247,7 @@ def test_schema_ops_without_autograd_registration_are_categorized():
     actual_missing = _schema_ops() - _autograd_registered_ops()
     assert sorted(actual_missing - expected_missing) == []
     assert sorted(expected_missing - actual_missing) == []
-    assert len(actual_missing) == 110
+    assert len(actual_missing) == 113
 
 
 def test_derivatives_not_implemented_inventory_is_classified():

--- a/tests/contract/test_mechanism_audit_pr1.py
+++ b/tests/contract/test_mechanism_audit_pr1.py
@@ -175,11 +175,11 @@ def test_npu_forward_ops_autograd_coverage_categorization_snapshot():
     assert (generated_only & both) == set()
     assert (handwritten_only & both) == set()
 
-    assert len(forward) == 444
+    assert len(forward) == 447
     assert len(generated_only) == 241
     assert len(handwritten_only) == 33
     assert len(both) == 55
-    assert len(missing) == 115
+    assert len(missing) == 118
 
 
 # ---------------------------------------------------------------------------

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1719,6 +1719,8 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "abs_",
         "acos_",
         "acosh_",
+        "addcdiv_",
+        "addcmul_",
         "allclose",
         "arange",
         "argmax",
@@ -1770,6 +1772,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "isposinf",
         "isreal",
         "leaky_relu_",
+        "lerp_",
         "linspace",
         "log10_",
         "log1p_",
@@ -1822,7 +1825,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
     }
 
     assert missing_autograd == expected_missing
-    assert len(forward_ops) == 444
+    assert len(forward_ops) == 447
     assert len(autograd_ops & forward_ops) == 329
 
 
@@ -2954,3 +2957,43 @@ def test_npu_operator_intake_tranche3n_registers_inplace_elu_leaky_relu():
 
     assert "def fast_elu_inplace(a, alpha):" in pyx_src
     assert "def fast_leaky_relu_inplace(a, negative_slope):" in pyx_src
+
+
+def test_npu_operator_intake_tranche3o_registers_inplace_addcmul_addcdiv_lerp():
+    """Operator intake tranche 3o extends the in-place elementwise surface
+    with `addcmul_`, `addcdiv_`, and `lerp_`. Each reuses the existing
+    `aclnnAddcmul`, `aclnnAddcdiv`, `aclnnLerp`, and `aclnnLerps` bindings
+    via new `fast_addcmul_inplace`, `fast_addcdiv_inplace`,
+    `fast_lerp_tensor_inplace`, and `fast_lerp_scalar_inplace` Cython
+    helpers that alias the output ptr to the `a` ptr — fully NPU-resident.
+    New schemas are added in `_dispatch/schemas.py`. All three ops live
+    in `ops/elementwise.py` and use the def-with-guard pattern since they
+    take ternary inputs plus scalar parameters. `lerp_` dispatches between
+    tensor-weight and scalar-weight paths.
+    """
+    elementwise_src = _source("src/candle/_backends/npu/ops/elementwise.py")
+    backend_init_src = _source("src/candle/_backends/npu/__init__.py")
+    pyx_src = _source("src/candle/_C/_npu_ops.pyx")
+    schemas_src = _source("src/candle/_dispatch/schemas.py")
+
+    for op_name, fast_name, guard in (
+        ("addcmul_", "_fast_addcmul_inplace_impl",
+         "_HAS_FAST_ADDCMUL_INPLACE"),
+        ("addcdiv_", "_fast_addcdiv_inplace_impl",
+         "_HAS_FAST_ADDCDIV_INPLACE"),
+        ("lerp_", "_fast_lerp_tensor_inplace_impl",
+         "_HAS_FAST_LERP_TENSOR_INPLACE"),
+    ):
+        assert f"def {op_name}(" in elementwise_src
+        assert fast_name in elementwise_src
+        assert guard in elementwise_src
+        assert f'registry.register("{op_name}", "npu", {op_name}' in backend_init_src
+        assert f'register_schema(\n        "{op_name}",' in schemas_src
+
+    assert "_fast_lerp_scalar_inplace_impl" in elementwise_src
+    assert "_HAS_FAST_LERP_SCALAR_INPLACE" in elementwise_src
+
+    assert "def fast_addcmul_inplace(a, b, c, value):" in pyx_src
+    assert "def fast_addcdiv_inplace(a, b, c, value):" in pyx_src
+    assert "def fast_lerp_tensor_inplace(a, b, weight):" in pyx_src
+    assert "def fast_lerp_scalar_inplace(a, b, value):" in pyx_src


### PR DESCRIPTION
## Summary

- Operator intake tranche 3o adds three in-place elementwise ops to the NPU surface: `addcmul_`, `addcdiv_`, and `lerp_`.
- All three reuse existing aclnn bindings via new `fast_*_inplace` Cython helpers that alias the output ptr to `a`'s ptr.
- New schemas added; Python wrappers in `ops/elementwise.py` use the def-with-guard pattern since they take ternary inputs plus scalar parameters.

## Details

* `addcmul_(a, b, c, value=1.0)` — `aclnnAddcmul` via `_ffi_ref.three_tensor_scalar_op`.
* `addcdiv_(a, b, c, value=1.0)` — `aclnnAddcdiv` via `_ffi_ref.three_tensor_scalar_op`.
* `lerp_(a, b, weight)` — dispatches between `aclnnLerp` (tensor weight, `_ffi_ref.four_tensor_op`) and `aclnnLerps` (scalar weight, `_ffi_ref.two_tensor_scalar_op`).

Audit counts bumped: forward 444→447, missing 115→118, INPLACE_OR_MUTATION_OPS 110→113.

## Test plan

- [x] `pylint src/candle/ --rcfile=.github/pylint.conf` → 10.00/10
- [x] `pytest tests/cpu/ tests/contract/ -v --tb=short` → 3415 passed, 30 skipped
- [x] New tranche 3o audit test asserts def-with-guard pattern, registration, and Cython entry points

🤖 Generated with [Claude Code](https://claude.com/claude-code)