### PR TITLE
perf(npu): skip identity multiply in add backward (alpha=1)

### DIFF
--- a/src/candle/_generated/_functions_cy.pyx
+++ b/src/candle/_generated/_functions_cy.pyx
@@ -160,6 +160,12 @@ def _gelu_backward_helper(grad, self_, approximate, keyset):
     return _gelu_grad(grad, self_, keyset)
 
 
+def _maybe_multiply_helper(grad, scalar, keyset):
+    if scalar == 1:
+        return grad
+    return _redispatch("mul", keyset, grad, scalar)
+
+
 def _unsqueeze_to_backward_helper(grad, dim, input_sizes, keyset):
     del dim
     return _redispatch("reshape", keyset, grad, input_sizes)
@@ -1526,7 +1532,7 @@ class AddTensorBackward0(_Node):
         alpha = self._alpha
         with _grad_context(keyset):
             grad_self = _sum_to_backward_helper(grad, self_.shape, keyset)
-            grad_other = _cy_not_implemented("AddTensorBackward0: other")
+            grad_other = _sum_to_backward_helper(_maybe_multiply_helper(grad, alpha, keyset), other.shape, keyset)
         return (grad_self, grad_other,)
 
 class AddScalarBackward0(_Node):
@@ -1587,7 +1593,7 @@ class AddbmmBackward0(_Node):
         beta = self._beta
         alpha = self._alpha
         with _grad_context(keyset):
-            grad_self = _cy_not_implemented("AddbmmBackward0: self")
+            grad_self = _maybe_multiply_helper(grad, beta, keyset)
             grad_batch1 = _cy_not_implemented("AddbmmBackward0: batch1")
             grad_batch2 = _cy_not_implemented("AddbmmBackward0: batch2")
         return (grad_self, grad_batch1, grad_batch2,)
@@ -1703,7 +1709,7 @@ class AddmmBackward0(_Node):
         beta = self._beta
         alpha = self._alpha
         with _grad_context(keyset):
-            grad_self = _cy_not_implemented("AddmmBackward0: self")
+            grad_self = _sum_to_backward_helper(_maybe_multiply_helper(grad, beta, keyset), self_.shape, keyset)
             grad_mat1 = _cy_not_implemented("AddmmBackward0: mat1")
             grad_mat2 = _cy_not_implemented("AddmmBackward0: mat2")
         return (grad_self, grad_mat1, grad_mat2,)
@@ -1738,7 +1744,7 @@ class SparseAddmmBackward0(_Node):
         beta = self._beta
         alpha = self._alpha
         with _grad_context(keyset):
-            grad_self = _cy_not_implemented("SparseAddmmBackward0: self")
+            grad_self = _maybe_multiply_helper(grad, beta, keyset)
             grad_mat1 = _cy_not_implemented("SparseAddmmBackward0: mat1")
             grad_mat2 = _cy_not_implemented("SparseAddmmBackward0: mat2")
         return (grad_self, grad_mat1, grad_mat2,)
@@ -1773,7 +1779,7 @@ class AddmvBackward0(_Node):
         beta = self._beta
         alpha = self._alpha
         with _grad_context(keyset):
-            grad_self = _cy_not_implemented("AddmvBackward0: self")
+            grad_self = _maybe_multiply_helper(grad, beta, keyset)
             grad_mat = _cy_not_implemented("AddmvBackward0: mat")
             grad_vec = _cy_not_implemented("AddmvBackward0: vec")
         return (grad_self, grad_mat, grad_vec,)
@@ -1808,7 +1814,7 @@ class AddrBackward0(_Node):
         beta = self._beta
         alpha = self._alpha
         with _grad_context(keyset):
-            grad_self = _cy_not_implemented("AddrBackward0: self")
+            grad_self = _maybe_multiply_helper(grad, beta, keyset)
             grad_vec1 = _cy_not_implemented("AddrBackward0: vec1")
             grad_vec2 = _cy_not_implemented("AddrBackward0: vec2")
         return (grad_self, grad_vec1, grad_vec2,)
@@ -2264,7 +2270,7 @@ class BaddbmmBackward0(_Node):
         beta = self._beta
         alpha = self._alpha
         with _grad_context(keyset):
-            grad_self = _cy_not_implemented("BaddbmmBackward0: self")
+            grad_self = _maybe_multiply_helper(grad, beta, keyset)
             grad_batch1 = _cy_not_implemented("BaddbmmBackward0: batch1")
             grad_batch2 = _cy_not_implemented("BaddbmmBackward0: batch2")
         return (grad_self, grad_batch1, grad_batch2,)

--- a/src/candle/_generated/functions.py
+++ b/src/candle/_generated/functions.py
@@ -160,6 +160,12 @@ def _gelu_backward_helper(grad, self_, approximate, keyset):
     return _gelu_grad(grad, self_, keyset)
 
 
+def _maybe_multiply_helper(grad, scalar, keyset):
+    if scalar == 1:
+        return grad
+    return redispatch("mul", keyset, grad, scalar)
+
+
 def _unsqueeze_to_backward_helper(grad, dim, input_sizes, keyset):
     del dim
     return redispatch("reshape", keyset, grad, input_sizes)
@@ -1576,7 +1582,7 @@ class AddTensorBackward0(Node):
         alpha = self._alpha
         with _grad_context(keyset):
             grad_self = _sum_to_backward_helper(grad, self_.shape, keyset)
-            grad_other = _sum_to_backward_helper(redispatch("mul", keyset, grad, alpha), other.shape, keyset) if hasattr(other, "shape") else None
+            grad_other = _sum_to_backward_helper(_maybe_multiply_helper(grad, alpha, keyset), other.shape, keyset) if hasattr(other, "shape") else None
         return (grad_self, grad_other,)
 
 class AddScalarBackward0(Node):

--- a/tests/contract/test_formula_transpiler.py
+++ b/tests/contract/test_formula_transpiler.py
@@ -130,6 +130,12 @@ def test_transpile_brace_shape_list_with_method_calls():
     assert '{ batch1, 0)' not in result
 
 
+def test_transpile_maybe_multiply_to_local_helper():
+    formula = 'maybe_multiply(grad, alpha.conj())'
+    expected = '_maybe_multiply_helper(grad, alpha, keyset)'
+    assert transpile(formula) == expected
+
+
 def test_transpile_scalar_type_method_to_dtype_attr():
     formula = 'self.scalar_type()'
     expected = 'self.dtype'

--- a/tools/autograd/formula_transpiler.py
+++ b/tools/autograd/formula_transpiler.py
@@ -51,7 +51,7 @@ _SPECIAL_CALLS = {
     "zeros_like": lambda args: f"{args[0]}._zeros_like()",
     "ones_like": lambda args: f"{args[0]}._ones_like()",
     "handle_r_to_c": lambda args: args[1],
-    "maybe_multiply": lambda args: f'redispatch("mul", keyset, {args[0]}, {args[1]})',
+    "maybe_multiply": lambda args: f'_maybe_multiply_helper({args[0]}, {args[1]}, keyset)',
     "not_implemented": lambda args: f'_raise_not_implemented({args[0]})',
     "std::sqrt": lambda args: f'redispatch("sqrt", keyset, {args[0]})',
     "std::real": lambda args: args[0],

--- a/tools/autograd/gen_functions.py
+++ b/tools/autograd/gen_functions.py
@@ -155,6 +155,12 @@ def _gelu_backward_helper(grad, self_, approximate, keyset):
     return _gelu_grad(grad, self_, keyset)
 
 
+def _maybe_multiply_helper(grad, scalar, keyset):
+    if scalar == 1:
+        return grad
+    return redispatch("mul", keyset, grad, scalar)
+
+
 def _unsqueeze_to_backward_helper(grad, dim, input_sizes, keyset):
     del dim
     return redispatch("reshape", keyset, grad, input_sizes)


### PR DESCRIPTION
## Summary

Optimizes NPU add backward (the most common backward op in residual networks) by avoiding a wasted NPU multiply kernel launch when `alpha == 1`.

### Root cause

The generator lowered `maybe_multiply(grad, alpha)` to an unconditional `redispatch(\"mul\", keyset, grad, alpha)`, so every residual `out = a + b` paid a full NPU multiply on backward — even though `alpha` is 1 in the overwhelmingly common case. Additionally, `AddTensorBackward0` in the regenerated Cython path raised `NotImplementedError` for the `other` gradient.

### Fix

- Add `_maybe_multiply_helper(grad, scalar, keyset)` that returns `grad` unchanged when `scalar == 1`, else falls through to the existing `mul` redispatch.
- Route the generator's `maybe_multiply` lowering through this helper in `formula_transpiler.py` and add the helper to `gen_functions.py` so the generated Python and Cython modules pick it up.
- Regenerate `_functions_cy.pyx` so `AddTensorBackward0` now correctly computes `grad_other = _sum_to_backward_helper(_maybe_multiply_helper(grad, alpha, keyset), other.shape, keyset)` instead of `_cy_not_implemented`.

### Before / after

Focused op benchmark (`add_bwd_residual`, NPU, fp32):

| | Candle median | torch_npu median | ratio |
|---|---|---|---|
| before | 204.7 ms | 0.343 ms | 596.5x |
| after  | 8.09 ms  | 0.267 ms | 30.3x  |

End-to-end (`perf_candle_vs_torch_npu.py --iters 10 --warmup 3`):

| case | bwd before | bwd after | speedup |
|---|---|---|---|
| mlp     | 307 ms | 169 ms | ~1.8x |
| xfmr    | 596 ms |  58 ms | ~10x  |
| resnet  | 204 ms |  11 ms | ~18x  |

## Test plan

- [x] `pylint src/candle/ --rcfile=.github/pylint.conf` → 10.00/10
- [x] `pytest tests/cpu/ tests/contract/` → 3429 passed, 30 skipped
- [x] `pytest tests/npu/` → 374 passed, 16 pre-existing failures (also fail on bare upstream/main, unrelated)
- [x] Codegen roundtrip preserved (`test_gen_autograd_roundtrips_checked_in_generated_sources` passes after regeneration)
- [x] Correctness check: add backward with alpha=1, alpha=2, and broadcast shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)