### PR TITLE
feat(npu): route group_norm through native ACLNN

### DIFF
--- a/src/candle/_backends/npu/ops/norm.py
+++ b/src/candle/_backends/npu/ops/norm.py
@@ -223,18 +223,9 @@ def _batch_norm_310b_fallback(input, running_mean, running_var, weight=None, bia
     return out
 
 
-def group_norm(input, num_groups, weight=None, bias=None, eps=1e-5):
-    """Compute group normalization using aclnnLayerNorm (composite implementation).
-
-    This avoids the aclnnGroupNorm state contamination bug in CANN 8.3.RC2.
-    Algorithm:
-    1. Reshape input from (N, C, H, W) to (N*num_groups, C//num_groups * H * W)
-    2. Apply layer_norm over the last dimension (normalizes each group independently)
-    3. Reshape back to (N, C, H, W)
-    4. Apply affine transform: result * weight + bias
-    """
+def _group_norm_layer_norm_fallback(input, num_groups, weight=None, bias=None, eps=1e-5):
     if not aclnn.layer_norm_symbols_ok():
-        raise RuntimeError("aclnnLayerNorm not available (required for group_norm)")
+        raise RuntimeError("aclnnLayerNorm not available (required for group_norm fallback)")
 
     N = input.shape[0]
     C = input.shape[1]
@@ -267,6 +258,53 @@ def group_norm(input, num_groups, weight=None, bias=None, eps=1e-5):
         result = add(result, bias_reshaped)
 
     return result
+
+
+def group_norm(input, num_groups, weight=None, bias=None, eps=1e-5):
+    """Compute group normalization using aclnnGroupNorm."""
+    if input.dim() < 2:
+        raise ValueError("group_norm expects input with at least 2 dims")
+
+    C = int(input.shape[1])
+    if C % num_groups != 0:
+        raise ValueError(f"num_channels ({C}) must be divisible by num_groups ({num_groups})")
+
+    if _use_soc_fallback("group_norm"):
+        return _group_norm_layer_norm_fallback(input, num_groups, weight=weight, bias=bias, eps=eps)
+
+    if not aclnn.group_norm_symbols_ok():
+        raise RuntimeError("aclnnGroupNorm not available")
+
+    runtime = npu_runtime.get_runtime((input.device.index or 0))
+    stream = npu_state.current_stream((input.device.index or 0))
+
+    out_shape = input.shape
+    out_stride = npu_runtime._contiguous_stride(out_shape)
+    out_numel = _numel(out_shape)
+    itemsize = _dtype_itemsize(input.dtype)
+    out_ptr = npu_runtime._alloc_device(max(out_numel, 1) * itemsize, runtime=runtime)
+
+    weight_ptr = _unwrap_storage(weight).data_ptr() if weight is not None else None
+    bias_ptr = _unwrap_storage(bias).data_ptr() if bias is not None else None
+
+    aclnn.group_norm(
+        _unwrap_storage(input).data_ptr(),
+        weight_ptr,
+        bias_ptr,
+        out_ptr,
+        input.shape, input.stride,
+        weight.shape if weight is not None else (),
+        weight.stride if weight is not None else (),
+        bias.shape if bias is not None else (),
+        bias.stride if bias is not None else (),
+        out_shape, out_stride,
+        int(num_groups), eps,
+        input.dtype,
+        runtime, stream=stream.stream,
+    )
+
+    out_storage = npu_typed_storage_from_ptr(out_ptr, max(out_numel, 1), input.dtype, device=input.device)
+    return _wrap_tensor(out_storage, out_shape, out_stride)
 
 
 def instance_norm(input, weight=None, bias=None, running_mean=None, running_var=None,

--- a/tests/contract/test_npu_no_fallback_contract.py
+++ b/tests/contract/test_npu_no_fallback_contract.py
@@ -13,6 +13,7 @@ from candle._backends.npu import creation as npu_creation
 from candle._backends.npu import runtime as npu_runtime
 from candle._backends.npu import allocator as npu_allocator
 from candle._backends.npu.ops import _helpers
+from candle._backends.npu.ops import norm as npu_norm
 
 
 @pytest.fixture(autouse=True)
@@ -4983,6 +4984,102 @@ def test_remaining_batch_group_norm_uses_native_ffi(monkeypatch):
 
     assert ("resolve_op", "GroupNorm") in calls
     assert ("group_norm_op", "getws:GroupNorm", "exec:GroupNorm") in calls
+
+
+def test_group_norm_npu_wrapper_uses_native_aclnn(monkeypatch):
+    calls = []
+
+    class _FakeStorage:
+        def __init__(self, ptr):
+            self._ptr = ptr
+
+        def data_ptr(self):
+            return self._ptr
+
+    class _FakeDevice:
+        index = 0
+
+    class _FakeTensor:
+        shape = (2, 4, 3, 3)
+        stride = (36, 9, 3, 1)
+        dtype = "float16"
+        device = _FakeDevice()
+
+        def __init__(self, ptr=11):
+            self._storage = _FakeStorage(ptr)
+
+        def dim(self):
+            return len(self.shape)
+
+    class _FakeStream:
+        stream = 456
+
+    runtime = _FakeRuntime()
+    input_tensor = _FakeTensor(11)
+    weight = _FakeTensor(22)
+    weight.shape = (4,)
+    weight.stride = (1,)
+    bias = _FakeTensor(33)
+    bias.shape = (4,)
+    bias.stride = (1,)
+
+    monkeypatch.setattr(npu_norm, "_use_soc_fallback", lambda name: False)
+    monkeypatch.setattr(npu_norm.aclnn, "group_norm_symbols_ok", lambda: True)
+    monkeypatch.setattr(npu_norm.npu_runtime, "get_runtime", lambda device_index: runtime)
+    monkeypatch.setattr(npu_norm.npu_state, "current_stream", lambda device_index: _FakeStream())
+    monkeypatch.setattr(npu_norm.npu_runtime, "_alloc_device", lambda size, runtime=None: 44)
+    monkeypatch.setattr(npu_norm, "_unwrap_storage", lambda tensor: tensor._storage)
+    monkeypatch.setattr(npu_norm, "npu_typed_storage_from_ptr", lambda ptr, numel, dtype, device: _FakeStorage(ptr))
+    monkeypatch.setattr(npu_norm, "_wrap_tensor", lambda storage, shape, stride: (storage.data_ptr(), shape, stride))
+
+    def fake_group_norm(*args, **kwargs):
+        calls.append((args, kwargs))
+
+    monkeypatch.setattr(npu_norm.aclnn, "group_norm", fake_group_norm)
+
+    out = npu_norm.group_norm(input_tensor, 2, weight=weight, bias=bias, eps=1e-5)
+
+    assert calls
+    args, kwargs = calls[0]
+    assert args[:4] == (11, 22, 33, 44)
+    assert args[4:14] == (
+        (2, 4, 3, 3), (36, 9, 3, 1),
+        (4,), (1,),
+        (4,), (1,),
+        (2, 4, 3, 3), (36, 9, 3, 1),
+        2, 1e-5,
+    )
+    assert args[14] == "float16"
+    assert args[15] is runtime
+    assert kwargs == {"stream": 456}
+    assert out == (44, (2, 4, 3, 3), (36, 9, 3, 1))
+
+
+def test_group_norm_npu_wrapper_uses_soc_fallback_gate(monkeypatch):
+    calls = []
+
+    class _FakeTensor:
+        shape = (2, 4, 3, 3)
+
+        def dim(self):
+            return len(self.shape)
+
+    def fake_fallback(input_tensor, num_groups, weight=None, bias=None, eps=1e-5):
+        calls.append((input_tensor, num_groups, weight, bias, eps))
+        return "fallback-output"
+
+    input_tensor = _FakeTensor()
+    weight = object()
+    bias = object()
+
+    monkeypatch.setattr(npu_norm, "_use_soc_fallback", lambda name: name == "group_norm")
+    monkeypatch.setattr(npu_norm, "_group_norm_layer_norm_fallback", fake_fallback)
+    monkeypatch.setattr(npu_norm.aclnn, "group_norm_symbols_ok", lambda: pytest.fail("native path should not run"))
+
+    out = npu_norm.group_norm(input_tensor, 2, weight=weight, bias=bias, eps=1e-4)
+
+    assert out == "fallback-output"
+    assert calls == [(input_tensor, 2, weight, bias, 1e-4)]
 
 
 def test_remaining_batch_convolution_uses_native_ffi(monkeypatch):


### PR DESCRIPTION
## Summary
- Route the NPU `group_norm` wrapper through the existing native `aclnnGroupNorm` binding by default.
- Keep the prior layer_norm composite behind the SoC fallback gate for affected hardware profiles.
- Add contract coverage for native wrapper dispatch and the fallback gate.

## Test plan
- [x] `python -m pytest tests/contract/test_npu_no_fallback_contract.py::test_group_norm_npu_wrapper_uses_native_aclnn tests/contract/test_npu_no_fallback_contract.py::test_group_norm_npu_wrapper_uses_soc_fallback_gate tests/contract/test_npu_no_fallback_contract.py::test_remaining_batch_group_norm_uses_native_ffi -q`
- [x] `LD_LIBRARY_PATH=/usr/local/Ascend/cann-9.0.0/aarch64-linux/lib64:/usr/local/Ascend/cann-9.0.0/aarch64-linux/lib64/device:$LD_LIBRARY_PATH PYTHONPATH=src python -m pytest tests/npu/common/test_nn.py -q -k group_norm`
- [x] `python -m pytest tests/cpu tests/contract -v --tb=short` — 3426 passed, 30 skipped
- [x] `pylint src/candle --rcfile=.github/pylint.conf` — 10.00/10
- [ ] `python -m pytest tests/npu -v --tb=short` — known unrelated/environment failures outside group_norm remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)