### PR TITLE
refactor(npu): register lgamma_ in-place op (batch 78)

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -7531,6 +7531,51 @@ def fast_digamma_inplace(a):
     return a
 
 
+def fast_lgamma_inplace(a):
+    """In-place lgamma_(a) using aclnnLgamma with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_lgamma()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _lgamma_getws_ptr, _lgamma_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _lgamma_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnLgamma execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
 def fast_sign_inplace(a):
     """In-place sign_(a) using aclnnSign with output aliased to input."""
     _ensure_npu_imports()

--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -349,6 +349,7 @@ from .ops import (
     digamma_,
     special_erfinv,
     special_gammaln,
+    lgamma_,
     special_sinc,
     linalg_inv,
     linalg_vector_norm_op,
@@ -593,6 +594,7 @@ registry.register("rsqrt_", "npu", rsqrt_, meta=meta_infer.infer_unary)
 registry.register("square_", "npu", square_, meta=meta_infer.infer_unary)
 registry.register("sign_", "npu", sign_, meta=meta_infer.infer_unary)
 registry.register("digamma_", "npu", digamma_, meta=meta_infer.infer_unary)
+registry.register("lgamma_", "npu", lgamma_, meta=meta_infer.infer_unary)
 registry.register("sub_", "npu", sub_, meta=meta_infer.infer_binary)
 registry.register("sub", "npu", sub, meta=meta_infer.infer_binary)
 registry.register("div", "npu", div, meta=meta_infer.infer_binary)

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -128,6 +128,7 @@ from .elementwise import (
 from .special import (
     special_digamma, special_erfinv, special_gammaln, special_sinc,
     digamma_,
+    lgamma_,
     special_entr_op, special_erfcx_op, special_logit_op,
     special_ndtr_op, special_log_ndtr_op,
     special_xlogy_op, special_xlog1py_op, special_multigammaln_op,

--- a/src/candle/_backends/npu/ops/special.py
+++ b/src/candle/_backends/npu/ops/special.py
@@ -13,6 +13,7 @@ try:
         fast_digamma_inplace as _fast_digamma_inplace_impl,
         fast_erfinv as _fast_erfinv_impl,
         fast_lgamma as _fast_lgamma_impl,
+        fast_lgamma_inplace as _fast_lgamma_inplace_impl,
     )
     _HAS_FAST_SPECIAL_COMPOSITES = True
     _HAS_FAST_SPECIAL_UNARY = True
@@ -29,6 +30,7 @@ except ImportError:
     _fast_digamma_inplace_impl = None  # type: ignore[assignment]
     _fast_erfinv_impl = None  # type: ignore[assignment]
     _fast_lgamma_impl = None  # type: ignore[assignment]
+    _fast_lgamma_inplace_impl = None  # type: ignore[assignment]
     _HAS_FAST_SPECIAL_COMPOSITES = False
     _HAS_FAST_SPECIAL_UNARY = False
 
@@ -58,6 +60,9 @@ special_erfinv = _fast_erfinv_impl
 
 
 special_gammaln = _fast_lgamma_impl
+
+
+lgamma_ = _fast_lgamma_inplace_impl
 
 
 def special_sinc(a):

--- a/src/candle/_dispatch/schemas.py
+++ b/src/candle/_dispatch/schemas.py
@@ -75,6 +75,7 @@ CORE_SCHEMA_OPS = (
     "rsqrt_",
     "square_",
     "digamma_",
+    "lgamma_",
     "sign_",
     "silu_",
     "mish_",
@@ -322,6 +323,7 @@ def register_schemas():
     registry.register_schema("rsqrt_", "rsqrt_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("square_", "square_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("digamma_", "digamma_(Tensor(a!) self) -> Tensor(a)")
+    registry.register_schema("lgamma_", "lgamma_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("sign_", "sign_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("silu_", "silu_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("mish_", "mish_(Tensor(a!) self) -> Tensor(a)")

--- a/tests/contract/test_autograd_audit_inventory.py
+++ b/tests/contract/test_autograd_audit_inventory.py
@@ -81,6 +81,7 @@ INPLACE_OR_MUTATION_OPS = {
     "hardtanh_",
     "leaky_relu_",
     "lerp_",
+    "lgamma_",
     "log10_",
     "log1p_",
     "log2_",
@@ -247,7 +248,7 @@ def test_schema_ops_without_autograd_registration_are_categorized():
     actual_missing = _schema_ops() - _autograd_registered_ops()
     assert sorted(actual_missing - expected_missing) == []
     assert sorted(expected_missing - actual_missing) == []
-    assert len(actual_missing) == 113
+    assert len(actual_missing) == 114
 
 
 def test_derivatives_not_implemented_inventory_is_classified():

--- a/tests/contract/test_mechanism_audit_pr1.py
+++ b/tests/contract/test_mechanism_audit_pr1.py
@@ -175,11 +175,11 @@ def test_npu_forward_ops_autograd_coverage_categorization_snapshot():
     assert (generated_only & both) == set()
     assert (handwritten_only & both) == set()
 
-    assert len(forward) == 449
+    assert len(forward) == 450
     assert len(generated_only) == 241
     assert len(handwritten_only) == 33
     assert len(both) == 55
-    assert len(missing) == 120
+    assert len(missing) == 121
 
 
 # ---------------------------------------------------------------------------

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1775,6 +1775,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "isreal",
         "leaky_relu_",
         "lerp_",
+        "lgamma_",
         "linspace",
         "log10_",
         "log1p_",
@@ -1827,7 +1828,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
     }
 
     assert missing_autograd == expected_missing
-    assert len(forward_ops) == 449
+    assert len(forward_ops) == 450
     assert len(autograd_ops & forward_ops) == 329
 
 
@@ -3038,3 +3039,29 @@ def test_npu_operator_intake_tranche3p_registers_bitwise_left_right_shift():
     assert 'name == "bitwise_right_shift"' in pyx_src
     assert '"LeftShift"' in pyx_src
     assert '"RightShift"' in pyx_src
+
+
+def test_npu_operator_intake_tranche3q_registers_inplace_lgamma():
+    """Operator intake tranche 3q extends the in-place unary surface with
+    `lgamma_`. It reuses the existing `aclnnLgamma` binding via a new
+    `fast_lgamma_inplace` Cython helper that aliases output to input —
+    fully NPU-resident. The schema is added to `_dispatch/schemas.py`
+    after `digamma_`. The Python alias lives in `ops/special.py`
+    alongside `digamma_` and `special_gammaln` (which already aliases
+    `_fast_lgamma_impl`).
+
+    `lgamma_` lands in the missing-autograd bucket (no derivative
+    formula for the in-place form), tracked in
+    `INPLACE_OR_MUTATION_OPS`.
+    """
+    special_src = _source("src/candle/_backends/npu/ops/special.py")
+    backend_init_src = _source("src/candle/_backends/npu/__init__.py")
+    pyx_src = _source("src/candle/_C/_npu_ops.pyx")
+    schemas_src = _source("src/candle/_dispatch/schemas.py")
+
+    assert "def lgamma_(" not in special_src
+    assert "lgamma_ = _fast_lgamma_inplace_impl" in special_src
+    assert 'registry.register("lgamma_", "npu", lgamma_' in backend_init_src
+    assert 'register_schema("lgamma_",' in schemas_src
+    assert "def fast_lgamma_inplace(a):" in pyx_src
+    assert "_ensure_ffi_lgamma()" in pyx_src


### PR DESCRIPTION
## Summary

NPU operator intake tranche 3q: registers the in-place `lgamma_` schema on NPU.

- New `fast_lgamma_inplace` Cython entry point in `_npu_ops.pyx` that aliases output to input through `_ffi_ref.unary_op`, reusing the existing `aclnnLgamma` binding (already wired for `special_gammaln`).
- New `lgamma_` schema in `_dispatch/schemas.py` after `digamma_`.
- Python alias `lgamma_ = _fast_lgamma_inplace_impl` in `ops/special.py` next to `digamma_`; registered on NPU in `_backends/npu/__init__.py`.
- Lands in `INPLACE_OR_MUTATION_OPS` (no derivative formula for the in-place form). Audit counts: NPU forward 449→450, missing-autograd 120→121, INPLACE_OR_MUTATION_OPS 113→114.

## Test plan

- [x] CPU + contract sweep (3417 passed, 30 skipped)
- [x] pylint 10.00/10
- [ ] NPU forward path exercised by audit tests (no hardware run gate in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)