### PR TITLE
bench(npu): compare candle and torch_npu blocks

### DIFF
--- a/benchmarks/perf_candle_vs_torch_npu.py
+++ b/benchmarks/perf_candle_vs_torch_npu.py
@@ -1,0 +1,318 @@
+"""End-to-end NPU perf comparison: candle vs torch_npu.
+
+Requires an Ascend NPU runtime and runs each framework in a separate subprocess.
+The same model code is executed with `import candle as torch` or real torch plus
+torch_npu; weights and inputs are initialized independently, so the table is for
+latency comparison rather than numerical equivalence.
+"""
+
+import argparse
+import json
+import os
+import statistics
+import subprocess
+import sys
+import time
+
+def build_mlp(torch, device, dtype):
+    nn = torch.nn
+    f = torch.nn.functional
+
+    class MLP(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.l1 = nn.Linear(1024, 4096)
+            self.l2 = nn.Linear(4096, 4096)
+            self.l3 = nn.Linear(4096, 1024)
+
+        def forward(self, x):
+            x = f.gelu(self.l1(x))
+            x = f.gelu(self.l2(x))
+            return self.l3(x)
+
+    model = MLP().to(device).to(dtype)
+    x = torch.randn(32, 1024, device=device, dtype=dtype, requires_grad=True)
+    return model, (x,)
+
+
+def build_xfmr(torch, device, dtype):
+    nn = torch.nn
+    f = torch.nn.functional
+
+    b, s, h, heads = 2, 128, 512, 8
+    head_dim = h // heads
+
+    class XfmrBlock(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.norm1 = nn.LayerNorm(h)
+            self.norm2 = nn.LayerNorm(h)
+            self.wq = nn.Linear(h, h)
+            self.wk = nn.Linear(h, h)
+            self.wv = nn.Linear(h, h)
+            self.wo = nn.Linear(h, h)
+            self.ff1 = nn.Linear(h, 4 * h)
+            self.ff2 = nn.Linear(4 * h, h)
+
+        def forward(self, x):
+            y = self.norm1(x)
+            q = self.wq(y).reshape(b, s, heads, head_dim).transpose(1, 2).contiguous()
+            k = self.wk(y).reshape(b, s, heads, head_dim).transpose(1, 2).contiguous()
+            v = self.wv(y).reshape(b, s, heads, head_dim).transpose(1, 2).contiguous()
+            attn = torch.matmul(q, k.transpose(-2, -1).contiguous())
+            attn = f.softmax(attn, dim=-1)
+            out = torch.matmul(attn, v)
+            out = out.transpose(1, 2).contiguous().reshape(b, s, h)
+            x = x + self.wo(out)
+            z = self.norm2(x)
+            z = f.gelu(self.ff1(z))
+            return x + self.ff2(z)
+
+    model = XfmrBlock().to(device).to(dtype)
+    x = torch.randn(b, s, h, device=device, dtype=dtype, requires_grad=True)
+    return model, (x,)
+
+
+def build_resnet(torch, device, dtype):
+    nn = torch.nn
+    f = torch.nn.functional
+
+    class ResBlock(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv1 = nn.Conv2d(64, 64, 3, padding=1, bias=False)
+            self.bn1 = nn.BatchNorm2d(64)
+            self.conv2 = nn.Conv2d(64, 64, 3, padding=1, bias=False)
+            self.bn2 = nn.BatchNorm2d(64)
+
+        def forward(self, x):
+            h = f.relu(self.bn1(self.conv1(x)))
+            h = self.bn2(self.conv2(h))
+            return f.relu(h + x)
+
+    model = ResBlock().to(device).to(dtype)
+    x = torch.randn(8, 64, 32, 32, device=device, dtype=dtype, requires_grad=True)
+    return model, (x,)
+
+
+CASES = {
+    "mlp": build_mlp,
+    "xfmr": build_xfmr,
+    "resnet": build_resnet,
+}
+
+
+def _import_framework(framework):
+    if framework == "candle":
+        import candle as torch  # pylint: disable=import-outside-toplevel
+        return torch
+    if framework == "torch_npu":
+        import torch  # pylint: disable=import-outside-toplevel
+        import torch_npu  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import
+        return torch
+    raise ValueError(f"unknown framework: {framework}")
+
+
+def _sync(torch):
+    if hasattr(torch, "npu") and hasattr(torch.npu, "synchronize"):
+        torch.npu.synchronize()
+
+
+def _resolve_dtype(torch, name):
+    return getattr(torch, name)
+
+
+def run_worker(framework, case, iters, warmup, dtype_name):
+    torch = _import_framework(framework)
+    dtype = _resolve_dtype(torch, dtype_name)
+
+    if not (hasattr(torch, "npu") and torch.npu.is_available()):
+        return {"error": f"NPU not available under {framework}"}
+
+    device = "npu:0"
+    builder = CASES[case]
+    model, inputs = builder(torch, device, dtype)
+
+    for _ in range(warmup):
+        out = model(*inputs)
+        loss = out.sum()
+        loss.backward()
+        for p in model.parameters():
+            if p.grad is not None:
+                p.grad = None
+        for x in inputs:
+            if getattr(x, "grad", None) is not None:
+                x.grad = None
+    _sync(torch)
+
+    fwd_samples = []
+    bwd_samples = []
+    for _ in range(iters):
+        _sync(torch)
+        t0 = time.perf_counter()
+        out = model(*inputs)
+        loss = out.sum()
+        _sync(torch)
+        t1 = time.perf_counter()
+        loss.backward()
+        _sync(torch)
+        t2 = time.perf_counter()
+
+        fwd_samples.append((t1 - t0) * 1000.0)
+        bwd_samples.append((t2 - t1) * 1000.0)
+
+        for p in model.parameters():
+            if p.grad is not None:
+                p.grad = None
+        for x in inputs:
+            if getattr(x, "grad", None) is not None:
+                x.grad = None
+
+    return {
+        "framework": framework,
+        "case": case,
+        "iters": iters,
+        "fwd_ms_median": statistics.median(fwd_samples),
+        "bwd_ms_median": statistics.median(bwd_samples),
+        "fwd_ms_min": min(fwd_samples),
+        "bwd_ms_min": min(bwd_samples),
+    }
+
+
+def _spawn_worker(framework, case, iters, warmup, dtype_name, python_exe=None):
+    cmd = [
+        python_exe or sys.executable,
+        os.path.abspath(__file__),
+        "--worker",
+        "--framework", framework,
+        "--case", case,
+        "--iters", str(iters),
+        "--warmup", str(warmup),
+        "--dtype", dtype_name,
+    ]
+    env = os.environ.copy()
+    src_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "src")
+    old_path = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = src_dir if not old_path else os.pathsep.join((src_dir, old_path))
+    try:
+        out = subprocess.check_output(cmd, env=env, stderr=subprocess.STDOUT, timeout=600)
+    except subprocess.CalledProcessError as exc:
+        return {
+            "framework": framework,
+            "case": case,
+            "error": f"worker exit {exc.returncode}",
+            "tail": exc.output.decode(errors="replace").splitlines()[-12:],
+        }
+    except subprocess.TimeoutExpired:
+        return {"framework": framework, "case": case, "error": "timeout"}
+
+    last_json = None
+    for line in out.decode(errors="replace").splitlines():
+        line = line.strip()
+        if line.startswith("{") and line.endswith("}"):
+            try:
+                last_json = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+    if last_json is None:
+        return {"framework": framework, "case": case, "error": "no json from worker"}
+    return last_json
+
+
+def _fmt(x):
+    if x is None:
+        return "    -"
+    return f"{x:7.2f}"
+
+
+def _print_table(results, frameworks):
+    by_case = {}
+    for r in results:
+        by_case.setdefault(r["case"], {})[r["framework"]] = r
+
+    header = ["algo", "fwd ms", "bwd ms", "ratio"]
+    print(" | ".join(f"{h:>18}" for h in header))
+    print("-+-".join("-" * 18 for _ in header))
+
+    for case, by_fw in by_case.items():
+        torch_ref = by_fw.get("torch_npu")
+        torch_fwd = torch_ref.get("fwd_ms_median") if torch_ref and "error" not in torch_ref else None
+        torch_bwd = torch_ref.get("bwd_ms_median") if torch_ref and "error" not in torch_ref else None
+        for fw in frameworks:
+            r = by_fw.get(fw)
+            algo = f"{case}/{fw}"
+            if r is None or "error" in r:
+                row = [algo, "err", "err", "-"]
+            else:
+                fwd = r["fwd_ms_median"]
+                bwd = r["bwd_ms_median"]
+                if fw == "torch_npu":
+                    ratio = "1.00x"
+                elif torch_fwd and torch_bwd:
+                    ratio = f"f {fwd / torch_fwd:.2f}x / b {bwd / torch_bwd:.2f}x"
+                else:
+                    ratio = "-"
+                row = [algo, _fmt(fwd), _fmt(bwd), ratio]
+            print(" | ".join(f"{c:>18}" for c in row))
+
+    for r in results:
+        if "error" in r:
+            print(f"\n[{r['framework']} / {r['case']}] ERROR: {r['error']}")
+            tail = r.get("tail")
+            if tail:
+                for line in tail:
+                    print(f"  | {line}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--framework", default="all", help="candle|torch_npu|all")
+    parser.add_argument("--case", default=None, help="single case for worker mode")
+    parser.add_argument("--cases", default=",".join(CASES.keys()),
+                        help="comma-separated case list for orchestrator")
+    parser.add_argument("--iters", type=int, default=20)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--dtype", default="float32")
+    parser.add_argument("--candle-python", default=None,
+                        help="Python executable for candle workers; defaults to current Python")
+    parser.add_argument("--torch-npu-python", default=None,
+                        help="Python executable for torch_npu workers; defaults to current Python")
+    args = parser.parse_args()
+
+    if args.worker:
+        result = run_worker(args.framework, args.case, args.iters, args.warmup, args.dtype)
+        print(json.dumps(result))
+        return
+
+    if args.framework == "all":
+        frameworks = ["candle", "torch_npu"]
+    else:
+        frameworks = [args.framework]
+    cases = [c.strip() for c in args.cases.split(",") if c.strip()]
+    unknown = [c for c in cases if c not in CASES]
+    if unknown:
+        raise SystemExit(f"unknown cases: {unknown}; known: {list(CASES)}")
+
+    print(f"# Perf bench: candle vs torch_npu (iters={args.iters}, warmup={args.warmup}, "
+          f"dtype={args.dtype})")
+    print(f"# Cases: {cases}")
+
+    python_for = {
+        "candle": args.candle_python,
+        "torch_npu": args.torch_npu_python,
+    }
+    results = []
+    for case in cases:
+        for fw in frameworks:
+            print(f"  [{fw} / {case}] running...", flush=True)
+            results.append(_spawn_worker(
+                fw, case, args.iters, args.warmup, args.dtype, python_for.get(fw)
+            ))
+
+    print()
+    _print_table(results, frameworks)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/known-kernel-issues.md
+++ b/docs/known-kernel-issues.md
@@ -56,6 +56,7 @@ All entries were verified by running `tests/npu/310b/` locally on the target har
 | `fmin` / `fmax` | `aten::fmin.out` / `aten::fmax.out` unsupported on torch_npu NPU backend | torch_npu falls back to CPU and returns result on original NPU device/dtype | host `np.fmin` / `np.fmax` fallback, then reconstruct tensor on original NPU device/dtype | CANN 8.5.0 / 910B |
 | native elementwise sequence stability (`maximum` / `max`, `where`, `logaddexp`, related unary neighbors) | native torch_npu / ACLNN path | repeated executions on 910B corrupt later results; reproduced side-by-side in Candle and real torch_npu on the same host, so this is not a Candle-only route mismatch | keep Candle on the same native route as torch_npu; do not add Candle-only fallback, and avoid asserting stronger sequence-stability guarantees than upstream on 910B | CANN 8.5.0 / 910B |
 | `matmul` (batched non-contiguous input) | `aclnnMatmul` | `GetWorkspaceSize failed: 561103` when any ≥3-D operand is non-row-major (e.g. after `.transpose(0, 1)`) | Python wrapper contiguifies ≥3-D non-contiguous operands on-device before the native call; matches torch_npu behaviour | CANN 8.5.0 / 910B |
+| `softmax` backward | `aclnnSoftmaxBackward` | segmentation fault when used from NPU autograd backward | composite: `softmax(x) * (grad - (grad * softmax(x)).sum(dim, keepdim=True))` on NPU | CANN 8.5.0 / 910B |
 
 ## 910A
 

--- a/src/candle/_backends/autograd.py
+++ b/src/candle/_backends/autograd.py
@@ -7479,7 +7479,6 @@ def _npu_group_norm_backward(grad, _a, saved_a, keyset, args, kwargs):
 # Register NPU-specific autograd kernels (overrides AutogradNPU dispatch key)
 for _npu_name, _npu_factory in (
     # Batch 1 — High-impact training ops
-    ("softmax", lambda: _autograd_unary_args("softmax", _npu_softmax_backward)),
     ("log_softmax", lambda: _autograd_unary_args("log_softmax", _npu_log_softmax_backward)),
     ("gelu", lambda: _autograd_unary("gelu", _npu_gelu_backward)),
     ("silu", lambda: _autograd_unary("silu", _npu_silu_backward)),
@@ -7768,8 +7767,31 @@ def _npu_grid_sample_backward_impl(grad, input, grid, saved_input, saved_grid, k
         results.append(grad_grid)
     return tuple(results) if results else (grad_input, grad_grid)
 
+def _npu_autograd_softmax(name="softmax"):
+    def wrapper(a, *args, **kwargs):
+        active_keyset = current_dispatch_keyset()
+        raw_keyset = _strip_autograd_keys(active_keyset)
+        out = redispatch(name, raw_keyset, a, *args, **kwargs)
+        if GradMode.enabled and getattr(a, "requires_grad", False):
+            node_holder = {}
+
+            def _backward(grad):
+                saved_a = node_holder["node"].saved_tensors()[0]
+                backward_keyset = _backward_dispatch_keyset(raw_keyset, active_keyset)
+                return _softmax_backward(grad, a, saved_a, backward_keyset, args, kwargs)
+
+            node = Node(_backward, (a,), name=f"{name.capitalize()}Backward0")
+            annotate_node_creation(node)
+            node_holder["node"] = weakref.proxy(node)
+            node.save_for_backward(a)
+            out.grad_fn = node
+            out.requires_grad = True
+        return out
+
+    return wrapper
+
+
 def _npu_autograd_grid_sample(name="grid_sample"):
-    """NPU-specific grid_sample autograd wrapper."""
     def wrapper(input, grid, *args, **kwargs):
         active_keyset = current_dispatch_keyset()
         raw_keyset = _strip_autograd_keys(active_keyset)
@@ -7843,6 +7865,8 @@ for _npu_name, _npu_factory in (
     ("upsample_bilinear2d", lambda: _autograd_pool("upsample_bilinear2d", _npu_upsample_bilinear2d_backward)),
     ("upsample_linear1d", lambda: _autograd_pool("upsample_linear1d", _npu_upsample_linear1d_backward)),
     ("upsample_bicubic2d", lambda: _autograd_pool("upsample_bicubic2d", _npu_upsample_bicubic2d_backward)),
+    # TODO: re-enable native softmax backward when aclnnSoftmaxBackward stops segfaulting on 910B/CANN 8.5.0.
+    ("softmax", lambda: _npu_autograd_softmax("softmax")),
     # Grid sample
     ("grid_sample", lambda: _npu_autograd_grid_sample("grid_sample")),
     # Dropout

--- a/tests/npu/common/test_ops.py
+++ b/tests/npu/common/test_ops.py
@@ -1013,6 +1013,28 @@ def test_npu_softmax(dtype):
     assert np.allclose(row_sums, np.ones(2), atol=1e-3)
 
 
+def test_npu_softmax_backward_stays_on_npu():
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+    data = np.array([[1.0, 2.0, 3.0], [2.0, 0.0, -1.0]], dtype=np.float32)
+    upstream = np.array([[0.5, -1.0, 2.0], [1.5, -0.5, 0.25]], dtype=np.float32)
+    x = torch.tensor(data, device="npu", requires_grad=True)
+    grad_out = torch.tensor(upstream, device="npu")
+
+    from candle.nn import functional as F
+    out = F.softmax(x, dim=-1)
+    (out * grad_out).sum().backward()
+
+    e_x = np.exp(data - np.max(data, axis=-1, keepdims=True))
+    softmax = e_x / np.sum(e_x, axis=-1, keepdims=True)
+    expected = softmax * (upstream - np.sum(upstream * softmax, axis=-1, keepdims=True))
+
+    assert x.grad is not None
+    assert x.grad.device.type == "npu"
+    assert x.grad.shape == x.shape
+    assert np.allclose(x.grad.to("cpu").numpy(), expected, atol=1e-3, rtol=1e-3)
+
+
 @pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
 def test_npu_log_softmax(dtype):
     if not torch.npu.is_available():


### PR DESCRIPTION
## Summary
- add a single-script NPU benchmark for MLP, transformer, and ResNet-style training blocks comparing `candle` against `torch_npu`
- support separate Python executables for candle and torch_npu workers so one script can compare different envs
- keep NPU softmax backward on-device via composite AutogradNPU path while `aclnnSoftmaxBackward` segfaults on 910B/CANN 8.5.0

## Test plan
- [x] `python -m py_compile benchmarks/perf_candle_vs_torch_npu.py`
- [x] `LD_PRELOAD=/home/jenkins/anaconda3/envs/candle311/lib/python3.11/site-packages/torch/lib/libgomp.so.1 PYTHONPATH=src /home/jenkins/anaconda3/envs/candle311/bin/python -m pytest tests/cpu/ tests/contract/ -v --tb=short` — 3428 passed, 30 skipped
- [x] `source /usr/local/Ascend/ascend-toolkit/set_env.sh && LD_PRELOAD=/home/jenkins/anaconda3/envs/candle311/lib/python3.11/site-packages/torch/lib/libgomp.so.1 PYTHONPATH=src /home/jenkins/anaconda3/envs/candle311/bin/python -m pytest tests/npu/common/test_ops.py::test_npu_softmax_backward_stays_on_npu tests/npu/common/test_ops.py::test_npu_softmax -v --tb=short` — 3 passed
- [x] `PYTHONPATH=src /home/jenkins/anaconda3/envs/candle311/bin/pylint src/candle/ --rcfile=.github/pylint.conf` — 10.00/10
- [x] `source /usr/local/Ascend/ascend-toolkit/set_env.sh && /home/jenkins/anaconda3/envs/candle311/bin/python benchmarks/perf_candle_vs_torch_npu.py --cases mlp,xfmr,resnet --iters 1 --warmup 1 --candle-python /home/jenkins/anaconda3/envs/candle311/bin/python --torch-npu-python /home/jenkins/anaconda3/envs/torchnpu311/bin/python`

🤖 Generated with [Claude Code](https://claude.com/claude-code)