### PR TITLE
fix(npu): contiguify >=3D matmul operands before aclnnMatmul

### DIFF
--- a/docs/known-kernel-issues.md
+++ b/docs/known-kernel-issues.md
@@ -55,6 +55,7 @@ All entries were verified by running `tests/npu/310b/` locally on the target har
 | `hypot` | `aten::hypot.out` unsupported on torch_npu NPU backend | torch_npu falls back to CPU and returns result on original NPU device/dtype | host `np.hypot` fallback, then reconstruct tensor on original NPU device/dtype | CANN 8.5.0 / 910B |
 | `fmin` / `fmax` | `aten::fmin.out` / `aten::fmax.out` unsupported on torch_npu NPU backend | torch_npu falls back to CPU and returns result on original NPU device/dtype | host `np.fmin` / `np.fmax` fallback, then reconstruct tensor on original NPU device/dtype | CANN 8.5.0 / 910B |
 | native elementwise sequence stability (`maximum` / `max`, `where`, `logaddexp`, related unary neighbors) | native torch_npu / ACLNN path | repeated executions on 910B corrupt later results; reproduced side-by-side in Candle and real torch_npu on the same host, so this is not a Candle-only route mismatch | keep Candle on the same native route as torch_npu; do not add Candle-only fallback, and avoid asserting stronger sequence-stability guarantees than upstream on 910B | CANN 8.5.0 / 910B |
+| `matmul` (batched non-contiguous input) | `aclnnMatmul` | `GetWorkspaceSize failed: 561103` when any ≥3-D operand is non-row-major (e.g. after `.transpose(0, 1)`) | Python wrapper contiguifies ≥3-D non-contiguous operands on-device before the native call; matches torch_npu behaviour | CANN 8.5.0 / 910B |
 
 ## 910A
 

--- a/src/candle/_backends/npu/ops/linalg.py
+++ b/src/candle/_backends/npu/ops/linalg.py
@@ -56,6 +56,15 @@ def matmul(a, b, out=None):
         a = _cast_tensor_dtype(a, float16_dtype)
         b = _cast_tensor_dtype(b, float16_dtype)
 
+    # aclnnMatmul rejects batched inputs with non-row-major strides
+    # (GetWorkspaceSize 561103). Match torch_npu by materialising a contiguous
+    # copy on-device before dispatching. 2-D operands tolerate transposed
+    # strides natively, so only contiguify when at least 3-D.
+    if a.dim() >= 3 and not a.is_contiguous():
+        a = contiguous(a)
+    if b.dim() >= 3 and not b.is_contiguous():
+        b = contiguous(b)
+
     itemsize = _dtype_itemsize(a.dtype)
     a_storage = _unwrap_storage(a)
     b_storage = _unwrap_storage(b)

--- a/tests/cpu/test_linalg.py
+++ b/tests/cpu/test_linalg.py
@@ -221,6 +221,12 @@ def test_npu_matmul_out_preserves_user_output_tensor(monkeypatch):
             self.copy_calls.append(other)
             return self
 
+        def dim(self):
+            return len(self.shape)
+
+        def is_contiguous(self):
+            return True
+
     class FakeStorage:
         def data_ptr(self):
             return 1234

--- a/tests/npu/common/test_ops.py
+++ b/tests/npu/common/test_ops.py
@@ -54,6 +54,25 @@ def test_npu_matmul_batched_broadcast():
     assert out.shape == (2, 4, 2, 5)
     assert np.allclose(out.to("cpu").numpy(), np.matmul(a.to("cpu").numpy(), b.to("cpu").numpy()))
 
+
+def test_npu_matmul_noncontig_batched_input():
+    """aclnnMatmul rejects batched non-row-major inputs with workspace error 561103.
+
+    Repro: ``a.transpose(0, 1)`` produces a contiguous-flag=False (3-D) tensor; the
+    raw aclnnMatmul call returns ``GetWorkspaceSize failed: 561103``. The Python
+    wrapper must contiguify on-device before dispatch.
+    """
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+    base = torch.randn(4, 16, 64, device="npu", dtype=torch.float16)
+    a = base.transpose(0, 1)
+    assert not a.is_contiguous()
+    b = torch.randn(64, 64, device="npu", dtype=torch.float16)
+    out = torch.matmul(a, b)
+    expected = np.matmul(a.contiguous().to("cpu").numpy(), b.to("cpu").numpy())
+    assert out.shape == (16, 4, 64)
+    assert np.allclose(out.to("cpu").numpy(), expected, atol=1e-2, rtol=1e-2)
+
 @pytest.mark.parametrize(
     "op_name, numpy_fn",
     [


### PR DESCRIPTION
## Summary

- NPU \`matmul\` previously raised \`GetWorkspaceSize failed: 561103\` whenever a batched operand was non-row-major (e.g. after \`.transpose(0, 1)\`), so \`MultiheadAttention\` / \`TransformerEncoderLayer\` and any model that reshapes batched activations crashed on NPU.
- Python wrapper now materialises a contiguous on-device copy for any ≥3-D non-contiguous operand before dispatching to \`aclnnMatmul\`. 2-D transposed operands keep the native fast path. Behaviour mirrors torch_npu.
- Added regression test \`test_npu_matmul_noncontig_batched_input\` and a 910B entry in \`docs/known-kernel-issues.md\`.

## Test plan
- [x] \`source /usr/local/Ascend/cann-9.0.0/set_env.sh && python -m pytest tests/npu/common/test_ops.py -k matmul -v\` — 4 passed.
- [x] \`python -m pytest tests/cpu/test_linalg.py -q\` — 38 passed (after extending the existing FakeTensor mock with \`dim()\` / \`is_contiguous()\`).
- [x] \`python -m pytest tests/cpu tests/contract -q\` — 3427 passed, 30 skipped; the one earlier failure was the FakeTensor mock and is fixed in this PR.
- [x] \`pylint src/candle/_backends/npu/ops/linalg.py --rcfile=.github/pylint.conf\` — 10.00/10.