### PR TITLE
feat(npu): wire aclnnAdaptiveMaxPool3d into NPU (intake tranche 3u)

### DIFF
--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -262,6 +262,7 @@ from .ops import (
     avg_pool2d,
     adaptive_avg_pool2d,
     adaptive_max_pool2d,
+    adaptive_max_pool3d_op,
     max_unpool2d,
     # P1 ops
     std_,
@@ -791,6 +792,7 @@ registry.register("max_pool3d", "npu", max_pool3d)
 registry.register("avg_pool2d", "npu", avg_pool2d)
 registry.register("adaptive_avg_pool2d", "npu", adaptive_avg_pool2d)
 registry.register("adaptive_max_pool2d", "npu", adaptive_max_pool2d)
+registry.register("adaptive_max_pool3d", "npu", adaptive_max_pool3d_op)
 registry.register("max_unpool2d", "npu", max_unpool2d)
 
 # P1 ops

--- a/src/candle/_backends/npu/aclnn.py
+++ b/src/candle/_backends/npu/aclnn.py
@@ -3402,6 +3402,20 @@ class AclnnBindings:
             [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
         )
 
+        # aclnnAdaptiveMaxPool3d (forward) — returns output + indices (int64)
+        self.aclnn_adaptive_max_pool3d_get_workspace = _optional_symbol(
+            libs, "aclnnAdaptiveMaxPool3dGetWorkspaceSize", ctypes.c_int32,
+            [ctypes.c_void_p,                   # const aclTensor* self
+             ctypes.c_void_p,                   # const aclIntArray* outputSize
+             ctypes.c_void_p,                   # aclTensor* outputOut
+             ctypes.c_void_p,                   # aclTensor* indicesOut
+             ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_adaptive_max_pool3d = _optional_symbol(
+            libs, "aclnnAdaptiveMaxPool3d", ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+
         # aclnnMaxPool3dWithArgmaxBackward — uses argmax indices from forward
         self.aclnn_max_pool3d_with_argmax_backward_get_workspace = _optional_symbol(
             libs, "aclnnMaxPool3dWithArgmaxBackwardGetWorkspaceSize", ctypes.c_int32,
@@ -4027,6 +4041,7 @@ _ACL_DTYPE = {
 
 _ACL_FORMAT_ND = 2
 _ACL_FORMAT_NCHW = 0
+_ACL_FORMAT_NCDHW = 30
 
 
 def _normalize_dtype(dtype):
@@ -16070,6 +16085,78 @@ def adaptive_max_pool2d(self_ptr, out_ptr, indices_ptr,
             ret = _ffi.execute(exec_ptr, int(workspace), ws_size, executor, stream_ptr)
             if ret != 0:
                 raise RuntimeError(f"aclnnAdaptiveMaxPool2d failed: {ret}")
+        _maybe_sync(runtime)
+    finally:
+        _defer_executor(ctypes.c_void_p(executor))
+        if workspace is not None:
+            runtime.defer_raw_free(workspace)
+
+
+# ---------------------------------------------------------------
+# adaptive_max_pool3d (forward)
+# ---------------------------------------------------------------
+
+def adaptive_max_pool3d_symbols_ok():
+    try:
+        b = get_bindings()
+        return all([b.aclnn_adaptive_max_pool3d_get_workspace,
+                    b.aclnn_adaptive_max_pool3d])
+    except Exception:
+        return False
+
+
+def adaptive_max_pool3d(self_ptr, out_ptr, indices_ptr,
+                         shape, stride_t, dtype,
+                         output_size,
+                         out_shape, out_stride,
+                         indices_shape, indices_stride,
+                         runtime, stream=None):
+    """AdaptiveMaxPool3d via aclnnAdaptiveMaxPool3d.
+
+    Returns output + indices (int32 — matches MaxPool3dWithArgmax convention).
+    """
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    if not adaptive_max_pool3d_symbols_ok():
+        raise RuntimeError("aclnnAdaptiveMaxPool3d symbols not available")
+    stream_ptr = int(runtime.stream if stream is None else stream)
+    dtype_code = _dtype_to_acl(dtype)
+    idx_dtype_code = _dtype_to_acl("int32")
+
+    _require_native_npu_ffi("adaptive_max_pool3d")
+    executor = 0
+    workspace = None
+    try:
+        getws_ptr, exec_ptr = _ffi.resolve_op("AdaptiveMaxPool3d")
+        ws_size, executor = _ffi.tensor_int_array_two_outputs_op(
+            getws_ptr,
+            exec_ptr,
+            shape,
+            stride_t,
+            out_shape,
+            out_stride,
+            indices_shape,
+            indices_stride,
+            tuple(output_size),
+            dtype_code,
+            dtype_code,
+            idx_dtype_code,
+            _ACL_FORMAT_NCDHW,
+            int(self_ptr),
+            int(out_ptr),
+            int(indices_ptr),
+            stream_ptr,
+        )
+        if ws_size:
+            workspace_ptr, ret = acl.rt.malloc(int(ws_size), 0)
+            if ret != 0:
+                raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+            workspace = workspace_ptr
+            ret = _ffi.execute(exec_ptr, int(workspace), ws_size, executor, stream_ptr)
+            if ret != 0:
+                raise RuntimeError(f"aclnnAdaptiveMaxPool3d failed: {ret}")
         _maybe_sync(runtime)
     finally:
         _defer_executor(ctypes.c_void_p(executor))

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -102,6 +102,7 @@ from .conv import (
     adaptive_avg_pool2d, adaptive_max_pool2d,
     adaptive_avg_pool3d_op, avg_pool3d_op,
     adaptive_avg_pool1d_op, avg_pool1d_op, max_pool1d_op, adaptive_max_pool1d_op,
+    adaptive_max_pool3d_op,
     upsample_nearest2d, upsample_bilinear2d,
     upsample_bicubic2d_op, upsample_linear1d_op, upsample_nearest1d_op,
     im2col_op, col2im_op,

--- a/src/candle/_backends/npu/ops/conv.py
+++ b/src/candle/_backends/npu/ops/conv.py
@@ -7,6 +7,7 @@ from ._helpers import (
     npu_index_put_impl,
     _cast_tensor_dtype,
     int64_dtype,
+    int32_dtype,
     npu_typed_storage_from_ptr, reshape,
     aclnn, npu_runtime, npu_state,
 )
@@ -1479,6 +1480,69 @@ def max_unpool2d(input, indices, kernel_size, stride, padding, output_size=None)
 
     out_storage = npu_typed_storage_from_ptr(out_ptr, max(out_numel, 1), input.dtype, device=input.device)
     return _wrap_tensor(out_storage, out_shape, out_stride)
+
+
+def adaptive_max_pool3d_op(input, output_size, return_indices=False):
+    """AdaptiveMaxPool3d forward using aclnnAdaptiveMaxPool3d.
+
+    Supports 4D (C, D, H, W) and 5D (N, C, D, H, W) input. Returns indices
+    on int64. When ``return_indices`` is True, returns (output, indices).
+    """
+    runtime = npu_runtime.get_runtime((input.device.index or 0))
+    stream = npu_state.current_stream((input.device.index or 0))
+
+    if isinstance(output_size, int):
+        oD = oH = oW = output_size
+    else:
+        oD, oH, oW = output_size
+
+    unsqueezed = False
+    if len(input.shape) == 4:
+        unsqueezed = True
+        C, D, H, W = input.shape
+        input = input.unsqueeze(0)  # (1, C, D, H, W)
+        N = 1
+    else:
+        N, C, D, H, W = input.shape
+
+    out_shape = (N, C, oD, oH, oW)
+    out_stride = npu_runtime._contiguous_stride(out_shape)
+    out_numel = _numel(out_shape)
+    itemsize = _dtype_itemsize(input.dtype)
+    out_ptr = npu_runtime._alloc_device(max(out_numel, 1) * itemsize, runtime=runtime)
+
+    indices_shape = out_shape
+    indices_stride = out_stride
+    indices_numel = out_numel
+    indices_ptr = npu_runtime._alloc_device(max(indices_numel, 1) * 4, runtime=runtime)
+
+    aclnn.adaptive_max_pool3d(
+        _unwrap_storage(input).data_ptr(), out_ptr, indices_ptr,
+        input.shape, input.stride, input.dtype,
+        [oD, oH, oW],
+        out_shape, out_stride,
+        indices_shape, indices_stride,
+        runtime, stream=stream.stream,
+    )
+
+    out_storage = npu_typed_storage_from_ptr(out_ptr, max(out_numel, 1), input.dtype, device=input.device)
+    out = _wrap_tensor(out_storage, out_shape, out_stride)
+    out._backward_data = {
+        "indices_ptr": indices_ptr, "indices_shape": indices_shape,
+        "indices_stride": indices_stride,
+    }
+
+    if unsqueezed:
+        out = out.squeeze(0)
+
+    if return_indices:
+        indices_storage = npu_typed_storage_from_ptr(indices_ptr, max(indices_numel, 1), int32_dtype, device=input.device)
+        indices_tensor = _wrap_tensor(indices_storage, indices_shape, indices_stride)
+        if unsqueezed:
+            indices_tensor = indices_tensor.squeeze(0)
+        return out, indices_tensor
+
+    return out
 
 
 # ---------- Other missing ops ----------

--- a/tests/contract/test_mechanism_audit_pr1.py
+++ b/tests/contract/test_mechanism_audit_pr1.py
@@ -175,8 +175,8 @@ def test_npu_forward_ops_autograd_coverage_categorization_snapshot():
     assert (generated_only & both) == set()
     assert (handwritten_only & both) == set()
 
-    assert len(forward) == 453
-    assert len(generated_only) == 243
+    assert len(forward) == 454
+    assert len(generated_only) == 244
     assert len(handwritten_only) == 33
     assert len(both) == 55
     assert len(missing) == 122

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1308,16 +1308,15 @@ def test_npu_reduce_does_not_import_unused_reshape_alias():
 
 
 def test_npu_ops_modules_do_not_import_unused_int32_dtype():
-    """`int32_dtype` is re-exported by `_helpers` so reduce ops (which
-    legitimately use it 13 times) can pick it up. Every other ops
-    module lists it in the `from ._helpers import (...)` block but
-    never references it — drop the dead listings so the import surface
-    stays in sync with what is used.
+    """`int32_dtype` is re-exported by `_helpers` so ops that legitimately
+    use it (reduce ops 13 times, conv.py once for adaptive_max_pool3d
+    indices) can pick it up. Every other ops module lists it in the
+    `from ._helpers import (...)` block but never references it — drop the
+    dead listings so the import surface stays in sync with what is used.
     """
     consumer_modules = (
         "src/candle/_backends/npu/ops/__init__.py",
         "src/candle/_backends/npu/ops/activation.py",
-        "src/candle/_backends/npu/ops/conv.py",
         "src/candle/_backends/npu/ops/elementwise.py",
         "src/candle/_backends/npu/ops/linalg.py",
         "src/candle/_backends/npu/ops/math.py",
@@ -1829,8 +1828,8 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
     }
 
     assert missing_autograd == expected_missing
-    assert len(forward_ops) == 453
-    assert len(autograd_ops & forward_ops) == 331
+    assert len(forward_ops) == 454
+    assert len(autograd_ops & forward_ops) == 332
 
 
 def test_npu_activation_module_consolidates_fast_helper_try_blocks():
@@ -3156,3 +3155,31 @@ def test_npu_operator_intake_tranche3t_registers_max_unpool2d():
     assert 'registry.register("max_unpool2d", "npu", max_unpool2d)' in backend_init_src
 
     assert "def two_tensor_int_array_op(" in ffi_pyx_src
+
+
+def test_npu_operator_intake_tranche3u_registers_adaptive_max_pool3d():
+    """Operator intake tranche 3u adds NPU forward registration for
+    `adaptive_max_pool3d` via the existing `tensor_int_array_two_outputs_op`
+    FFI helper. The 3d kernel mirrors `adaptive_max_pool2d`'s
+    `(self, outputSize, output, indices)` C signature.
+
+    `adaptive_max_pool3d` has generated autograd via
+    `_VT.adaptive_max_pool3d_autograd`, so NPU forward registration lands it
+    in the `generated_only` bucket.
+    """
+    aclnn_src = _source("src/candle/_backends/npu/aclnn.py")
+    conv_src = _source("src/candle/_backends/npu/ops/conv.py")
+    backend_init_src = _source("src/candle/_backends/npu/__init__.py")
+    ops_init_src = _source("src/candle/_backends/npu/ops/__init__.py")
+
+    assert "aclnnAdaptiveMaxPool3dGetWorkspaceSize" in aclnn_src
+    assert "aclnnAdaptiveMaxPool3d" in aclnn_src
+    assert "def adaptive_max_pool3d_symbols_ok()" in aclnn_src
+    assert "def adaptive_max_pool3d(" in aclnn_src
+    assert 'resolve_op("AdaptiveMaxPool3d")' in aclnn_src
+
+    assert "def adaptive_max_pool3d_op(" in conv_src
+    assert "aclnn.adaptive_max_pool3d(" in conv_src
+
+    assert "adaptive_max_pool3d_op," in ops_init_src
+    assert 'registry.register("adaptive_max_pool3d", "npu", adaptive_max_pool3d_op)' in backend_init_src


### PR DESCRIPTION
## Summary
- Adds NPU forward registration for `adaptive_max_pool3d` via new `aclnnAdaptiveMaxPool3d*` ctypes bindings.
- Reuses the existing `tensor_int_array_two_outputs_op` FFI helper — same C signature as `adaptive_max_pool2d`.
- `adaptive_max_pool3d` has generated autograd via `_VT.adaptive_max_pool3d_autograd`, so NPU forward registration lands it in the `generated_only` audit bucket (forward 453→454, generated_only 243→244).

## Test plan
- [x] `tests/contract/test_mechanism_audit_pr1.py` audit counts updated and pass
- [x] `tests/contract/test_npu_mechanism_audit.py::test_npu_operator_intake_tranche3u_registers_adaptive_max_pool3d` added and passes
- [x] `tests/contract/test_npu_mechanism_audit.py::test_npu_ops_modules_do_not_import_unused_int32_dtype` updated (conv.py now legitimately uses `int32_dtype` for the indices buffer)
- [x] NPU smoke test against torch reference: 5D `(2,3,4,5,6) → (2,3,4)`, 4D `(3,4,5,6) → (2,3,4)`, and int `output_size=2` all match
- [x] Pylint 10.00/10 on `src/candle/`

Note: ACL `aclnnAdaptiveMaxPool3d` requires `_ACL_FORMAT_NCDHW` (30) and `int32` indices, unlike the 2D variant which uses `_ACL_FORMAT_ND` (2) and `int64` indices. Format constant added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)