### PR TITLE
perf(npu): submit same-device d2d clone async on current stream

### DIFF
--- a/src/candle/_backends/common/convert.py
+++ b/src/candle/_backends/common/convert.py
@@ -38,7 +38,10 @@ def to_device(a, dev, dtype=None, non_blocking=False, copy=False, memory_format=
                 nbytes = src_storage.nbytes()
                 count = src_storage.size()
                 dst_ptr = npu_runtime._alloc_device(nbytes, runtime=runtime)
-                npu_runtime.memcpy_d2d(dst_ptr, nbytes, src_storage.data_ptr(), runtime=runtime)
+                npu_runtime.memcpy_d2d(
+                    dst_ptr, nbytes, src_storage.data_ptr(),
+                    runtime=runtime, non_blocking=True,
+                )
                 storage = npu_typed_storage_from_ptr(dst_ptr, count, a.dtype, device=dev)
                 return _wrap_like(a, storage)
 
@@ -131,7 +134,10 @@ def to_device(a, dev, dtype=None, non_blocking=False, copy=False, memory_format=
         nbytes = src_storage.nbytes()
         count = src_storage.size()
         dst_ptr = npu_runtime._alloc_device(nbytes, runtime=dst_runtime)
-        npu_runtime.memcpy_d2d(dst_ptr, nbytes, src_storage.data_ptr(), runtime=src_runtime)
+        npu_runtime.memcpy_d2d(
+            dst_ptr, nbytes, src_storage.data_ptr(),
+            runtime=src_runtime, non_blocking=True,
+        )
         storage = npu_typed_storage_from_ptr(dst_ptr, count, a.dtype, device=dev)
         return _wrap_like(a, storage)
 


### PR DESCRIPTION
## Summary

PR #545 switched the NPU same-device `to_device(..., copy=True)`
path from host-roundtrip to device-to-device memcpy. The copy
was still issued synchronously (blocking `aclrtMemcpy`), which
on 67 MB tensors makes the host wait ~14 ms per call.

Pass `non_blocking=True` so `memcpy_d2d` uses `aclrtMemcpyAsync`
on the current stream. Downstream NPU ops issued on the same
stream serialize after the copy naturally via stream ordering,
so this is purely an overhead removal — no correctness change.

## Impact (NPU 910B, fp32)

### Op microbench

```
clone (4096, 4096) fp32:  17.4 ms → 2.9 ms  (single-call median)
clone (32, 4096) fp32:    0.49 ms → 0.31 ms
```

### Backward op bench vs torch_npu

| op | before PR #545 | after PR #545 | this PR |
|---|---|---|---|
| linear_bwd_mlp_4096_4096 | 549x | 100x | **9.6x** |
| linear_bwd_mlp_1024_4096 | 53x | 32x | **10.1x** |
| matmul_bwd_attn_output | 26x | 21x | **18.0x** |
| linear_bwd_xfmr_ff2 | 24x | 18x | **9.5x** |
| linear_bwd_xfmr_ff1 | 21x | 16x | **9.6x** |
| add_bwd_residual | 19x | 15x | **7.9x** |
| layer_norm_bwd | — | 8.7x | **7.7x** |
| gelu_bwd | — | 7.2x | **6.2x** |
| **backward avg** | — | 20.7x | **9.7x** |

## Test plan

- [x] `pylint src/candle/ --rcfile=.github/pylint.conf` clean (10.00/10)
- [x] `pytest tests/cpu/ tests/contract/` — 3429 passed
- [x] `pytest tests/npu/ -k 'clone or copy or to_device or to_op or convert or view_copy'` — 27 passed
- [x] `pytest tests/npu/ -k 'autograd or backward or grad'` — 4 passed
- [x] `benchmarks/op_benchmark_npu/run.py --mode bwd` — every backward op improved, avg ratio 20.7x → 9.7x
- [x] Correctness: `clone(x).cpu() == x.cpu()` verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)