### PR TITLE
feat(npu): wire max_unpool1d composite into NPU

### DIFF
--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -263,6 +263,7 @@ from .ops import (
     adaptive_avg_pool2d,
     adaptive_max_pool2d,
     adaptive_max_pool3d_op,
+    max_unpool1d,
     max_unpool2d,
     max_unpool3d,
     # P1 ops
@@ -795,6 +796,7 @@ registry.register("avg_pool2d", "npu", avg_pool2d)
 registry.register("adaptive_avg_pool2d", "npu", adaptive_avg_pool2d)
 registry.register("adaptive_max_pool2d", "npu", adaptive_max_pool2d)
 registry.register("adaptive_max_pool3d", "npu", adaptive_max_pool3d_op)
+registry.register("max_unpool1d", "npu", max_unpool1d)
 registry.register("max_unpool2d", "npu", max_unpool2d)
 registry.register("max_unpool3d", "npu", max_unpool3d)
 

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -109,6 +109,7 @@ from .conv import (
     im2col_op, col2im_op,
     grid_sample_op, affine_grid_op,
     pad, constant_pad_nd, ctc_loss_op,
+    max_unpool1d,
     max_unpool2d,
     max_unpool3d,
 )

--- a/src/candle/_backends/npu/ops/conv.py
+++ b/src/candle/_backends/npu/ops/conv.py
@@ -1509,6 +1509,49 @@ def max_unpool2d(input, indices, kernel_size, stride, padding, output_size=None)
     return _wrap_tensor(out_storage, out_shape, out_stride)
 
 
+def max_unpool1d(input, indices, kernel_size, stride, padding, output_size=None):
+    """MaxUnpool1d forward via max_unpool2d composite.
+
+    Routes through max_unpool2d by adding a height-1 spatial dim: (N,C,L) →
+    (N,C,1,L). Matches torch semantics; computes ``L_out = (L_in-1)*s - 2*p + k``
+    when ``output_size`` is None.
+    """
+    if input.shape != indices.shape:
+        raise ValueError("input and indices must have the same shape")
+    if len(input.shape) != 3:
+        raise ValueError(f"Expected 3D input, got {len(input.shape)}D")
+
+    from ...._dispatch.dispatcher import dispatch
+    from ...common import view as view_backend
+
+    N, C, L_in = input.shape
+    kL = int(kernel_size[0]) if isinstance(kernel_size, (list, tuple)) else int(kernel_size)
+    sL = int(stride[0]) if isinstance(stride, (list, tuple)) else int(stride)
+    pL = int(padding[0]) if isinstance(padding, (list, tuple)) else int(padding)
+
+    if output_size is not None:
+        if isinstance(output_size, (list, tuple)):
+            if len(output_size) == 3:
+                L_out = int(output_size[2])
+            elif len(output_size) == 1:
+                L_out = int(output_size[0])
+            else:
+                raise ValueError("output_size must have length 1 or 3 for max_unpool1d")
+        else:
+            L_out = int(output_size)
+    else:
+        L_out = (L_in - 1) * sL - 2 * pL + kL
+
+    input_4d = view_backend.reshape(input, (N, C, 1, L_in))
+    indices_4d = view_backend.reshape(indices, (N, C, 1, L_in))
+
+    out_4d = dispatch(
+        "max_unpool2d", "npu",
+        input_4d, indices_4d, [1, kL], [1, sL], [0, pL], [1, L_out],
+    )
+    return view_backend.reshape(out_4d, (N, C, L_out))
+
+
 def max_unpool3d(input, indices, kernel_size, stride, padding, output_size=None):
     """MaxUnpool3d forward via aclnnMaxUnpool3d.
 

--- a/tests/contract/test_mechanism_audit_pr1.py
+++ b/tests/contract/test_mechanism_audit_pr1.py
@@ -175,9 +175,9 @@ def test_npu_forward_ops_autograd_coverage_categorization_snapshot():
     assert (generated_only & both) == set()
     assert (handwritten_only & both) == set()
 
-    assert len(forward) == 456
+    assert len(forward) == 457
     assert len(generated_only) == 246
-    assert len(handwritten_only) == 33
+    assert len(handwritten_only) == 34
     assert len(both) == 55
     assert len(missing) == 122
 

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1828,8 +1828,8 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
     }
 
     assert missing_autograd == expected_missing
-    assert len(forward_ops) == 456
-    assert len(autograd_ops & forward_ops) == 334
+    assert len(forward_ops) == 457
+    assert len(autograd_ops & forward_ops) == 335
 
 
 def test_npu_activation_module_consolidates_fast_helper_try_blocks():
@@ -3246,3 +3246,26 @@ def test_npu_operator_intake_tranche3w_registers_upsample_trilinear3d():
     assert 'registry.register("upsample_trilinear3d", "npu", upsample_trilinear3d_op)' in backend_init_src
 
     assert "def tensor_int_array_bool_three_doubles_op(" in ffi_pyx_src
+
+
+def test_npu_operator_intake_tranche3x_registers_max_unpool1d():
+    """Operator intake tranche 3x adds NPU forward registration for
+    `max_unpool1d` as a composite over the existing NPU `max_unpool2d` kernel:
+    the 3D input ``(N, C, L)`` is reshaped to ``(N, C, 1, L)``, dispatched into
+    `max_unpool2d`, and reshaped back to ``(N, C, L_out)``. The composite path
+    matches the 1D-via-2D pattern already used by `upsample_nearest1d_op` and
+    keeps all computation on-device.
+
+    `max_unpool1d` has handwritten autograd via `_autograd_max_unpool1d`
+    registered under `AutogradNPU`, so NPU forward registration lands it in the
+    `handwritten_only` bucket of the autograd coverage snapshot.
+    """
+    conv_src = _source("src/candle/_backends/npu/ops/conv.py")
+    backend_init_src = _source("src/candle/_backends/npu/__init__.py")
+    ops_init_src = _source("src/candle/_backends/npu/ops/__init__.py")
+
+    assert "def max_unpool1d(" in conv_src
+    assert "max_unpool2d" in conv_src
+
+    assert "max_unpool1d," in ops_init_src
+    assert 'registry.register("max_unpool1d", "npu", max_unpool1d)' in backend_init_src


### PR DESCRIPTION
## Summary
- Register `max_unpool1d` on NPU using a 1D-over-2D composite through the existing `max_unpool2d` NPU kernel.
- Export and register the new NPU forward path, keeping all computation on-device via reshape + NPU dispatch + reshape.
- Update NPU mechanism audit snapshots and add the tranche 3x audit test; `max_unpool1d` lands in the handwritten autograd bucket.

## Test plan
- [x] `PYTHONPATH=src LD_LIBRARY_PATH=/usr/local/Ascend/cann-9.0.0/aarch64-linux/lib64:/usr/local/Ascend/cann-9.0.0/aarch64-linux/lib64/device:$LD_LIBRARY_PATH LD_PRELOAD=... python -c '<max_unpool1d torch parity smoke>'`
- [x] `/home/jenkins/anaconda3/envs/candle311/bin/python -m pytest tests/contract/test_mechanism_audit_pr1.py tests/contract/test_npu_mechanism_audit.py -v --tb=short`
- [x] `/home/jenkins/anaconda3/envs/candle311/bin/pylint src/candle/ --rcfile=.github/pylint.conf`
- [x] `/home/jenkins/anaconda3/envs/candle311/bin/python -m pytest tests/cpu/ tests/contract/ -q --tb=line`

🤖 Generated with [Claude Code](https://claude.com/claude-code)