### PR TITLE
feat(npu): wire aclnnUniqueConsecutive into NPU (intake tranche 3s)

### DIFF
--- a/src/candle/_C/_aclnn_ffi.pyx
+++ b/src/candle/_C/_aclnn_ffi.pyx
@@ -9656,3 +9656,101 @@ def rms_norm_op(
             _fast_destroy_tensor(gamma_t)
             _fast_destroy_tensor(y_t)
             _fast_destroy_tensor(rstd_t)
+
+
+def unary_two_bools_int_three_outputs_op(
+        uintptr_t getws_ptr, uintptr_t exec_ptr,
+        self_shape, self_stride,
+        out_shape, out_stride,
+        inverse_shape, inverse_stride,
+        counts_shape, counts_stride,
+        bint flag_a, bint flag_b,
+        int64_t dim_val,
+        int32_t self_dtype_code, int32_t out_dtype_code,
+        int32_t inverse_dtype_code, int32_t counts_dtype_code,
+        int32_t fmt,
+        uintptr_t self_ptr, uintptr_t out_ptr,
+        uintptr_t inverse_ptr, uintptr_t counts_ptr,
+        uintptr_t stream):
+    cdef int self_ndim = len(self_shape)
+    cdef int out_ndim = len(out_shape)
+    cdef int inverse_ndim = len(inverse_shape)
+    cdef int counts_ndim = len(counts_shape)
+    cdef int64_t[MAX_NDIM] self_shape_buf, self_stride_buf
+    cdef int64_t[MAX_NDIM] out_shape_buf, out_stride_buf
+    cdef int64_t[MAX_NDIM] inverse_shape_buf, inverse_stride_buf
+    cdef int64_t[MAX_NDIM] counts_shape_buf, counts_stride_buf
+    cdef int i
+    for i in range(self_ndim):
+        self_shape_buf[i] = self_shape[i]
+        self_stride_buf[i] = self_stride[i]
+    for i in range(out_ndim):
+        out_shape_buf[i] = out_shape[i]
+        out_stride_buf[i] = out_stride[i]
+    for i in range(inverse_ndim):
+        inverse_shape_buf[i] = inverse_shape[i]
+        inverse_stride_buf[i] = inverse_stride[i]
+    for i in range(counts_ndim):
+        counts_shape_buf[i] = counts_shape[i]
+        counts_stride_buf[i] = counts_stride[i]
+    cdef void* self_t = NULL
+    cdef void* out_t = NULL
+    cdef void* inverse_t = NULL
+    cdef void* counts_t = NULL
+    cdef uint64_t ws_size = 0
+    cdef void* executor = NULL
+    cdef int32_t ret
+    with nogil:
+        self_t = _fast_create_tensor(self_shape_buf, self_stride_buf, <uint64_t>self_ndim, self_dtype_code, fmt, <void*>self_ptr)
+        out_t = _fast_create_tensor(out_shape_buf, out_stride_buf, <uint64_t>out_ndim, out_dtype_code, fmt, <void*>out_ptr)
+        inverse_t = _fast_create_tensor(inverse_shape_buf, inverse_stride_buf, <uint64_t>inverse_ndim, inverse_dtype_code, fmt, <void*>inverse_ptr)
+        counts_t = _fast_create_tensor(counts_shape_buf, counts_stride_buf, <uint64_t>counts_ndim, counts_dtype_code, fmt, <void*>counts_ptr)
+    if self_t == NULL or out_t == NULL or inverse_t == NULL or counts_t == NULL:
+        if self_t != NULL:
+            _fast_destroy_tensor(self_t)
+        if out_t != NULL:
+            _fast_destroy_tensor(out_t)
+        if inverse_t != NULL:
+            _fast_destroy_tensor(inverse_t)
+        if counts_t != NULL:
+            _fast_destroy_tensor(counts_t)
+        raise RuntimeError("aclCreateTensor returned null")
+    try:
+        with nogil:
+            ret = (<int32_t (*)(void*, bint, bint, int64_t, void*, void*, void*, uint64_t*, void**) noexcept nogil>getws_ptr)(
+                self_t, flag_a, flag_b, dim_val, out_t, inverse_t, counts_t, &ws_size, &executor)
+        if ret != 0:
+            raise RuntimeError(f"GetWorkspaceSize failed: {ret}")
+        _register_executor_cleanup(
+            <uintptr_t>executor,
+            ([('t', <uintptr_t>self_t)] if self_t != NULL else [])
+            + ([('t', <uintptr_t>out_t)] if out_t != NULL else [])
+            + ([('t', <uintptr_t>inverse_t)] if inverse_t != NULL else [])
+            + ([('t', <uintptr_t>counts_t)] if counts_t != NULL else []),
+        )
+        self_t = NULL
+        out_t = NULL
+        inverse_t = NULL
+        counts_t = NULL
+        if ws_size == 0:
+            try:
+                with nogil:
+                    ret = (<aclnnExec_t>exec_ptr)(NULL, 0, executor, <void*>stream)
+                if ret != 0:
+                    raise RuntimeError(f"Execute failed: {ret}")
+            except Exception:
+                destroy_executor(<uintptr_t>executor)
+                executor = NULL
+                raise
+        return (ws_size, <uintptr_t>executor)
+    finally:
+        with nogil:
+            if self_t != NULL:
+                _fast_destroy_tensor(self_t)
+            if out_t != NULL:
+                _fast_destroy_tensor(out_t)
+            if inverse_t != NULL:
+                _fast_destroy_tensor(inverse_t)
+            if counts_t != NULL:
+                _fast_destroy_tensor(counts_t)
+

--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -302,6 +302,7 @@ from .ops import (
     # Search / unique
     searchsorted,
     unique,
+    unique_consecutive,
     # Random
     randperm,
     # Shape
@@ -630,6 +631,7 @@ registry.register("mv", "npu", mv, meta=meta_infer.infer_matmul)
 registry.register("outer", "npu", outer, meta=meta_infer.infer_binary)
 registry.register("searchsorted", "npu", searchsorted, meta=meta_infer.infer_unary)
 registry.register("unique", "npu", unique)
+registry.register("unique_consecutive", "npu", unique_consecutive)
 registry.register("flatten", "npu", flatten_op, meta=meta_infer.infer_view)
 registry.register("lerp", "npu", lerp, meta=meta_infer.infer_binary)
 registry.register("lerp_", "npu", lerp_, meta=meta_infer.infer_binary)

--- a/src/candle/_backends/npu/aclnn.py
+++ b/src/candle/_backends/npu/aclnn.py
@@ -2003,6 +2003,19 @@ class AclnnBindings:
             ctypes.c_int32,
             [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
         )
+        # UniqueConsecutive: aclnnUniqueConsecutiveGetWorkspaceSize(self, returnInverse, returnCounts, dim, valueOut, inverseOut, countsOut, workspaceSize, executor)
+        self.aclnn_unique_consecutive_get_workspace = _optional_symbol(
+            libs,
+            "aclnnUniqueConsecutiveGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_bool, ctypes.c_bool, ctypes.c_int64, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_unique_consecutive = _optional_symbol(
+            libs,
+            "aclnnUniqueConsecutive",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
         # Randperm: aclnnRandpermGetWorkspaceSize(n, seed, offset, out, workspaceSize, executor)
         self.aclnn_randperm_get_workspace = _optional_symbol(
             libs,
@@ -7767,6 +7780,14 @@ def unique_symbols_ok():
         return False
 
 
+def unique_consecutive_symbols_ok():
+    try:
+        bindings = get_bindings()
+        return all([bindings.aclnn_unique_consecutive_get_workspace, bindings.aclnn_unique_consecutive])
+    except Exception:
+        return False
+
+
 def randperm_symbols_ok():
     try:
         bindings = get_bindings()
@@ -12099,6 +12120,71 @@ def unique(self_ptr, out_ptr, inverse_indices_ptr,
             ret = _ffi.execute(exec_ptr, int(workspace), ws_size, executor, stream_ptr)
             if ret != 0:
                 raise RuntimeError(f"aclnnUnique failed: {ret}")
+        _maybe_sync(runtime)
+    finally:
+        _defer_executor(ctypes.c_void_p(executor))
+        if workspace is not None:
+            runtime.defer_raw_free(workspace)
+
+
+# UniqueConsecutive
+def unique_consecutive(self_ptr, out_ptr, inverse_indices_ptr, counts_ptr,
+                       shape, stride, dtype,
+                       out_shape, out_stride,
+                       inverse_shape, inverse_stride,
+                       counts_shape, counts_stride,
+                       return_inverse, return_counts, dim,
+                       runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    if bindings.aclnn_unique_consecutive_get_workspace is None or bindings.aclnn_unique_consecutive is None:
+        raise RuntimeError("aclnnUniqueConsecutive symbols not available")
+
+    stream_ptr = int(runtime.stream if stream is None else stream)
+    self_dtype_code = _dtype_to_acl(dtype)
+    inverse_dtype_code = _dtype_to_acl("int64")
+    counts_dtype_code = _dtype_to_acl("int64")
+
+    _require_native_npu_ffi("unique_consecutive")
+    executor = 0
+    workspace = None
+    try:
+        getws_ptr, exec_ptr = _ffi.resolve_op("UniqueConsecutive")
+        ws_size, executor = _ffi.unary_two_bools_int_three_outputs_op(
+            getws_ptr,
+            exec_ptr,
+            shape,
+            stride,
+            out_shape,
+            out_stride,
+            inverse_shape,
+            inverse_stride,
+            counts_shape,
+            counts_stride,
+            bool(return_inverse),
+            bool(return_counts),
+            int(dim),
+            self_dtype_code,
+            self_dtype_code,
+            inverse_dtype_code,
+            counts_dtype_code,
+            _ACL_FORMAT_ND,
+            int(self_ptr),
+            int(out_ptr),
+            int(inverse_indices_ptr),
+            int(counts_ptr),
+            stream_ptr,
+        )
+        if ws_size:
+            workspace_ptr, ret = acl.rt.malloc(ws_size, 0)
+            if ret != 0:
+                raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+            workspace = workspace_ptr
+            ret = _ffi.execute(exec_ptr, int(workspace), ws_size, executor, stream_ptr)
+            if ret != 0:
+                raise RuntimeError(f"aclnnUniqueConsecutive failed: {ret}")
         _maybe_sync(runtime)
     finally:
         _defer_executor(ctypes.c_void_p(executor))

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -27,7 +27,7 @@ from .comparison import (
 )
 
 from .reduce import (
-    argmax, argmin, median, kthvalue, searchsorted, unique,
+    argmax, argmin, median, kthvalue, searchsorted, unique, unique_consecutive,
     amax, amin, count_nonzero, all_, any_,
     min_, max_, maximum, minimum, fmin, fmax,
     cumsum, cumprod, cummax, argsort, sort, topk,

--- a/src/candle/_backends/npu/ops/reduce.py
+++ b/src/candle/_backends/npu/ops/reduce.py
@@ -649,6 +649,85 @@ def unique(a, sorted=True, return_inverse=False, return_counts=False, dim=None):
         return out
 
 
+def unique_consecutive(a, return_inverse=False, return_counts=False, dim=None):
+    """Eliminates all but the first element from every consecutive group of equivalent elements."""
+    if not aclnn.unique_consecutive_symbols_ok():
+        raise RuntimeError("aclnnUniqueConsecutive symbols not available")
+    runtime = npu_runtime.get_runtime((a.device.index or 0))
+    stream = npu_state.current_stream((a.device.index or 0))
+
+    storage = _unwrap_storage(a)
+    itemsize = _dtype_itemsize(a.dtype)
+    numel = _numel(a.shape)
+
+    if dim is None:
+        # When dim is None, behavior matches dim=0 with flattened input per ACLNN convention;
+        # ACLNN signature requires int64 dim — use 0 as sentinel and rely on flat output shapes.
+        dim_val = 0
+        out_shape = (numel,)
+        out_stride = (1,)
+        inverse_shape = (numel,)
+        inverse_stride = (1,)
+        counts_shape = (numel,)
+        counts_stride = (1,)
+    else:
+        ndim = len(a.shape)
+        if dim < -ndim or dim >= ndim:
+            raise IndexError(
+                f"Dimension out of range (expected to be in range of [{-ndim}, {ndim - 1}], but got {dim})"
+            )
+        dim_val = dim if dim >= 0 else dim + ndim
+        # Worst-case sizes: dim dimension can have up to its original length
+        out_shape = tuple(a.shape)
+        out_stride = tuple(a.stride)
+        inverse_shape = (a.shape[dim_val],)
+        inverse_stride = (1,)
+        counts_shape = (a.shape[dim_val],)
+        counts_stride = (1,)
+
+    out_ptr = npu_runtime._alloc_device(_numel(out_shape) * itemsize, runtime=runtime)
+    inverse_ptr = npu_runtime._alloc_device(_numel(inverse_shape) * _dtype_itemsize("int64"), runtime=runtime)
+    counts_ptr = npu_runtime._alloc_device(_numel(counts_shape) * _dtype_itemsize("int64"), runtime=runtime)
+
+    aclnn.unique_consecutive(
+        storage.data_ptr(),
+        out_ptr,
+        inverse_ptr,
+        counts_ptr,
+        a.shape, a.stride, a.dtype,
+        out_shape, out_stride,
+        inverse_shape, inverse_stride,
+        counts_shape, counts_stride,
+        return_inverse, return_counts, dim_val,
+        runtime, stream=stream.stream,
+    )
+
+    out_storage = npu_typed_storage_from_ptr(out_ptr, _numel(out_shape), a.dtype, device=a.device)
+    out = _wrap_tensor(out_storage, out_shape, out_stride)
+
+    inv = None
+    if return_inverse:
+        inv_storage = npu_typed_storage_from_ptr(inverse_ptr, _numel(inverse_shape), "int64", device=a.device)
+        inv = _wrap_tensor(inv_storage, inverse_shape, inverse_stride)
+    else:
+        runtime.defer_free(inverse_ptr)
+
+    counts = None
+    if return_counts:
+        counts_storage = npu_typed_storage_from_ptr(counts_ptr, _numel(counts_shape), "int64", device=a.device)
+        counts = _wrap_tensor(counts_storage, counts_shape, counts_stride)
+    else:
+        runtime.defer_free(counts_ptr)
+
+    if return_inverse and return_counts:
+        return out, inv, counts
+    if return_inverse:
+        return out, inv
+    if return_counts:
+        return out, counts
+    return out
+
+
 def sum_(a, dim=None, keepdim=False, dtype=None):
     if dtype is not None:
         # Cast input to target dtype before summing

--- a/tests/contract/test_mechanism_audit_pr1.py
+++ b/tests/contract/test_mechanism_audit_pr1.py
@@ -175,8 +175,8 @@ def test_npu_forward_ops_autograd_coverage_categorization_snapshot():
     assert (generated_only & both) == set()
     assert (handwritten_only & both) == set()
 
-    assert len(forward) == 451
-    assert len(generated_only) == 241
+    assert len(forward) == 452
+    assert len(generated_only) == 242
     assert len(handwritten_only) == 33
     assert len(both) == 55
     assert len(missing) == 122

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1829,8 +1829,8 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
     }
 
     assert missing_autograd == expected_missing
-    assert len(forward_ops) == 451
-    assert len(autograd_ops & forward_ops) == 329
+    assert len(forward_ops) == 452
+    assert len(autograd_ops & forward_ops) == 330
 
 
 def test_npu_activation_module_consolidates_fast_helper_try_blocks():
@@ -3092,3 +3092,37 @@ def test_npu_operator_intake_tranche3r_registers_inplace_bitwise_not():
     assert 'register_schema("bitwise_not_",' in schemas_src
     assert "def fast_bitwise_not_inplace(a):" in pyx_src
     assert "_ensure_ffi_bitwise_not()" in pyx_src
+
+
+def test_npu_operator_intake_tranche3s_registers_unique_consecutive():
+    """Operator intake tranche 3s adds NPU forward registration for
+    `unique_consecutive`. Unlike prior tranches that piggyback on existing
+    ACLNN bindings, this one wires up new `aclnnUniqueConsecutive*` ctypes
+    bindings plus a new `unary_two_bools_int_three_outputs_op` FFI helper
+    in `_aclnn_ffi.pyx` — matching the existing `unique` pattern but with
+    an extra `dim` parameter (int64) and an extra `counts` output tensor.
+
+    `unique_consecutive` is classified `LIKELY_NONDIFFERENTIABLE_NOT_IMPLEMENTED`
+    in `test_autograd_audit_inventory.py`, so it lands in the missing-autograd
+    bucket after forward registration.
+    """
+    aclnn_src = _source("src/candle/_backends/npu/aclnn.py")
+    reduce_src = _source("src/candle/_backends/npu/ops/reduce.py")
+    backend_init_src = _source("src/candle/_backends/npu/__init__.py")
+    ops_init_src = _source("src/candle/_backends/npu/ops/__init__.py")
+    ffi_pyx_src = _source("src/candle/_C/_aclnn_ffi.pyx")
+
+    assert "aclnnUniqueConsecutiveGetWorkspaceSize" in aclnn_src
+    assert "aclnnUniqueConsecutive" in aclnn_src
+    assert "def unique_consecutive_symbols_ok()" in aclnn_src
+    assert "def unique_consecutive(" in aclnn_src
+    assert 'resolve_op("UniqueConsecutive")' in aclnn_src
+
+    assert "def unique_consecutive(" in reduce_src
+    assert "aclnn.unique_consecutive_symbols_ok()" in reduce_src
+    assert "aclnn.unique_consecutive(" in reduce_src
+
+    assert "unique_consecutive," in ops_init_src
+    assert 'registry.register("unique_consecutive", "npu", unique_consecutive)' in backend_init_src
+
+    assert "def unary_two_bools_int_three_outputs_op(" in ffi_pyx_src


### PR DESCRIPTION
## Summary

- Wires `unique_consecutive` forward kernel into NPU via new ACLNN bindings + new FFI helper
- Adds `aclnnUniqueConsecutive*` ctypes signatures to `aclnn.py`
- Adds `unary_two_bools_int_three_outputs_op` FFI helper to `_aclnn_ffi.pyx` (mirrors `unary_two_bools_two_outputs_op` with one extra `int64` `dim` param + one extra `counts` output tensor)
- Adds Python kernel `aclnn.unique_consecutive` and `ops/reduce.py` wrapper using the established `unique()` pattern
- Updates audit counts (forward 451→452, generated_only 241→242)

`unique_consecutive` is classified `LIKELY_NONDIFFERENTIABLE_NOT_IMPLEMENTED` with generated autograd routing already in place, so this completes the NPU dispatch story.

## Test plan

- [x] `pytest tests/contract/ -v` — 117 passed
- [x] `pytest tests/cpu/ tests/contract/ -v` — 3419 passed, 30 skipped
- [x] `pylint src/candle/ --rcfile=.github/pylint.conf` — 10.00/10
- [x] Cython rebuild succeeds with new FFI helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)