### PR TITLE
refactor(npu): register bitwise_not_ in-place op (batch 79)

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -3477,6 +3477,51 @@ def fast_bitwise_not(a):
     return _cy_make_npu_tensor(out_ptr, n, a_dtype, a_dev, out_shape, out_stride)
 
 
+def fast_bitwise_not_inplace(a):
+    """In-place bitwise_not_(a) using aclnnBitwiseNot with output aliased to input."""
+    _ensure_npu_imports()
+    _ensure_ffi_bitwise_not()
+
+    cdef int dev_idx = a.device.index or 0
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    a_stride = a.stride
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    cdef uintptr_t stream_raw = int(stream.stream)
+
+    ws_size, executor = _ffi_ref.unary_op(
+        _bitwise_not_getws_ptr, _bitwise_not_exec_ptr,
+        a_shape, a_stride,
+        a_shape, a_stride,
+        dtype_code, dtype_code, 2,
+        a_ptr, a_ptr,
+        stream_raw)
+
+    if ws_size:
+        workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+        if ret != 0:
+            raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+        try:
+            ret = _ffi_ref.execute(
+                _bitwise_not_exec_ptr, int(workspace_ptr), ws_size,
+                executor, stream_raw)
+            if ret != 0:
+                raise RuntimeError(f"aclnnBitwiseNot execute failed: {ret}")
+        finally:
+            runtime.defer_raw_free(workspace_ptr)
+
+    _defer_executor_fn(executor)
+    return a
+
+
 def fast_square(a):
     """Optimized out-of-place square(a) that calls _ffi.unary_op directly."""
     _ensure_npu_imports()

--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -285,6 +285,7 @@ from .ops import (
     bitwise_and_,
     bitwise_or_,
     bitwise_xor_,
+    bitwise_not_,
     # Math ops
     expm1,
     log1p,
@@ -620,6 +621,7 @@ registry.register("bitwise_right_shift", "npu", bitwise_right_shift, meta=meta_i
 registry.register("bitwise_and_", "npu", bitwise_and_, meta=meta_infer.infer_binary)
 registry.register("bitwise_or_", "npu", bitwise_or_, meta=meta_infer.infer_binary)
 registry.register("bitwise_xor_", "npu", bitwise_xor_, meta=meta_infer.infer_binary)
+registry.register("bitwise_not_", "npu", bitwise_not_, meta=meta_infer.infer_unary)
 # Math ops
 registry.register("expm1", "npu", expm1, meta=meta_infer.infer_unary)
 registry.register("log1p", "npu", log1p, meta=meta_infer.infer_unary)

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -22,7 +22,7 @@ from .comparison import (
     logical_and, logical_or, logical_not, logical_xor,
     bitwise_not, bitwise_and, bitwise_or, bitwise_xor,
     bitwise_left_shift, bitwise_right_shift,
-    bitwise_and_, bitwise_or_, bitwise_xor_,
+    bitwise_and_, bitwise_or_, bitwise_xor_, bitwise_not_,
     equal, allclose, isclose,
 )
 

--- a/src/candle/_backends/npu/ops/comparison.py
+++ b/src/candle/_backends/npu/ops/comparison.py
@@ -22,6 +22,7 @@ try:
         fast_bitwise_and_inplace as _fast_bitwise_and_inplace_impl,
         fast_bitwise_or_inplace as _fast_bitwise_or_inplace_impl,
         fast_bitwise_xor_inplace as _fast_bitwise_xor_inplace_impl,
+        fast_bitwise_not_inplace as _fast_bitwise_not_inplace_impl,
     )  # pylint: disable=import-error,no-name-in-module
     _HAS_FAST_LOGICAL_NOT = True
     _HAS_FAST_BITWISE_NOT = True
@@ -43,6 +44,7 @@ try:
     _HAS_FAST_BITWISE_AND_INPLACE = True
     _HAS_FAST_BITWISE_OR_INPLACE = True
     _HAS_FAST_BITWISE_XOR_INPLACE = True
+    _HAS_FAST_BITWISE_NOT_INPLACE = True
 except ImportError:
     _fast_logical_not_impl = None  # type: ignore[assignment]
     _fast_bitwise_not_impl = None  # type: ignore[assignment]
@@ -213,6 +215,7 @@ def bitwise_right_shift(a, b):
 bitwise_and_ = _fast_bitwise_and_inplace_impl
 bitwise_or_ = _fast_bitwise_or_inplace_impl
 bitwise_xor_ = _fast_bitwise_xor_inplace_impl
+bitwise_not_ = _fast_bitwise_not_inplace_impl
 
 
 def equal(a, b):

--- a/src/candle/_dispatch/schemas.py
+++ b/src/candle/_dispatch/schemas.py
@@ -86,6 +86,7 @@ CORE_SCHEMA_OPS = (
     "bitwise_and_",
     "bitwise_or_",
     "bitwise_xor_",
+    "bitwise_not_",
     "uniform_",
     "normal_",
     "fill_",
@@ -357,6 +358,7 @@ def register_schemas():
     registry.register_schema("bitwise_and_", "bitwise_and_(Tensor(a!) self, Any other) -> Tensor(a)")
     registry.register_schema("bitwise_or_", "bitwise_or_(Tensor(a!) self, Any other) -> Tensor(a)")
     registry.register_schema("bitwise_xor_", "bitwise_xor_(Tensor(a!) self, Any other) -> Tensor(a)")
+    registry.register_schema("bitwise_not_", "bitwise_not_(Tensor(a!) self) -> Tensor(a)")
     registry.register_schema("uniform_", "uniform_(Tensor(a!) self, float low=0.0, float high=1.0, *, Generator? generator=None) -> Tensor(a)")
     registry.register_schema("normal_", "normal_(Tensor(a!) self, float mean=0.0, float std=1.0, *, Generator? generator=None) -> Tensor(a)")
     registry.register_schema("fill_", "fill_(Tensor(a!) self, Scalar value) -> Tensor(a)")

--- a/tests/contract/test_autograd_audit_inventory.py
+++ b/tests/contract/test_autograd_audit_inventory.py
@@ -64,6 +64,7 @@ INPLACE_OR_MUTATION_OPS = {
     "atan_",
     "atanh_",
     "bitwise_and_",
+    "bitwise_not_",
     "bitwise_or_",
     "bitwise_xor_",
     "ceil_",
@@ -248,7 +249,7 @@ def test_schema_ops_without_autograd_registration_are_categorized():
     actual_missing = _schema_ops() - _autograd_registered_ops()
     assert sorted(actual_missing - expected_missing) == []
     assert sorted(expected_missing - actual_missing) == []
-    assert len(actual_missing) == 114
+    assert len(actual_missing) == 115
 
 
 def test_derivatives_not_implemented_inventory_is_classified():

--- a/tests/contract/test_mechanism_audit_pr1.py
+++ b/tests/contract/test_mechanism_audit_pr1.py
@@ -175,11 +175,11 @@ def test_npu_forward_ops_autograd_coverage_categorization_snapshot():
     assert (generated_only & both) == set()
     assert (handwritten_only & both) == set()
 
-    assert len(forward) == 450
+    assert len(forward) == 451
     assert len(generated_only) == 241
     assert len(handwritten_only) == 33
     assert len(both) == 55
-    assert len(missing) == 121
+    assert len(missing) == 122
 
 
 # ---------------------------------------------------------------------------

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1737,6 +1737,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "bitwise_and_",
         "bitwise_left_shift",
         "bitwise_not",
+        "bitwise_not_",
         "bitwise_or",
         "bitwise_or_",
         "bitwise_right_shift",
@@ -1828,7 +1829,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
     }
 
     assert missing_autograd == expected_missing
-    assert len(forward_ops) == 450
+    assert len(forward_ops) == 451
     assert len(autograd_ops & forward_ops) == 329
 
 
@@ -3065,3 +3066,29 @@ def test_npu_operator_intake_tranche3q_registers_inplace_lgamma():
     assert 'register_schema("lgamma_",' in schemas_src
     assert "def fast_lgamma_inplace(a):" in pyx_src
     assert "_ensure_ffi_lgamma()" in pyx_src
+
+
+def test_npu_operator_intake_tranche3r_registers_inplace_bitwise_not():
+    """Operator intake tranche 3r extends the in-place bitwise surface with
+    `bitwise_not_`. It reuses the existing `aclnnBitwiseNot` binding via a
+    new `fast_bitwise_not_inplace` Cython helper that aliases output to
+    input — fully NPU-resident. The schema is added to
+    `_dispatch/schemas.py` after `bitwise_xor_`. The Python alias lives
+    in `ops/comparison.py` alongside `bitwise_and_`, `bitwise_or_`, and
+    `bitwise_xor_`.
+
+    `bitwise_not_` lands in the missing-autograd bucket (no derivative
+    formula for the in-place form), tracked in
+    `INPLACE_OR_MUTATION_OPS`.
+    """
+    comparison_src = _source("src/candle/_backends/npu/ops/comparison.py")
+    backend_init_src = _source("src/candle/_backends/npu/__init__.py")
+    pyx_src = _source("src/candle/_C/_npu_ops.pyx")
+    schemas_src = _source("src/candle/_dispatch/schemas.py")
+
+    assert "def bitwise_not_(" not in comparison_src
+    assert "bitwise_not_ = _fast_bitwise_not_inplace_impl" in comparison_src
+    assert 'registry.register("bitwise_not_", "npu", bitwise_not_' in backend_init_src
+    assert 'register_schema("bitwise_not_",' in schemas_src
+    assert "def fast_bitwise_not_inplace(a):" in pyx_src
+    assert "_ensure_ffi_bitwise_not()" in pyx_src


### PR DESCRIPTION
## Summary

- Operator intake tranche 3r registers `bitwise_not_` on NPU via the alias pattern
- New `fast_bitwise_not_inplace` Cython helper reuses the existing `aclnnBitwiseNot` binding, aliasing output to input for zero-copy in-place semantics — fully NPU-resident, no CPU fallback
- Python alias lives next to `bitwise_and_/or_/xor_` in `ops/comparison.py`
- Lands in the missing-autograd bucket (no derivative for the in-place form), tracked in `INPLACE_OR_MUTATION_OPS`

## Test plan

- [x] `pytest tests/cpu/ tests/contract/` — 3418 passed, 30 skipped
- [x] `pylint src/candle/` — 10.00/10
- [x] New tranche 3r audit test passes
- [x] NPU forward count: 450 → 451
- [x] Missing-autograd count: 121 → 122
- [x] `INPLACE_OR_MUTATION_OPS` count: 114 → 115

Generated with [Claude Code](https://claude.com/claude-code)