### PR TITLE
feat(npu): wire aclnnMaxUnpool3d into NPU (intake tranche 3v)

### DIFF
--- a/src/candle/_C/_aclnn_ffi.pyx
+++ b/src/candle/_C/_aclnn_ffi.pyx
@@ -9857,3 +9857,159 @@ def two_tensor_int_array_op(
         if array_buf != NULL:
             free(array_buf)
 
+
+def two_tensor_three_int_arrays_op(
+        uintptr_t getws_ptr, uintptr_t exec_ptr,
+        self_shape, self_stride,
+        indices_shape, indices_stride,
+        first_values, second_values, third_values,
+        out_shape, out_stride,
+        int32_t self_dtype_code, int32_t indices_dtype_code,
+        int32_t out_dtype_code, int32_t fmt,
+        uintptr_t self_ptr, uintptr_t indices_ptr, uintptr_t out_ptr,
+        uintptr_t stream):
+    cdef int self_ndim = len(self_shape)
+    cdef int indices_ndim = len(indices_shape)
+    cdef int out_ndim = len(out_shape)
+    cdef int first_ndim = len(first_values)
+    cdef int second_ndim = len(second_values)
+    cdef int third_ndim = len(third_values)
+    cdef int64_t[MAX_NDIM] self_shape_buf, self_stride_buf
+    cdef int64_t[MAX_NDIM] indices_shape_buf, indices_stride_buf
+    cdef int64_t[MAX_NDIM] out_shape_buf, out_stride_buf
+    cdef int64_t* first_buf = NULL
+    cdef int64_t* second_buf = NULL
+    cdef int64_t* third_buf = NULL
+    cdef int i
+    cdef void* self_t = NULL
+    cdef void* indices_t = NULL
+    cdef void* out_t = NULL
+    cdef void* first_handle = NULL
+    cdef void* second_handle = NULL
+    cdef void* third_handle = NULL
+    cdef uint64_t ws_size = 0
+    cdef void* executor = NULL
+    cdef int32_t ret
+    for i in range(self_ndim):
+        self_shape_buf[i] = self_shape[i]
+        self_stride_buf[i] = self_stride[i]
+    for i in range(indices_ndim):
+        indices_shape_buf[i] = indices_shape[i]
+        indices_stride_buf[i] = indices_stride[i]
+    for i in range(out_ndim):
+        out_shape_buf[i] = out_shape[i]
+        out_stride_buf[i] = out_stride[i]
+    if first_ndim > 0:
+        first_buf = <int64_t*>malloc(first_ndim * sizeof(int64_t))
+        if first_buf == NULL:
+            raise MemoryError("malloc failed for first int array buffer")
+        for i in range(first_ndim):
+            first_buf[i] = first_values[i]
+    if second_ndim > 0:
+        second_buf = <int64_t*>malloc(second_ndim * sizeof(int64_t))
+        if second_buf == NULL:
+            if first_buf != NULL:
+                free(first_buf)
+            raise MemoryError("malloc failed for second int array buffer")
+        for i in range(second_ndim):
+            second_buf[i] = second_values[i]
+    if third_ndim > 0:
+        third_buf = <int64_t*>malloc(third_ndim * sizeof(int64_t))
+        if third_buf == NULL:
+            if first_buf != NULL:
+                free(first_buf)
+            if second_buf != NULL:
+                free(second_buf)
+            raise MemoryError("malloc failed for third int array buffer")
+        for i in range(third_ndim):
+            third_buf[i] = third_values[i]
+    with nogil:
+        self_t = _fast_create_tensor(self_shape_buf, self_stride_buf, <uint64_t>self_ndim, self_dtype_code, fmt, <void*>self_ptr)
+        indices_t = _fast_create_tensor(indices_shape_buf, indices_stride_buf, <uint64_t>indices_ndim, indices_dtype_code, fmt, <void*>indices_ptr)
+        out_t = _fast_create_tensor(out_shape_buf, out_stride_buf, <uint64_t>out_ndim, out_dtype_code, fmt, <void*>out_ptr)
+        if first_ndim > 0:
+            first_handle = _fn_create_int_array(first_buf, <uint64_t>first_ndim)
+        if second_ndim > 0:
+            second_handle = _fn_create_int_array(second_buf, <uint64_t>second_ndim)
+        if third_ndim > 0:
+            third_handle = _fn_create_int_array(third_buf, <uint64_t>third_ndim)
+    if (self_t == NULL or indices_t == NULL or out_t == NULL
+            or (first_ndim > 0 and first_handle == NULL)
+            or (second_ndim > 0 and second_handle == NULL)
+            or (third_ndim > 0 and third_handle == NULL)):
+        if self_t != NULL:
+            _fast_destroy_tensor(self_t)
+        if indices_t != NULL:
+            _fast_destroy_tensor(indices_t)
+        if out_t != NULL:
+            _fast_destroy_tensor(out_t)
+        if first_handle != NULL:
+            _fn_destroy_int_array(first_handle)
+        if second_handle != NULL:
+            _fn_destroy_int_array(second_handle)
+        if third_handle != NULL:
+            _fn_destroy_int_array(third_handle)
+        if first_buf != NULL:
+            free(first_buf)
+        if second_buf != NULL:
+            free(second_buf)
+        if third_buf != NULL:
+            free(third_buf)
+        if ((first_ndim > 0 and first_handle == NULL)
+                or (second_ndim > 0 and second_handle == NULL)
+                or (third_ndim > 0 and third_handle == NULL)):
+            raise RuntimeError("aclCreateIntArray returned null")
+        raise RuntimeError("aclCreateTensor returned null")
+    try:
+        with nogil:
+            ret = (<int32_t (*)(void*, void*, void*, void*, void*, void*, uint64_t*, void**) noexcept nogil>getws_ptr)(
+                self_t, indices_t, first_handle, second_handle, third_handle, out_t, &ws_size, &executor)
+        if ret != 0:
+            raise RuntimeError(f"GetWorkspaceSize failed: {ret}")
+        _register_executor_cleanup(
+            <uintptr_t>executor,
+            ([('i', <uintptr_t>first_handle)] if first_handle != NULL else [])
+            + ([('i', <uintptr_t>second_handle)] if second_handle != NULL else [])
+            + ([('i', <uintptr_t>third_handle)] if third_handle != NULL else [])
+            + ([('t', <uintptr_t>self_t)] if self_t != NULL else [])
+            + ([('t', <uintptr_t>indices_t)] if indices_t != NULL else [])
+            + ([('t', <uintptr_t>out_t)] if out_t != NULL else []),
+        )
+        first_handle = NULL
+        second_handle = NULL
+        third_handle = NULL
+        self_t = NULL
+        indices_t = NULL
+        out_t = NULL
+        if ws_size == 0:
+            try:
+                with nogil:
+                    ret = (<aclnnExec_t>exec_ptr)(NULL, 0, executor, <void*>stream)
+                if ret != 0:
+                    raise RuntimeError(f"Execute failed: {ret}")
+            except Exception:
+                destroy_executor(<uintptr_t>executor)
+                executor = NULL
+                raise
+        return (ws_size, <uintptr_t>executor)
+    finally:
+        with nogil:
+            if first_handle != NULL:
+                _fn_destroy_int_array(first_handle)
+            if second_handle != NULL:
+                _fn_destroy_int_array(second_handle)
+            if third_handle != NULL:
+                _fn_destroy_int_array(third_handle)
+            if self_t != NULL:
+                _fast_destroy_tensor(self_t)
+            if indices_t != NULL:
+                _fast_destroy_tensor(indices_t)
+            if out_t != NULL:
+                _fast_destroy_tensor(out_t)
+        if first_buf != NULL:
+            free(first_buf)
+        if second_buf != NULL:
+            free(second_buf)
+        if third_buf != NULL:
+            free(third_buf)
+

--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -264,6 +264,7 @@ from .ops import (
     adaptive_max_pool2d,
     adaptive_max_pool3d_op,
     max_unpool2d,
+    max_unpool3d,
     # P1 ops
     std_,
     reciprocal,
@@ -794,6 +795,7 @@ registry.register("adaptive_avg_pool2d", "npu", adaptive_avg_pool2d)
 registry.register("adaptive_max_pool2d", "npu", adaptive_max_pool2d)
 registry.register("adaptive_max_pool3d", "npu", adaptive_max_pool3d_op)
 registry.register("max_unpool2d", "npu", max_unpool2d)
+registry.register("max_unpool3d", "npu", max_unpool3d)
 
 # P1 ops
 registry.register("std", "npu", std_, meta=meta_infer.infer_sum)

--- a/src/candle/_backends/npu/aclnn.py
+++ b/src/candle/_backends/npu/aclnn.py
@@ -2029,6 +2029,19 @@ class AclnnBindings:
             ctypes.c_int32,
             [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
         )
+        # MaxUnpool3d: aclnnMaxUnpool3dGetWorkspaceSize(self, indices, outputSize, stride, padding, out, workspaceSize, executor)
+        self.aclnn_max_unpool3d_get_workspace = _optional_symbol(
+            libs,
+            "aclnnMaxUnpool3dGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_max_unpool3d = _optional_symbol(
+            libs,
+            "aclnnMaxUnpool3d",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
         # Randperm: aclnnRandpermGetWorkspaceSize(n, seed, offset, out, workspaceSize, executor)
         self.aclnn_randperm_get_workspace = _optional_symbol(
             libs,
@@ -12278,6 +12291,73 @@ def max_unpool2d(self_ptr, indices_ptr, out_ptr,
             ret = _ffi.execute(exec_ptr, int(workspace), ws_size, executor, stream_ptr)
             if ret != 0:
                 raise RuntimeError(f"aclnnMaxUnpool2d failed: {ret}")
+        _maybe_sync(runtime)
+    finally:
+        _defer_executor(ctypes.c_void_p(executor))
+        if workspace is not None:
+            runtime.defer_raw_free(workspace)
+
+
+# MaxUnpool3d
+def max_unpool3d_symbols_ok():
+    try:
+        bindings = get_bindings()
+        return all([bindings.aclnn_max_unpool3d_get_workspace, bindings.aclnn_max_unpool3d])
+    except OSError:
+        return False
+
+
+def max_unpool3d(self_ptr, indices_ptr, out_ptr,
+                 self_shape, self_stride, self_dtype,
+                 indices_shape, indices_stride, indices_dtype,
+                 out_shape, out_stride,
+                 output_size, stride, padding,
+                 runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    if bindings.aclnn_max_unpool3d_get_workspace is None or bindings.aclnn_max_unpool3d is None:
+        raise RuntimeError("aclnnMaxUnpool3d symbols not available")
+
+    stream_ptr = int(runtime.stream if stream is None else stream)
+    self_dtype_code = _dtype_to_acl(self_dtype)
+    indices_dtype_code = _dtype_to_acl(indices_dtype)
+
+    _require_native_npu_ffi("max_unpool3d")
+    executor = 0
+    workspace = None
+    try:
+        getws_ptr, exec_ptr = _ffi.resolve_op("MaxUnpool3d")
+        ws_size, executor = _ffi.two_tensor_three_int_arrays_op(
+            getws_ptr,
+            exec_ptr,
+            self_shape,
+            self_stride,
+            indices_shape,
+            indices_stride,
+            tuple(int(v) for v in output_size),
+            tuple(int(v) for v in stride),
+            tuple(int(v) for v in padding),
+            out_shape,
+            out_stride,
+            self_dtype_code,
+            indices_dtype_code,
+            self_dtype_code,
+            _ACL_FORMAT_NCDHW,
+            int(self_ptr),
+            int(indices_ptr),
+            int(out_ptr),
+            stream_ptr,
+        )
+        if ws_size:
+            workspace_ptr, ret = acl.rt.malloc(ws_size, 0)
+            if ret != 0:
+                raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+            workspace = workspace_ptr
+            ret = _ffi.execute(exec_ptr, int(workspace), ws_size, executor, stream_ptr)
+            if ret != 0:
+                raise RuntimeError(f"aclnnMaxUnpool3d failed: {ret}")
         _maybe_sync(runtime)
     finally:
         _defer_executor(ctypes.c_void_p(executor))

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -109,6 +109,7 @@ from .conv import (
     grid_sample_op, affine_grid_op,
     pad, constant_pad_nd, ctc_loss_op,
     max_unpool2d,
+    max_unpool3d,
 )
 
 from .random import (

--- a/src/candle/_backends/npu/ops/conv.py
+++ b/src/candle/_backends/npu/ops/conv.py
@@ -1482,6 +1482,65 @@ def max_unpool2d(input, indices, kernel_size, stride, padding, output_size=None)
     return _wrap_tensor(out_storage, out_shape, out_stride)
 
 
+def max_unpool3d(input, indices, kernel_size, stride, padding, output_size=None):
+    """MaxUnpool3d forward via aclnnMaxUnpool3d.
+
+    Scatters pooled values back to their original positions using flat DHW indices.
+    Indices must be int64 and shape-match input. Computes output spatial size from
+    kernel_size/stride/padding when ``output_size`` is None, matching torch semantics.
+    """
+    if input.shape != indices.shape:
+        raise ValueError("input and indices must have the same shape")
+    if len(input.shape) != 5:
+        raise ValueError(f"Expected 5D input, got {len(input.shape)}D")
+
+    runtime = npu_runtime.get_runtime((input.device.index or 0))
+    stream = npu_state.current_stream((input.device.index or 0))
+
+    N, C, D_in, H_in, W_in = input.shape
+    kD, kH, kW = (int(kernel_size[0]), int(kernel_size[1]), int(kernel_size[2]))
+    sD, sH, sW = (int(stride[0]), int(stride[1]), int(stride[2]))
+    pD, pH, pW = (int(padding[0]), int(padding[1]), int(padding[2]))
+
+    if output_size is not None:
+        if len(output_size) == 5:
+            out_shape = tuple(int(v) for v in output_size)
+        elif len(output_size) == 3:
+            out_shape = (N, C, int(output_size[0]), int(output_size[1]), int(output_size[2]))
+        else:
+            raise ValueError("output_size must have length 3 or 5 for max_unpool3d")
+        if out_shape[0] != N or out_shape[1] != C:
+            raise ValueError("output_size batch/channel dimensions must match input")
+    else:
+        D_out = (D_in - 1) * sD - 2 * pD + kD
+        H_out = (H_in - 1) * sH - 2 * pH + kH
+        W_out = (W_in - 1) * sW - 2 * pW + kW
+        out_shape = (N, C, D_out, H_out, W_out)
+
+    indices_c = contiguous(indices) if indices.dtype == int64_dtype else _cast_tensor_dtype(indices, int64_dtype)
+
+    out_stride = npu_runtime._contiguous_stride(out_shape)
+    out_numel = _numel(out_shape)
+    itemsize = _dtype_itemsize(input.dtype)
+    out_ptr = npu_runtime._alloc_device(max(out_numel, 1) * itemsize, runtime=runtime)
+
+    aclnn.max_unpool3d(
+        _unwrap_storage(input).data_ptr(),
+        _unwrap_storage(indices_c).data_ptr(),
+        out_ptr,
+        input.shape, input.stride, input.dtype,
+        indices_c.shape, indices_c.stride, indices_c.dtype,
+        out_shape, out_stride,
+        [out_shape[2], out_shape[3], out_shape[4]],
+        [sD, sH, sW],
+        [pD, pH, pW],
+        runtime, stream=stream.stream,
+    )
+
+    out_storage = npu_typed_storage_from_ptr(out_ptr, max(out_numel, 1), input.dtype, device=input.device)
+    return _wrap_tensor(out_storage, out_shape, out_stride)
+
+
 def adaptive_max_pool3d_op(input, output_size, return_indices=False):
     """AdaptiveMaxPool3d forward using aclnnAdaptiveMaxPool3d.
 

--- a/tests/contract/test_mechanism_audit_pr1.py
+++ b/tests/contract/test_mechanism_audit_pr1.py
@@ -175,8 +175,8 @@ def test_npu_forward_ops_autograd_coverage_categorization_snapshot():
     assert (generated_only & both) == set()
     assert (handwritten_only & both) == set()
 
-    assert len(forward) == 454
-    assert len(generated_only) == 244
+    assert len(forward) == 455
+    assert len(generated_only) == 245
     assert len(handwritten_only) == 33
     assert len(both) == 55
     assert len(missing) == 122

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1828,8 +1828,8 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
     }
 
     assert missing_autograd == expected_missing
-    assert len(forward_ops) == 454
-    assert len(autograd_ops & forward_ops) == 332
+    assert len(forward_ops) == 455
+    assert len(autograd_ops & forward_ops) == 333
 
 
 def test_npu_activation_module_consolidates_fast_helper_try_blocks():
@@ -3183,3 +3183,35 @@ def test_npu_operator_intake_tranche3u_registers_adaptive_max_pool3d():
 
     assert "adaptive_max_pool3d_op," in ops_init_src
     assert 'registry.register("adaptive_max_pool3d", "npu", adaptive_max_pool3d_op)' in backend_init_src
+
+
+def test_npu_operator_intake_tranche3v_registers_max_unpool3d():
+    """Operator intake tranche 3v adds NPU forward registration for
+    `max_unpool3d` via a new `two_tensor_three_int_arrays_op` FFI helper.
+    The 3d kernel mirrors `max_unpool2d` but takes three IntArray parameters
+    (outputSize, stride, padding) instead of one (outputSize), so the existing
+    `two_tensor_int_array_op` helper is insufficient.
+
+    `max_unpool3d` has generated autograd via
+    `_VT.max_unpool3d_autograd`, so NPU forward registration lands it in the
+    `generated_only` bucket.
+    """
+    aclnn_src = _source("src/candle/_backends/npu/aclnn.py")
+    conv_src = _source("src/candle/_backends/npu/ops/conv.py")
+    backend_init_src = _source("src/candle/_backends/npu/__init__.py")
+    ops_init_src = _source("src/candle/_backends/npu/ops/__init__.py")
+    ffi_pyx_src = _source("src/candle/_C/_aclnn_ffi.pyx")
+
+    assert "aclnnMaxUnpool3dGetWorkspaceSize" in aclnn_src
+    assert "aclnnMaxUnpool3d" in aclnn_src
+    assert "def max_unpool3d_symbols_ok()" in aclnn_src
+    assert "def max_unpool3d(" in aclnn_src
+    assert 'resolve_op("MaxUnpool3d")' in aclnn_src
+
+    assert "def max_unpool3d(" in conv_src
+    assert "aclnn.max_unpool3d(" in conv_src
+
+    assert "max_unpool3d," in ops_init_src
+    assert 'registry.register("max_unpool3d", "npu", max_unpool3d)' in backend_init_src
+
+    assert "def two_tensor_three_int_arrays_op(" in ffi_pyx_src


### PR DESCRIPTION
## Summary

- Wire `aclnnMaxUnpool3d` end-to-end on NPU with a new `two_tensor_three_int_arrays_op` Cython FFI helper.
- 5D wrapper `max_unpool3d(input, indices, kernel_size, stride, padding, output_size=None)` in `ops/conv.py` matches torch semantics.
- Forward registration lands `max_unpool3d` in the `generated_only` autograd bucket (forward 454→455, generated_only 244→245).

## Validation

- Pylint 10.00/10
- CPU + contract tests: 3422 passed, 30 skipped
- NPU smoke test against torch reference on 5D float32 input (kernel_size=2, stride=2) — matches to atol=1e-6

## Test plan

- [x] Pylint clean
- [x] Contract audit tests updated and pass
- [x] CPU + contract suite green
- [x] NPU smoke test matches torch

🤖 Generated with [Claude Code](https://claude.com/claude-code)