### PR TITLE
perf(autograd): SumBackward0 uses expand+contiguous instead of zeros+add

### DIFF
--- a/src/candle/_backends/meta/__init__.py
+++ b/src/candle/_backends/meta/__init__.py
@@ -48,6 +48,7 @@ from .ops import (
     _meta_addcmul_meta,
     _meta_addcdiv_meta,
     _meta_view_meta,
+    _meta_expand_meta,
     _meta_contiguous_meta,
     _meta_equal_meta,
     _meta_cummax_meta,
@@ -200,6 +201,8 @@ registry.register("std", "meta", _meta_sum_meta)
 registry.register("var_mean", "meta", _meta_sum_meta)
 registry.register("reshape", "meta", view_backend.reshape, meta=_meta_view_meta)
 registry.register("view", "meta", view_backend.view, meta=_meta_view_meta)
+registry.register("expand", "meta", _meta_expand_meta)
+registry.register("broadcast_to", "meta", _meta_expand_meta)
 registry.register("view_as_real", "meta", view_backend.view_as_real, meta=infer_view_as_real)
 registry.register("view_as_complex", "meta", view_backend.view_as_complex, meta=infer_view_as_complex)
 registry.register("transpose", "meta", view_backend.transpose, meta=_meta_transpose_meta)

--- a/src/candle/_backends/meta/ops.py
+++ b/src/candle/_backends/meta/ops.py
@@ -473,6 +473,27 @@ def _meta_view_meta(a, shape):
     return _meta_tensor(tuple(shape), a.dtype, a.device)
 
 
+def _meta_expand_meta(a, sizes):
+    sizes = tuple(sizes)
+    ndiff = len(sizes) - a.dim()
+    if ndiff < 0:
+        raise RuntimeError("expand: number of sizes must be >= tensor dim")
+    src_shape = (1,) * ndiff + a.shape
+    out_shape = []
+    for i, sz in enumerate(sizes):
+        if sz == -1:
+            out_shape.append(src_shape[i])
+        elif src_shape[i] == 1:
+            out_shape.append(sz)
+        elif src_shape[i] == sz:
+            out_shape.append(sz)
+        else:
+            raise RuntimeError(
+                f"expand: size {sz} not compatible with dim size {src_shape[i]}"
+            )
+    return _meta_tensor(tuple(out_shape), a.dtype, a.device)
+
+
 def _meta_transpose_meta(a, dim0, dim1):
     shape = list(a.shape)
     shape[dim0], shape[dim1] = shape[dim1], shape[dim0]
@@ -642,5 +663,6 @@ __all__ = [
     "_meta_clamp_max_meta",
     "_meta_hardtanh_meta",
     "_meta_view_meta",
+    "_meta_expand_meta",
     "_meta_contiguous_meta",
 ]

--- a/src/candle/_backends/npu/ops/shape.py
+++ b/src/candle/_backends/npu/ops/shape.py
@@ -1308,6 +1308,8 @@ def flatten_op(a, start_dim=0, end_dim=-1):
 
 
 def contiguous(a):
+    if not a.is_contiguous():
+        return _npu_copy_view_to_contiguous(a)
     runtime = npu_runtime.get_runtime((a.device.index or 0))
 
     a_storage = _unwrap_storage(a)

--- a/src/candle/_generated/functions.py
+++ b/src/candle/_generated/functions.py
@@ -10932,9 +10932,8 @@ class SumBackward0(Node):
         self_ = _saved[self._saved_self_idx]
         dtype = self._dtype
         with _grad_context(keyset):
-            grad_self = redispatch("add", keyset,
-                redispatch("zeros", keyset, self_.shape, dtype=grad.dtype, device=grad.device),
-                grad)
+            grad_self = redispatch("contiguous", keyset,
+                redispatch("expand", keyset, grad, self_.shape))
         return (grad_self,)
 
 class SumDimIntListBackward0(Node):

--- a/tests/contract/test_sum_backward_uses_expand.py
+++ b/tests/contract/test_sum_backward_uses_expand.py
@@ -1,0 +1,28 @@
+"""Lock SumBackward0 to expand + contiguous, not the legacy zeros+add path.
+
+The yaml formula for `sum` is `grad.expand_symint(self.sym_sizes())`. Earlier
+versions of the preserved generated `functions.py` used a two-step
+`add(zeros(self.shape), grad)` workaround which cost ~300us per backward step
+on NPU and showed up as one of the largest dispatch overheads in the
+linear_bwd_mlp_4096_4096 microbenchmark. Replacing it with `expand` removes
+the zeros allocation, and the subsequent `contiguous` ensures downstream
+backward consumers receive a materialized (not stride-0) gradient.
+
+This test guards against regressing to the zeros+add pattern.
+"""
+import inspect
+
+from candle._generated import functions as gen_functions
+
+
+def test_sum_backward0_uses_expand_not_zeros_add():
+    src = inspect.getsource(gen_functions.SumBackward0.backward)
+    assert 'redispatch("expand"' in src, (
+        f"SumBackward0.backward should use expand:\n{src}"
+    )
+    assert 'redispatch("zeros"' not in src, (
+        f"SumBackward0.backward should not allocate zeros:\n{src}"
+    )
+    assert 'redispatch("add"' not in src, (
+        f"SumBackward0.backward should not add into zeros:\n{src}"
+    )


### PR DESCRIPTION
## Summary

- Replace SumBackward0's legacy `add(zeros(self.shape), grad)` path with a single `contiguous(expand(grad, self.shape))`. The yaml derivative formula for `sum` is `grad.expand_symint(self.sym_sizes())`, but the preserved generated `functions.py` had the older zeros+add workaround, which cost ~296us per backward step on NPU (207us zeros + 89us add).
- Fix NPU `contiguous`: the previous implementation did a flat `memcpy_d2d` of the whole storage block ignoring strides, so a stride-0 expand view of a scalar materialized garbage. It now routes non-contiguous inputs through `_npu_copy_view_to_contiguous`, which uses `aclnnInplaceCopy` for arbitrary strides. This fixes a real correctness bug — `mul(x, scalar_weight).sum().backward()` was returning the wrong grad on NPU when SumBackward0 used `expand`.
- Add `expand`/`broadcast_to` registrations for the meta backend so `Tensor.to('meta')` users can run the new backward path.
- Add `tests/contract/test_sum_backward_uses_expand.py` to lock the formula and prevent regression to zeros+add.

## Test plan

- [x] CPU + contract: 3430 passed, 30 skipped — no regressions
- [x] NPU: 374 passed (vs 372 before this PR); now fixes `test_mul_zero_dim_npu_parameter_keeps_gradients` and `test_npu_softmax_backward_stays_on_npu`. The remaining 16 failures are pre-existing on `upstream/main`.
- [x] Pylint: 10.00/10
- [x] Op-bench: `linear_bwd_mlp_4096_4096` improved 9.57x → 7.69x
- [x] Contract test `test_sum_backward0_uses_expand_not_zeros_add` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)