### PR TITLE
perf(npu): fast path for broadcast/stride-0 contiguous copies

### DIFF
--- a/src/candle/_backends/npu/ops/shape.py
+++ b/src/candle/_backends/npu/ops/shape.py
@@ -2920,8 +2920,10 @@ def _npu_strided_linear_indices(shape, stride, offset, device):
 def _npu_copy_view_to_contiguous(view):
     """Copy a possibly non-contiguous NPU view to a new contiguous tensor.
 
-    Uses memcpy_d2d for contiguous views (fast path) and index_select with
-    computed linear indices for non-contiguous views.
+    Uses memcpy_d2d for contiguous views (fast path), aclnnInplaceCopy for
+    broadcast/stride-0 views (single-kernel path), and falls back to
+    index_select with computed linear indices for general non-contiguous cases
+    that aclnnInplaceCopy does not accept (e.g., slice with step > 1).
     """
     out_shape = tuple(view.shape)
 
@@ -2936,21 +2938,68 @@ def _npu_copy_view_to_contiguous(view):
         out_storage = npu_typed_storage_from_ptr(out_ptr, out_numel, view.dtype, device=view.device)
         return _wrap_tensor(out_storage, out_shape, out_stride)
 
-    # Non-contiguous: flatten storage, compute linear indices, gather, reshape
+    # Broadcast/stride-0 view fast path: aclnnInplaceCopy supports a strided
+    # source as long as it does not require gather semantics. Detect the
+    # broadcast pattern (some strides are 0, the rest are contiguous on a
+    # contiguous subview).
+    if _is_broadcast_view(view.shape, view.stride):
+        runtime = npu_runtime.get_runtime((view.device.index or 0))
+        out_stride = npu_runtime._contiguous_stride(out_shape)
+        out_numel = max(_numel(out_shape), 1)
+        out_ptr = npu_runtime._alloc_device(out_numel * _dtype_itemsize(view.dtype), runtime=runtime)
+        src_ptr = _npu_data_ptr(view)
+        stream = npu_state.current_stream((view.device.index or 0))
+        aclnn.inplace_copy(
+            out_ptr,
+            src_ptr,
+            out_shape,
+            out_stride,
+            view.dtype,
+            view.shape,
+            view.stride,
+            view.dtype,
+            runtime,
+            stream=stream.stream,
+        )
+        out_storage = npu_typed_storage_from_ptr(out_ptr, out_numel, view.dtype, device=view.device)
+        return _wrap_tensor(out_storage, out_shape, out_stride)
+
+    # General non-contiguous: flatten storage, compute linear indices, gather, reshape
     from ...._dispatch import dispatch
     dev = view.device.type
-    # Get flat storage as 1-D tensor
     storage = view.storage()
     flat_storage = dispatch("reshape", dev,
         _wrap_tensor(storage, (storage.size(),), (1,)),
         (-1,),
     )
-    # Compute linear indices from shape/stride/offset
     indices = _npu_strided_linear_indices(view.shape, view.stride, view.offset, view.device)
-    # Gather elements
     gathered = index_select(flat_storage, 0, indices)
-    # Reshape to target shape
     return dispatch("reshape", dev, gathered, out_shape)
+
+
+def _is_broadcast_view(shape, stride):
+    """Detect broadcast/stride-0 views that aclnnInplaceCopy can handle.
+
+    Returns True when every non-zero stride matches the natural contiguous
+    stride for the non-broadcast dims.
+    """
+    if not shape:
+        return False
+    natural_stride = []
+    acc = 1
+    for d in reversed(shape):
+        natural_stride.append(acc)
+        if d != 1:
+            acc *= d
+    natural_stride.reverse()
+    for sz, st, ns in zip(shape, stride, natural_stride):
+        if st == 0:
+            continue
+        if sz == 1:
+            continue
+        if st != ns:
+            return False
+    return True
 
 
 def as_strided_copy_npu(a, size, stride, storage_offset=None):


### PR DESCRIPTION
## Summary

After #547 switched `SumBackward0` to `expand+contiguous`, the NPU `contiguous` op materialized broadcast/stride-0 views through the slow `index_select` gather path, taking ~23 ms per call for a `1 -> 1024x4096` expand. End-to-end MLP backward regressed to about 40x torch_npu and ResNet backward stayed at about 128x.

This PR adds a fast path inside `_npu_copy_view_to_contiguous`: when every non-zero stride matches the natural contiguous stride for non-broadcast dims (the broadcast/stride-0 pattern), use `aclnnInplaceCopy` directly instead of building linear indices and gathering. `aclnnInplaceCopy` accepts strided sources for broadcast patterns but rejects general strided sources like slice-with-step (`GetWorkspaceSize failed: 561103`), so the existing `index_select` path is retained as a fallback for those cases.

Measured impact (NPU, candle311 env):

- `expand(1 -> 1024x4096).contiguous()`: 23377 us -> 367 us per call (~64x).
- End-to-end mlp bwd vs torch_npu: ~40x -> 11.56x.
- End-to-end resnet bwd vs torch_npu: ~128x -> 4.93x.
- xfmr is not improved by this change and is tracked as a separate bottleneck.

## Test plan

- [x] `tests/npu/common/test_view_copy_ops.py::TestAsStridedCopy::test_strided_view_becomes_contiguous` passes (verifies slice-with-step still works via the index_select fallback).
- [x] `tests/npu/common/test_view_copy_ops.py::TestSlice::test_slice_step` passes.
- [x] Full `tests/npu/` suite: 374 passed / 16 pre-existing failures (no new regressions vs upstream/main).
- [x] `tests/cpu/` + `tests/contract/`: 3430 passed.
- [x] `pylint src/candle/`: 10.00/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)