### PR TITLE
feat(npu): route einsum through composite kernels

### DIFF
--- a/src/candle/_backends/npu/ops/linalg.py
+++ b/src/candle/_backends/npu/ops/linalg.py
@@ -372,10 +372,10 @@ def baddbmm(self_tensor, batch1, batch2, beta=1.0, alpha=1.0):
 
 
 def einsum_(equation, operands):
-    """Compute einsum.
+    """Compute einsum using on-device composite kernels.
 
-    When fallback is active (910B, 310B): aclnnEinsum returns 161002 on 910B;
-    untested on 310B — composite is used for both.
+    Native aclnnEinsum has unclear parity across SoCs, so keep the binding in
+    aclnn.py and route supported patterns through smaller NPU ops.
 
     Supported patterns:
     - matmul:  ...ij,...jk->...ik
@@ -383,10 +383,6 @@ def einsum_(equation, operands):
     - inner product: i,i-> or ...i,...i->...
     - batch diagonal sum: ...ii->...i (trace-like)
     """
-    if not _use_soc_fallback("einsum"):
-        # TODO: re-enable native aclnnEinsum when CANN fixes 161002 on 910B
-        #       and once aclnnEinsum availability is confirmed on 310B.
-        raise NotImplementedError("native aclnnEinsum not yet enabled")
     from ...._dispatch import dispatch as _dispatch
 
     eq = equation.replace(' ', '')

--- a/tests/contract/test_npu_no_fallback_contract.py
+++ b/tests/contract/test_npu_no_fallback_contract.py
@@ -8,11 +8,13 @@ from pathlib import Path
 
 import pytest
 
+import candle._dispatch as candle_dispatch
 from candle._backends.npu import aclnn
 from candle._backends.npu import creation as npu_creation
 from candle._backends.npu import runtime as npu_runtime
 from candle._backends.npu import allocator as npu_allocator
 from candle._backends.npu.ops import _helpers
+from candle._backends.npu.ops import linalg as npu_linalg
 from candle._backends.npu.ops import norm as npu_norm
 
 
@@ -4845,6 +4847,43 @@ def test_remaining_batch_adaptive_max_pool2d_uses_native_ffi(monkeypatch):
 
     assert ("resolve_op", "AdaptiveMaxPool2d") in calls
     assert ("tensor_int_array_two_outputs_op", "getws:AdaptiveMaxPool2d", "exec:AdaptiveMaxPool2d") in calls
+
+
+def test_einsum_npu_wrapper_uses_composite_without_soc_fallback(monkeypatch):
+    calls = []
+
+    class _FakeDevice:
+        type = "npu"
+
+    class _FakeTensor:
+        device = _FakeDevice()
+
+        def __init__(self, shape):
+            self.shape = shape
+
+    def fake_dispatch(op_name, device_type, *args, **kwargs):
+        calls.append((op_name, device_type, args, kwargs))
+        return "composite-output"
+
+    monkeypatch.setattr(
+        npu_linalg,
+        "_use_soc_fallback",
+        lambda name: pytest.fail("einsum should not consult SoC fallback"),
+    )
+    monkeypatch.setattr(candle_dispatch, "dispatch", fake_dispatch)
+
+    a = _FakeTensor((2, 3))
+    b = _FakeTensor((3, 4))
+    out = npu_linalg.einsum_("ij,jk->ik", [a, b])
+
+    assert out == "composite-output"
+    assert calls == [("matmul", "npu", (a, b), {})]
+
+    calls.clear()
+    out = npu_linalg.einsum_("ij->ji", [a])
+
+    assert out == "composite-output"
+    assert calls == [("permute", "npu", (a, [1, 0]), {})]
 
 
 def test_remaining_batch_einsum_uses_native_ffi(monkeypatch):


### PR DESCRIPTION
## Summary
- NPU `einsum_` now uses the existing supported-pattern composite on every SoC instead of raising `NotImplementedError` on non-fallback profiles.
- Native `aclnnEinsum` binding and its low-level FFI contract are preserved for future re-enable.
- Added wrapper contract coverage in `tests/contract/test_npu_no_fallback_contract.py` asserting both matmul and transpose patterns dispatch on NPU without consulting `_use_soc_fallback`.

## Test plan
- [x] `python -m pytest tests/contract/test_npu_no_fallback_contract.py -q -k "einsum_npu_wrapper or remaining_batch_einsum"` — 2 passed.
- [x] `source /usr/local/Ascend/cann-9.0.0/set_env.sh && python -m pytest tests/npu/910b/test_910b_watchlist.py -q -k einsum` — 2 passed.
- [x] `python -m pytest tests/cpu tests/contract -v --tb=short` — 3427 passed, 30 skipped.
- [x] `pylint src/candle/ --rcfile=.github/pylint.conf` — 10.00/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)