### PR TITLE
fix(npu): prefer device autograd overrides

### DIFF
--- a/src/candle/_C/_dispatcher_core.pyx
+++ b/src/candle/_C/_dispatcher_core.pyx
@@ -448,6 +448,27 @@ cdef inline object _fast_kernel_for_entry_skip_autograd(object entry, unsigned i
     return None, None
 
 
+cdef inline bint _has_device_autograd_override(object entry, unsigned int m):
+    cdef dict kernels = entry.kernels
+    cdef object default_kernel = kernels.get(_DispatchKey.Autograd)
+    cdef object device_kernel = None
+
+    if m & _KEY_AutogradNPU:
+        device_kernel = kernels.get(_DispatchKey.AutogradNPU)
+    elif m & _KEY_AutogradCUDA:
+        device_kernel = kernels.get(_DispatchKey.AutogradCUDA)
+    elif m & _KEY_AutogradXPU:
+        device_kernel = kernels.get(_DispatchKey.AutogradXPU)
+    elif m & _KEY_PrivateUse3:
+        device_kernel = kernels.get(_DispatchKey.PrivateUse3)
+    elif m & _KEY_AutogradCPU:
+        device_kernel = kernels.get(_DispatchKey.AutogradCPU)
+    elif m & _KEY_AutogradMeta:
+        device_kernel = kernels.get(_DispatchKey.AutogradMeta)
+
+    return device_kernel is not None and device_kernel is not default_kernel
+
+
 # ---------------------------------------------------------------------------
 # Inline keyset construction — replaces _dispatch.pyx::_cy_from_tensors
 # ---------------------------------------------------------------------------
@@ -777,7 +798,7 @@ cdef object _dispatch_core(str name, object dispatch_device,
     if has_autograd:
         autograd_post_fn = getattr(entry, "autograd_post", None)
 
-    if has_autograd and autograd_post_fn is not None:
+    if has_autograd and autograd_post_fn is not None and not _has_device_autograd_override(entry, m):
         # Single-pass: find backend kernel directly, skip autograd wrapper
         backend_kernel, backend_key = _fast_kernel_for_entry_skip_autograd(entry, m)
         if backend_kernel is not None:

--- a/tests/contract/test_autograd_backward_storage_isolation.py
+++ b/tests/contract/test_autograd_backward_storage_isolation.py
@@ -44,3 +44,19 @@ def test_target_autograd_npu_kernels_are_registered_and_not_cpu_only_config():
         assert DispatchKey.AutogradNPU in entry.kernels, (
             f"missing AutogradNPU registration for {op}"
         )
+
+
+def test_autograd_post_ops_keep_npu_specific_autograd_overrides():
+    src = _autograd_backend_source()
+    dispatcher = (Path(candle.__file__).resolve().parent / "_C" / "_dispatcher_core.pyx").read_text(
+        encoding="utf-8"
+    )
+
+    assert "def _npu_autograd_conv" in src
+    assert "not _has_device_autograd_override(entry, m)" in dispatcher
+
+    for op in ("conv1d", "conv2d", "conv3d", "conv_transpose1d", "conv_transpose2d", "conv_transpose3d"):
+        entry = registry.get(f"aten::{op}")
+        assert entry.autograd_post is not None
+        assert DispatchKey.AutogradNPU in entry.kernels
+        assert entry.kernels[DispatchKey.AutogradNPU] is not entry.kernels[DispatchKey.Autograd]

--- a/tests/npu/common/test_nn.py
+++ b/tests/npu/common/test_nn.py
@@ -97,6 +97,26 @@ class TestNormalizationNPU:
         )
 
 
+def test_residual_conv_bn_relu_backward_stays_on_npu():
+    conv1 = nn.Conv2d(32, 32, 3, padding=1, bias=False).to("npu")
+    bn1 = nn.BatchNorm2d(32).to("npu")
+    conv2 = nn.Conv2d(32, 32, 3, padding=1, bias=False).to("npu")
+    bn2 = nn.BatchNorm2d(32).to("npu")
+    x = torch.randn(8, 32, 16, 16, device="npu", requires_grad=True)
+
+    h = nn.functional.relu(bn1(conv1(x)))
+    h = bn2(conv2(h))
+    y = nn.functional.relu(h + x)
+    y.sum().backward()
+
+    assert x.grad is not None
+    assert x.grad.device.type == "npu"
+    assert conv1.weight.grad is not None
+    assert conv1.weight.grad.device.type == "npu"
+    assert conv2.weight.grad is not None
+    assert conv2.weight.grad.device.type == "npu"
+
+
 class TestModulesNPU:
     """Test nn.Module classes with NPU backend."""
 


### PR DESCRIPTION
## Summary
- Prefer distinct device-specific autograd kernels over generated `autograd_post` single-pass handling.
- Prevent NPU conv backward from falling through generated CPU/numpy-style backward paths that can leak Python `TypedStorage` into NPU graphs.
- Add contract and NPU residual conv/batchnorm/relu backward regression coverage.

## Test plan
- [x] `source ~/anaconda3/etc/profile.d/conda.sh && conda activate candle311 && python setup.py build_ext --inplace`
- [x] `source /usr/local/Ascend/cann-9.0.0/set_env.sh && source ~/anaconda3/etc/profile.d/conda.sh && conda activate candle311 && PYTHONPATH=src python -m pytest tests/contract/test_autograd_backward_storage_isolation.py tests/npu/common/test_nn.py::test_residual_conv_bn_relu_backward_stays_on_npu -v --tb=short`
- [x] `source /usr/local/Ascend/cann-9.0.0/set_env.sh && source ~/anaconda3/etc/profile.d/conda.sh && conda activate candle311 && PYTHONPATH=src python -m pytest tests/npu/common/test_nn.py -v --tb=short`
- [x] `source ~/anaconda3/etc/profile.d/conda.sh && conda activate candle311 && LD_PRELOAD=/home/jenkins/anaconda3/envs/candle311/lib/python3.11/site-packages/torch/lib/libgomp.so.1 PYTHONPATH=src python -m pytest tests/cpu/ tests/contract/ -v --tb=short`
- [x] `source ~/anaconda3/etc/profile.d/conda.sh && conda activate candle311 && PYTHONPATH=src pylint src/candle/ --rcfile=.github/pylint.conf`

Note: a combined `tests/contract/ tests/npu/common/test_nn.py` run after sourcing CANN segfaulted during PyTorch import/collection (`libgomp`/TLS environment issue) before executing Candle tests, so CPU+contract and NPU slices were validated in separate processes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)