### PR TITLE
perf(npu): bypass dispatch for NPU same-device clone hot path

### DIFF
--- a/src/candle/_C/_tensor_api.pyx
+++ b/src/candle/_C/_tensor_api.pyx
@@ -58,6 +58,8 @@ cdef object _f32_to_bf16_fn = None
 cdef object _cast_tensor_dtype_npu_fn = None
 cdef object _pinned_cpu_typed_storage_from_numpy_fn = None
 cdef object _npu_available_fn = None
+cdef object _to_device_fn = None
+cdef object _is_profiler_enabled_fn = None
 
 
 cdef inline void _ensure_base():
@@ -159,6 +161,15 @@ cdef inline void _ensure_grad_mode_ref():
     if _is_grad_enabled_fn is None:
         from candle.autograd.grad_mode import is_grad_enabled
         _is_grad_enabled_fn = is_grad_enabled
+
+
+cdef inline void _ensure_clone_fast_refs():
+    global _to_device_fn, _is_profiler_enabled_fn
+    if _to_device_fn is None:
+        from candle._backends.common.convert import to_device
+        from candle.profiler.profiler import is_profiler_enabled
+        _to_device_fn = to_device
+        _is_profiler_enabled_fn = is_profiler_enabled
 
 
 cdef inline void _validate_as_strided_args(tuple size, tuple stride, Py_ssize_t storage_offset):
@@ -475,8 +486,22 @@ def tensor_clone(self, *, memory_format=None):
     cdef object fmt_name
     cdef object out
     cdef object _cl
+    cdef object dev
 
     _ensure_functional_refs()
+
+    # Fast path: NPU same-device clone with no memory_format, no autograd
+    # tracking required, no profiler — bypass dispatch entirely.
+    # When self.requires_grad is False, no autograd metadata needs to attach
+    # regardless of grad_mode, so we only need to gate on the profiler and
+    # layout (channels_last requires the existing relayout branch).
+    if memory_format is None and not self.requires_grad:
+        dev = self.device
+        if dev.type == "npu":
+            _ensure_clone_fast_refs()
+            if (not _is_profiler_enabled_fn()
+                    and not _is_channels_last_stride_tuple(self.shape, self.stride)):
+                return _to_device_fn(self, dev, copy=True)
 
     memory_format = _normalize_memory_format(memory_format)
     fmt_name = _memory_format_name(memory_format)


### PR DESCRIPTION
## Summary

Add a Cython-level fast path to `tensor_clone` (`src/candle/_C/_tensor_api.pyx`) that bypasses the full dispatch chain when:
- no `memory_format` is requested,
- `self.requires_grad is False` (no autograd metadata to attach),
- `self.device.type == 'npu'`,
- profiler is off, and
- source layout is not channels_last (which still needs the relayout branch).

The autograd engine's `_accumulate_tensor_grad` clones leaf gradients on every backward pass (`stored_grad = grad.clone()` at `_autograd_engine.pyx:360`); those grads always satisfy the above conditions, so the fast path fires on every leaf-grad accumulation. All other clone cases (`requires_grad=True`, explicit `memory_format`, non-NPU devices, profiler active, channels_last sources) fall back to the existing dispatch path unchanged.

The fast path delegates to `convert.to_device(self, self.device, copy=True)`, which is already optimized for NPU same-device copies via `_alloc_device + memcpy_d2d(non_blocking=True)`.

## Measurements

Microbenchmark on a (4,4) NPU tensor (isolates dispatch overhead — memcpy is negligible at this shape):
- `tensor.clone()`: ~208us → ~83us
- raw `to_device`: ~60us (unchanged reference)

End-to-end `benchmarks/perf_candle_vs_torch_npu.py --cases mlp,xfmr,resnet --iters 50 --warmup 10`:

| case      | fwd (before → after) | bwd (before → after)    |
|-----------|----------------------|-------------------------|
| mlp       | 3.26 → 3.26 ms       | 8.65 → **7.61 ms** (-12%) |
| xfmr      | 11.80 → 12.26 ms     | 26.18 → **24.87 ms** (-5%) |
| resnet    | 3.27 → 3.37 ms       | 4.43 → **3.58 ms** (-19%) |

(Forward deltas are within run-to-run noise; the change is only reachable from backward leaf-grad accumulation in these benchmarks.)

## Test plan

- [x] pylint passes (10.00/10) on `src/candle/`
- [x] Manual MLP backward sanity check on NPU: gradients flow, all stay on NPU
- [x] 16 autograd-related contract tests pass
- [x] No behavior change for `requires_grad=True`, explicit `memory_format`, non-NPU devices, or profiler-active clones

🤖 Generated with [Claude Code](https://claude.com/claude-code)