### PR TITLE
bench(npu): add backward op bottleneck cases

### DIFF
--- a/benchmarks/op_benchmark_npu/cases.py
+++ b/benchmarks/op_benchmark_npu/cases.py
@@ -1,6 +1,6 @@
-"""Op benchmark case definitions for Llama-7B / Qwen-7B shapes."""
+"""Op benchmark case definitions for NPU workloads."""
 
-# Model constants
+# LLM-style constants used by the existing forward cases.
 HIDDEN = 4096
 INTERMEDIATE = 11008
 HEADS = 32
@@ -18,8 +18,34 @@ DTYPES = {
     "fp32": "float32",
 }
 
+MODES = {
+    "fwd": "Forward",
+    "bwd": "Backward",
+}
+
+
+def _clear_grads(*values):
+    for value in values:
+        if value is None:
+            continue
+        if isinstance(value, (list, tuple)):
+            _clear_grads(*value)
+            continue
+        if getattr(value, "grad", None) is not None:
+            value.grad = None
+
+
+def _with_cleanup(fn, *values, setup=None):
+    def cleanup():
+        _clear_grads(*values)
+    if setup is not None:
+        fn.setup = setup
+    fn.cleanup = cleanup
+    return fn
+
 
 def _build_matmul_qkv(torch_mod, F, device, dtype, batch, seq):
+    del F
     x = torch_mod.randn((batch, seq, HIDDEN), device=device, dtype=dtype)
     w = torch_mod.randn((HIDDEN, HIDDEN), device=device, dtype=dtype)
     def fn():
@@ -28,6 +54,7 @@ def _build_matmul_qkv(torch_mod, F, device, dtype, batch, seq):
 
 
 def _build_matmul_ffn_up(torch_mod, F, device, dtype, batch, seq):
+    del F
     x = torch_mod.randn((batch, seq, HIDDEN), device=device, dtype=dtype)
     w = torch_mod.randn((HIDDEN, INTERMEDIATE), device=device, dtype=dtype)
     def fn():
@@ -36,6 +63,7 @@ def _build_matmul_ffn_up(torch_mod, F, device, dtype, batch, seq):
 
 
 def _build_matmul_ffn_down(torch_mod, F, device, dtype, batch, seq):
+    del F
     x = torch_mod.randn((batch, seq, INTERMEDIATE), device=device, dtype=dtype)
     w = torch_mod.randn((INTERMEDIATE, HIDDEN), device=device, dtype=dtype)
     def fn():
@@ -44,6 +72,7 @@ def _build_matmul_ffn_down(torch_mod, F, device, dtype, batch, seq):
 
 
 def _build_bmm_attn_scores(torch_mod, F, device, dtype, batch, seq):
+    del F
     n = batch * HEADS
     q = torch_mod.randn((n, seq, HEAD_DIM), device=device, dtype=dtype)
     k = torch_mod.randn((n, HEAD_DIM, seq), device=device, dtype=dtype)
@@ -53,6 +82,7 @@ def _build_bmm_attn_scores(torch_mod, F, device, dtype, batch, seq):
 
 
 def _build_bmm_attn_output(torch_mod, F, device, dtype, batch, seq):
+    del F
     n = batch * HEADS
     s = torch_mod.randn((n, seq, seq), device=device, dtype=dtype)
     v = torch_mod.randn((n, seq, HEAD_DIM), device=device, dtype=dtype)
@@ -70,6 +100,7 @@ def _build_softmax(torch_mod, F, device, dtype, batch, seq):
 
 
 def _build_rms_norm(torch_mod, F, device, dtype, batch, seq):
+    del F
     x = torch_mod.randn((batch, seq, HIDDEN), device=device, dtype=dtype)
     eps = 1e-6
     def fn():
@@ -85,6 +116,7 @@ def _build_silu(torch_mod, F, device, dtype, batch, seq):
 
 
 def _build_mul(torch_mod, F, device, dtype, batch, seq):
+    del F
     a = torch_mod.randn((batch, seq, INTERMEDIATE), device=device, dtype=dtype)
     b = torch_mod.randn((batch, seq, INTERMEDIATE), device=device, dtype=dtype)
     def fn():
@@ -93,6 +125,7 @@ def _build_mul(torch_mod, F, device, dtype, batch, seq):
 
 
 def _build_add(torch_mod, F, device, dtype, batch, seq):
+    del F
     a = torch_mod.randn((batch, seq, HIDDEN), device=device, dtype=dtype)
     b = torch_mod.randn((batch, seq, HIDDEN), device=device, dtype=dtype)
     def fn():
@@ -101,6 +134,7 @@ def _build_add(torch_mod, F, device, dtype, batch, seq):
 
 
 def _build_rope(torch_mod, F, device, dtype, batch, seq):
+    del F
     x = torch_mod.randn((batch, HEADS, seq, HEAD_DIM), device=device, dtype=dtype)
     cos = torch_mod.randn((batch, HEADS, seq, HEAD_DIM), device=device, dtype=dtype)
     sin = torch_mod.randn((batch, HEADS, seq, HEAD_DIM), device=device, dtype=dtype)
@@ -138,19 +172,190 @@ def _build_dropout(torch_mod, F, device, dtype, batch, seq):
     return fn
 
 
+# Backward cases use fixed shapes from benchmarks/perf_candle_vs_torch_npu.py.
+def _build_linear_bwd(torch_mod, F, device, dtype, batch, in_features, out_features):
+    del F
+    x = torch_mod.randn((batch, in_features), device=device, dtype=dtype, requires_grad=True)
+    w = torch_mod.randn((in_features, out_features), device=device, dtype=dtype, requires_grad=True)
+    loss = None
+    def setup():
+        nonlocal loss
+        loss = torch_mod.matmul(x, w).sum()
+    def fn():
+        loss.backward()
+    return _with_cleanup(fn, x, w, setup=setup)
+
+
+def _build_linear_bwd_mlp_1024_4096(torch_mod, F, device, dtype, batch, seq):
+    del seq
+    return _build_linear_bwd(torch_mod, F, device, dtype, 32, 1024, 4096)
+
+
+def _build_linear_bwd_mlp_4096_4096(torch_mod, F, device, dtype, batch, seq):
+    del batch, seq
+    return _build_linear_bwd(torch_mod, F, device, dtype, 32, 4096, 4096)
+
+
+def _build_linear_bwd_xfmr_512_512(torch_mod, F, device, dtype, batch, seq):
+    del batch, seq
+    return _build_linear_bwd(torch_mod, F, device, dtype, 2 * 128, 512, 512)
+
+
+def _build_linear_bwd_xfmr_ff1(torch_mod, F, device, dtype, batch, seq):
+    del batch, seq
+    return _build_linear_bwd(torch_mod, F, device, dtype, 2 * 128, 512, 2048)
+
+
+def _build_linear_bwd_xfmr_ff2(torch_mod, F, device, dtype, batch, seq):
+    del batch, seq
+    return _build_linear_bwd(torch_mod, F, device, dtype, 2 * 128, 2048, 512)
+
+
+def _build_gelu_bwd(torch_mod, F, device, dtype, batch, seq):
+    del batch, seq
+    x = torch_mod.randn((32, 4096), device=device, dtype=dtype, requires_grad=True)
+    loss = None
+    def setup():
+        nonlocal loss
+        loss = F.gelu(x).sum()
+    def fn():
+        loss.backward()
+    return _with_cleanup(fn, x, setup=setup)
+
+
+def _build_layer_norm_bwd(torch_mod, F, device, dtype, batch, seq):
+    del F, batch, seq
+    module = torch_mod.nn.LayerNorm(512).to(device).to(dtype)
+    x = torch_mod.randn((2, 128, 512), device=device, dtype=dtype, requires_grad=True)
+    params = list(module.parameters())
+    loss = None
+    def setup():
+        nonlocal loss
+        loss = module(x).sum()
+    def fn():
+        loss.backward()
+    return _with_cleanup(fn, x, params, setup=setup)
+
+
+def _build_softmax_bwd(torch_mod, F, device, dtype, batch, seq):
+    del batch, seq
+    x = torch_mod.randn((2, 8, 128, 128), device=device, dtype=dtype, requires_grad=True)
+    grad = torch_mod.randn((2, 8, 128, 128), device=device, dtype=dtype)
+    loss = None
+    def setup():
+        nonlocal loss
+        loss = (F.softmax(x, dim=-1) * grad).sum()
+    def fn():
+        loss.backward()
+    return _with_cleanup(fn, x, setup=setup)
+
+
+def _build_matmul_bwd_attn_scores(torch_mod, F, device, dtype, batch, seq):
+    del F, batch, seq
+    q = torch_mod.randn((2, 8, 128, 64), device=device, dtype=dtype, requires_grad=True)
+    k = torch_mod.randn((2, 8, 64, 128), device=device, dtype=dtype, requires_grad=True)
+    loss = None
+    def setup():
+        nonlocal loss
+        loss = torch_mod.matmul(q, k).sum()
+    def fn():
+        loss.backward()
+    return _with_cleanup(fn, q, k, setup=setup)
+
+
+def _build_matmul_bwd_attn_output(torch_mod, F, device, dtype, batch, seq):
+    del F, batch, seq
+    attn = torch_mod.randn((2, 8, 128, 128), device=device, dtype=dtype, requires_grad=True)
+    v = torch_mod.randn((2, 8, 128, 64), device=device, dtype=dtype, requires_grad=True)
+    loss = None
+    def setup():
+        nonlocal loss
+        loss = torch_mod.matmul(attn, v).sum()
+    def fn():
+        loss.backward()
+    return _with_cleanup(fn, attn, v, setup=setup)
+
+
+def _build_conv2d_bwd_resnet(torch_mod, F, device, dtype, batch, seq):
+    del F, batch, seq
+    module = torch_mod.nn.Conv2d(64, 64, 3, padding=1, bias=False).to(device).to(dtype)
+    x = torch_mod.randn((8, 64, 32, 32), device=device, dtype=dtype, requires_grad=True)
+    params = list(module.parameters())
+    loss = None
+    def setup():
+        nonlocal loss
+        loss = module(x).sum()
+    def fn():
+        loss.backward()
+    return _with_cleanup(fn, x, params, setup=setup)
+
+
+def _build_batch_norm_bwd_resnet(torch_mod, F, device, dtype, batch, seq):
+    del F, batch, seq
+    module = torch_mod.nn.BatchNorm2d(64).to(device).to(dtype)
+    x = torch_mod.randn((8, 64, 32, 32), device=device, dtype=dtype, requires_grad=True)
+    params = list(module.parameters())
+    loss = None
+    def setup():
+        nonlocal loss
+        loss = module(x).sum()
+    def fn():
+        loss.backward()
+    return _with_cleanup(fn, x, params, setup=setup)
+
+
+def _build_relu_bwd_resnet(torch_mod, F, device, dtype, batch, seq):
+    del batch, seq
+    x = torch_mod.randn((8, 64, 32, 32), device=device, dtype=dtype, requires_grad=True)
+    loss = None
+    def setup():
+        nonlocal loss
+        loss = F.relu(x).sum()
+    def fn():
+        loss.backward()
+    return _with_cleanup(fn, x, setup=setup)
+
+
+def _build_add_bwd_residual(torch_mod, F, device, dtype, batch, seq):
+    del F, batch, seq
+    a = torch_mod.randn((8, 64, 32, 32), device=device, dtype=dtype, requires_grad=True)
+    b = torch_mod.randn((8, 64, 32, 32), device=device, dtype=dtype, requires_grad=True)
+    loss = None
+    def setup():
+        nonlocal loss
+        loss = torch_mod.add(a, b).sum()
+    def fn():
+        loss.backward()
+    return _with_cleanup(fn, a, b, setup=setup)
+
+
 OP_CASES = [
-    {"name": "matmul_qkv", "build": _build_matmul_qkv},
-    {"name": "matmul_ffn_up", "build": _build_matmul_ffn_up},
-    {"name": "matmul_ffn_down", "build": _build_matmul_ffn_down},
-    {"name": "bmm_attn_scores", "build": _build_bmm_attn_scores},
-    {"name": "bmm_attn_output", "build": _build_bmm_attn_output},
-    {"name": "softmax", "build": _build_softmax},
-    {"name": "rms_norm", "build": _build_rms_norm},
-    {"name": "silu", "build": _build_silu},
-    {"name": "mul", "build": _build_mul},
-    {"name": "add", "build": _build_add},
-    {"name": "rope", "build": _build_rope},
-    {"name": "cross_entropy", "build": _build_cross_entropy},
-    {"name": "embedding", "build": _build_embedding},
-    {"name": "dropout", "build": _build_dropout},
+    {"name": "matmul_qkv", "mode": "fwd", "build": _build_matmul_qkv},
+    {"name": "matmul_ffn_up", "mode": "fwd", "build": _build_matmul_ffn_up},
+    {"name": "matmul_ffn_down", "mode": "fwd", "build": _build_matmul_ffn_down},
+    {"name": "bmm_attn_scores", "mode": "fwd", "build": _build_bmm_attn_scores},
+    {"name": "bmm_attn_output", "mode": "fwd", "build": _build_bmm_attn_output},
+    {"name": "softmax", "mode": "fwd", "build": _build_softmax},
+    {"name": "rms_norm", "mode": "fwd", "build": _build_rms_norm},
+    {"name": "silu", "mode": "fwd", "build": _build_silu},
+    {"name": "mul", "mode": "fwd", "build": _build_mul},
+    {"name": "add", "mode": "fwd", "build": _build_add},
+    {"name": "rope", "mode": "fwd", "build": _build_rope},
+    {"name": "cross_entropy", "mode": "fwd", "build": _build_cross_entropy},
+    {"name": "embedding", "mode": "fwd", "build": _build_embedding},
+    {"name": "dropout", "mode": "fwd", "build": _build_dropout},
+    {"name": "linear_bwd_mlp_1024_4096", "mode": "bwd", "build": _build_linear_bwd_mlp_1024_4096},
+    {"name": "linear_bwd_mlp_4096_4096", "mode": "bwd", "build": _build_linear_bwd_mlp_4096_4096},
+    {"name": "linear_bwd_xfmr_512_512", "mode": "bwd", "build": _build_linear_bwd_xfmr_512_512},
+    {"name": "linear_bwd_xfmr_ff1", "mode": "bwd", "build": _build_linear_bwd_xfmr_ff1},
+    {"name": "linear_bwd_xfmr_ff2", "mode": "bwd", "build": _build_linear_bwd_xfmr_ff2},
+    {"name": "gelu_bwd", "mode": "bwd", "build": _build_gelu_bwd},
+    {"name": "layer_norm_bwd", "mode": "bwd", "build": _build_layer_norm_bwd},
+    {"name": "softmax_bwd", "mode": "bwd", "build": _build_softmax_bwd},
+    {"name": "matmul_bwd_attn_scores", "mode": "bwd", "build": _build_matmul_bwd_attn_scores},
+    {"name": "matmul_bwd_attn_output", "mode": "bwd", "build": _build_matmul_bwd_attn_output},
+    {"name": "conv2d_bwd_resnet", "mode": "bwd", "build": _build_conv2d_bwd_resnet},
+    {"name": "batch_norm_bwd_resnet", "mode": "bwd", "build": _build_batch_norm_bwd_resnet},
+    {"name": "relu_bwd_resnet", "mode": "bwd", "build": _build_relu_bwd_resnet},
+    {"name": "add_bwd_residual", "mode": "bwd", "build": _build_add_bwd_residual},
 ]

--- a/benchmarks/op_benchmark_npu/report.py
+++ b/benchmarks/op_benchmark_npu/report.py
@@ -2,30 +2,24 @@
 import os
 from datetime import datetime
 
-from .cases import SCENARIOS, DTYPES
+from .cases import SCENARIOS, DTYPES, MODES
 
 
-def _format_ratio(candle_ms, torch_ms):
-    if torch_ms <= 0 or candle_ms <= 0:
-        return "N/A"
-    ratio = candle_ms / torch_ms
-    return f"{ratio:.2f}x"
-
-
-def _build_section(dtype_key, scen_key, candle_map, torch_map, op_names):
-    """Build one table section. Returns (lines, ratios) where ratios is list of floats."""
+def _build_section(mode_key, dtype_key, scen_key, candle_map, torch_map, op_names):
     dtype_label = DTYPES[dtype_key]
+    mode_label = MODES[mode_key]
     scen_label = SCENARIOS[scen_key]["label"]
-    header = f"### {dtype_label} — {scen_label}"
+    header = f"### {mode_label} — {dtype_label} — {scen_label}"
 
     lines = [header, ""]
-    lines.append("| Op | candle (ms) | torch_npu (ms) | ratio |")
-    lines.append("|---|---|---|---|")
+    lines.append("| Op | candle (ms) | torch_npu (ms) | ratio | impact |")
+    lines.append("|---|---|---|---|---|")
 
     ratios = []
+    rows = []
     for op in op_names:
-        c = candle_map.get((op, dtype_key, scen_key))
-        t = torch_map.get((op, dtype_key, scen_key))
+        c = candle_map.get((op, mode_key, dtype_key, scen_key))
+        t = torch_map.get((op, mode_key, dtype_key, scen_key))
 
         c_med = c["median_ms"] if c and c["status"] == "ok" else None
         t_med = t["median_ms"] if t and t["status"] == "ok" else None
@@ -33,30 +27,38 @@ def _build_section(dtype_key, scen_key, candle_map, torch_map, op_names):
         c_str = f"{c_med:.4f}" if c_med is not None else ("ERR" if c else "—")
         t_str = f"{t_med:.4f}" if t_med is not None else ("ERR" if t else "—")
 
+        ratio = None
+        impact = None
         if c_med is not None and t_med is not None and t_med > 0:
             ratio = c_med / t_med
+            impact = c_med - t_med
+            ratios.append((op, ratio))
             r_str = f"{ratio:.2f}x"
-            ratios.append(ratio)
+            impact_str = f"{impact:.4f}"
         else:
             r_str = "N/A"
+            impact_str = "N/A"
 
-        # Show error detail if any
         if c and c["status"] != "ok":
             c_str = c["status"][:30]
         if t and t["status"] != "ok":
             t_str = t["status"][:30]
 
-        lines.append(f"| {op} | {c_str} | {t_str} | {r_str} |")
+        rows.append((ratio if ratio is not None else -1.0, impact if impact is not None else -1.0,
+                     f"| {op} | {c_str} | {t_str} | {r_str} | {impact_str} |"))
 
+    rows.sort(key=lambda item: (item[0], item[1]), reverse=True)
+    lines.extend(row for _, _, row in rows)
     lines.append("")
     return lines, ratios
 
 
-def generate_report(candle_results, torch_results, op_names, dtype_keys, scen_keys):
+def generate_report(candle_results, torch_results, op_names, dtype_keys, scen_keys, mode_keys=None):
     """Generate full report. Returns markdown string."""
-    # Index results by (op, dtype, scenario)
-    candle_map = {(r["op"], r["dtype"], r["scenario"]): r for r in candle_results}
-    torch_map = {(r["op"], r["dtype"], r["scenario"]): r for r in torch_results}
+    if mode_keys is None:
+        mode_keys = ["fwd"]
+    candle_map = {(r["op"], r.get("mode", "fwd"), r["dtype"], r["scenario"]): r for r in candle_results}
+    torch_map = {(r["op"], r.get("mode", "fwd"), r["dtype"], r["scenario"]): r for r in torch_results}
 
     now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     lines = [
@@ -66,53 +68,50 @@ def generate_report(candle_results, torch_results, op_names, dtype_keys, scen_ke
         "",
     ]
 
-    # Try to get device info
     try:
-        with open("/usr/local/Ascend/firmware/version.info", "r") as f:
-            lines.append(f"Device info: {f.read().strip()}")
+        with open("/usr/local/Ascend/firmware/version.info", "r", encoding="utf-8") as handle:
+            lines.append(f"Device info: {handle.read().strip()}")
             lines.append("")
     except (FileNotFoundError, PermissionError):
         pass
 
     summary_rows = []
 
-    for dtype_key in dtype_keys:
-        for scen_key in scen_keys:
-            section_lines, ratios = _build_section(
-                dtype_key, scen_key, candle_map, torch_map, op_names
-            )
-            lines.extend(section_lines)
+    for mode_key in mode_keys:
+        for dtype_key in dtype_keys:
+            for scen_key in scen_keys:
+                mode_ops = [
+                    op for op in op_names
+                    if ((op, mode_key, dtype_key, scen_key) in candle_map
+                        or (op, mode_key, dtype_key, scen_key) in torch_map)
+                ]
+                if not mode_ops:
+                    continue
+                section_lines, ratios = _build_section(
+                    mode_key, dtype_key, scen_key, candle_map, torch_map, mode_ops
+                )
+                lines.extend(section_lines)
 
-            if ratios:
-                avg = sum(ratios) / len(ratios)
-                worst_idx = max(range(len(ratios)), key=ratios.__getitem__)
-                # Find which op corresponds to worst
-                valid_ops = []
-                for op in op_names:
-                    c = candle_map.get((op, dtype_key, scen_key))
-                    t = torch_map.get((op, dtype_key, scen_key))
-                    if (c and c["status"] == "ok" and t and t["status"] == "ok"
-                            and t["median_ms"] > 0):
-                        valid_ops.append(op)
-                worst_op = valid_ops[worst_idx] if worst_idx < len(valid_ops) else "?"
-                worst_ratio = ratios[worst_idx]
-                summary_rows.append({
-                    "dtype": DTYPES[dtype_key],
-                    "scenario": scen_key,
-                    "avg_ratio": avg,
-                    "worst_op": worst_op,
-                    "worst_ratio": worst_ratio,
-                })
+                if ratios:
+                    avg = sum(ratio for _, ratio in ratios) / len(ratios)
+                    worst_op, worst_ratio = max(ratios, key=lambda item: item[1])
+                    summary_rows.append({
+                        "mode": MODES[mode_key],
+                        "dtype": DTYPES[dtype_key],
+                        "scenario": scen_key,
+                        "avg_ratio": avg,
+                        "worst_op": worst_op,
+                        "worst_ratio": worst_ratio,
+                    })
 
-    # Summary table
     if summary_rows:
         lines.append("### Summary")
         lines.append("")
-        lines.append("| dtype | scenario | avg ratio | worst op (ratio) |")
-        lines.append("|---|---|---|---|")
+        lines.append("| mode | dtype | scenario | avg ratio | worst op (ratio) |")
+        lines.append("|---|---|---|---|---|")
         for row in summary_rows:
             lines.append(
-                f"| {row['dtype']} | {row['scenario']} | "
+                f"| {row['mode']} | {row['dtype']} | {row['scenario']} | "
                 f"{row['avg_ratio']:.2f}x | "
                 f"{row['worst_op']} ({row['worst_ratio']:.2f}x) |"
             )
@@ -131,6 +130,6 @@ def write_markdown(report_md, output_dir):
     os.makedirs(output_dir, exist_ok=True)
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
     path = os.path.join(output_dir, f"op_benchmark_{ts}.md")
-    with open(path, "w") as f:
-        f.write(report_md)
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(report_md)
     return path

--- a/benchmarks/op_benchmark_npu/run.py
+++ b/benchmarks/op_benchmark_npu/run.py
@@ -2,17 +2,18 @@
 import argparse
 import json
 import os
+import shlex
 import subprocess
 import sys
 
-from .cases import OP_CASES, SCENARIOS, DTYPES
+from .cases import OP_CASES, SCENARIOS, DTYPES, MODES
 from .report import generate_report, print_terminal, write_markdown
 
 # Conda environments for each framework
 CONDA_PREFIX = os.environ.get("CONDA_PREFIX_BASE", "/opt/miniconda3")
 CONDA_ENVS = {
-    "candle": "candle",
-    "torch": "mindie",
+    "candle": os.environ.get("CANDLE_CONDA_ENV", "candle"),
+    "torch": os.environ.get("TORCH_NPU_CONDA_ENV", "mindie"),
 }
 
 
@@ -31,6 +32,8 @@ def _run_worker(framework, args):
         worker_args.extend(["--scenario", args.scenario])
     if args.dtype:
         worker_args.extend(["--dtype", args.dtype])
+    if args.mode:
+        worker_args.extend(["--mode", args.mode])
 
     # Source CANN env + conda env in a shell so workers get correct LD_LIBRARY_PATH
     cann_env = os.environ.get(
@@ -39,7 +42,7 @@ def _run_worker(framework, args):
     conda_sh = os.environ.get(
         "CONDA_SH", "/opt/miniconda3/etc/profile.d/conda.sh"
     )
-    worker_args_str = " ".join(worker_args)
+    worker_args_str = " ".join(shlex.quote(arg) for arg in worker_args)
     shell_cmd = (
         f"source {cann_env} 2>/dev/null; "
         f"source {conda_sh} && "
@@ -82,6 +85,8 @@ def main():
                         help="Only run one scenario")
     parser.add_argument("--dtype", default=None,
                         help="Comma-separated dtype keys: fp16,bf16,fp32")
+    parser.add_argument("--mode", default="fwd", choices=["fwd", "bwd", "both"],
+                        help="Run forward cases, backward cases, or both")
     parser.add_argument("--warmup", type=int, default=10)
     parser.add_argument("--iters", type=int, default=50)
     parser.add_argument("--output", default=None,
@@ -89,10 +94,15 @@ def main():
     args = parser.parse_args()
 
     # Determine what we're running
+    if args.mode == "both":
+        mode_keys = list(MODES.keys())
+    else:
+        mode_keys = [args.mode]
+
     if args.ops:
         op_names = args.ops.split(",")
     else:
-        op_names = [c["name"] for c in OP_CASES]
+        op_names = [c["name"] for c in OP_CASES if c.get("mode", "fwd") in mode_keys]
 
     if args.scenario:
         scen_keys = [args.scenario]
@@ -114,7 +124,7 @@ def main():
 
     # Generate report
     report = generate_report(candle_results, torch_results,
-                             op_names, dtype_keys, scen_keys)
+                             op_names, dtype_keys, scen_keys, mode_keys)
     print_terminal(report)
 
     if args.output:

--- a/benchmarks/op_benchmark_npu/runner.py
+++ b/benchmarks/op_benchmark_npu/runner.py
@@ -1,15 +1,21 @@
 import time
 
 
-def benchmark_op(fn, warmup=10, iters=50, sync=None):
+def benchmark_op(fn, warmup=10, iters=50, sync=None, setup=None, cleanup=None):
     """Run fn with warmup, then time iters iterations. Returns list of ms."""
     for _ in range(warmup):
+        if setup:
+            setup()
         fn()
         if sync:
             sync()
+        if cleanup:
+            cleanup()
 
     times = []
     for _ in range(iters):
+        if setup:
+            setup()
         if sync:
             sync()
         t0 = time.perf_counter()
@@ -18,6 +24,8 @@ def benchmark_op(fn, warmup=10, iters=50, sync=None):
             sync()
         t1 = time.perf_counter()
         times.append((t1 - t0) * 1000.0)
+        if cleanup:
+            cleanup()
     return times
 
 

--- a/benchmarks/op_benchmark_npu/worker.py
+++ b/benchmarks/op_benchmark_npu/worker.py
@@ -4,7 +4,7 @@ import json
 import sys
 
 from .runner import benchmark_op, summarize
-from .cases import OP_CASES, SCENARIOS, DTYPES
+from .cases import OP_CASES, SCENARIOS, DTYPES, MODES
 
 
 def _get_framework(framework):
@@ -36,6 +36,7 @@ def main():
     parser.add_argument("--ops", default=None, help="Comma-separated op names")
     parser.add_argument("--scenario", default=None, choices=["infer", "train"])
     parser.add_argument("--dtype", default=None, help="Comma-separated: fp16,bf16,fp32")
+    parser.add_argument("--mode", default="fwd", choices=["fwd", "bwd", "both"])
     parser.add_argument("--warmup", type=int, default=10)
     parser.add_argument("--iters", type=int, default=50)
     args = parser.parse_args()
@@ -44,6 +45,11 @@ def main():
 
     # Filter ops
     cases = OP_CASES
+    if args.mode and args.mode != "both":
+        cases = [c for c in cases if c.get("mode", "fwd") == args.mode]
+    elif args.mode == "both":
+        mode_names = set(MODES.keys())
+        cases = [c for c in cases if c.get("mode", "fwd") in mode_names]
     if args.ops:
         op_names = set(args.ops.split(","))
         cases = [c for c in cases if c["name"] in op_names]
@@ -68,11 +74,18 @@ def main():
                 op_name = case["name"]
                 try:
                     fn = case["build"](torch_mod, F, device, dtype, batch, seq)
-                    samples = benchmark_op(fn, warmup=args.warmup,
-                                           iters=args.iters, sync=sync)
+                    samples = benchmark_op(
+                        fn,
+                        warmup=args.warmup,
+                        iters=args.iters,
+                        sync=sync,
+                        setup=getattr(fn, "setup", None),
+                        cleanup=getattr(fn, "cleanup", None),
+                    )
                     mean, median, p95 = summarize(samples)
                     results.append({
                         "op": op_name,
+                        "mode": case.get("mode", "fwd"),
                         "dtype": dtype_key,
                         "scenario": scen_key,
                         "mean_ms": round(mean, 4),
@@ -83,6 +96,7 @@ def main():
                 except Exception as e:
                     results.append({
                         "op": op_name,
+                        "mode": case.get("mode", "fwd"),
                         "dtype": dtype_key,
                         "scenario": scen_key,
                         "mean_ms": 0.0,


### PR DESCRIPTION
## Summary
- Add `--mode fwd|bwd|both` to the NPU op benchmark harness while keeping forward as the default.
- Add fixed-shape backward cases that map the end-to-end MLP, Transformer, and ResNet benchmark gaps to concrete training ops.
- Report mode-aware ratio tables sorted by bottleneck severity with an impact column.

## Test plan
- `python -m py_compile benchmarks/op_benchmark_npu/cases.py benchmarks/op_benchmark_npu/runner.py benchmarks/op_benchmark_npu/worker.py benchmarks/op_benchmark_npu/run.py benchmarks/op_benchmark_npu/report.py`
- `pylint benchmarks/op_benchmark_npu/cases.py benchmarks/op_benchmark_npu/runner.py benchmarks/op_benchmark_npu/worker.py benchmarks/op_benchmark_npu/run.py benchmarks/op_benchmark_npu/report.py --rcfile=.github/pylint.conf` → 10.00/10
- `python -m benchmarks.op_benchmark_npu.run --ops gelu_bwd,add_bwd_residual --mode bwd --scenario train --dtype fp32 --warmup 1 --iters 1`
- `python -m benchmarks.op_benchmark_npu.run --mode bwd --scenario train --dtype fp32 --warmup 1 --iters 1`
- `python -m benchmarks.op_benchmark_npu.run --ops add --scenario train --dtype fp32 --warmup 1 --iters 1`

Smoke bwd top gaps from the full run:
- `add_bwd_residual`: 596.53x
- `linear_bwd_mlp_4096_4096`: 430.42x
- `linear_bwd_mlp_1024_4096`: 25.69x

🤖 Generated with [Claude Code](https://claude.com/claude-code)