### PR TITLE
perf(autograd): collapse reduce_grad sums into single multi-dim calls

### DIFF
--- a/src/candle/_C/_autograd_utils.pyx
+++ b/src/candle/_C/_autograd_utils.pyx
@@ -32,10 +32,24 @@ def _reduce_grad_dispatch(grad, shape):
     from candle.autograd.grad_mode import no_grad
 
     result = grad
+    cdef int rank_diff
     with no_grad():
-        while len(result.shape) > len(shape):
-            result = torch_sum(result, dim=0)
-        for i, (g_dim, s_dim) in enumerate(zip(result.shape, shape)):
-            if s_dim == 1 and g_dim != 1:
-                result = torch_sum(result, dim=i, keepdim=True)
+        # Squash leading broadcast dims (where grad has more dims than target)
+        # in a single multi-dim sum rather than looping one dim at a time.
+        # Cuts dispatch overhead when grad is rank > target rank by more than 1.
+        rank_diff = len(result.shape) - len(shape)
+        if rank_diff > 0:
+            if rank_diff == 1:
+                result = torch_sum(result, dim=0)
+            else:
+                result = torch_sum(result, dim=tuple(range(rank_diff)))
+        # Reduce broadcast-stretched dims (size 1 in target, larger in grad)
+        # in a single multi-dim sum with keepdim=True. Same motivation.
+        reduce_axes = [i for i, (g_dim, s_dim) in enumerate(zip(result.shape, shape))
+                       if s_dim == 1 and g_dim != 1]
+        if reduce_axes:
+            if len(reduce_axes) == 1:
+                result = torch_sum(result, dim=reduce_axes[0], keepdim=True)
+            else:
+                result = torch_sum(result, dim=tuple(reduce_axes), keepdim=True)
     return result


### PR DESCRIPTION
## Summary

`_reduce_grad_dispatch` previously looped one dim at a time, issuing N back-to-back `sum` ops when a gradient needed to be reduced along multiple broadcast axes. ACLNN `aclnnReduceSum` accepts a tuple of dims and Candle's dispatch already supports `sum(dim=(...), keepdim=...)`, so collapse the loops into a single multi-dim call.

## Changes

`src/candle/_C/_autograd_utils.pyx::_reduce_grad_dispatch`:
- Leading rank-diff reduction: when `len(grad.shape) - len(shape) > 1`, issue one `sum(dim=tuple(range(rank_diff)))` instead of `rank_diff` sequential `sum(dim=0)` calls.
- Broadcast-stretched reduction: when more than one axis has `s_dim == 1 and g_dim != 1`, issue one `sum(dim=tuple(reduce_axes), keepdim=True)` instead of looping per axis.
- Rank-diff == 1 and single-axis cases keep the existing single-dim call (no regression).

## Why

Backward functions that go through `reduce_grad` (matmul/add/sub/mul/div backward, etc.) pay one ACLNN dispatch per reduced axis. The kernel itself accepts multiple axes, so the loop turns into pure dispatch overhead.

## Microbenchmark

NPU, fp32, `grad.shape = (32, 16, 128, 64)` reduced to `(1, 1, 128, 64)` — two reduce-axes both keepdim=True:

| Path | Per-call (us) |
|---|---|
| Two sequential `sum(dim=i, keepdim=True)` | 747 |
| One `sum(dim=(0,1), keepdim=True)` | 321 |

~2.3x cheaper per call. End-to-end mlp/xfmr/resnet stay within noise of the post-#551 baseline because those models' bias-grad paths only hit rank_diff == 1 (single sum either way); the win shows up in workloads with deeper broadcasting (e.g. higher-rank attention or general broadcast gradients).

## Correctness

6 manual reduce_grad cases verified on NPU (mlp bias-grad, rank-diff 2, keepdim 1-dim, multi-keepdim, mixed leading+keepdim, no-op) and MLP backward sanity (all grads on NPU, correct shapes).

## Test plan

- [ ] pylint passes
- [ ] CPU + contract tests pass on CI
- [ ] No new NPU test regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)