### PR TITLE
feat(npu): wire aclnnUpsampleTrilinear3d into NPU (intake tranche 3w)

### DIFF
--- a/src/candle/_C/_aclnn_ffi.pyx
+++ b/src/candle/_C/_aclnn_ffi.pyx
@@ -10013,3 +10013,82 @@ def two_tensor_three_int_arrays_op(
         if third_buf != NULL:
             free(third_buf)
 
+
+def tensor_int_array_bool_three_doubles_op(
+        uintptr_t getws_ptr, uintptr_t exec_ptr,
+        self_shape, self_stride,
+        out_shape, out_stride,
+        dims_tuple, bint flag,
+        double scalar_a, double scalar_b, double scalar_c,
+        int32_t self_dtype_code, int32_t out_dtype_code, int32_t fmt,
+        uintptr_t self_ptr, uintptr_t out_ptr,
+        uintptr_t stream):
+    cdef int self_ndim = len(self_shape)
+    cdef int out_ndim = len(out_shape)
+    cdef int dims_ndim = len(dims_tuple)
+    cdef int64_t[MAX_NDIM] s_shape, s_stride
+    cdef int64_t[MAX_NDIM] r_shape, r_stride
+    cdef int64_t[MAX_NDIM] dims_buf
+    cdef int i
+    for i in range(self_ndim):
+        s_shape[i] = self_shape[i]
+        s_stride[i] = self_stride[i]
+    for i in range(out_ndim):
+        r_shape[i] = out_shape[i]
+        r_stride[i] = out_stride[i]
+    for i in range(dims_ndim):
+        dims_buf[i] = dims_tuple[i]
+    cdef void* self_t = NULL
+    cdef void* out_t = NULL
+    cdef void* dims_handle = NULL
+    cdef uint64_t ws_size = 0
+    cdef void* executor = NULL
+    cdef int32_t ret
+    with nogil:
+        self_t = _fast_create_tensor(s_shape, s_stride, <uint64_t>self_ndim, self_dtype_code, fmt, <void*>self_ptr)
+        out_t = _fast_create_tensor(r_shape, r_stride, <uint64_t>out_ndim, out_dtype_code, fmt, <void*>out_ptr)
+        if dims_ndim > 0:
+            dims_handle = _fn_create_int_array(dims_buf, <uint64_t>dims_ndim)
+    if self_t == NULL or out_t == NULL or (dims_ndim > 0 and dims_handle == NULL):
+        if self_t != NULL:
+            _fast_destroy_tensor(self_t)
+        if out_t != NULL:
+            _fast_destroy_tensor(out_t)
+        if dims_handle != NULL:
+            _fn_destroy_int_array(dims_handle)
+        raise RuntimeError("ACLNN descriptor creation failed")
+    try:
+        with nogil:
+            ret = (<int32_t (*)(void*, void*, bint, double, double, double, void*, uint64_t*, void**) noexcept nogil>getws_ptr)(
+                self_t, dims_handle, flag, scalar_a, scalar_b, scalar_c, out_t, &ws_size, &executor)
+        if ret != 0:
+            raise RuntimeError(f"GetWorkspaceSize failed: {ret}")
+        _register_executor_cleanup(
+            <uintptr_t>executor,
+            ([('i', <uintptr_t>dims_handle)] if dims_handle != NULL else [])
+            + ([('t', <uintptr_t>self_t)] if self_t != NULL else [])
+            + ([('t', <uintptr_t>out_t)] if out_t != NULL else []),
+        )
+        dims_handle = NULL
+        self_t = NULL
+        out_t = NULL
+        if ws_size == 0:
+            try:
+                with nogil:
+                    ret = (<aclnnExec_t>exec_ptr)(NULL, 0, executor, <void*>stream)
+                if ret != 0:
+                    raise RuntimeError(f"Execute failed: {ret}")
+            except Exception:
+                destroy_executor(<uintptr_t>executor)
+                executor = NULL
+                raise
+        return (ws_size, <uintptr_t>executor)
+    finally:
+        with nogil:
+            if dims_handle != NULL:
+                _fn_destroy_int_array(dims_handle)
+            if self_t != NULL:
+                _fast_destroy_tensor(self_t)
+            if out_t != NULL:
+                _fast_destroy_tensor(out_t)
+

--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -363,6 +363,7 @@ from .ops import (
     adaptive_avg_pool3d_op,
     upsample_bicubic2d_op,
     upsample_linear1d_op,
+    upsample_trilinear3d_op,
     _adam_step_op,
     # Phase 2: activation composites
     selu_op,
@@ -872,6 +873,7 @@ registry.register("linalg_vector_norm", "npu", linalg_vector_norm_op)
 registry.register("adaptive_avg_pool3d", "npu", adaptive_avg_pool3d_op)
 registry.register("upsample_bicubic2d", "npu", upsample_bicubic2d_op)
 registry.register("upsample_linear1d", "npu", upsample_linear1d_op)
+registry.register("upsample_trilinear3d", "npu", upsample_trilinear3d_op)
 registry.register("_adam_step", "npu", _adam_step_op)
 registry.register("_adamw_step", "npu", _adam_step_op)
 

--- a/src/candle/_backends/npu/aclnn.py
+++ b/src/candle/_backends/npu/aclnn.py
@@ -3505,6 +3505,19 @@ class AclnnBindings:
             [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
         )
 
+        # aclnnUpsampleTrilinear3d: (self, outputSize, alignCorners, scalesD, scalesH, scalesW, out)
+        self.aclnn_upsample_trilinear3d_get_workspace = _optional_symbol(
+            libs, "aclnnUpsampleTrilinear3dGetWorkspaceSize", ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_bool,
+             ctypes.c_double, ctypes.c_double, ctypes.c_double,
+             ctypes.c_void_p,
+             ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_upsample_trilinear3d = _optional_symbol(
+            libs, "aclnnUpsampleTrilinear3d", ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+
         # aclnnUpsampleNearest2dBackward(gradOut, outputSize, inputSize, scalesH, scalesW, gradInput)
         self.aclnn_upsample_nearest2d_backward_get_workspace = _optional_symbol(
             libs, "aclnnUpsampleNearest2dBackwardGetWorkspaceSize", ctypes.c_int32,
@@ -11706,6 +11719,61 @@ def upsample_bilinear2d(input_ptr, out_ptr, input_shape, input_stride, dtype,
             ret = _ffi.execute(exec_ptr, int(workspace), ws_size, executor, stream_ptr)
             if ret != 0:
                 raise RuntimeError(f"aclnnUpsampleBilinear2d failed: {ret}")
+        _maybe_sync(runtime)
+    finally:
+        _defer_executor(ctypes.c_void_p(executor))
+        if workspace is not None:
+            runtime.defer_raw_free(workspace)
+
+
+def upsample_trilinear3d_symbols_ok():
+    b = get_bindings()
+    return b.aclnn_upsample_trilinear3d_get_workspace is not None and b.aclnn_upsample_trilinear3d is not None
+
+
+def upsample_trilinear3d(input_ptr, out_ptr, input_shape, input_stride, dtype,
+                         output_size, align_corners, scales_d, scales_h, scales_w,
+                         out_shape, out_stride, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    if not upsample_trilinear3d_symbols_ok():
+        raise RuntimeError("aclnnUpsampleTrilinear3d symbols not available")
+    stream_ptr = int(runtime.stream if stream is None else stream)
+    dtype_code = _dtype_to_acl(dtype)
+
+    _require_native_npu_ffi("upsample_trilinear3d")
+    executor = 0
+    workspace = None
+    try:
+        getws_ptr, exec_ptr = _ffi.resolve_op("UpsampleTrilinear3d")
+        ws_size, executor = _ffi.tensor_int_array_bool_three_doubles_op(
+            getws_ptr,
+            exec_ptr,
+            input_shape,
+            input_stride,
+            out_shape,
+            out_stride,
+            tuple(output_size),
+            bool(align_corners),
+            0.0 if scales_d is None else float(scales_d),
+            0.0 if scales_h is None else float(scales_h),
+            0.0 if scales_w is None else float(scales_w),
+            dtype_code,
+            dtype_code,
+            _ACL_FORMAT_NCDHW,
+            int(input_ptr),
+            int(out_ptr),
+            stream_ptr,
+        )
+        if ws_size:
+            workspace_ptr, ret = acl.rt.malloc(int(ws_size), 0)
+            if ret != 0:
+                raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+            workspace = workspace_ptr
+            ret = _ffi.execute(exec_ptr, int(workspace), ws_size, executor, stream_ptr)
+            if ret != 0:
+                raise RuntimeError(f"aclnnUpsampleTrilinear3d failed: {ret}")
         _maybe_sync(runtime)
     finally:
         _defer_executor(ctypes.c_void_p(executor))

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -105,6 +105,7 @@ from .conv import (
     adaptive_max_pool3d_op,
     upsample_nearest2d, upsample_bilinear2d,
     upsample_bicubic2d_op, upsample_linear1d_op, upsample_nearest1d_op,
+    upsample_trilinear3d_op,
     im2col_op, col2im_op,
     grid_sample_op, affine_grid_op,
     pad, constant_pad_nd, ctc_loss_op,

--- a/src/candle/_backends/npu/ops/conv.py
+++ b/src/candle/_backends/npu/ops/conv.py
@@ -924,6 +924,33 @@ def upsample_bilinear2d(input, output_size, align_corners, scales_h, scales_w):
     return _wrap_tensor(out_storage, out_shape, out_stride)
 
 
+def upsample_trilinear3d_op(a, output_size, align_corners=False, scales_d=None, scales_h=None, scales_w=None):
+    """UpsampleTrilinear3d forward via aclnnUpsampleTrilinear3d.
+
+    Expects 5D input (N, C, D, H, W) and ``output_size`` of length 3 (oD, oH, oW).
+    """
+    runtime = npu_runtime.get_runtime((a.device.index or 0))
+    stream = npu_state.current_stream((a.device.index or 0))
+    s = _unwrap_storage(a)
+
+    N, C = a.shape[0], a.shape[1]
+    oD, oH, oW = (int(output_size[0]), int(output_size[1]), int(output_size[2]))
+    out_shape = (N, C, oD, oH, oW)
+    out_stride = npu_runtime._contiguous_stride(out_shape)
+    out_nbytes = _numel(out_shape) * _dtype_itemsize(a.dtype)
+    out_ptr = npu_runtime._alloc_device(max(out_nbytes, 4), runtime=runtime)
+    out_storage = npu_typed_storage_from_ptr(out_ptr, _numel(out_shape), a.dtype, device=a.device)
+
+    aclnn.upsample_trilinear3d(
+        s.data_ptr(), out_ptr,
+        a.shape, a.stride, a.dtype,
+        [oD, oH, oW], align_corners, scales_d, scales_h, scales_w,
+        out_shape, out_stride,
+        runtime, stream=stream.stream,
+    )
+    return _wrap_tensor(out_storage, out_shape, out_stride)
+
+
 def upsample_bicubic2d_op(a, output_size, align_corners=False, scales_h=None, scales_w=None):
     runtime = npu_runtime.get_runtime((a.device.index or 0))
     stream = npu_state.current_stream((a.device.index or 0))

--- a/tests/contract/test_mechanism_audit_pr1.py
+++ b/tests/contract/test_mechanism_audit_pr1.py
@@ -175,8 +175,8 @@ def test_npu_forward_ops_autograd_coverage_categorization_snapshot():
     assert (generated_only & both) == set()
     assert (handwritten_only & both) == set()
 
-    assert len(forward) == 455
-    assert len(generated_only) == 245
+    assert len(forward) == 456
+    assert len(generated_only) == 246
     assert len(handwritten_only) == 33
     assert len(both) == 55
     assert len(missing) == 122

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1828,8 +1828,8 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
     }
 
     assert missing_autograd == expected_missing
-    assert len(forward_ops) == 455
-    assert len(autograd_ops & forward_ops) == 333
+    assert len(forward_ops) == 456
+    assert len(autograd_ops & forward_ops) == 334
 
 
 def test_npu_activation_module_consolidates_fast_helper_try_blocks():
@@ -3215,3 +3215,34 @@ def test_npu_operator_intake_tranche3v_registers_max_unpool3d():
     assert 'registry.register("max_unpool3d", "npu", max_unpool3d)' in backend_init_src
 
     assert "def two_tensor_three_int_arrays_op(" in ffi_pyx_src
+
+
+def test_npu_operator_intake_tranche3w_registers_upsample_trilinear3d():
+    """Operator intake tranche 3w adds NPU forward registration for
+    `upsample_trilinear3d` via a new `tensor_int_array_bool_three_doubles_op`
+    FFI helper. The 3d signature mirrors aclnnUpsampleBilinear2d but with one
+    more double parameter (scalesD) for the depth dimension.
+
+    `upsample_trilinear3d` has generated autograd via
+    `_VT.upsample_trilinear3d_autograd`, so NPU forward registration lands it
+    in the `generated_only` bucket.
+    """
+    aclnn_src = _source("src/candle/_backends/npu/aclnn.py")
+    conv_src = _source("src/candle/_backends/npu/ops/conv.py")
+    backend_init_src = _source("src/candle/_backends/npu/__init__.py")
+    ops_init_src = _source("src/candle/_backends/npu/ops/__init__.py")
+    ffi_pyx_src = _source("src/candle/_C/_aclnn_ffi.pyx")
+
+    assert "aclnnUpsampleTrilinear3dGetWorkspaceSize" in aclnn_src
+    assert "aclnnUpsampleTrilinear3d" in aclnn_src
+    assert "def upsample_trilinear3d_symbols_ok()" in aclnn_src
+    assert "def upsample_trilinear3d(" in aclnn_src
+    assert 'resolve_op("UpsampleTrilinear3d")' in aclnn_src
+
+    assert "def upsample_trilinear3d_op(" in conv_src
+    assert "aclnn.upsample_trilinear3d(" in conv_src
+
+    assert "upsample_trilinear3d_op," in ops_init_src
+    assert 'registry.register("upsample_trilinear3d", "npu", upsample_trilinear3d_op)' in backend_init_src
+
+    assert "def tensor_int_array_bool_three_doubles_op(" in ffi_pyx_src


### PR DESCRIPTION
## Summary

- Wire `aclnnUpsampleTrilinear3d` end-to-end on NPU with a new `tensor_int_array_bool_three_doubles_op` Cython FFI helper.
- 5D wrapper `upsample_trilinear3d_op(input, output_size, align_corners, scales_d, scales_h, scales_w)` in `ops/conv.py`.
- Forward registration lands `upsample_trilinear3d` in the `generated_only` autograd bucket (forward 455→456, generated_only 245→246).

## Validation

- Pylint 10.00/10
- CPU + contract tests: 3423 passed, 30 skipped
- NPU smoke test against torch reference on 5D float32 input (interpolate trilinear 4x upsampling) — matches to atol=1e-5 for both align_corners=True and False

## Test plan

- [x] Pylint clean
- [x] Contract audit tests updated and pass
- [x] CPU + contract suite green
- [x] NPU smoke test matches torch (both align_corners modes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)