### PR TITLE
perf(npu): use device-to-device memcpy for same-device copy

### DIFF
--- a/src/candle/_backends/common/convert.py
+++ b/src/candle/_backends/common/convert.py
@@ -34,12 +34,12 @@ def to_device(a, dev, dtype=None, non_blocking=False, copy=False, memory_format=
             if dev.type == "npu":
                 from ..npu import runtime as npu_runtime
                 runtime = npu_runtime.get_runtime(dev.index or 0)
-                runtime.synchronize()
-                arr = npu_runtime._copy_npu_to_cpu(
-                    a.storage().data_ptr(), a.storage().nbytes(), a.shape, a.dtype, runtime=runtime
-                )
-                ptr, _ = npu_runtime._copy_cpu_to_npu(arr, runtime=runtime)
-                storage = npu_typed_storage_from_ptr(ptr, arr.size, a.dtype, device=dev)
+                src_storage = a.storage()
+                nbytes = src_storage.nbytes()
+                count = src_storage.size()
+                dst_ptr = npu_runtime._alloc_device(nbytes, runtime=runtime)
+                npu_runtime.memcpy_d2d(dst_ptr, nbytes, src_storage.data_ptr(), runtime=runtime)
+                storage = npu_typed_storage_from_ptr(dst_ptr, count, a.dtype, device=dev)
                 return _wrap_like(a, storage)
 
             if dev.type == "mps":
@@ -126,18 +126,13 @@ def to_device(a, dev, dtype=None, non_blocking=False, copy=False, memory_format=
         from ..npu import runtime as npu_runtime
 
         src_runtime = npu_runtime.get_runtime(a.device.index or 0)
-        src_runtime.synchronize()
-        src_storage = a.storage()
-        arr = npu_runtime._copy_npu_to_cpu(
-            src_storage.data_ptr(),
-            src_storage.nbytes(),
-            (src_storage.size(),),
-            a.dtype,
-            runtime=src_runtime,
-        )
         dst_runtime = npu_runtime.get_runtime(dev.index or 0)
-        ptr, _ = npu_runtime._copy_cpu_to_npu(arr, runtime=dst_runtime)
-        storage = npu_typed_storage_from_ptr(ptr, arr.size, a.dtype, device=dev)
+        src_storage = a.storage()
+        nbytes = src_storage.nbytes()
+        count = src_storage.size()
+        dst_ptr = npu_runtime._alloc_device(nbytes, runtime=dst_runtime)
+        npu_runtime.memcpy_d2d(dst_ptr, nbytes, src_storage.data_ptr(), runtime=src_runtime)
+        storage = npu_typed_storage_from_ptr(dst_ptr, count, a.dtype, device=dev)
         return _wrap_like(a, storage)
 
     if a.device.type == "npu" and dev.type == "cpu":


### PR DESCRIPTION
## Summary

NPU same-device `to_device(..., copy=True)` (used by `clone`,
`detach.clone`, and the autograd grad-accumulation path) was
routing through the host (NPU→CPU→NPU) for every call. On a
(4096, 4096) fp32 tensor that's a 150 ms host roundtrip per clone.

The autograd engine triggers this in
`_C/_autograd_engine.pyx::_accumulate_tensor_grad` (`stored_grad = grad.clone()`)
the first time a gradient lands on a leaf parameter, so every
backward pass on a model with large parameters paid this tax twice
(once per parameter input).

This PR switches the two NPU branches in
`_backends/common/convert.py::to_device` (same-device same-index
copy, and cross-NPU copy) to allocate a destination buffer with
the existing NPU allocator and perform a true device-to-device
copy via the existing `memcpy_d2d` helper. No new bindings; we
only use APIs already exercised elsewhere in the backend.

## Impact (NPU 910B, fp32)

### Op microbench

```
clone (4096,4096): 150.0 ms → 17.4 ms (per call, includes mid-step sync overhead)
clone (32, 4096):   0.81 ms →  0.49 ms
```

### Backward op bench vs torch_npu

| op | before | after |
|---|---|---|
| linear_bwd_mlp_4096_4096 | 549x | 100x |
| linear_bwd_mlp_1024_4096 | 53x | 32x |
| matmul_bwd_attn_output | 26x | 21x |
| linear_bwd_xfmr_ff2 | 24x | 18x |
| linear_bwd_xfmr_ff1 | 21x | 16x |
| add_bwd_residual | 19x | 15x |
| ... | | |

### End-to-end (mlp/xfmr/resnet)

| case | before | after |
|---|---|---|
| mlp bwd | 268x | 58x |
| xfmr bwd | 24.8x | 19.8x |

## Test plan

- [x] `pylint src/candle/ --rcfile=.github/pylint.conf` clean (10.00/10)
- [x] `pytest tests/cpu/ tests/contract/` — 3429 passed
- [x] `pytest tests/npu/` — 240 passed; 6 pre-existing failures on main, none touched by this change
- [x] `benchmarks/op_benchmark_npu/run.py --mode bwd` — every backward op improved
- [x] `benchmarks/perf_candle_vs_torch_npu.py --cases mlp,xfmr` — measured deltas above
- [x] Correctness: `clone(x).cpu() == x.cpu()` verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)