### PR TITLE
bench(npu): add performance benchmark gates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,4 +198,8 @@ compat/pytorch/_pytorch.local/
 compat/_pytorch/
 compat/_torch_npu/
 compat/reference/reports/
+
+# Benchmark artifacts
+/results/npu_perf_gate/
+
 *.c

--- a/benchmarks/npu_perf_gate.py
+++ b/benchmarks/npu_perf_gate.py
@@ -4,6 +4,8 @@ import os
 import subprocess
 import sys
 
+_BENCHMARKS_DIR = os.path.dirname(os.path.abspath(__file__))
+
 
 def build_commands(*, output_dir, warmup, iters, dtype, cases, pipeline_cases):
     return [
@@ -31,7 +33,7 @@ def build_commands(*, output_dir, warmup, iters, dtype, cases, pipeline_cases):
         ],
         [
             sys.executable,
-            "benchmarks/perf_candle_vs_torch_npu.py",
+            os.path.join(_BENCHMARKS_DIR, "perf_candle_vs_torch_npu.py"),
             "--cases", cases,
             "--dtype", "float16" if dtype == "fp16" else dtype,
             "--warmup", str(warmup),

--- a/benchmarks/npu_perf_gate.py
+++ b/benchmarks/npu_perf_gate.py
@@ -1,0 +1,80 @@
+"""Run L0/L1/L2 NPU performance gates and write JSON artifacts."""
+import argparse
+import os
+import subprocess
+import sys
+
+
+def build_commands(*, output_dir, warmup, iters, dtype, cases, pipeline_cases):
+    return [
+        [
+            sys.executable,
+            "-m", "benchmarks.op_benchmark_npu.run",
+            "--mode", "both",
+            "--dtype", dtype,
+            "--warmup", str(warmup),
+            "--iters", str(iters),
+            "--max-ratio", "1.0",
+            "--json-output", os.path.join(output_dir, "l0_ops.json"),
+            "--fail-on-ratio",
+        ],
+        [
+            sys.executable,
+            "-m", "benchmarks.pipeline_npu.run",
+            "--cases", pipeline_cases,
+            "--mode", "eager",
+            "--warmup", str(warmup),
+            "--iters", str(iters),
+            "--max-ratio", "0.99",
+            "--json-output", os.path.join(output_dir, "l1_pipeline.json"),
+            "--fail-on-ratio",
+        ],
+        [
+            sys.executable,
+            "benchmarks/perf_candle_vs_torch_npu.py",
+            "--cases", cases,
+            "--dtype", "float16" if dtype == "fp16" else dtype,
+            "--warmup", str(warmup),
+            "--iters", str(iters),
+            "--max-fwd-ratio", "0.99",
+            "--max-bwd-ratio", "0.99",
+            "--max-total-ratio", "0.99",
+            "--json-output", os.path.join(output_dir, "l2_models.json"),
+            "--fail-on-ratio",
+        ],
+    ]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", default="results/npu_perf_gate/latest")
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--iters", type=int, default=20)
+    parser.add_argument("--dtype", default="fp16")
+    parser.add_argument("--cases", default="mlp,xfmr,resnet")
+    parser.add_argument("--pipeline-cases", default="A1,A2s,A3,B1s,B2,D2")
+    args = parser.parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    failures = []
+    for command in build_commands(
+        output_dir=args.output_dir,
+        warmup=args.warmup,
+        iters=args.iters,
+        dtype=args.dtype,
+        cases=args.cases,
+        pipeline_cases=args.pipeline_cases,
+    ):
+        print("$ " + " ".join(command), flush=True)
+        proc = subprocess.run(command, check=False)
+        if proc.returncode != 0:
+            failures.append((command, proc.returncode))
+
+    if failures:
+        for command, returncode in failures:
+            print(f"gate failed with exit {returncode}: {' '.join(command)}", file=sys.stderr)
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/npu_perf_gates.py
+++ b/benchmarks/npu_perf_gates.py
@@ -1,5 +1,7 @@
 """Shared metrics and ratio gates for NPU performance benchmarks."""
 
+import statistics
+
 
 def _round_ms(value):
     return round(float(value), 4)
@@ -8,7 +10,7 @@ def _round_ms(value):
 def _nearest_percentile(sorted_values, percentile):
     if not sorted_values:
         return 0.0
-    index = round((len(sorted_values) - 1) * percentile)
+    index = int((len(sorted_values) - 1) * percentile + 0.5)
     return sorted_values[index]
 
 
@@ -30,7 +32,7 @@ def summarize_samples(samples):
     return {
         "sample_count": len(values),
         "mean_ms": _round_ms(sum(values) / len(values)),
-        "median_ms": _round_ms(_nearest_percentile(values, 0.50)),
+        "median_ms": _round_ms(statistics.median(values)),
         "min_ms": _round_ms(values[0]),
         "max_ms": _round_ms(values[-1]),
         "p10_ms": _round_ms(_nearest_percentile(values, 0.10)),
@@ -71,7 +73,9 @@ def annotate_ratio_rows(rows, *, key_fields, metric="median_ms"):
             candle[ratio_field] = round(float(candle_value) / float(ref_value), 4)
 
 
-def collect_ratio_failures(rows, *, key_fields, expected_keys, max_ratio, ratio_field):
+def collect_ratio_failures(
+    rows, *, key_fields, expected_keys, max_ratio, ratio_field, inclusive=True
+):
     """Return human-readable gate failures for missing, errored, or slow rows."""
     by_key = {}
     for row in rows:
@@ -102,9 +106,10 @@ def collect_ratio_failures(rows, *, key_fields, expected_keys, max_ratio, ratio_
         ratio = candle.get(ratio_field)
         if ratio is None:
             failures.append(f"{label}: missing candle {ratio_field}")
-        elif ratio > max_ratio:
+        elif (inclusive and ratio > max_ratio) or (not inclusive and ratio >= max_ratio):
+            comparator = ">" if inclusive else ">="
             failures.append(
-                f"{label}: candle {ratio_field} {ratio:.2f}x > {max_ratio:.2f}x"
+                f"{label}: candle {ratio_field} {ratio:.2f}x {comparator} {max_ratio:.2f}x"
             )
 
     return failures

--- a/benchmarks/npu_perf_gates.py
+++ b/benchmarks/npu_perf_gates.py
@@ -1,0 +1,110 @@
+"""Shared metrics and ratio gates for NPU performance benchmarks."""
+
+
+def _round_ms(value):
+    return round(float(value), 4)
+
+
+def _nearest_percentile(sorted_values, percentile):
+    if not sorted_values:
+        return 0.0
+    index = round((len(sorted_values) - 1) * percentile)
+    return sorted_values[index]
+
+
+def summarize_samples(samples):
+    """Return stable millisecond distribution fields for benchmark samples."""
+    if not samples:
+        return {
+            "sample_count": 0,
+            "mean_ms": 0.0,
+            "median_ms": 0.0,
+            "min_ms": 0.0,
+            "max_ms": 0.0,
+            "p10_ms": 0.0,
+            "p90_ms": 0.0,
+            "p95_ms": 0.0,
+        }
+
+    values = sorted(float(sample) for sample in samples)
+    return {
+        "sample_count": len(values),
+        "mean_ms": _round_ms(sum(values) / len(values)),
+        "median_ms": _round_ms(_nearest_percentile(values, 0.50)),
+        "min_ms": _round_ms(values[0]),
+        "max_ms": _round_ms(values[-1]),
+        "p10_ms": _round_ms(_nearest_percentile(values, 0.10)),
+        "p90_ms": _round_ms(_nearest_percentile(values, 0.90)),
+        "p95_ms": _round_ms(_nearest_percentile(values, 0.95)),
+    }
+
+
+def _row_key(row, key_fields):
+    return tuple(row[field] for field in key_fields)
+
+
+def _ratio_field_name(metric):
+    if metric.endswith("_ms"):
+        return f"{metric[:-3]}_ratio"
+    return f"{metric}_ratio"
+
+
+def annotate_ratio_rows(rows, *, key_fields, metric="median_ms"):
+    """Annotate Candle rows with Candle/torch_npu ratio for matching keys."""
+    by_key = {}
+    for row in rows:
+        by_key.setdefault(_row_key(row, key_fields), {})[row.get("framework")] = row
+
+    ratio_field = _ratio_field_name(metric)
+    for framework_rows in by_key.values():
+        torch_ref = framework_rows.get("torch_npu")
+        candle = framework_rows.get("candle")
+        if torch_ref is not None and torch_ref.get("status", "ok") == "ok":
+            torch_ref[ratio_field] = 1.0
+        if candle is None or torch_ref is None:
+            continue
+        if candle.get("status", "ok") != "ok" or torch_ref.get("status", "ok") != "ok":
+            continue
+        ref_value = torch_ref.get(metric, 0.0)
+        candle_value = candle.get(metric, 0.0)
+        if ref_value:
+            candle[ratio_field] = round(float(candle_value) / float(ref_value), 4)
+
+
+def collect_ratio_failures(rows, *, key_fields, expected_keys, max_ratio, ratio_field):
+    """Return human-readable gate failures for missing, errored, or slow rows."""
+    by_key = {}
+    for row in rows:
+        by_key.setdefault(_row_key(row, key_fields), {})[row.get("framework")] = row
+
+    failures = []
+    for key in expected_keys:
+        by_framework = by_key.get(tuple(key), {})
+        label = "/".join(str(part) for part in key)
+        candle = by_framework.get("candle")
+        torch_ref = by_framework.get("torch_npu")
+
+        if candle is None:
+            failures.append(f"{label}: missing candle result")
+        elif candle.get("status", "ok") != "ok":
+            failures.append(f"{label}/candle: {candle['status']}")
+
+        if torch_ref is None:
+            failures.append(f"{label}: missing torch_npu result")
+        elif torch_ref.get("status", "ok") != "ok":
+            failures.append(f"{label}/torch_npu: {torch_ref['status']}")
+
+        if candle is None or torch_ref is None:
+            continue
+        if candle.get("status", "ok") != "ok" or torch_ref.get("status", "ok") != "ok":
+            continue
+
+        ratio = candle.get(ratio_field)
+        if ratio is None:
+            failures.append(f"{label}: missing candle {ratio_field}")
+        elif ratio > max_ratio:
+            failures.append(
+                f"{label}: candle {ratio_field} {ratio:.2f}x > {max_ratio:.2f}x"
+            )
+
+    return failures

--- a/benchmarks/op_benchmark_npu/report.py
+++ b/benchmarks/op_benchmark_npu/report.py
@@ -82,7 +82,7 @@ def _build_section(mode_key, dtype_key, scen_key, candle_map, torch_map, op_name
 def ratio_failures(candle_results, torch_results, op_names, dtype_keys, scen_keys, mode_keys,
                    max_ratio):
     """Return single-op median ratio gate failures for expected benchmark rows."""
-    rows = list(candle_results) + list(torch_results)
+    rows = [dict(row) for row in candle_results] + [dict(row) for row in torch_results]
     annotate_ratio_rows(rows, key_fields=_KEY_FIELDS, metric="median_ms")
     expected_keys = [
         (op, mode_key, dtype_key, scen_key)
@@ -104,9 +104,12 @@ def generate_report(candle_results, torch_results, op_names, dtype_keys, scen_ke
     """Generate full report. Returns markdown string."""
     if mode_keys is None:
         mode_keys = ["fwd"]
-    rows = list(candle_results) + list(torch_results)
+    rows = [dict(row) for row in candle_results] + [dict(row) for row in torch_results]
     annotate_ratio_rows(rows, key_fields=_KEY_FIELDS, metric="median_ms")
-    candle_map, torch_map = _build_maps(candle_results, torch_results)
+    candle_map, torch_map = _build_maps(
+        rows[:len(candle_results)],
+        rows[len(candle_results):],
+    )
 
     now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     lines = [

--- a/benchmarks/op_benchmark_npu/report.py
+++ b/benchmarks/op_benchmark_npu/report.py
@@ -2,7 +2,27 @@
 import os
 from datetime import datetime
 
+from benchmarks.npu_perf_gates import annotate_ratio_rows, collect_ratio_failures
+
 from .cases import SCENARIOS, DTYPES, MODES
+
+
+_KEY_FIELDS = ("op", "mode", "dtype", "scenario")
+
+
+def _row_key(row):
+    return tuple(row[field] for field in _KEY_FIELDS)
+
+
+def _build_maps(candle_results, torch_results):
+    return ({_row_key(row): row for row in candle_results},
+            {_row_key(row): row for row in torch_results})
+
+
+def _format_p10_p90(row):
+    if row is None or row.get("status") != "ok":
+        return "N/A"
+    return f"{row.get('p10_ms', 0.0):.4f}/{row.get('p90_ms', 0.0):.4f}"
 
 
 def _build_section(mode_key, dtype_key, scen_key, candle_map, torch_map, op_names):
@@ -12,14 +32,15 @@ def _build_section(mode_key, dtype_key, scen_key, candle_map, torch_map, op_name
     header = f"### {mode_label} — {dtype_label} — {scen_label}"
 
     lines = [header, ""]
-    lines.append("| Op | candle (ms) | torch_npu (ms) | ratio | impact |")
-    lines.append("|---|---|---|---|---|")
+    lines.append("| Op | candle median | torch_npu median | ratio | candle p10/p90 | torch_npu p10/p90 | impact |")
+    lines.append("|---|---|---|---|---|---|---|")
 
     ratios = []
     rows = []
     for op in op_names:
-        c = candle_map.get((op, mode_key, dtype_key, scen_key))
-        t = torch_map.get((op, mode_key, dtype_key, scen_key))
+        key = (op, mode_key, dtype_key, scen_key)
+        c = candle_map.get(key)
+        t = torch_map.get(key)
 
         c_med = c["median_ms"] if c and c["status"] == "ok" else None
         t_med = t["median_ms"] if t and t["status"] == "ok" else None
@@ -27,13 +48,15 @@ def _build_section(mode_key, dtype_key, scen_key, candle_map, torch_map, op_name
         c_str = f"{c_med:.4f}" if c_med is not None else ("ERR" if c else "—")
         t_str = f"{t_med:.4f}" if t_med is not None else ("ERR" if t else "—")
 
-        ratio = None
+        ratio = c.get("median_ratio") if c else None
         impact = None
-        if c_med is not None and t_med is not None and t_med > 0:
-            ratio = c_med / t_med
+        if c_med is not None and t_med is not None:
             impact = c_med - t_med
-            ratios.append((op, ratio))
-            r_str = f"{ratio:.2f}x"
+            if ratio is not None:
+                ratios.append((op, ratio))
+                r_str = f"{ratio:.2f}x"
+            else:
+                r_str = "N/A"
             impact_str = f"{impact:.4f}"
         else:
             r_str = "N/A"
@@ -44,8 +67,11 @@ def _build_section(mode_key, dtype_key, scen_key, candle_map, torch_map, op_name
         if t and t["status"] != "ok":
             t_str = t["status"][:30]
 
-        rows.append((ratio if ratio is not None else -1.0, impact if impact is not None else -1.0,
-                     f"| {op} | {c_str} | {t_str} | {r_str} | {impact_str} |"))
+        rows.append((ratio if ratio is not None else -1.0,
+                     impact if impact is not None else -1.0,
+                     f"| {op} | {c_str} | {t_str} | {r_str} | "
+                     f"{_format_p10_p90(c)} | {_format_p10_p90(t)} | "
+                     f"{impact_str} |"))
 
     rows.sort(key=lambda item: (item[0], item[1]), reverse=True)
     lines.extend(row for _, _, row in rows)
@@ -53,12 +79,34 @@ def _build_section(mode_key, dtype_key, scen_key, candle_map, torch_map, op_name
     return lines, ratios
 
 
+def ratio_failures(candle_results, torch_results, op_names, dtype_keys, scen_keys, mode_keys,
+                   max_ratio):
+    """Return single-op median ratio gate failures for expected benchmark rows."""
+    rows = list(candle_results) + list(torch_results)
+    annotate_ratio_rows(rows, key_fields=_KEY_FIELDS, metric="median_ms")
+    expected_keys = [
+        (op, mode_key, dtype_key, scen_key)
+        for mode_key in mode_keys
+        for dtype_key in dtype_keys
+        for scen_key in scen_keys
+        for op in op_names
+    ]
+    return collect_ratio_failures(
+        rows,
+        key_fields=_KEY_FIELDS,
+        expected_keys=expected_keys,
+        max_ratio=max_ratio,
+        ratio_field="median_ratio",
+    )
+
+
 def generate_report(candle_results, torch_results, op_names, dtype_keys, scen_keys, mode_keys=None):
     """Generate full report. Returns markdown string."""
     if mode_keys is None:
         mode_keys = ["fwd"]
-    candle_map = {(r["op"], r.get("mode", "fwd"), r["dtype"], r["scenario"]): r for r in candle_results}
-    torch_map = {(r["op"], r.get("mode", "fwd"), r["dtype"], r["scenario"]): r for r in torch_results}
+    rows = list(candle_results) + list(torch_results)
+    annotate_ratio_rows(rows, key_fields=_KEY_FIELDS, metric="median_ms")
+    candle_map, torch_map = _build_maps(candle_results, torch_results)
 
     now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     lines = [

--- a/benchmarks/op_benchmark_npu/run.py
+++ b/benchmarks/op_benchmark_npu/run.py
@@ -64,7 +64,12 @@ def _run_worker(framework, args):
     if proc.returncode != 0:
         print(f"ERROR: {framework} worker exited with code {proc.returncode}",
               file=sys.stderr)
-        return []
+        return [{
+            "framework": "torch_npu" if framework == "torch" else framework,
+            "status": f"error: worker exit {proc.returncode}",
+            "stderr": proc.stderr,
+            "stdout": proc.stdout,
+        }]
 
     try:
         return json.loads(proc.stdout)
@@ -72,11 +77,29 @@ def _run_worker(framework, args):
         print(f"ERROR: failed to parse {framework} JSON output: {e}",
               file=sys.stderr)
         print(f"  stdout was: {proc.stdout[:500]}", file=sys.stderr)
-        return []
+        return [{
+            "framework": "torch_npu" if framework == "torch" else framework,
+            "status": f"error: malformed worker JSON: {e}",
+            "stderr": proc.stderr,
+            "stdout": proc.stdout,
+        }]
+
+def _status_failures(candle_results, torch_results):
+    """Return infrastructure/case failures from worker result rows."""
+    failures = []
+    for row in candle_results + torch_results:
+        status = row.get("status")
+        if status and status != "ok":
+            failures.append(
+                f"{row.get('op', '-')}/{row.get('mode', '-')}/{row.get('dtype', '-')}/"
+                f"{row.get('scenario', '-')}/{row.get('framework', '-')}: {status}"
+            )
+    return failures
 
 def _output_stream(json_output):
     """Return stream name for human-readable output."""
     return "stderr" if json_output == "-" else "stdout"
+
 
 
 def _print_human(text="", stream="stdout"):
@@ -139,10 +162,10 @@ def main():
         print("ERROR: both workers returned no results", file=sys.stderr)
         sys.exit(1)
 
-    failures = []
+    failures = _status_failures(candle_results, torch_results)
     human_stream = _output_stream(args.json_output)
     if args.fail_on_ratio:
-        failures = ratio_failures(
+        failures.extend(ratio_failures(
             candle_results,
             torch_results,
             op_names=op_names,
@@ -150,11 +173,11 @@ def main():
             scen_keys=scen_keys,
             mode_keys=mode_keys,
             max_ratio=args.max_ratio,
-        )
-        if failures:
-            _print_human("\n# Ratio gate failures", stream=human_stream)
-            for failure in failures:
-                _print_human(f"- {failure}", stream=human_stream)
+        ))
+    if failures:
+        _print_human("\n# Gate failures", stream=human_stream)
+        for failure in failures:
+            _print_human(f"- {failure}", stream=human_stream)
 
     # Generate report
     report = generate_report(candle_results, torch_results,

--- a/benchmarks/op_benchmark_npu/run.py
+++ b/benchmarks/op_benchmark_npu/run.py
@@ -74,6 +74,15 @@ def _run_worker(framework, args):
         print(f"  stdout was: {proc.stdout[:500]}", file=sys.stderr)
         return []
 
+def _output_stream(json_output):
+    """Return stream name for human-readable output."""
+    return "stderr" if json_output == "-" else "stdout"
+
+
+def _print_human(text="", stream="stdout"):
+    """Print human-readable output to the selected stream."""
+    print(text, file=sys.stderr if stream == "stderr" else sys.stdout)
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -131,6 +140,7 @@ def main():
         sys.exit(1)
 
     failures = []
+    human_stream = _output_stream(args.json_output)
     if args.fail_on_ratio:
         failures = ratio_failures(
             candle_results,
@@ -142,14 +152,17 @@ def main():
             max_ratio=args.max_ratio,
         )
         if failures:
-            print("\n# Ratio gate failures")
+            _print_human("\n# Ratio gate failures", stream=human_stream)
             for failure in failures:
-                print(f"- {failure}")
+                _print_human(f"- {failure}", stream=human_stream)
 
     # Generate report
     report = generate_report(candle_results, torch_results,
                              op_names, dtype_keys, scen_keys, mode_keys)
-    print_terminal(report)
+    if args.json_output != "-":
+        print_terminal(report)
+    else:
+        _print_human(report, stream=human_stream)
 
     if args.output:
         path = write_markdown(report, args.output)

--- a/benchmarks/op_benchmark_npu/run.py
+++ b/benchmarks/op_benchmark_npu/run.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 
 from .cases import OP_CASES, SCENARIOS, DTYPES, MODES
-from .report import generate_report, print_terminal, write_markdown
+from .report import generate_report, print_terminal, ratio_failures, write_markdown
 
 # Conda environments for each framework
 CONDA_PREFIX = os.environ.get("CONDA_PREFIX_BASE", "/opt/miniconda3")
@@ -91,7 +91,15 @@ def main():
     parser.add_argument("--iters", type=int, default=50)
     parser.add_argument("--output", default=None,
                         help="Directory to write markdown report")
+    parser.add_argument("--json-output", default=None,
+                        help="Path to write JSON results, or '-' for stdout")
+    parser.add_argument("--fail-on-ratio", action="store_true",
+                        help="Exit nonzero when candle median ratio exceeds --max-ratio")
+    parser.add_argument("--max-ratio", type=float, default=1.0,
+                        help="Maximum allowed candle/torch_npu median ratio")
     args = parser.parse_args()
+    if args.max_ratio <= 0:
+        parser.error("--max-ratio must be > 0")
 
     # Determine what we're running
     if args.mode == "both":
@@ -122,6 +130,22 @@ def main():
         print("ERROR: both workers returned no results", file=sys.stderr)
         sys.exit(1)
 
+    failures = []
+    if args.fail_on_ratio:
+        failures = ratio_failures(
+            candle_results,
+            torch_results,
+            op_names=op_names,
+            dtype_keys=dtype_keys,
+            scen_keys=scen_keys,
+            mode_keys=mode_keys,
+            max_ratio=args.max_ratio,
+        )
+        if failures:
+            print("\n# Ratio gate failures")
+            for failure in failures:
+                print(f"- {failure}")
+
     # Generate report
     report = generate_report(candle_results, torch_results,
                              op_names, dtype_keys, scen_keys, mode_keys)
@@ -130,6 +154,32 @@ def main():
     if args.output:
         path = write_markdown(report, args.output)
         print(f"\nReport saved to: {path}", file=sys.stderr)
+
+    if args.json_output:
+        payload = {
+            "warmup": args.warmup,
+            "iters": args.iters,
+            "op_names": op_names,
+            "dtype_keys": dtype_keys,
+            "scenario_keys": scen_keys,
+            "mode_keys": mode_keys,
+            "max_ratio": args.max_ratio,
+            "failures": failures,
+            "results": {
+                "candle": candle_results,
+                "torch_npu": torch_results,
+            },
+        }
+        json_text = json.dumps(payload, indent=2, sort_keys=True)
+        if args.json_output == "-":
+            print(json_text)
+        else:
+            with open(args.json_output, "w", encoding="utf-8") as handle:
+                handle.write(json_text)
+                handle.write("\n")
+
+    if failures:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/benchmarks/op_benchmark_npu/run.py
+++ b/benchmarks/op_benchmark_npu/run.py
@@ -17,6 +17,68 @@ CONDA_ENVS = {
 }
 
 
+def _selected_modes(args):
+    """Return selected benchmark mode keys for worker args."""
+    if args.mode == "both":
+        return list(MODES.keys())
+    return [args.mode]
+
+
+def _selected_op_names(args):
+    """Return selected op names for worker args."""
+    mode_keys = _selected_modes(args)
+    if args.ops:
+        return [op.strip() for op in args.ops.split(",") if op.strip()]
+    return [case["name"] for case in OP_CASES if case.get("mode", "fwd") in mode_keys]
+
+
+def _selected_scenarios(args):
+    """Return selected benchmark scenario keys for worker args."""
+    if args.scenario:
+        return [args.scenario]
+    return list(SCENARIOS.keys())
+
+
+def _selected_dtypes(args):
+    """Return selected benchmark dtype keys for worker args."""
+    if args.dtype:
+        return [dtype.strip() for dtype in args.dtype.split(",") if dtype.strip()]
+    return list(DTYPES.keys())
+
+
+def _worker_failure_rows(framework, args, status, stderr="", stdout=""):
+    """Return structured rows for every expected case when a worker fails."""
+    framework_name = "torch_npu" if framework == "torch" else framework
+    op_names = set(_selected_op_names(args))
+    selected_cases = [
+        case for case in OP_CASES
+        if case["name"] in op_names and case.get("mode", "fwd") in _selected_modes(args)
+    ]
+    rows = []
+    for dtype_key in _selected_dtypes(args):
+        for scen_key in _selected_scenarios(args):
+            for case in selected_cases:
+                rows.append({
+                    "framework": framework_name,
+                    "op": case["name"],
+                    "mode": case.get("mode", "fwd"),
+                    "dtype": dtype_key,
+                    "scenario": scen_key,
+                    "sample_count": 0,
+                    "mean_ms": 0.0,
+                    "median_ms": 0.0,
+                    "min_ms": 0.0,
+                    "max_ms": 0.0,
+                    "p10_ms": 0.0,
+                    "p90_ms": 0.0,
+                    "p95_ms": 0.0,
+                    "status": status,
+                    "stderr": stderr,
+                    "stdout": stdout,
+                })
+    return rows
+
+
 def _run_worker(framework, args):
     """Spawn a subprocess worker in the appropriate conda env."""
     env_name = CONDA_ENVS[framework]
@@ -64,12 +126,13 @@ def _run_worker(framework, args):
     if proc.returncode != 0:
         print(f"ERROR: {framework} worker exited with code {proc.returncode}",
               file=sys.stderr)
-        return [{
-            "framework": "torch_npu" if framework == "torch" else framework,
-            "status": f"error: worker exit {proc.returncode}",
-            "stderr": proc.stderr,
-            "stdout": proc.stdout,
-        }]
+        return _worker_failure_rows(
+            framework,
+            args,
+            f"error: worker exit {proc.returncode}",
+            stderr=proc.stderr,
+            stdout=proc.stdout,
+        )
 
     try:
         return json.loads(proc.stdout)
@@ -77,12 +140,13 @@ def _run_worker(framework, args):
         print(f"ERROR: failed to parse {framework} JSON output: {e}",
               file=sys.stderr)
         print(f"  stdout was: {proc.stdout[:500]}", file=sys.stderr)
-        return [{
-            "framework": "torch_npu" if framework == "torch" else framework,
-            "status": f"error: malformed worker JSON: {e}",
-            "stderr": proc.stderr,
-            "stdout": proc.stdout,
-        }]
+        return _worker_failure_rows(
+            framework,
+            args,
+            f"error: malformed worker JSON: {e}",
+            stderr=proc.stderr,
+            stdout=proc.stdout,
+        )
 
 def _status_failures(candle_results, torch_results):
     """Return infrastructure/case failures from worker result rows."""
@@ -134,25 +198,10 @@ def main():
         parser.error("--max-ratio must be > 0")
 
     # Determine what we're running
-    if args.mode == "both":
-        mode_keys = list(MODES.keys())
-    else:
-        mode_keys = [args.mode]
-
-    if args.ops:
-        op_names = args.ops.split(",")
-    else:
-        op_names = [c["name"] for c in OP_CASES if c.get("mode", "fwd") in mode_keys]
-
-    if args.scenario:
-        scen_keys = [args.scenario]
-    else:
-        scen_keys = list(SCENARIOS.keys())
-
-    if args.dtype:
-        dtype_keys = args.dtype.split(",")
-    else:
-        dtype_keys = list(DTYPES.keys())
+    mode_keys = _selected_modes(args)
+    op_names = _selected_op_names(args)
+    scen_keys = _selected_scenarios(args)
+    dtype_keys = _selected_dtypes(args)
 
     # Run both workers
     candle_results = _run_worker("candle", args)

--- a/benchmarks/op_benchmark_npu/runner.py
+++ b/benchmarks/op_benchmark_npu/runner.py
@@ -1,5 +1,7 @@
 import time
 
+from benchmarks.npu_perf_gates import summarize_samples
+
 
 def benchmark_op(fn, warmup=10, iters=50, sync=None, setup=None, cleanup=None):
     """Run fn with warmup, then time iters iterations. Returns list of ms."""
@@ -30,11 +32,5 @@ def benchmark_op(fn, warmup=10, iters=50, sync=None, setup=None, cleanup=None):
 
 
 def summarize(samples):
-    """Return (mean_ms, median_ms, p95_ms) from a list of ms samples."""
-    if not samples:
-        return 0.0, 0.0, 0.0
-    values = sorted(samples)
-    mean = sum(values) / len(values)
-    median = values[len(values) // 2]
-    p95 = values[int(len(values) * 0.95) - 1] if len(values) >= 2 else values[-1]
-    return mean, median, p95
+    """Return shared distribution fields from a list of ms samples."""
+    return summarize_samples(samples)

--- a/benchmarks/op_benchmark_npu/worker.py
+++ b/benchmarks/op_benchmark_npu/worker.py
@@ -82,25 +82,30 @@ def main():
                         setup=getattr(fn, "setup", None),
                         cleanup=getattr(fn, "cleanup", None),
                     )
-                    mean, median, p95 = summarize(samples)
+                    summary = summarize(samples)
                     results.append({
+                        "framework": "torch_npu" if args.framework == "torch" else args.framework,
                         "op": op_name,
                         "mode": case.get("mode", "fwd"),
                         "dtype": dtype_key,
                         "scenario": scen_key,
-                        "mean_ms": round(mean, 4),
-                        "median_ms": round(median, 4),
-                        "p95_ms": round(p95, 4),
+                        **summary,
                         "status": "ok",
                     })
                 except Exception as e:
                     results.append({
+                        "framework": "torch_npu" if args.framework == "torch" else args.framework,
                         "op": op_name,
                         "mode": case.get("mode", "fwd"),
                         "dtype": dtype_key,
                         "scenario": scen_key,
+                        "sample_count": 0,
                         "mean_ms": 0.0,
                         "median_ms": 0.0,
+                        "min_ms": 0.0,
+                        "max_ms": 0.0,
+                        "p10_ms": 0.0,
+                        "p90_ms": 0.0,
                         "p95_ms": 0.0,
                         "status": f"error: {e}",
                     })

--- a/benchmarks/perf_candle_vs_torch_npu.py
+++ b/benchmarks/perf_candle_vs_torch_npu.py
@@ -294,6 +294,9 @@ def _spawn_worker(framework, case, iters, warmup, dtype_name, python_exe=None,
                 continue
     if last_json is None:
         return {"framework": framework, "case": case, "error": "no json from worker"}
+    if isinstance(last_json, dict):
+        last_json.setdefault("framework", framework)
+        last_json.setdefault("case", case)
     return last_json
 
 

--- a/benchmarks/perf_candle_vs_torch_npu.py
+++ b/benchmarks/perf_candle_vs_torch_npu.py
@@ -9,10 +9,15 @@ latency comparison rather than numerical equivalence.
 import argparse
 import json
 import os
-import statistics
 import subprocess
 import sys
 import time
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from benchmarks.npu_perf_gates import summarize_samples
 
 
 def build_mlp(torch, device, dtype):
@@ -203,6 +208,7 @@ def run_worker(framework, case, iters, warmup, dtype_name, profile_candle=False,
 
     fwd_samples = []
     bwd_samples = []
+    total_samples = []
     for _ in range(iters):
         _sync(torch)
         t0 = time.perf_counter()
@@ -216,16 +222,28 @@ def run_worker(framework, case, iters, warmup, dtype_name, profile_candle=False,
 
         fwd_samples.append((t1 - t0) * 1000.0)
         bwd_samples.append((t2 - t1) * 1000.0)
+        total_samples.append((t2 - t0) * 1000.0)
         _clear_grads(model, inputs)
 
+    fwd_summary = summarize_samples(fwd_samples)
+    bwd_summary = summarize_samples(bwd_samples)
+    total_summary = summarize_samples(total_samples)
     result = {
         "framework": framework,
         "case": case,
         "iters": iters,
-        "fwd_ms_median": statistics.median(fwd_samples),
-        "bwd_ms_median": statistics.median(bwd_samples),
-        "fwd_ms_min": min(fwd_samples),
-        "bwd_ms_min": min(bwd_samples),
+        "fwd_ms_median": fwd_summary["median_ms"],
+        "bwd_ms_median": bwd_summary["median_ms"],
+        "total_ms_median": total_summary["median_ms"],
+        "fwd_ms_min": fwd_summary["min_ms"],
+        "bwd_ms_min": bwd_summary["min_ms"],
+        "total_ms_min": total_summary["min_ms"],
+        "fwd_ms_p10": fwd_summary["p10_ms"],
+        "bwd_ms_p10": bwd_summary["p10_ms"],
+        "total_ms_p10": total_summary["p10_ms"],
+        "fwd_ms_p90": fwd_summary["p90_ms"],
+        "bwd_ms_p90": bwd_summary["p90_ms"],
+        "total_ms_p90": total_summary["p90_ms"],
     }
     if profile is not None:
         result["profile"] = profile
@@ -303,13 +321,16 @@ def _annotate_ratios(results):
             continue
         torch_fwd = torch_ref.get("fwd_ms_median")
         torch_bwd = torch_ref.get("bwd_ms_median")
+        torch_total = torch_ref.get("total_ms_median")
         if torch_fwd:
             candle["fwd_ratio"] = candle["fwd_ms_median"] / torch_fwd
         if torch_bwd:
             candle["bwd_ratio"] = candle["bwd_ms_median"] / torch_bwd
+        if torch_total:
+            candle["total_ratio"] = candle["total_ms_median"] / torch_total
 
 
-def _ratio_failures(results, cases, max_fwd_ratio, max_bwd_ratio):
+def _ratio_failures(results, cases, max_fwd_ratio, max_bwd_ratio, max_total_ratio):
     failures = []
     by_case = _index_results(results)
     for case in cases:
@@ -327,20 +348,23 @@ def _ratio_failures(results, cases, max_fwd_ratio, max_bwd_ratio):
             continue
         fwd_ratio = candle.get("fwd_ratio")
         bwd_ratio = candle.get("bwd_ratio")
-        if fwd_ratio is None or bwd_ratio is None:
+        total_ratio = candle.get("total_ratio")
+        if fwd_ratio is None or bwd_ratio is None or total_ratio is None:
             failures.append(f"{case}: unable to compute candle/torch_npu ratio")
             continue
         if fwd_ratio > max_fwd_ratio:
             failures.append(f"{case}: fwd ratio {fwd_ratio:.2f}x > {max_fwd_ratio:.2f}x")
         if bwd_ratio > max_bwd_ratio:
             failures.append(f"{case}: bwd ratio {bwd_ratio:.2f}x > {max_bwd_ratio:.2f}x")
+        if total_ratio > max_total_ratio:
+            failures.append(f"{case}: total ratio {total_ratio:.2f}x > {max_total_ratio:.2f}x")
     return failures
 
 
 def _print_table(results, frameworks):
     by_case = _index_results(results)
 
-    header = ["algo", "fwd ms", "bwd ms", "ratio"]
+    header = ["algo", "fwd ms", "bwd ms", "total ms", "ratio"]
     print(" | ".join(f"{h:>18}" for h in header))
     print("-+-".join("-" * 18 for _ in header))
 
@@ -349,17 +373,19 @@ def _print_table(results, frameworks):
             r = by_fw.get(fw)
             algo = f"{case}/{fw}"
             if r is None or "error" in r:
-                row = [algo, "err", "err", "-"]
+                row = [algo, "err", "err", "err", "-"]
             else:
                 fwd = r["fwd_ms_median"]
                 bwd = r["bwd_ms_median"]
+                total = r.get("total_ms_median")
                 if fw == "torch_npu":
                     ratio = "1.00x"
                 elif "fwd_ratio" in r and "bwd_ratio" in r:
-                    ratio = f"f {r['fwd_ratio']:.2f}x / b {r['bwd_ratio']:.2f}x"
+                    total_part = f" / t {r['total_ratio']:.2f}x" if "total_ratio" in r else ""
+                    ratio = f"f {r['fwd_ratio']:.2f}x / b {r['bwd_ratio']:.2f}x{total_part}"
                 else:
                     ratio = "-"
-                row = [algo, _fmt(fwd), _fmt(bwd), ratio]
+                row = [algo, _fmt(fwd), _fmt(bwd), _fmt(total), ratio]
             print(" | ".join(f"{c:>18}" for c in row))
 
     for r in results:
@@ -413,6 +439,8 @@ def main():
                         help="maximum allowed candle/torch_npu forward ratio for --fail-on-ratio")
     parser.add_argument("--max-bwd-ratio", type=float, default=1.0,
                         help="maximum allowed candle/torch_npu backward ratio for --fail-on-ratio")
+    parser.add_argument("--max-total-ratio", type=float, default=0.99,
+                        help="maximum allowed candle/torch_npu total ratio for --fail-on-ratio")
     parser.add_argument("--json-output", default=None,
                         help="write final results payload to this path, or '-' for stdout")
     parser.add_argument("--profile-candle", action="store_true",
@@ -429,6 +457,8 @@ def main():
         parser.error("--max-fwd-ratio must be > 0")
     if args.max_bwd_ratio <= 0:
         parser.error("--max-bwd-ratio must be > 0")
+    if args.max_total_ratio <= 0:
+        parser.error("--max-total-ratio must be > 0")
 
     if args.worker:
         result = run_worker(
@@ -480,7 +510,13 @@ def main():
     _annotate_ratios(results)
     failures = []
     if args.fail_on_ratio:
-        failures = _ratio_failures(results, cases, args.max_fwd_ratio, args.max_bwd_ratio)
+        failures = _ratio_failures(
+            results,
+            cases,
+            args.max_fwd_ratio,
+            args.max_bwd_ratio,
+            args.max_total_ratio,
+        )
 
     print()
     _print_table(results, frameworks)
@@ -500,6 +536,7 @@ def main():
         "frameworks": frameworks,
         "max_fwd_ratio": args.max_fwd_ratio,
         "max_bwd_ratio": args.max_bwd_ratio,
+        "max_total_ratio": args.max_total_ratio,
         "failures": failures,
         "results": results,
     }

--- a/benchmarks/perf_candle_vs_torch_npu.py
+++ b/benchmarks/perf_candle_vs_torch_npu.py
@@ -364,12 +364,13 @@ def _ratio_failures(results, cases, max_fwd_ratio, max_bwd_ratio, max_total_rati
     return failures
 
 
-def _print_table(results, frameworks):
+def _print_table(results, frameworks, stream=None):
+    stream = stream or sys.stdout
     by_case = _index_results(results)
 
     header = ["algo", "fwd ms", "bwd ms", "total ms", "ratio"]
-    print(" | ".join(f"{h:>18}" for h in header))
-    print("-+-".join("-" * 18 for _ in header))
+    print(" | ".join(f"{h:>18}" for h in header), file=stream)
+    print("-+-".join("-" * 18 for _ in header), file=stream)
 
     for case, by_fw in by_case.items():
         for fw in frameworks:
@@ -389,27 +390,28 @@ def _print_table(results, frameworks):
                 else:
                     ratio = "-"
                 row = [algo, _fmt(fwd), _fmt(bwd), _fmt(total), ratio]
-            print(" | ".join(f"{c:>18}" for c in row))
+            print(" | ".join(f"{c:>18}" for c in row), file=stream)
 
     for r in results:
         if "error" in r:
-            print(f"\n[{r['framework']} / {r['case']}] ERROR: {r['error']}")
+            print(f"\n[{r['framework']} / {r['case']}] ERROR: {r['error']}", file=stream)
             tail = r.get("tail")
             if tail:
                 for line in tail:
-                    print(f"  | {line}")
+                    print(f"  | {line}", file=stream)
 
 
-def _print_profile_tables(results):
+def _print_profile_tables(results, stream=None):
+    stream = stream or sys.stdout
     for result in results:
         profile = result.get("profile")
         if not profile:
             continue
-        print(f"\n# Candle profiler: {result['case']}")
+        print(f"\n# Candle profiler: {result['case']}", file=stream)
         trace_path = profile.get("trace_path")
         if trace_path:
-            print(f"# Trace: {trace_path}")
-        print(profile["table"])
+            print(f"# Trace: {trace_path}", file=stream)
+        print(profile["table"], file=stream)
 
 
 def _write_json_output(path, payload):
@@ -420,6 +422,14 @@ def _write_json_output(path, payload):
     with open(path, "w", encoding="utf-8") as handle:
         handle.write(text)
         handle.write("\n")
+
+
+def _worker_failures(results):
+    failures = []
+    for result in results:
+        if "error" in result:
+            failures.append(f"{result.get('case', '-')}/{result.get('framework', '-')}: {result['error']}")
+    return failures
 
 
 def main():
@@ -486,9 +496,10 @@ def main():
     if unknown:
         raise SystemExit(f"unknown cases: {unknown}; known: {list(CASES)}")
 
+    human_stream = sys.stderr if args.json_output == "-" else sys.stdout
     print(f"# Perf bench: candle vs torch_npu (iters={args.iters}, warmup={args.warmup}, "
-          f"dtype={args.dtype})")
-    print(f"# Cases: {cases}")
+          f"dtype={args.dtype})", file=human_stream)
+    print(f"# Cases: {cases}", file=human_stream)
 
     python_for = {
         "candle": args.candle_python,
@@ -497,7 +508,7 @@ def main():
     results = []
     for case in cases:
         for fw in frameworks:
-            print(f"  [{fw} / {case}] running...", flush=True)
+            print(f"  [{fw} / {case}] running...", flush=True, file=human_stream)
             results.append(_spawn_worker(
                 fw,
                 case,
@@ -511,25 +522,25 @@ def main():
             ))
 
     _annotate_ratios(results)
-    failures = []
+    failures = _worker_failures(results)
     if args.fail_on_ratio:
-        failures = _ratio_failures(
+        failures.extend(_ratio_failures(
             results,
             cases,
             args.max_fwd_ratio,
             args.max_bwd_ratio,
             args.max_total_ratio,
-        )
+        ))
 
-    print()
-    _print_table(results, frameworks)
+    print(file=human_stream)
+    _print_table(results, frameworks, stream=human_stream)
     if args.print_candle_profile_table:
-        _print_profile_tables(results)
+        _print_profile_tables(results, stream=human_stream)
 
     if failures:
-        print("\n# Ratio gate failures")
+        print("\n# Gate failures", file=human_stream)
         for failure in failures:
-            print(f"- {failure}")
+            print(f"- {failure}", file=human_stream)
 
     payload = {
         "iters": args.iters,

--- a/benchmarks/pipeline_npu/bench.py
+++ b/benchmarks/pipeline_npu/bench.py
@@ -1,26 +1,45 @@
+import importlib
+
 import candle
+import candle.nn.functional as candle_F
 
 from .cases import CASES
 from .utils import measure, summarize
 
 
-def _resolve_dtype(dtype_name):
-    return getattr(candle, dtype_name)
+def _import_framework(framework):
+    if framework == "candle":
+        return candle, candle_F, "npu"
+    if framework == "torch_npu":
+        torch_mod = importlib.import_module("torch")
+        importlib.import_module("torch_npu")
+        return torch_mod, importlib.import_module("torch.nn.functional"), "npu"
+    raise ValueError(f"unknown framework: {framework}")
 
 
-def _sync_for(device):
-    if device == "npu" and hasattr(candle, "npu") and candle.npu.is_available():
-        return candle.npu.synchronize
+def _resolve_dtype(torch_mod, dtype_name):
+    return getattr(torch_mod, dtype_name)
+
+
+def _sync_for(torch_mod, device):
+    if device == "npu" and hasattr(torch_mod, "npu") and torch_mod.npu.is_available():
+        return torch_mod.npu.synchronize
     return None
 
 
-def run_case(case, *, device="cpu", pipeline=False, warmup=5, iters=20):
-    dtype = _resolve_dtype(case["dtype"])
-    forward = case["builder"](device, dtype)
-    sync = _sync_for(device)
+def run_case(case, *, framework="candle", device="cpu", mode="eager", warmup=5, iters=20):
+    torch_mod, F, default_device = _import_framework(framework)
+    if device is None:
+        device = default_device
+    dtype = _resolve_dtype(torch_mod, case["dtype"])
+    forward = case["builder"](torch_mod, F, device, dtype)
+    sync = _sync_for(torch_mod, device)
 
     def _run_once():
-        if pipeline:
+        if mode == "pipeline":
+            if framework != "candle":
+                forward()
+                return
             with candle.pipeline(max_ops=64):
                 forward()
         else:
@@ -30,7 +49,7 @@ def run_case(case, *, device="cpu", pipeline=False, warmup=5, iters=20):
     mean, median, p95 = summarize(samples)
 
     op_count = 0
-    if pipeline:
+    if mode == "pipeline" and framework == "candle":
         with candle.pipeline(max_ops=64) as pipe:
             forward()
             pipe.flush()
@@ -38,7 +57,9 @@ def run_case(case, *, device="cpu", pipeline=False, warmup=5, iters=20):
             op_count = len(dump.get("entries", []))
 
     return {
+        "framework": framework,
         "case_id": case["case_id"],
+        "mode": mode,
         "batch": case["batch"],
         "seq": case["seq"],
         "hidden": case["hidden"],
@@ -48,13 +69,14 @@ def run_case(case, *, device="cpu", pipeline=False, warmup=5, iters=20):
         "median_ms": float(median),
         "p95_ms": float(p95),
         "op_count": int(op_count),
+        "status": "ok",
     }
 
 
 def run():
     results = {}
     for name, case in CASES.items():
-        results[name] = run_case(case, device="cpu", pipeline=False, warmup=1, iters=1)
+        results[name] = run_case(case, framework="candle", device="cpu", mode="eager", warmup=1, iters=1)
     return results
 
 

--- a/benchmarks/pipeline_npu/bench.py
+++ b/benchmarks/pipeline_npu/bench.py
@@ -1,14 +1,13 @@
 import importlib
 
-import candle
-import candle.nn.functional as candle_F
-
 from .cases import CASES
 from .utils import measure, summarize
 
 
 def _import_framework(framework):
     if framework == "candle":
+        candle = importlib.import_module("candle")  # pylint: disable=import-outside-toplevel
+        candle_F = importlib.import_module("candle.nn.functional")  # pylint: disable=import-outside-toplevel
         return candle, candle_F, "npu"
     if framework == "torch_npu":
         torch_mod = importlib.import_module("torch")
@@ -40,7 +39,7 @@ def run_case(case, *, framework="candle", device="cpu", mode="eager", warmup=5, 
             if framework != "candle":
                 forward()
                 return
-            with candle.pipeline(max_ops=64):
+            with torch_mod.pipeline(max_ops=64):
                 forward()
         else:
             forward()
@@ -50,7 +49,7 @@ def run_case(case, *, framework="candle", device="cpu", mode="eager", warmup=5, 
 
     op_count = 0
     if mode == "pipeline" and framework == "candle":
-        with candle.pipeline(max_ops=64) as pipe:
+        with torch_mod.pipeline(max_ops=64) as pipe:
             forward()
             pipe.flush()
             dump = pipe.debug_dump()

--- a/benchmarks/pipeline_npu/cases.py
+++ b/benchmarks/pipeline_npu/cases.py
@@ -1,11 +1,7 @@
-import candle
-import candle.nn.functional as F
-
-
-def _case_a1(device, dtype):
-    x = candle.randn((1, 128, 1024), device=device, dtype=dtype)
-    w1 = candle.randn((1024, 1024), device=device, dtype=dtype)
-    w2 = candle.randn((1024, 1024), device=device, dtype=dtype)
+def _case_a1(torch_mod, F, device, dtype):
+    x = torch_mod.randn((1, 128, 1024), device=device, dtype=dtype)
+    w1 = torch_mod.randn((1024, 1024), device=device, dtype=dtype)
+    w2 = torch_mod.randn((1024, 1024), device=device, dtype=dtype)
 
     def forward():
         y = (x @ w1).relu()
@@ -15,13 +11,13 @@ def _case_a1(device, dtype):
     return forward
 
 
-def _case_a2(device, dtype):
+def _case_a2(torch_mod, F, device, dtype):
     b, s, h, heads = 1, 512, 1024, 16
-    x = candle.randn((b, s, h), device=device, dtype=dtype)
-    wq = candle.randn((h, h), device=device, dtype=dtype)
-    wk = candle.randn((h, h), device=device, dtype=dtype)
-    wv = candle.randn((h, h), device=device, dtype=dtype)
-    wo = candle.randn((h, h), device=device, dtype=dtype)
+    x = torch_mod.randn((b, s, h), device=device, dtype=dtype)
+    wq = torch_mod.randn((h, h), device=device, dtype=dtype)
+    wk = torch_mod.randn((h, h), device=device, dtype=dtype)
+    wv = torch_mod.randn((h, h), device=device, dtype=dtype)
+    wo = torch_mod.randn((h, h), device=device, dtype=dtype)
     head_dim = h // heads
 
     def forward():
@@ -31,22 +27,22 @@ def _case_a2(device, dtype):
         q = q.reshape((b, s, heads, head_dim)).transpose(1, 2)
         k = k.reshape((b, s, heads, head_dim)).transpose(1, 2)
         v = v.reshape((b, s, heads, head_dim)).transpose(1, 2)
-        attn = candle.matmul(q.contiguous(), k.contiguous().transpose(-2, -1))
+        attn = torch_mod.matmul(q.contiguous(), k.contiguous().transpose(-2, -1))
         attn = F.softmax(attn, dim=-1)
-        out = candle.matmul(attn.contiguous(), v.contiguous())
+        out = torch_mod.matmul(attn.contiguous(), v.contiguous())
         out = out.transpose(1, 2).reshape((b, s, h))
         return out @ wo
 
     return forward
 
 
-def _case_a2s(device, dtype):
+def _case_a2s(torch_mod, F, device, dtype):
     b, s, h, heads = 2, 256, 512, 8
-    x = candle.randn((b, s, h), device=device, dtype=dtype)
-    wq = candle.randn((h, h), device=device, dtype=dtype)
-    wk = candle.randn((h, h), device=device, dtype=dtype)
-    wv = candle.randn((h, h), device=device, dtype=dtype)
-    wo = candle.randn((h, h), device=device, dtype=dtype)
+    x = torch_mod.randn((b, s, h), device=device, dtype=dtype)
+    wq = torch_mod.randn((h, h), device=device, dtype=dtype)
+    wk = torch_mod.randn((h, h), device=device, dtype=dtype)
+    wv = torch_mod.randn((h, h), device=device, dtype=dtype)
+    wo = torch_mod.randn((h, h), device=device, dtype=dtype)
     head_dim = h // heads
 
     def forward():
@@ -56,20 +52,20 @@ def _case_a2s(device, dtype):
         q = q.reshape((b, s, heads, head_dim)).transpose(1, 2)
         k = k.reshape((b, s, heads, head_dim)).transpose(1, 2)
         v = v.reshape((b, s, heads, head_dim)).transpose(1, 2)
-        attn = candle.matmul(q.contiguous(), k.contiguous().transpose(-2, -1))
+        attn = torch_mod.matmul(q.contiguous(), k.contiguous().transpose(-2, -1))
         attn = F.softmax(attn, dim=-1)
-        out = candle.matmul(attn.contiguous(), v.contiguous())
+        out = torch_mod.matmul(attn.contiguous(), v.contiguous())
         out = out.transpose(1, 2).reshape((b, s, h))
         return out @ wo
 
     return forward
 
 
-def _case_a3(device, dtype):
+def _case_a3(torch_mod, F, device, dtype):
     b, s, h = 8, 128, 2048
-    x = candle.randn((b, s, h), device=device, dtype=dtype)
-    w1 = candle.randn((h, 4 * h), device=device, dtype=dtype)
-    w2 = candle.randn((4 * h, h), device=device, dtype=dtype)
+    x = torch_mod.randn((b, s, h), device=device, dtype=dtype)
+    w1 = torch_mod.randn((h, 4 * h), device=device, dtype=dtype)
+    w2 = torch_mod.randn((4 * h, h), device=device, dtype=dtype)
 
     def forward():
         y = F.silu(x @ w1)
@@ -78,14 +74,14 @@ def _case_a3(device, dtype):
     return forward
 
 
-def _block(device, dtype, *, b, s, h, heads):
-    x = candle.randn((b, s, h), device=device, dtype=dtype)
-    wq = candle.randn((h, h), device=device, dtype=dtype)
-    wk = candle.randn((h, h), device=device, dtype=dtype)
-    wv = candle.randn((h, h), device=device, dtype=dtype)
-    wo = candle.randn((h, h), device=device, dtype=dtype)
-    w1 = candle.randn((h, 4 * h), device=device, dtype=dtype)
-    w2 = candle.randn((4 * h, h), device=device, dtype=dtype)
+def _block(torch_mod, F, device, dtype, *, b, s, h, heads):
+    x = torch_mod.randn((b, s, h), device=device, dtype=dtype)
+    wq = torch_mod.randn((h, h), device=device, dtype=dtype)
+    wk = torch_mod.randn((h, h), device=device, dtype=dtype)
+    wv = torch_mod.randn((h, h), device=device, dtype=dtype)
+    wo = torch_mod.randn((h, h), device=device, dtype=dtype)
+    w1 = torch_mod.randn((h, 4 * h), device=device, dtype=dtype)
+    w2 = torch_mod.randn((4 * h, h), device=device, dtype=dtype)
     head_dim = h // heads
 
     def forward():
@@ -96,9 +92,9 @@ def _block(device, dtype, *, b, s, h, heads):
         q = q.reshape((b, s, heads, head_dim)).transpose(1, 2)
         k = k.reshape((b, s, heads, head_dim)).transpose(1, 2)
         v = v.reshape((b, s, heads, head_dim)).transpose(1, 2)
-        attn = candle.matmul(q.contiguous(), k.contiguous().transpose(-2, -1))
+        attn = torch_mod.matmul(q.contiguous(), k.contiguous().transpose(-2, -1))
         attn = F.softmax(attn, dim=-1)
-        out = candle.matmul(attn.contiguous(), v.contiguous())
+        out = torch_mod.matmul(attn.contiguous(), v.contiguous())
         out = out.transpose(1, 2).reshape((b, s, h))
         x1 = x + (out @ wo)
         z = F.layer_norm(x1, (h,))
@@ -108,37 +104,24 @@ def _block(device, dtype, *, b, s, h, heads):
     return forward
 
 
-def _case_b1(device, dtype):
-    return _block(device, dtype, b=1, s=512, h=2048, heads=16)
+def _case_b1(torch_mod, F, device, dtype):
+    return _block(torch_mod, F, device, dtype, b=1, s=512, h=2048, heads=16)
 
 
-def _case_b1s(device, dtype):
-    return _block(device, dtype, b=2, s=256, h=512, heads=8)
+def _case_b1s(torch_mod, F, device, dtype):
+    return _block(torch_mod, F, device, dtype, b=2, s=256, h=512, heads=8)
 
 
-def _case_b2(device, dtype):
-    return _block(device, dtype, b=4, s=128, h=1024, heads=8)
+def _case_b2(torch_mod, F, device, dtype):
+    return _block(torch_mod, F, device, dtype, b=4, s=128, h=1024, heads=8)
 
 
-def _case_b3(device, dtype):
-    return _block(device, dtype, b=1, s=2048, h=1024, heads=16)
+def _case_b3(torch_mod, F, device, dtype):
+    return _block(torch_mod, F, device, dtype, b=1, s=2048, h=1024, heads=16)
 
 
-def _case_c1(device, dtype):
-    block = _block(device, dtype, b=1, s=512, h=1024, heads=16)
-
-    def forward():
-        out = block()
-        out = block()
-        out = block()
-        out = block()
-        return out
-
-    return forward
-
-
-def _case_c2(device, dtype):
-    block = _block(device, dtype, b=2, s=256, h=1024, heads=16)
+def _case_c1(torch_mod, F, device, dtype):
+    block = _block(torch_mod, F, device, dtype, b=1, s=512, h=1024, heads=16)
 
     def forward():
         out = block()
@@ -150,8 +133,21 @@ def _case_c2(device, dtype):
     return forward
 
 
-def _case_d1(device, dtype):
-    block = _block(device, dtype, b=2, s=256, h=512, heads=8)
+def _case_c2(torch_mod, F, device, dtype):
+    block = _block(torch_mod, F, device, dtype, b=2, s=256, h=1024, heads=16)
+
+    def forward():
+        out = block()
+        out = block()
+        out = block()
+        out = block()
+        return out
+
+    return forward
+
+
+def _case_d1(torch_mod, F, device, dtype):
+    block = _block(torch_mod, F, device, dtype, b=2, s=256, h=512, heads=8)
 
     def forward():
         out = block()
@@ -167,11 +163,11 @@ def _case_d1(device, dtype):
     return forward
 
 
-def _case_d2(device, dtype):
+def _case_d2(torch_mod, F, device, dtype):
     b, s, h = 8, 128, 256
-    x = candle.randn((b, s, h), device=device, dtype=dtype)
-    bias = candle.randn((h,), device=device, dtype=dtype)
-    scale = candle.randn((h,), device=device, dtype=dtype)
+    x = torch_mod.randn((b, s, h), device=device, dtype=dtype)
+    bias = torch_mod.randn((h,), device=device, dtype=dtype)
+    scale = torch_mod.randn((h,), device=device, dtype=dtype)
 
     def forward():
         y = x

--- a/benchmarks/pipeline_npu/run.py
+++ b/benchmarks/pipeline_npu/run.py
@@ -15,6 +15,7 @@ def _repo_root():
 
 
 def _spawn_worker(framework, args):
+    repo_root = _repo_root()
     cmd = [
         args.python or sys.executable,
         "-m",
@@ -33,25 +34,30 @@ def _spawn_worker(framework, args):
         str(args.iters),
     ]
     env = os.environ.copy()
-    src_path = os.path.join(_repo_root(), "src")
+    src_path = os.path.join(repo_root, "src")
     existing = env.get("PYTHONPATH")
-    env["PYTHONPATH"] = src_path if not existing else os.pathsep.join([src_path, existing])
-    proc = subprocess.run(cmd, capture_output=True, text=True, env=env, check=False)
+    paths = [repo_root, src_path]
+    if existing:
+        paths.append(existing)
+    env["PYTHONPATH"] = os.pathsep.join(paths)
+    proc = subprocess.run(cmd, capture_output=True, text=True, env=env, check=False, cwd=repo_root)
     if proc.returncode != 0:
         if proc.stdout:
             print(proc.stdout, file=sys.stderr, end="" if proc.stdout.endswith("\n") else "\n")
         if proc.stderr:
             print(proc.stderr, file=sys.stderr, end="" if proc.stderr.endswith("\n") else "\n")
-        return []
+        raise RuntimeError(f"{framework} worker failed with exit code {proc.returncode}")
     try:
-        return json.loads(proc.stdout)
+        rows = json.loads(proc.stdout)
     except json.JSONDecodeError as exc:
-        print(f"failed to parse {framework} worker JSON: {exc}", file=sys.stderr)
         if proc.stdout:
             print(proc.stdout, file=sys.stderr, end="" if proc.stdout.endswith("\n") else "\n")
         if proc.stderr:
             print(proc.stderr, file=sys.stderr, end="" if proc.stderr.endswith("\n") else "\n")
-        return []
+        raise RuntimeError(f"failed to parse {framework} worker JSON: {exc}") from exc
+    if not rows:
+        raise RuntimeError(f"{framework} worker returned no rows")
+    return rows
 
 
 def annotate_pipeline_ratios(rows):

--- a/benchmarks/pipeline_npu/run.py
+++ b/benchmarks/pipeline_npu/run.py
@@ -31,10 +31,20 @@ def _worker_failure_rows(framework, args, status):
     ]
 
 
+def _worker_python(framework, args):
+    candle_python = getattr(args, "candle_python", None)
+    torch_npu_python = getattr(args, "torch_npu_python", None)
+    if framework == "candle" and candle_python:
+        return candle_python
+    if framework == "torch_npu" and torch_npu_python:
+        return torch_npu_python
+    return args.python or sys.executable
+
+
 def _spawn_worker(framework, args):
     repo_root = _repo_root()
     cmd = [
-        args.python or sys.executable,
+        _worker_python(framework, args),
         "-m",
         "benchmarks.pipeline_npu.worker",
         "--framework",
@@ -141,6 +151,8 @@ def main():
     parser.add_argument("--warmup", type=int, default=5)
     parser.add_argument("--iters", type=int, default=20)
     parser.add_argument("--python")
+    parser.add_argument("--candle-python")
+    parser.add_argument("--torch-npu-python")
     parser.add_argument("--json-output")
     parser.add_argument("--fail-on-ratio", action="store_true")
     parser.add_argument("--max-ratio", type=float, default=0.99)

--- a/benchmarks/pipeline_npu/run.py
+++ b/benchmarks/pipeline_npu/run.py
@@ -14,6 +14,23 @@ def _repo_root():
     return os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 
 
+def _worker_failure_rows(framework, args, status):
+    """Return structured rows for every selected pipeline case on worker failure."""
+    return [
+        {
+            "framework": framework,
+            "case_id": case_id,
+            "mode": args.mode,
+            "mean_ms": 0.0,
+            "median_ms": 0.0,
+            "p95_ms": 0.0,
+            "op_count": 0,
+            "status": status,
+        }
+        for case_id in _parse_case_ids(args.cases)
+    ]
+
+
 def _spawn_worker(framework, args):
     repo_root = _repo_root()
     cmd = [
@@ -46,7 +63,7 @@ def _spawn_worker(framework, args):
             print(proc.stdout, file=sys.stderr, end="" if proc.stdout.endswith("\n") else "\n")
         if proc.stderr:
             print(proc.stderr, file=sys.stderr, end="" if proc.stderr.endswith("\n") else "\n")
-        raise RuntimeError(f"{framework} worker failed with exit code {proc.returncode}")
+        return _worker_failure_rows(framework, args, f"error: worker exit {proc.returncode}")
     try:
         rows = json.loads(proc.stdout)
     except json.JSONDecodeError as exc:
@@ -54,9 +71,9 @@ def _spawn_worker(framework, args):
             print(proc.stdout, file=sys.stderr, end="" if proc.stdout.endswith("\n") else "\n")
         if proc.stderr:
             print(proc.stderr, file=sys.stderr, end="" if proc.stderr.endswith("\n") else "\n")
-        raise RuntimeError(f"failed to parse {framework} worker JSON: {exc}") from exc
+        return _worker_failure_rows(framework, args, f"error: malformed worker JSON: {exc}")
     if not rows:
-        raise RuntimeError(f"{framework} worker returned no rows")
+        return _worker_failure_rows(framework, args, "error: worker returned no rows")
     return rows
 
 

--- a/benchmarks/pipeline_npu/run.py
+++ b/benchmarks/pipeline_npu/run.py
@@ -74,8 +74,9 @@ def pipeline_ratio_failures(rows, *, case_ids, mode, max_ratio):
     )
 
 
-def _print_table(rows):
-    print("case | framework | mode | median ms | ratio | status")
+def _print_table(rows, stream=None):
+    stream = stream or sys.stdout
+    print("case | framework | mode | median ms | ratio | status", file=stream)
     for row in sorted(rows, key=lambda item: (item.get("case_id", ""), item.get("framework", ""), item.get("mode", ""))):
         ratio = row.get("median_ratio")
         ratio_text = "-" if ratio is None else f"{ratio:.2f}x"
@@ -85,8 +86,30 @@ def _print_table(rows):
             f"{row.get('mode', '-')} | "
             f"{row.get('median_ms', 0.0):.4f} | "
             f"{ratio_text} | "
-            f"{row.get('status', '-') }"
+            f"{row.get('status', '-') }",
+            file=stream,
         )
+
+
+def _status_failures(rows):
+    failures = []
+    for row in rows:
+        if row.get("status") != "ok":
+            failures.append(
+                f"{row.get('case_id', '-')}/{row.get('mode', '-')}/{row.get('framework', '-')}: "
+                f"{row.get('status', '-') }"
+            )
+    return failures
+
+
+def _write_json_output(path, payload):
+    text = json.dumps(payload, indent=2, sort_keys=True)
+    if path == "-":
+        print(text)
+        return
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(text)
+        handle.write("\n")
 
 
 def _parse_case_ids(cases_arg):
@@ -119,20 +142,30 @@ def main():
     rows.extend(_spawn_worker("torch_npu", args))
     annotate_pipeline_ratios(rows)
 
-    failures = []
+    failures = _status_failures(rows)
     if args.fail_on_ratio:
-        failures = pipeline_ratio_failures(rows, case_ids=case_ids, mode=args.mode, max_ratio=args.max_ratio)
+        failures.extend(pipeline_ratio_failures(rows, case_ids=case_ids, mode=args.mode, max_ratio=args.max_ratio))
 
-    _print_table(rows)
+    human_stream = sys.stderr if args.json_output == "-" else sys.stdout
+    _print_table(rows, stream=human_stream)
     if failures:
-        print("failures:")
+        print("failures:", file=human_stream)
         for failure in failures:
-            print(f"- {failure}")
+            print(f"- {failure}", file=human_stream)
 
-    payload = {"rows": rows, "failures": failures}
+    payload = {
+        "warmup": args.warmup,
+        "iters": args.iters,
+        "cases": case_ids,
+        "mode": args.mode,
+        "device": args.device,
+        "max_ratio": args.max_ratio,
+        "frameworks": ["candle", "torch_npu"],
+        "rows": rows,
+        "failures": failures,
+    }
     if args.json_output:
-        with open(args.json_output, "w", encoding="utf-8") as handle:
-            json.dump(payload, handle, indent=2, sort_keys=True)
+        _write_json_output(args.json_output, payload)
 
     if failures:
         sys.exit(1)

--- a/benchmarks/pipeline_npu/run.py
+++ b/benchmarks/pipeline_npu/run.py
@@ -1,0 +1,136 @@
+"""Orchestrator for pipeline NPU benchmark comparisons."""
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+from benchmarks.npu_perf_gates import annotate_ratio_rows, collect_ratio_failures
+
+from .cases import CASES
+
+
+def _repo_root():
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+def _spawn_worker(framework, args):
+    cmd = [
+        args.python or sys.executable,
+        "-m",
+        "benchmarks.pipeline_npu.worker",
+        "--framework",
+        framework,
+        "--cases",
+        args.cases,
+        "--mode",
+        args.mode,
+        "--device",
+        args.device,
+        "--warmup",
+        str(args.warmup),
+        "--iters",
+        str(args.iters),
+    ]
+    env = os.environ.copy()
+    src_path = os.path.join(_repo_root(), "src")
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = src_path if not existing else os.pathsep.join([src_path, existing])
+    proc = subprocess.run(cmd, capture_output=True, text=True, env=env, check=False)
+    if proc.returncode != 0:
+        if proc.stdout:
+            print(proc.stdout, file=sys.stderr, end="" if proc.stdout.endswith("\n") else "\n")
+        if proc.stderr:
+            print(proc.stderr, file=sys.stderr, end="" if proc.stderr.endswith("\n") else "\n")
+        return []
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        print(f"failed to parse {framework} worker JSON: {exc}", file=sys.stderr)
+        if proc.stdout:
+            print(proc.stdout, file=sys.stderr, end="" if proc.stdout.endswith("\n") else "\n")
+        if proc.stderr:
+            print(proc.stderr, file=sys.stderr, end="" if proc.stderr.endswith("\n") else "\n")
+        return []
+
+
+def annotate_pipeline_ratios(rows):
+    annotate_ratio_rows(rows, key_fields=("case_id", "mode"), metric="median_ms")
+
+
+def pipeline_ratio_failures(rows, *, case_ids, mode, max_ratio):
+    return collect_ratio_failures(
+        rows,
+        key_fields=("case_id", "mode"),
+        expected_keys=[(case_id, mode) for case_id in case_ids],
+        max_ratio=max_ratio,
+        ratio_field="median_ratio",
+    )
+
+
+def _print_table(rows):
+    print("case | framework | mode | median ms | ratio | status")
+    for row in sorted(rows, key=lambda item: (item.get("case_id", ""), item.get("framework", ""), item.get("mode", ""))):
+        ratio = row.get("median_ratio")
+        ratio_text = "-" if ratio is None else f"{ratio:.2f}x"
+        print(
+            f"{row.get('case_id', '-')} | "
+            f"{row.get('framework', '-')} | "
+            f"{row.get('mode', '-')} | "
+            f"{row.get('median_ms', 0.0):.4f} | "
+            f"{ratio_text} | "
+            f"{row.get('status', '-') }"
+        )
+
+
+def _parse_case_ids(cases_arg):
+    return [case_id.strip() for case_id in cases_arg.split(",") if case_id.strip()]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cases", default=",".join(CASES.keys()))
+    parser.add_argument("--mode", default="eager", choices=["eager", "pipeline"])
+    parser.add_argument("--device", default="npu")
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--iters", type=int, default=20)
+    parser.add_argument("--python")
+    parser.add_argument("--json-output")
+    parser.add_argument("--fail-on-ratio", action="store_true")
+    parser.add_argument("--max-ratio", type=float, default=0.99)
+    args = parser.parse_args()
+
+    if args.max_ratio <= 0:
+        parser.error("--max-ratio must be > 0")
+
+    case_ids = _parse_case_ids(args.cases)
+    unknown = [case_id for case_id in case_ids if case_id not in CASES]
+    if unknown:
+        parser.error(f"unknown cases: {','.join(unknown)}")
+
+    rows = []
+    rows.extend(_spawn_worker("candle", args))
+    rows.extend(_spawn_worker("torch_npu", args))
+    annotate_pipeline_ratios(rows)
+
+    failures = []
+    if args.fail_on_ratio:
+        failures = pipeline_ratio_failures(rows, case_ids=case_ids, mode=args.mode, max_ratio=args.max_ratio)
+
+    _print_table(rows)
+    if failures:
+        print("failures:")
+        for failure in failures:
+            print(f"- {failure}")
+
+    payload = {"rows": rows, "failures": failures}
+    if args.json_output:
+        with open(args.json_output, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+
+    if failures:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/pipeline_npu/worker.py
+++ b/benchmarks/pipeline_npu/worker.py
@@ -18,7 +18,20 @@ def main():
     selected = [case_id.strip() for case_id in args.cases.split(",") if case_id.strip()]
     results = []
     for case_id in selected:
-        case = CASES[case_id]
+        try:
+            case = CASES[case_id]
+        except KeyError:
+            results.append({
+                "framework": args.framework,
+                "case_id": case_id,
+                "mode": args.mode,
+                "mean_ms": 0.0,
+                "median_ms": 0.0,
+                "p95_ms": 0.0,
+                "op_count": 0,
+                "status": f"error: unknown case: {case_id}",
+            })
+            continue
         try:
             results.append(run_case(
                 case,

--- a/benchmarks/pipeline_npu/worker.py
+++ b/benchmarks/pipeline_npu/worker.py
@@ -1,0 +1,46 @@
+"""Subprocess worker for pipeline NPU benchmark cases."""
+import argparse
+import json
+
+from .bench import CASES, run_case
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--framework", required=True, choices=["candle", "torch_npu"])
+    parser.add_argument("--cases", default=",".join(CASES.keys()))
+    parser.add_argument("--mode", default="eager", choices=["eager", "pipeline"])
+    parser.add_argument("--device", default="npu")
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--iters", type=int, default=20)
+    args = parser.parse_args()
+
+    selected = [case_id.strip() for case_id in args.cases.split(",") if case_id.strip()]
+    results = []
+    for case_id in selected:
+        case = CASES[case_id]
+        try:
+            results.append(run_case(
+                case,
+                framework=args.framework,
+                device=args.device,
+                mode=args.mode,
+                warmup=args.warmup,
+                iters=args.iters,
+            ))
+        except Exception as exc:
+            results.append({
+                "framework": args.framework,
+                "case_id": case_id,
+                "mode": args.mode,
+                "mean_ms": 0.0,
+                "median_ms": 0.0,
+                "p95_ms": 0.0,
+                "op_count": 0,
+                "status": f"error: {exc}",
+            })
+    print(json.dumps(results))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/superpowers/plans/2026-05-29-npu-performance-benchmark-gates.md
+++ b/docs/superpowers/plans/2026-05-29-npu-performance-benchmark-gates.md
@@ -1,0 +1,1724 @@
+# NPU Performance Benchmark Gates Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the Phase 0 benchmark gate infrastructure that measures Candle NPU against torch_npu for L0 single ops, L1 composite blocks, and L2 end-to-end models.
+
+**Architecture:** Keep existing benchmark entry points, add one shared metrics/gating helper, make pipeline cases framework-neutral, and add machine-readable JSON outputs plus ratio gates. This phase does not optimize kernels; it creates the measurement and regression system required before native fast-path and graph work.
+
+**Tech Stack:** Python 3.11, pytest, Candle benchmark scripts, torch_npu subprocess workers, JSON benchmark artifacts, existing conda/CANN environment conventions.
+
+---
+
+## Scope
+
+This plan implements Phase 0 from `docs/superpowers/specs/2026-05-29-npu-performance-core-redesign.md`.
+
+It intentionally does not change NPU kernels, Cython, C++, C, Rust, ACLNN bindings, or autograd execution. Performance results may fail the new gates after this phase; that is expected because the phase creates truthful gates before performance fixes.
+
+## File Structure
+
+Create:
+
+- `benchmarks/npu_perf_gates.py` — shared sample summaries, ratio annotation, and gate failure helpers for benchmark scripts.
+- `benchmarks/pipeline_npu/worker.py` — subprocess worker for one framework and selected pipeline cases.
+- `benchmarks/pipeline_npu/run.py` — orchestrator that runs Candle and torch_npu pipeline workers, merges ratios, writes JSON, and fails gates.
+- `tests/cpu/test_npu_perf_gates.py` — unit tests for shared metrics and ratio helpers.
+- `tests/cpu/test_pipeline_npu_framework_neutral.py` — CPU tests that pipeline cases build against a torch-like module argument rather than hard-coded Candle imports.
+- `tests/cpu/test_pipeline_npu_report.py` — unit tests for pipeline result ratio annotations and gate failures.
+- `tests/cpu/test_perf_candle_vs_torch_npu_ratios.py` — unit tests for L2 ratio annotation and total-ratio gates.
+
+Modify:
+
+- `benchmarks/op_benchmark_npu/runner.py` — use shared summary helper and expose p10/p90/min/max/sample_count.
+- `benchmarks/op_benchmark_npu/worker.py` — include extended summary fields in worker JSON rows.
+- `benchmarks/op_benchmark_npu/report.py` — include p10/p90, impact, and gate summary from extended rows.
+- `benchmarks/op_benchmark_npu/run.py` — add `--json-output`, `--fail-on-ratio`, and `--max-ratio`.
+- `benchmarks/pipeline_npu/cases.py` — make builders framework-neutral by passing `torch_mod` and `F` into every case.
+- `benchmarks/pipeline_npu/bench.py` — add `framework`, `mode`, and torch_npu support while preserving existing CPU smoke-test behavior.
+- `benchmarks/perf_candle_vs_torch_npu.py` — add total latency summaries, p10/p90 fields, total ratio, JSON gate metadata, and total-ratio failure checks.
+- `tests/npu/test_pipeline_npu_bench_smoke.py` — assert the new pipeline result fields without requiring NPU hardware.
+
+---
+
+### Task 1: Add shared benchmark metrics and gate helpers
+
+**Files:**
+- Create: `benchmarks/npu_perf_gates.py`
+- Test: `tests/cpu/test_npu_perf_gates.py`
+
+- [ ] **Step 1: Write failing tests for sample summaries and ratio gates**
+
+Create `tests/cpu/test_npu_perf_gates.py`:
+
+```python
+from benchmarks.npu_perf_gates import (
+    annotate_ratio_rows,
+    collect_ratio_failures,
+    summarize_samples,
+)
+
+
+def test_summarize_samples_reports_distribution_fields():
+    summary = summarize_samples([4.0, 1.0, 3.0, 2.0, 5.0])
+
+    assert summary == {
+        "sample_count": 5,
+        "mean_ms": 3.0,
+        "median_ms": 3.0,
+        "min_ms": 1.0,
+        "max_ms": 5.0,
+        "p10_ms": 1.0,
+        "p90_ms": 5.0,
+        "p95_ms": 5.0,
+    }
+
+
+def test_summarize_samples_empty_list_returns_zero_distribution():
+    summary = summarize_samples([])
+
+    assert summary == {
+        "sample_count": 0,
+        "mean_ms": 0.0,
+        "median_ms": 0.0,
+        "min_ms": 0.0,
+        "max_ms": 0.0,
+        "p10_ms": 0.0,
+        "p90_ms": 0.0,
+        "p95_ms": 0.0,
+    }
+
+
+def test_annotate_ratio_rows_adds_candle_ratio_against_torch_npu():
+    rows = [
+        {"framework": "torch_npu", "case": "add", "median_ms": 2.0, "status": "ok"},
+        {"framework": "candle", "case": "add", "median_ms": 3.0, "status": "ok"},
+    ]
+
+    annotate_ratio_rows(rows, key_fields=("case",), metric="median_ms")
+
+    candle = next(row for row in rows if row["framework"] == "candle")
+    torch_ref = next(row for row in rows if row["framework"] == "torch_npu")
+    assert candle["median_ratio"] == 1.5
+    assert torch_ref["median_ratio"] == 1.0
+
+
+def test_collect_ratio_failures_reports_missing_errors_and_slow_rows():
+    rows = [
+        {"framework": "torch_npu", "case": "add", "median_ms": 2.0, "status": "ok"},
+        {"framework": "candle", "case": "add", "median_ms": 3.0, "status": "ok", "median_ratio": 1.5},
+        {"framework": "candle", "case": "mul", "median_ms": 0.0, "status": "error: boom"},
+    ]
+
+    failures = collect_ratio_failures(
+        rows,
+        key_fields=("case",),
+        expected_keys=[("add",), ("mul",), ("div",)],
+        max_ratio=1.0,
+        ratio_field="median_ratio",
+    )
+
+    assert failures == [
+        "add: candle median_ratio 1.50x > 1.00x",
+        "mul/candle: error: boom",
+        "mul: missing torch_npu result",
+        "div: missing candle result",
+        "div: missing torch_npu result",
+    ]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/cpu/test_npu_perf_gates.py -q
+```
+
+Expected: FAIL because `benchmarks.npu_perf_gates` does not exist.
+
+- [ ] **Step 3: Implement shared helpers**
+
+Create `benchmarks/npu_perf_gates.py`:
+
+```python
+"""Shared metrics and ratio gates for NPU performance benchmarks."""
+
+
+def _round_ms(value):
+    return round(float(value), 4)
+
+
+def _nearest_percentile(sorted_values, percentile):
+    if not sorted_values:
+        return 0.0
+    index = round((len(sorted_values) - 1) * percentile)
+    return sorted_values[index]
+
+
+def summarize_samples(samples):
+    """Return stable millisecond distribution fields for benchmark samples."""
+    if not samples:
+        return {
+            "sample_count": 0,
+            "mean_ms": 0.0,
+            "median_ms": 0.0,
+            "min_ms": 0.0,
+            "max_ms": 0.0,
+            "p10_ms": 0.0,
+            "p90_ms": 0.0,
+            "p95_ms": 0.0,
+        }
+
+    values = sorted(float(sample) for sample in samples)
+    return {
+        "sample_count": len(values),
+        "mean_ms": _round_ms(sum(values) / len(values)),
+        "median_ms": _round_ms(_nearest_percentile(values, 0.50)),
+        "min_ms": _round_ms(values[0]),
+        "max_ms": _round_ms(values[-1]),
+        "p10_ms": _round_ms(_nearest_percentile(values, 0.10)),
+        "p90_ms": _round_ms(_nearest_percentile(values, 0.90)),
+        "p95_ms": _round_ms(_nearest_percentile(values, 0.95)),
+    }
+
+
+def _row_key(row, key_fields):
+    return tuple(row[field] for field in key_fields)
+
+
+def _ratio_field_name(metric):
+    if metric.endswith("_ms"):
+        return f"{metric[:-3]}_ratio"
+    return f"{metric}_ratio"
+
+
+def annotate_ratio_rows(rows, *, key_fields, metric="median_ms"):
+    """Annotate Candle rows with Candle/torch_npu ratio for matching keys."""
+    by_key = {}
+    for row in rows:
+        by_key.setdefault(_row_key(row, key_fields), {})[row.get("framework")] = row
+
+    ratio_field = _ratio_field_name(metric)
+    for framework_rows in by_key.values():
+        torch_ref = framework_rows.get("torch_npu")
+        candle = framework_rows.get("candle")
+        if torch_ref is not None and torch_ref.get("status", "ok") == "ok":
+            torch_ref[ratio_field] = 1.0
+        if candle is None or torch_ref is None:
+            continue
+        if candle.get("status", "ok") != "ok" or torch_ref.get("status", "ok") != "ok":
+            continue
+        ref_value = torch_ref.get(metric, 0.0)
+        candle_value = candle.get(metric, 0.0)
+        if ref_value:
+            candle[ratio_field] = round(float(candle_value) / float(ref_value), 4)
+
+
+def collect_ratio_failures(rows, *, key_fields, expected_keys, max_ratio, ratio_field):
+    """Return human-readable gate failures for missing, errored, or slow rows."""
+    by_key = {}
+    for row in rows:
+        by_key.setdefault(_row_key(row, key_fields), {})[row.get("framework")] = row
+
+    failures = []
+    for key in expected_keys:
+        by_framework = by_key.get(tuple(key), {})
+        label = "/".join(str(part) for part in key)
+        candle = by_framework.get("candle")
+        torch_ref = by_framework.get("torch_npu")
+
+        if candle is None:
+            failures.append(f"{label}: missing candle result")
+        elif candle.get("status", "ok") != "ok":
+            failures.append(f"{label}/candle: {candle['status']}")
+
+        if torch_ref is None:
+            failures.append(f"{label}: missing torch_npu result")
+        elif torch_ref.get("status", "ok") != "ok":
+            failures.append(f"{label}/torch_npu: {torch_ref['status']}")
+
+        if candle is None or torch_ref is None:
+            continue
+        if candle.get("status", "ok") != "ok" or torch_ref.get("status", "ok") != "ok":
+            continue
+
+        ratio = candle.get(ratio_field)
+        if ratio is None:
+            failures.append(f"{label}: missing candle {ratio_field}")
+        elif ratio > max_ratio:
+            failures.append(
+                f"{label}: candle {ratio_field} {ratio:.2f}x > {max_ratio:.2f}x"
+            )
+
+    return failures
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/cpu/test_npu_perf_gates.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 1 changes**
+
+```bash
+git add benchmarks/npu_perf_gates.py tests/cpu/test_npu_perf_gates.py
+git commit -m "bench(npu): add shared performance gate helpers"
+```
+
+---
+
+### Task 2: Extend L0 op benchmark JSON and ratio gates
+
+**Files:**
+- Modify: `benchmarks/op_benchmark_npu/runner.py:1-40`
+- Modify: `benchmarks/op_benchmark_npu/worker.py:6-110`
+- Modify: `benchmarks/op_benchmark_npu/report.py:1-135`
+- Modify: `benchmarks/op_benchmark_npu/run.py:1-136`
+- Test: `tests/cpu/test_npu_op_benchmark_report.py`
+
+- [ ] **Step 1: Write failing tests for op benchmark reports and gates**
+
+Create `tests/cpu/test_npu_op_benchmark_report.py`:
+
+```python
+from benchmarks.op_benchmark_npu.report import generate_report, ratio_failures
+
+
+def test_generate_report_includes_distribution_columns():
+    candle = [{
+        "framework": "candle",
+        "op": "add",
+        "mode": "fwd",
+        "dtype": "fp16",
+        "scenario": "infer",
+        "median_ms": 2.0,
+        "p10_ms": 1.5,
+        "p90_ms": 2.5,
+        "status": "ok",
+        "median_ratio": 2.0,
+    }]
+    torch_ref = [{
+        "framework": "torch_npu",
+        "op": "add",
+        "mode": "fwd",
+        "dtype": "fp16",
+        "scenario": "infer",
+        "median_ms": 1.0,
+        "p10_ms": 0.8,
+        "p90_ms": 1.2,
+        "status": "ok",
+        "median_ratio": 1.0,
+    }]
+
+    report = generate_report(candle, torch_ref, ["add"], ["fp16"], ["infer"], ["fwd"])
+
+    assert "| Op | candle median | torch_npu median | ratio | candle p10/p90 | torch_npu p10/p90 | impact |" in report
+    assert "| add | 2.0000 | 1.0000 | 2.00x | 1.5000/2.5000 | 0.8000/1.2000 | 1.0000 |" in report
+
+
+def test_ratio_failures_reports_slow_op():
+    candle = [{
+        "framework": "candle",
+        "op": "add",
+        "mode": "fwd",
+        "dtype": "fp16",
+        "scenario": "infer",
+        "median_ms": 2.0,
+        "status": "ok",
+        "median_ratio": 2.0,
+    }]
+    torch_ref = [{
+        "framework": "torch_npu",
+        "op": "add",
+        "mode": "fwd",
+        "dtype": "fp16",
+        "scenario": "infer",
+        "median_ms": 1.0,
+        "status": "ok",
+        "median_ratio": 1.0,
+    }]
+
+    failures = ratio_failures(
+        candle,
+        torch_ref,
+        op_names=["add"],
+        dtype_keys=["fp16"],
+        scen_keys=["infer"],
+        mode_keys=["fwd"],
+        max_ratio=1.0,
+    )
+
+    assert failures == ["add/fwd/fp16/infer: candle median_ratio 2.00x > 1.00x"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/cpu/test_npu_op_benchmark_report.py -q
+```
+
+Expected: FAIL because `ratio_failures` is not exported and the report columns are not extended.
+
+- [ ] **Step 3: Update op benchmark sample summary helper**
+
+Modify `benchmarks/op_benchmark_npu/runner.py` to use the shared summary helper:
+
+```python
+import time
+
+from benchmarks.npu_perf_gates import summarize_samples
+
+
+def benchmark_op(fn, warmup=10, iters=50, sync=None, setup=None, cleanup=None):
+    """Run fn with warmup, then time iters iterations. Returns list of ms."""
+    for _ in range(warmup):
+        if setup:
+            setup()
+        fn()
+        if sync:
+            sync()
+        if cleanup:
+            cleanup()
+
+    times = []
+    for _ in range(iters):
+        if setup:
+            setup()
+        if sync:
+            sync()
+        t0 = time.perf_counter()
+        fn()
+        if sync:
+            sync()
+        t1 = time.perf_counter()
+        times.append((t1 - t0) * 1000.0)
+        if cleanup:
+            cleanup()
+    return times
+
+
+def summarize(samples):
+    """Return stable millisecond distribution fields for benchmark samples."""
+    return summarize_samples(samples)
+```
+
+- [ ] **Step 4: Update op benchmark worker rows**
+
+In `benchmarks/op_benchmark_npu/worker.py`, replace lines 85-95 with:
+
+```python
+                    summary = summarize(samples)
+                    results.append({
+                        "framework": "torch_npu" if args.framework == "torch" else args.framework,
+                        "op": op_name,
+                        "mode": case.get("mode", "fwd"),
+                        "dtype": dtype_key,
+                        "scenario": scen_key,
+                        **summary,
+                        "status": "ok",
+                    })
+```
+
+Replace lines 97-105 with:
+
+```python
+                    results.append({
+                        "framework": "torch_npu" if args.framework == "torch" else args.framework,
+                        "op": op_name,
+                        "mode": case.get("mode", "fwd"),
+                        "dtype": dtype_key,
+                        "scenario": scen_key,
+                        "sample_count": 0,
+                        "mean_ms": 0.0,
+                        "median_ms": 0.0,
+                        "min_ms": 0.0,
+                        "max_ms": 0.0,
+                        "p10_ms": 0.0,
+                        "p90_ms": 0.0,
+                        "p95_ms": 0.0,
+                        "status": f"error: {e}",
+                    })
+```
+
+- [ ] **Step 5: Update op benchmark report generation**
+
+At the top of `benchmarks/op_benchmark_npu/report.py`, add the shared helpers import:
+
+```python
+from benchmarks.npu_perf_gates import annotate_ratio_rows, collect_ratio_failures
+```
+
+Replace `_build_section` with:
+
+```python
+def _fmt_ms(value):
+    return f"{value:.4f}" if value is not None else "—"
+
+
+def _build_section(mode_key, dtype_key, scen_key, candle_map, torch_map, op_names):
+    dtype_label = DTYPES[dtype_key]
+    mode_label = MODES[mode_key]
+    scen_label = SCENARIOS[scen_key]["label"]
+    header = f"### {mode_label} — {dtype_label} — {scen_label}"
+
+    lines = [header, ""]
+    lines.append("| Op | candle median | torch_npu median | ratio | candle p10/p90 | torch_npu p10/p90 | impact |")
+    lines.append("|---|---|---|---|---|---|---|")
+
+    ratios = []
+    rows = []
+    for op in op_names:
+        c = candle_map.get((op, mode_key, dtype_key, scen_key))
+        t = torch_map.get((op, mode_key, dtype_key, scen_key))
+
+        c_ok = c and c["status"] == "ok"
+        t_ok = t and t["status"] == "ok"
+        c_med = c["median_ms"] if c_ok else None
+        t_med = t["median_ms"] if t_ok else None
+
+        if c_ok and t_ok and t_med > 0:
+            ratio = c.get("median_ratio", c_med / t_med)
+            impact = c_med - t_med
+            ratios.append((op, ratio))
+            ratio_str = f"{ratio:.2f}x"
+            impact_str = f"{impact:.4f}"
+        else:
+            ratio = None
+            impact = None
+            ratio_str = "N/A"
+            impact_str = "N/A"
+
+        candle_dist = "ERR" if c and c["status"] != "ok" else f"{_fmt_ms(c.get('p10_ms') if c else None)}/{_fmt_ms(c.get('p90_ms') if c else None)}"
+        torch_dist = "ERR" if t and t["status"] != "ok" else f"{_fmt_ms(t.get('p10_ms') if t else None)}/{_fmt_ms(t.get('p90_ms') if t else None)}"
+        c_str = c["status"][:30] if c and c["status"] != "ok" else _fmt_ms(c_med)
+        t_str = t["status"][:30] if t and t["status"] != "ok" else _fmt_ms(t_med)
+
+        rows.append((
+            ratio if ratio is not None else -1.0,
+            impact if impact is not None else -1.0,
+            f"| {op} | {c_str} | {t_str} | {ratio_str} | {candle_dist} | {torch_dist} | {impact_str} |",
+        ))
+
+    rows.sort(key=lambda item: (item[0], item[1]), reverse=True)
+    lines.extend(row for _, _, row in rows)
+    lines.append("")
+    return lines, ratios
+```
+
+Add this function below `generate_report`:
+
+```python
+def ratio_failures(candle_results, torch_results, op_names, dtype_keys, scen_keys, mode_keys, max_ratio):
+    rows = list(candle_results) + list(torch_results)
+    annotate_ratio_rows(rows, key_fields=("op", "mode", "dtype", "scenario"), metric="median_ms")
+    expected_keys = [
+        (op, mode, dtype, scen)
+        for mode in mode_keys
+        for dtype in dtype_keys
+        for scen in scen_keys
+        for op in op_names
+    ]
+    return collect_ratio_failures(
+        rows,
+        key_fields=("op", "mode", "dtype", "scenario"),
+        expected_keys=expected_keys,
+        max_ratio=max_ratio,
+        ratio_field="median_ratio",
+    )
+```
+
+At the start of `generate_report`, after `torch_map` is created, add:
+
+```python
+    rows = list(candle_results) + list(torch_results)
+    annotate_ratio_rows(rows, key_fields=("op", "mode", "dtype", "scenario"), metric="median_ms")
+```
+
+- [ ] **Step 6: Add op benchmark JSON output and ratio gate CLI**
+
+In `benchmarks/op_benchmark_npu/run.py`, update imports:
+
+```python
+from .report import generate_report, print_terminal, ratio_failures, write_markdown
+```
+
+Add parser arguments after `--output`:
+
+```python
+    parser.add_argument("--json-output", default=None,
+                        help="Write merged benchmark payload to this JSON path, or '-' for stdout")
+    parser.add_argument("--fail-on-ratio", action="store_true",
+                        help="Exit nonzero if any Candle op is slower than --max-ratio")
+    parser.add_argument("--max-ratio", type=float, default=1.0,
+                        help="Maximum allowed Candle/torch_npu median ratio for --fail-on-ratio")
+```
+
+After `args = parser.parse_args()`, add:
+
+```python
+    if args.max_ratio <= 0:
+        parser.error("--max-ratio must be > 0")
+```
+
+After `report = generate_report(...)`, add:
+
+```python
+    failures = []
+    if args.fail_on_ratio:
+        failures = ratio_failures(
+            candle_results,
+            torch_results,
+            op_names,
+            dtype_keys,
+            scen_keys,
+            mode_keys,
+            args.max_ratio,
+        )
+```
+
+After `print_terminal(report)`, add:
+
+```python
+    if failures:
+        print("\n# Ratio gate failures")
+        for failure in failures:
+            print(f"- {failure}")
+
+    payload = {
+        "warmup": args.warmup,
+        "iters": args.iters,
+        "op_names": op_names,
+        "dtype_keys": dtype_keys,
+        "scenario_keys": scen_keys,
+        "mode_keys": mode_keys,
+        "max_ratio": args.max_ratio,
+        "failures": failures,
+        "results": {
+            "candle": candle_results,
+            "torch_npu": torch_results,
+        },
+    }
+    if args.json_output:
+        text = json.dumps(payload, indent=2, sort_keys=True)
+        if args.json_output == "-":
+            print(text)
+        else:
+            with open(args.json_output, "w", encoding="utf-8") as handle:
+                handle.write(text)
+                handle.write("\n")
+```
+
+Before the end of `main()`, after optional markdown writing, add:
+
+```python
+    if failures:
+        sys.exit(1)
+```
+
+- [ ] **Step 7: Run op benchmark unit tests**
+
+Run:
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/cpu/test_npu_perf_gates.py tests/cpu/test_npu_op_benchmark_report.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run op benchmark import smoke without NPU**
+
+Run:
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m benchmarks.op_benchmark_npu.run --help
+```
+
+Expected: command prints help including `--json-output`, `--fail-on-ratio`, and `--max-ratio`.
+
+- [ ] **Step 9: Commit Task 2 changes**
+
+```bash
+git add benchmarks/op_benchmark_npu/runner.py \
+  benchmarks/op_benchmark_npu/worker.py \
+  benchmarks/op_benchmark_npu/report.py \
+  benchmarks/op_benchmark_npu/run.py \
+  tests/cpu/test_npu_op_benchmark_report.py
+git commit -m "bench(npu): add single-op ratio gates"
+```
+
+---
+
+### Task 3: Make pipeline cases framework-neutral
+
+**Files:**
+- Modify: `benchmarks/pipeline_npu/cases.py:1-297`
+- Test: `tests/cpu/test_pipeline_npu_framework_neutral.py`
+
+- [ ] **Step 1: Write failing tests for framework-neutral builders**
+
+Create `tests/cpu/test_pipeline_npu_framework_neutral.py`:
+
+```python
+import candle
+import candle.nn.functional as F
+
+from benchmarks.pipeline_npu.cases import CASES
+
+
+def test_pipeline_case_builders_accept_framework_module():
+    for name in ["A1", "A2s", "D2"]:
+        case = CASES[name]
+        forward = case["builder"](candle, F, "cpu", candle.float32)
+        out = forward()
+        assert hasattr(out, "shape")
+
+
+def test_pipeline_cases_do_not_require_global_candle_module_argument():
+    case = CASES["A1"]
+    forward = case["builder"](candle, F, "cpu", candle.float32)
+    out = forward()
+    assert tuple(out.shape) == (1, 128, 1024)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/cpu/test_pipeline_npu_framework_neutral.py -q
+```
+
+Expected: FAIL because builders currently accept `(device, dtype)` and import Candle globally.
+
+- [ ] **Step 3: Update imports and function signatures in pipeline cases**
+
+In `benchmarks/pipeline_npu/cases.py`, delete the first two import lines:
+
+```python
+import candle
+import candle.nn.functional as F
+```
+
+Change every builder signature and call as follows:
+
+```python
+def _case_a1(torch_mod, F, device, dtype):
+```
+
+```python
+def _case_a2(torch_mod, F, device, dtype):
+```
+
+```python
+def _case_a2s(torch_mod, F, device, dtype):
+```
+
+```python
+def _case_a3(torch_mod, F, device, dtype):
+```
+
+```python
+def _block(torch_mod, F, device, dtype, *, b, s, h, heads):
+```
+
+```python
+def _case_b1(torch_mod, F, device, dtype):
+    return _block(torch_mod, F, device, dtype, b=1, s=512, h=2048, heads=16)
+```
+
+```python
+def _case_b1s(torch_mod, F, device, dtype):
+    return _block(torch_mod, F, device, dtype, b=2, s=256, h=512, heads=8)
+```
+
+```python
+def _case_b2(torch_mod, F, device, dtype):
+    return _block(torch_mod, F, device, dtype, b=4, s=128, h=1024, heads=8)
+```
+
+```python
+def _case_b3(torch_mod, F, device, dtype):
+    return _block(torch_mod, F, device, dtype, b=1, s=2048, h=1024, heads=16)
+```
+
+```python
+def _case_c1(torch_mod, F, device, dtype):
+    block = _block(torch_mod, F, device, dtype, b=1, s=512, h=1024, heads=16)
+```
+
+```python
+def _case_c2(torch_mod, F, device, dtype):
+    block = _block(torch_mod, F, device, dtype, b=2, s=256, h=1024, heads=16)
+```
+
+```python
+def _case_d1(torch_mod, F, device, dtype):
+    block = _block(torch_mod, F, device, dtype, b=2, s=256, h=512, heads=8)
+```
+
+```python
+def _case_d2(torch_mod, F, device, dtype):
+```
+
+Inside the file, replace every `candle.randn` with `torch_mod.randn` and every `candle.matmul` with `torch_mod.matmul`.
+
+The `CASE_METADATA` dictionary does not need to change; each `"builder"` value still references the same function names.
+
+- [ ] **Step 4: Run framework-neutral builder tests**
+
+Run:
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/cpu/test_pipeline_npu_framework_neutral.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run existing pipeline smoke tests**
+
+Run:
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/npu/test_pipeline_npu_bench_smoke.py -q
+```
+
+Expected: FAIL until Task 4 updates `bench.py` to call builders with framework arguments.
+
+- [ ] **Step 6: Commit Task 3 changes after Task 4 passes**
+
+Do not commit Task 3 until Task 4 updates the caller and both test files pass together.
+
+---
+
+### Task 4: Add L1 pipeline Candle vs torch_npu runner
+
+**Files:**
+- Modify: `benchmarks/pipeline_npu/bench.py:1-61`
+- Create: `benchmarks/pipeline_npu/worker.py`
+- Create: `benchmarks/pipeline_npu/run.py`
+- Modify: `tests/npu/test_pipeline_npu_bench_smoke.py:1-18`
+- Test: `tests/cpu/test_pipeline_npu_report.py`
+
+- [ ] **Step 1: Write failing tests for pipeline ratio gates**
+
+Create `tests/cpu/test_pipeline_npu_report.py`:
+
+```python
+from benchmarks.pipeline_npu.run import annotate_pipeline_ratios, pipeline_ratio_failures
+
+
+def test_annotate_pipeline_ratios_adds_candle_ratio():
+    rows = [
+        {"framework": "torch_npu", "case_id": "A1", "mode": "eager", "median_ms": 10.0, "status": "ok"},
+        {"framework": "candle", "case_id": "A1", "mode": "eager", "median_ms": 8.0, "status": "ok"},
+    ]
+
+    annotate_pipeline_ratios(rows)
+
+    candle = next(row for row in rows if row["framework"] == "candle")
+    assert candle["median_ratio"] == 0.8
+
+
+def test_pipeline_ratio_failures_require_candle_to_be_faster_than_torch_npu():
+    rows = [
+        {"framework": "torch_npu", "case_id": "A1", "mode": "eager", "median_ms": 10.0, "status": "ok", "median_ratio": 1.0},
+        {"framework": "candle", "case_id": "A1", "mode": "eager", "median_ms": 10.5, "status": "ok", "median_ratio": 1.05},
+    ]
+
+    failures = pipeline_ratio_failures(rows, case_ids=["A1"], mode="eager", max_ratio=0.99)
+
+    assert failures == ["A1/eager: candle median_ratio 1.05x > 0.99x"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/cpu/test_pipeline_npu_report.py -q
+```
+
+Expected: FAIL because `benchmarks.pipeline_npu.run` does not exist.
+
+- [ ] **Step 3: Update `bench.py` to import frameworks and preserve CPU behavior**
+
+Replace `benchmarks/pipeline_npu/bench.py` with:
+
+```python
+import importlib
+
+import candle
+import candle.nn.functional as candle_F
+
+from .cases import CASES
+from .utils import measure, summarize
+
+
+def _import_framework(framework):
+    if framework == "candle":
+        return candle, candle_F, "npu"
+    if framework == "torch_npu":
+        torch_mod = importlib.import_module("torch")
+        importlib.import_module("torch_npu")
+        return torch_mod, importlib.import_module("torch.nn.functional"), "npu"
+    raise ValueError(f"unknown framework: {framework}")
+
+
+def _resolve_dtype(torch_mod, dtype_name):
+    return getattr(torch_mod, dtype_name)
+
+
+def _sync_for(torch_mod, device):
+    if device == "npu" and hasattr(torch_mod, "npu") and torch_mod.npu.is_available():
+        return torch_mod.npu.synchronize
+    return None
+
+
+def run_case(case, *, framework="candle", device="cpu", mode="eager", warmup=5, iters=20):
+    torch_mod, F, default_device = _import_framework(framework)
+    if device is None:
+        device = default_device
+    dtype = _resolve_dtype(torch_mod, case["dtype"])
+    forward = case["builder"](torch_mod, F, device, dtype)
+    sync = _sync_for(torch_mod, device)
+
+    def _run_once():
+        if mode == "pipeline":
+            if framework != "candle":
+                forward()
+                return
+            with candle.pipeline(max_ops=64):
+                forward()
+        else:
+            forward()
+
+    samples = measure(_run_once, warmup=warmup, iters=iters, sync=sync)
+    mean, median, p95 = summarize(samples)
+
+    op_count = 0
+    if mode == "pipeline" and framework == "candle":
+        with candle.pipeline(max_ops=64) as pipe:
+            forward()
+            pipe.flush()
+            dump = pipe.debug_dump()
+            op_count = len(dump.get("entries", []))
+
+    return {
+        "framework": framework,
+        "case_id": case["case_id"],
+        "mode": mode,
+        "batch": case["batch"],
+        "seq": case["seq"],
+        "hidden": case["hidden"],
+        "heads": case["heads"],
+        "dtype": case["dtype"],
+        "mean_ms": float(mean),
+        "median_ms": float(median),
+        "p95_ms": float(p95),
+        "op_count": int(op_count),
+        "status": "ok",
+    }
+
+
+def run():
+    results = {}
+    for name, case in CASES.items():
+        results[name] = run_case(case, framework="candle", device="cpu", mode="eager", warmup=1, iters=1)
+    return results
+
+
+__all__ = ["CASES", "run_case", "run"]
+```
+
+- [ ] **Step 4: Add pipeline worker**
+
+Create `benchmarks/pipeline_npu/worker.py`:
+
+```python
+"""Subprocess worker for pipeline NPU benchmark cases."""
+import argparse
+import json
+
+from .bench import CASES, run_case
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--framework", required=True, choices=["candle", "torch_npu"])
+    parser.add_argument("--cases", default=",".join(CASES.keys()))
+    parser.add_argument("--mode", default="eager", choices=["eager", "pipeline"])
+    parser.add_argument("--device", default="npu")
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--iters", type=int, default=20)
+    args = parser.parse_args()
+
+    selected = [case_id.strip() for case_id in args.cases.split(",") if case_id.strip()]
+    results = []
+    for case_id in selected:
+        case = CASES[case_id]
+        try:
+            results.append(run_case(
+                case,
+                framework=args.framework,
+                device=args.device,
+                mode=args.mode,
+                warmup=args.warmup,
+                iters=args.iters,
+            ))
+        except Exception as exc:
+            results.append({
+                "framework": args.framework,
+                "case_id": case_id,
+                "mode": args.mode,
+                "mean_ms": 0.0,
+                "median_ms": 0.0,
+                "p95_ms": 0.0,
+                "op_count": 0,
+                "status": f"error: {exc}",
+            })
+    print(json.dumps(results))
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 5: Add pipeline orchestrator**
+
+Create `benchmarks/pipeline_npu/run.py`:
+
+```python
+"""Pipeline NPU benchmark orchestrator for Candle vs torch_npu."""
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+from benchmarks.npu_perf_gates import annotate_ratio_rows, collect_ratio_failures
+from .bench import CASES
+
+
+def _spawn_worker(framework, args):
+    cmd = [
+        args.python or sys.executable,
+        "-m", "benchmarks.pipeline_npu.worker",
+        "--framework", framework,
+        "--cases", args.cases,
+        "--mode", args.mode,
+        "--device", args.device,
+        "--warmup", str(args.warmup),
+        "--iters", str(args.iters),
+    ]
+    env = os.environ.copy()
+    src_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "src")
+    old_path = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = src_dir if not old_path else os.pathsep.join((src_dir, old_path))
+    proc = subprocess.run(cmd, env=env, text=True, capture_output=True, timeout=1800, check=False)
+    if proc.returncode != 0:
+        print(proc.stdout, file=sys.stderr)
+        print(proc.stderr, file=sys.stderr)
+        return []
+    return json.loads(proc.stdout)
+
+
+def annotate_pipeline_ratios(rows):
+    annotate_ratio_rows(rows, key_fields=("case_id", "mode"), metric="median_ms")
+
+
+def pipeline_ratio_failures(rows, *, case_ids, mode, max_ratio):
+    expected_keys = [(case_id, mode) for case_id in case_ids]
+    return collect_ratio_failures(
+        rows,
+        key_fields=("case_id", "mode"),
+        expected_keys=expected_keys,
+        max_ratio=max_ratio,
+        ratio_field="median_ratio",
+    )
+
+
+def _print_table(rows):
+    print("case | framework | mode | median ms | ratio | status")
+    print("---|---|---|---|---|---")
+    for row in sorted(rows, key=lambda item: (item["case_id"], item["framework"], item["mode"])):
+        ratio = row.get("median_ratio")
+        ratio_str = "-" if ratio is None else f"{ratio:.2f}x"
+        print(
+            f"{row['case_id']} | {row['framework']} | {row['mode']} | "
+            f"{row.get('median_ms', 0.0):.4f} | {ratio_str} | {row.get('status', 'ok')}"
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cases", default=",".join(CASES.keys()))
+    parser.add_argument("--mode", default="eager", choices=["eager", "pipeline"])
+    parser.add_argument("--device", default="npu")
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--iters", type=int, default=20)
+    parser.add_argument("--python", default=None, help="Python executable for workers")
+    parser.add_argument("--json-output", default=None, help="Write merged payload to path, or '-' for stdout")
+    parser.add_argument("--fail-on-ratio", action="store_true")
+    parser.add_argument("--max-ratio", type=float, default=0.99)
+    args = parser.parse_args()
+
+    if args.max_ratio <= 0:
+        parser.error("--max-ratio must be > 0")
+
+    case_ids = [case_id.strip() for case_id in args.cases.split(",") if case_id.strip()]
+    unknown = [case_id for case_id in case_ids if case_id not in CASES]
+    if unknown:
+        raise SystemExit(f"unknown cases: {unknown}; known: {list(CASES)}")
+
+    rows = _spawn_worker("candle", args) + _spawn_worker("torch_npu", args)
+    annotate_pipeline_ratios(rows)
+    failures = []
+    if args.fail_on_ratio:
+        failures = pipeline_ratio_failures(rows, case_ids=case_ids, mode=args.mode, max_ratio=args.max_ratio)
+
+    _print_table(rows)
+    if failures:
+        print("\n# Ratio gate failures")
+        for failure in failures:
+            print(f"- {failure}")
+
+    payload = {
+        "warmup": args.warmup,
+        "iters": args.iters,
+        "cases": case_ids,
+        "mode": args.mode,
+        "device": args.device,
+        "max_ratio": args.max_ratio,
+        "failures": failures,
+        "results": rows,
+    }
+    if args.json_output:
+        text = json.dumps(payload, indent=2, sort_keys=True)
+        if args.json_output == "-":
+            print(text)
+        else:
+            with open(args.json_output, "w", encoding="utf-8") as handle:
+                handle.write(text)
+                handle.write("\n")
+    if failures:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 6: Update pipeline smoke tests for new result fields**
+
+Modify `tests/npu/test_pipeline_npu_bench_smoke.py`:
+
+```python
+from benchmarks.pipeline_npu.bench import CASES, run_case
+
+
+def test_pipeline_bench_smoke_cpu():
+    case = CASES["A1"]
+    result = run_case(case, framework="candle", device="cpu", mode="eager", warmup=1, iters=1)
+    assert result["framework"] == "candle"
+    assert result["case_id"] == "A1"
+    assert result["mode"] == "eager"
+    assert result["status"] == "ok"
+    assert "mean_ms" in result
+    assert "median_ms" in result
+    assert "p95_ms" in result
+    assert isinstance(result["mean_ms"], float)
+    assert isinstance(result["median_ms"], float)
+    assert isinstance(result["p95_ms"], float)
+
+
+def test_pipeline_bench_cases_matrix():
+    for key in ["A1", "A2", "A2s", "A3", "B1", "B1s", "B2", "B3", "C1", "C2", "D1", "D2"]:
+        assert key in CASES
+```
+
+- [ ] **Step 7: Run pipeline tests**
+
+Run:
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/cpu/test_pipeline_npu_framework_neutral.py \
+    tests/cpu/test_pipeline_npu_report.py \
+    tests/npu/test_pipeline_npu_bench_smoke.py -q
+```
+
+Expected: PASS on CPU-only machines because NPU-specific cases are not executed with `device="npu"` in tests.
+
+- [ ] **Step 8: Run pipeline CLI help smoke**
+
+Run:
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m benchmarks.pipeline_npu.run --help
+```
+
+Expected: command prints help including `--json-output`, `--fail-on-ratio`, and `--max-ratio`.
+
+- [ ] **Step 9: Commit Tasks 3 and 4 together**
+
+```bash
+git add benchmarks/pipeline_npu/cases.py \
+  benchmarks/pipeline_npu/bench.py \
+  benchmarks/pipeline_npu/worker.py \
+  benchmarks/pipeline_npu/run.py \
+  tests/cpu/test_pipeline_npu_framework_neutral.py \
+  tests/cpu/test_pipeline_npu_report.py \
+  tests/npu/test_pipeline_npu_bench_smoke.py
+git commit -m "bench(npu): compare pipeline blocks with torch_npu"
+```
+
+---
+
+### Task 5: Extend L2 end-to-end benchmark ratios
+
+**Files:**
+- Modify: `benchmarks/perf_candle_vs_torch_npu.py:179-513`
+- Test: `tests/cpu/test_perf_candle_vs_torch_npu_ratios.py`
+
+- [ ] **Step 1: Write failing tests for total ratio annotation and failures**
+
+Create `tests/cpu/test_perf_candle_vs_torch_npu_ratios.py`:
+
+```python
+from benchmarks.perf_candle_vs_torch_npu import _annotate_ratios, _ratio_failures
+
+
+def test_annotate_ratios_adds_total_ratio():
+    results = [
+        {
+            "framework": "torch_npu",
+            "case": "xfmr",
+            "fwd_ms_median": 2.0,
+            "bwd_ms_median": 3.0,
+            "total_ms_median": 5.0,
+        },
+        {
+            "framework": "candle",
+            "case": "xfmr",
+            "fwd_ms_median": 1.5,
+            "bwd_ms_median": 2.0,
+            "total_ms_median": 3.5,
+        },
+    ]
+
+    _annotate_ratios(results)
+
+    candle = next(row for row in results if row["framework"] == "candle")
+    assert candle["fwd_ratio"] == 0.75
+    assert candle["bwd_ratio"] == 2.0 / 3.0
+    assert candle["total_ratio"] == 0.7
+
+
+def test_ratio_failures_checks_total_ratio():
+    results = [
+        {
+            "framework": "torch_npu",
+            "case": "xfmr",
+            "fwd_ms_median": 2.0,
+            "bwd_ms_median": 3.0,
+            "total_ms_median": 5.0,
+        },
+        {
+            "framework": "candle",
+            "case": "xfmr",
+            "fwd_ms_median": 2.0,
+            "bwd_ms_median": 3.0,
+            "total_ms_median": 5.2,
+            "fwd_ratio": 1.0,
+            "bwd_ratio": 1.0,
+            "total_ratio": 1.04,
+        },
+    ]
+
+    failures = _ratio_failures(
+        results,
+        cases=["xfmr"],
+        max_fwd_ratio=1.0,
+        max_bwd_ratio=1.0,
+        max_total_ratio=0.99,
+    )
+
+    assert failures == ["xfmr: total ratio 1.04x > 0.99x"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/cpu/test_perf_candle_vs_torch_npu_ratios.py -q
+```
+
+Expected: FAIL because `_ratio_failures` does not accept `max_total_ratio` and total ratios are not annotated.
+
+- [ ] **Step 3: Add total latency samples and distribution fields**
+
+In `benchmarks/perf_candle_vs_torch_npu.py`, import the shared summary helper near the top:
+
+```python
+from benchmarks.npu_perf_gates import summarize_samples
+```
+
+In `run_worker`, after `bwd_samples = []`, add:
+
+```python
+    total_samples = []
+```
+
+After appending `bwd_samples`, add:
+
+```python
+        total_samples.append((t2 - t0) * 1000.0)
+```
+
+Replace the `result = { ... }` block at lines 221-229 with:
+
+```python
+    fwd_summary = summarize_samples(fwd_samples)
+    bwd_summary = summarize_samples(bwd_samples)
+    total_summary = summarize_samples(total_samples)
+    result = {
+        "framework": framework,
+        "case": case,
+        "iters": iters,
+        "fwd_ms_median": fwd_summary["median_ms"],
+        "bwd_ms_median": bwd_summary["median_ms"],
+        "total_ms_median": total_summary["median_ms"],
+        "fwd_ms_min": fwd_summary["min_ms"],
+        "bwd_ms_min": bwd_summary["min_ms"],
+        "total_ms_min": total_summary["min_ms"],
+        "fwd_ms_p10": fwd_summary["p10_ms"],
+        "bwd_ms_p10": bwd_summary["p10_ms"],
+        "total_ms_p10": total_summary["p10_ms"],
+        "fwd_ms_p90": fwd_summary["p90_ms"],
+        "bwd_ms_p90": bwd_summary["p90_ms"],
+        "total_ms_p90": total_summary["p90_ms"],
+    }
+```
+
+- [ ] **Step 4: Add total ratio annotation**
+
+In `_annotate_ratios`, after `torch_bwd = torch_ref.get("bwd_ms_median")`, add:
+
+```python
+        torch_total = torch_ref.get("total_ms_median")
+```
+
+After the backward-ratio block, add:
+
+```python
+        if torch_total:
+            candle["total_ratio"] = candle["total_ms_median"] / torch_total
+```
+
+- [ ] **Step 5: Add total ratio failure gate**
+
+Change `_ratio_failures` signature to:
+
+```python
+def _ratio_failures(results, cases, max_fwd_ratio, max_bwd_ratio, max_total_ratio):
+```
+
+Inside `_ratio_failures`, after `bwd_ratio = candle.get("bwd_ratio")`, add:
+
+```python
+        total_ratio = candle.get("total_ratio")
+```
+
+Replace the missing-ratio check with:
+
+```python
+        if fwd_ratio is None or bwd_ratio is None or total_ratio is None:
+            failures.append(f"{case}: unable to compute candle/torch_npu ratio")
+            continue
+```
+
+After the backward-ratio failure block, add:
+
+```python
+        if total_ratio > max_total_ratio:
+            failures.append(f"{case}: total ratio {total_ratio:.2f}x > {max_total_ratio:.2f}x")
+```
+
+- [ ] **Step 6: Add CLI argument and payload metadata**
+
+In `main()`, after `--max-bwd-ratio`, add:
+
+```python
+    parser.add_argument("--max-total-ratio", type=float, default=0.99,
+                        help="maximum allowed candle/torch_npu total ratio for --fail-on-ratio")
+```
+
+After the `args.max_bwd_ratio` validation, add:
+
+```python
+    if args.max_total_ratio <= 0:
+        parser.error("--max-total-ratio must be > 0")
+```
+
+Change the `_ratio_failures` call to:
+
+```python
+        failures = _ratio_failures(
+            results,
+            cases,
+            args.max_fwd_ratio,
+            args.max_bwd_ratio,
+            args.max_total_ratio,
+        )
+```
+
+Add `"max_total_ratio": args.max_total_ratio,` to the JSON payload next to `max_fwd_ratio` and `max_bwd_ratio`.
+
+- [ ] **Step 7: Update L2 table output to include total ratio**
+
+In `_print_table`, change:
+
+```python
+    header = ["algo", "fwd ms", "bwd ms", "ratio"]
+```
+
+to:
+
+```python
+    header = ["algo", "fwd ms", "bwd ms", "total ms", "ratio"]
+```
+
+Change each successful row from:
+
+```python
+                row = [algo, _fmt(fwd), _fmt(bwd), ratio]
+```
+
+to:
+
+```python
+                total = r.get("total_ms_median")
+                row = [algo, _fmt(fwd), _fmt(bwd), _fmt(total), ratio]
+```
+
+Change error rows from four fields to five fields:
+
+```python
+                row = [algo, "err", "err", "err", "-"]
+```
+
+Change the Candle ratio string to:
+
+```python
+                    total_part = f" / t {r['total_ratio']:.2f}x" if "total_ratio" in r else ""
+                    ratio = f"f {r['fwd_ratio']:.2f}x / b {r['bwd_ratio']:.2f}x{total_part}"
+```
+
+- [ ] **Step 8: Run L2 unit tests**
+
+Run:
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/cpu/test_perf_candle_vs_torch_npu_ratios.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Run L2 CLI help smoke**
+
+Run:
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python benchmarks/perf_candle_vs_torch_npu.py --help
+```
+
+Expected: command prints help including `--max-total-ratio`.
+
+- [ ] **Step 10: Commit Task 5 changes**
+
+```bash
+git add benchmarks/perf_candle_vs_torch_npu.py tests/cpu/test_perf_candle_vs_torch_npu_ratios.py
+git commit -m "bench(npu): add end-to-end total ratio gate"
+```
+
+---
+
+### Task 6: Add top-level NPU performance gate orchestrator
+
+**Files:**
+- Create: `benchmarks/npu_perf_gate.py`
+- Test: `tests/cpu/test_npu_perf_gate.py`
+
+- [ ] **Step 1: Write failing tests for orchestrator command construction**
+
+Create `tests/cpu/test_npu_perf_gate.py`:
+
+```python
+from benchmarks.npu_perf_gate import build_commands
+
+
+def test_build_commands_writes_l0_l1_l2_artifacts_under_output_dir():
+    commands = build_commands(
+        output_dir="results/npu_perf_gate/test",
+        warmup=1,
+        iters=2,
+        dtype="fp16",
+        cases="xfmr",
+        pipeline_cases="A1,B1s",
+    )
+
+    assert commands[0][-5:] == ["--max-ratio", "1.0", "--json-output", "results/npu_perf_gate/test/l0_ops.json", "--fail-on-ratio"]
+    assert "benchmarks.op_benchmark_npu.run" in commands[0]
+    assert "benchmarks.pipeline_npu.run" in commands[1]
+    assert "benchmarks/perf_candle_vs_torch_npu.py" in commands[2]
+    assert "results/npu_perf_gate/test/l1_pipeline.json" in commands[1]
+    assert "results/npu_perf_gate/test/l2_models.json" in commands[2]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/cpu/test_npu_perf_gate.py -q
+```
+
+Expected: FAIL because `benchmarks.npu_perf_gate` does not exist.
+
+- [ ] **Step 3: Implement top-level orchestrator**
+
+Create `benchmarks/npu_perf_gate.py`:
+
+```python
+"""Run L0/L1/L2 NPU performance gates and write JSON artifacts."""
+import argparse
+import os
+import subprocess
+import sys
+
+
+def build_commands(*, output_dir, warmup, iters, dtype, cases, pipeline_cases):
+    return [
+        [
+            sys.executable,
+            "-m", "benchmarks.op_benchmark_npu.run",
+            "--mode", "both",
+            "--dtype", dtype,
+            "--warmup", str(warmup),
+            "--iters", str(iters),
+            "--max-ratio", "1.0",
+            "--json-output", os.path.join(output_dir, "l0_ops.json"),
+            "--fail-on-ratio",
+        ],
+        [
+            sys.executable,
+            "-m", "benchmarks.pipeline_npu.run",
+            "--cases", pipeline_cases,
+            "--mode", "eager",
+            "--warmup", str(warmup),
+            "--iters", str(iters),
+            "--max-ratio", "0.99",
+            "--json-output", os.path.join(output_dir, "l1_pipeline.json"),
+            "--fail-on-ratio",
+        ],
+        [
+            sys.executable,
+            "benchmarks/perf_candle_vs_torch_npu.py",
+            "--cases", cases,
+            "--dtype", "float16" if dtype == "fp16" else dtype,
+            "--warmup", str(warmup),
+            "--iters", str(iters),
+            "--max-fwd-ratio", "0.99",
+            "--max-bwd-ratio", "0.99",
+            "--max-total-ratio", "0.99",
+            "--json-output", os.path.join(output_dir, "l2_models.json"),
+            "--fail-on-ratio",
+        ],
+    ]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", default="results/npu_perf_gate/latest")
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--iters", type=int, default=20)
+    parser.add_argument("--dtype", default="fp16")
+    parser.add_argument("--cases", default="mlp,xfmr,resnet")
+    parser.add_argument("--pipeline-cases", default="A1,A2s,A3,B1s,B2,D2")
+    args = parser.parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    failures = []
+    for command in build_commands(
+        output_dir=args.output_dir,
+        warmup=args.warmup,
+        iters=args.iters,
+        dtype=args.dtype,
+        cases=args.cases,
+        pipeline_cases=args.pipeline_cases,
+    ):
+        print("$ " + " ".join(command), flush=True)
+        proc = subprocess.run(command, check=False)
+        if proc.returncode != 0:
+            failures.append((command, proc.returncode))
+
+    if failures:
+        for command, returncode in failures:
+            print(f"gate failed with exit {returncode}: {' '.join(command)}", file=sys.stderr)
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run orchestrator unit test**
+
+Run:
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest tests/cpu/test_npu_perf_gate.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run orchestrator help smoke**
+
+Run:
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python benchmarks/npu_perf_gate.py --help
+```
+
+Expected: command prints help including `--output-dir`, `--pipeline-cases`, and `--cases`.
+
+- [ ] **Step 6: Commit Task 6 changes**
+
+```bash
+git add benchmarks/npu_perf_gate.py tests/cpu/test_npu_perf_gate.py
+git commit -m "bench(npu): add performance gate orchestrator"
+```
+
+---
+
+### Task 7: Final validation for Phase 0
+
+**Files:**
+- No source changes unless validation finds a defect in prior tasks.
+
+- [ ] **Step 1: Run targeted CPU/unit tests**
+
+Run:
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m pytest \
+    tests/cpu/test_npu_perf_gates.py \
+    tests/cpu/test_npu_op_benchmark_report.py \
+    tests/cpu/test_pipeline_npu_framework_neutral.py \
+    tests/cpu/test_pipeline_npu_report.py \
+    tests/cpu/test_perf_candle_vs_torch_npu_ratios.py \
+    tests/cpu/test_npu_perf_gate.py \
+    tests/npu/test_pipeline_npu_bench_smoke.py \
+    -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run benchmark CLI help commands**
+
+Run:
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m benchmarks.op_benchmark_npu.run --help
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python -m benchmarks.pipeline_npu.run --help
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python benchmarks/perf_candle_vs_torch_npu.py --help
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python benchmarks/npu_perf_gate.py --help
+```
+
+Expected: all commands exit 0 and print their CLI help.
+
+- [ ] **Step 3: Run pylint only if implementation touches import style or public modules flagged by local policy**
+
+Run when lint is required for the PR scope:
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  pylint benchmarks/ tests/cpu/test_npu_perf_gates.py \
+    tests/cpu/test_npu_op_benchmark_report.py \
+    tests/cpu/test_pipeline_npu_framework_neutral.py \
+    tests/cpu/test_pipeline_npu_report.py \
+    tests/cpu/test_perf_candle_vs_torch_npu_ratios.py \
+    tests/cpu/test_npu_perf_gate.py \
+    --rcfile=.github/pylint.conf
+```
+
+Expected: PASS or only pre-existing benchmark lint findings documented before PR creation.
+
+- [ ] **Step 4: On NPU hardware, run a low-iteration non-gating artifact pass**
+
+Run:
+
+```bash
+source ~/miniconda3/etc/profile.d/conda.sh && conda run -n candle \
+  python benchmarks/npu_perf_gate.py \
+    --output-dir results/npu_perf_gate/smoke \
+    --warmup 1 \
+    --iters 2 \
+    --dtype fp16 \
+    --cases xfmr \
+    --pipeline-cases A1,A2s
+```
+
+Expected: The command may exit nonzero because ratio gates reflect current performance gaps. It must write any completed JSON artifacts under `results/npu_perf_gate/smoke/` before the failing gate, and failures must name specific slow or missing rows.
+
+- [ ] **Step 5: Commit final validation fixes if any were needed**
+
+If validation required fixes, commit only the files changed by those fixes:
+
+```bash
+git add <fixed-files>
+git commit -m "test(npu): stabilize performance gate validation"
+```
+
+If no fixes were needed, do not create an empty commit.
+
+---
+
+## Execution Notes
+
+- Use `.worktrees/npu-performance-core-redesign-spec` or a new worktree branched from this plan branch for implementation.
+- Do not run destructive git commands.
+- Do not push or create a PR unless explicitly requested.
+- Current Phase 0 gates are expected to expose failures; do not weaken thresholds to make current performance look better.
+- The single-op L0 threshold is `max_ratio=1.0` because single ops must not be slower than torch_npu.
+- The L1/L2 model thresholds are `max_ratio=0.99` because composed workloads must be faster than torch_npu.

--- a/docs/superpowers/specs/2026-05-29-npu-l0-operator-parity-batch1-design.md
+++ b/docs/superpowers/specs/2026-05-29-npu-l0-operator-parity-batch1-design.md
@@ -1,0 +1,219 @@
+# NPU L0 Operator Parity Batch 1 Design
+
+## Goal
+
+Bring Candle NPU's first tranche of high-impact single-operator benchmarks to parity with torch_npu, while preserving full PyTorch-compatible API behavior and NPU no-CPU-fallback guarantees.
+
+This phase targets L0 parity first. L1/L2 model benchmarks remain observation gates in this phase; model-level superiority is deferred to the later graph/fusion phase after the underlying op latencies are no longer the dominant bottleneck.
+
+## Current baseline
+
+Baseline was collected on this machine using:
+
+- Candle env: `/home/jenkins/anaconda3/envs/candle311`
+- torch_npu env: `/home/jenkins/anaconda3/envs/torchnpu311`
+- CANN env: `/usr/local/Ascend/cann-9.0.0/set_env.sh`
+
+Representative L0 fp16 inference gaps:
+
+| Operator | Current Candle / torch_npu |
+|---|---:|
+| rms_norm | ~11241x slower |
+| mul | ~3.82x slower |
+| silu | ~2.43x slower |
+| add | ~2.43x slower |
+| matmul_qkv | ~2.02x slower |
+| softmax | ~1.16x slower |
+| rope | Candle error: `GetWorkspaceSize failed: 561103 [op=neg, device=npu]` |
+| cross_entropy | Candle error: `NPU mul requires matching dtypes` |
+
+Representative L1/L2 gaps:
+
+- L1 A2s: ~12.78x slower
+- L1 B1s: ~10.72x slower
+- L1 A1: ~8.45x slower
+- L2 xfmr total: ~12.17x slower
+- L2 mlp total: ~9.91x slower
+
+## Scope
+
+### In scope
+
+1. Ensure L0 benchmarks measure the intended native Candle NPU operator paths rather than accidental Python composites.
+2. Add or repair native NPU routing for the first high-impact tranche:
+   - `rms_norm`
+   - `add`
+   - `mul`
+   - `silu`
+   - `matmul_qkv` / bmm attention cases
+   - `softmax`
+3. Fix correctness errors blocking L0 gate completeness:
+   - `rope`
+   - `cross_entropy`
+4. Use benchmark gates as acceptance checks for each operator batch.
+5. Keep every optimization as a default path, not an optional fast flag.
+
+### Out of scope
+
+- Full graph/fusion replay for L1/L2 composed workloads.
+- C++ autograd engine replacement.
+- Broad dispatcher rewrite.
+- CPU fallback for NPU limitations.
+- API shortcuts that diverge from PyTorch semantics.
+
+## Architecture
+
+Phase 1 keeps the Python API stable and attacks the NPU hot path from closest-to-benchmark to lowest-level implementation.
+
+```text
+L0 benchmark case
+  -> torch-compatible Candle API
+  -> dispatch/autograd wrapper
+  -> NPU backend op
+  -> _C/_npu_ops.pyx fast path or ACLNN binding
+  -> ACLNN/ACLRT launch
+```
+
+Each operator fix must identify which layer is the bottleneck:
+
+1. Benchmark case is measuring the wrong thing.
+2. Public API is not routing to the native op.
+3. NPU backend is falling back to a Python composite.
+4. `_C/_npu_ops.pyx` fast path exists but has avoidable host overhead.
+5. ACLNN binding itself is missing, broken, or using an unfavorable call shape.
+6. Allocator/workspace/tensor-wrapper overhead dominates the operator.
+
+Only after the failing layer is identified should implementation changes be made.
+
+## Batch 1A: rms_norm native route
+
+The current `rms_norm` benchmark uses a Python expression:
+
+```python
+x * torch_mod.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps)
+```
+
+That measures a composite chain, not Candle's native NPU `rms_norm` path. Since Candle already has ACLNN `rms_norm` / `rms_norm_grad` bindings, the first task is to align benchmark and API routing.
+
+Required behavior:
+
+- Add an L0 benchmark case that calls the same public Candle API path users should call for RMSNorm.
+- Ensure the Candle path reaches the NPU native `rms_norm` backend instead of expanding into `pow + mean + rsqrt + mul`.
+- Ensure torch_npu baseline uses equivalent PyTorch/torch_npu behavior.
+- Preserve the composite expression only as a separate benchmark if needed, named clearly as a composite chain.
+
+Acceptance:
+
+- Native `rms_norm` benchmark runs without error.
+- Its L0 ratio is reported separately from the composite chain.
+- If native Candle is still slower than torch_npu, the remaining gap is attributable to the native binding/host overhead rather than the benchmark measuring the wrong implementation.
+
+## Batch 1B: add/mul/silu host overhead
+
+Current ratios show host overhead dominates small elementwise ops:
+
+- add: ~2.43x slower
+- mul: ~3.82x slower
+- silu: ~2.43x slower
+
+These ops already have Cython fast paths in `_C/_npu_ops.pyx`. Phase 1B profiles and tightens those paths.
+
+Investigation order:
+
+1. Verify benchmark dispatch reaches `fast_add`, `fast_mul`, and `fast_silu`.
+2. Measure per-call costs for:
+   - descriptor/executor creation
+   - workspace allocation/free
+   - output storage allocation
+   - tensor wrapper construction
+   - stream synchronization
+3. Compare Cython fast path with Python ACLNN wrapper path to verify the fast path is actually faster.
+4. Implement the smallest native-path change that removes the measured bottleneck.
+
+Likely implementation areas:
+
+- `_C/_npu_ops.pyx` binary/unary helpers
+- `_C/_aclnn_ffi.pyx` executor binding usage
+- NPU allocator fast path and workspace reuse
+- backend registration paths that choose fast ops
+
+Acceptance:
+
+- `add`, `mul`, and `silu` L0 fp16 inference ratios are each `<= 1.0`, or a documented blocker identifies why ACLNN cannot match torch_npu with the current public runtime.
+- No correctness regressions in affected NPU tests.
+
+## Batch 1C: matmul/bmm/softmax
+
+Current representative ratios:
+
+- matmul_qkv: ~2.02x slower
+- bmm attention scores/output: ~1.6-1.7x slower in broader baseline
+- softmax: ~1.16x slower
+
+Investigation order:
+
+1. Confirm operands are already contiguous or identify unnecessary contiguity conversions.
+2. Confirm batched matmul uses one ACLNN batched matmul where possible rather than Python loops.
+3. Check shape flattening and descriptor construction overhead for repeated static shapes.
+4. Check softmax backend route and whether it is using ACLNN native softmax or a composite.
+
+Acceptance:
+
+- matmul_qkv, bmm attention cases, and softmax ratios each reach `<= 1.0`, or have a measured blocker recorded for Phase 2 graph/fusion.
+
+## Batch 1D: correctness blockers
+
+Two L0 cases currently error:
+
+1. `rope`: `GetWorkspaceSize failed: 561103 [op=neg, device=npu]`
+2. `cross_entropy`: `NPU mul requires matching dtypes`
+
+These must be fixed before the single-op gate can be meaningful.
+
+Required behavior:
+
+- `rope` must run fully on NPU without CPU fallback.
+- `cross_entropy` must preserve torch-compatible dtype behavior and avoid internal mismatched NPU `mul` inputs.
+- Fix source behavior, not the benchmark, unless the benchmark is calling an invalid torch-incompatible path.
+
+Acceptance:
+
+- Both cases produce successful L0 benchmark rows.
+- Numerical parity checks are added where practical for the affected op behavior.
+
+## Testing and validation
+
+For each batch:
+
+1. Add or update focused tests before implementation.
+2. Run affected tests.
+3. Run targeted L0 benchmark for the touched operators with:
+
+```bash
+source /usr/local/Ascend/cann-9.0.0/set_env.sh
+source /home/jenkins/anaconda3/etc/profile.d/conda.sh
+CONDA_SH=/home/jenkins/anaconda3/etc/profile.d/conda.sh \
+CANN_SET_ENV=/usr/local/Ascend/cann-9.0.0/set_env.sh \
+CANDLE_CONDA_ENV=candle311 \
+TORCH_NPU_CONDA_ENV=torchnpu311 \
+conda run -n candle311 --no-capture-output \
+  python -m benchmarks.op_benchmark_npu.run \
+  --ops <ops> --dtype fp16 --scenario infer --mode fwd \
+  --warmup 5 --iters 30 --json-output <artifact>.json
+```
+
+4. Run L1/L2 observation probes after each batch to ensure no major regressions.
+
+Phase 1 is complete when:
+
+- No Batch 1 L0 operator is slower than torch_npu without a documented blocker.
+- `rope` and `cross_entropy` no longer error in L0.
+- L1/L2 observation results improve or remain stable.
+
+## Risks
+
+- Optimizing the benchmark path but not the real model path. Mitigation: trace dispatch for both benchmark and L1/L2 cases.
+- Executor caching with stale tensor addresses. Mitigation: cache only safe descriptors/plans and rebind addresses at launch time.
+- Workspace reuse causing stream safety bugs. Mitigation: stream-scoped ownership and targeted tests.
+- Native RMSNorm API mismatch. Mitigation: keep public API torch-compatible and isolate benchmark-only variants clearly.
+- Spending too long on micro-op parity when graph fusion will dominate. Mitigation: stop after the first high-impact tranche and reassess L1/L2.

--- a/docs/superpowers/specs/2026-05-29-npu-performance-core-redesign.md
+++ b/docs/superpowers/specs/2026-05-29-npu-performance-core-redesign.md
@@ -1,0 +1,239 @@
+# NPU Performance Core Redesign
+
+## Goals
+
+Candle NPU has three hard requirements:
+
+1. Single-operator performance must not be lower than torch_npu.
+2. Composite/model performance must be better than torch_npu.
+3. Python-visible APIs must remain fully PyTorch compatible.
+
+Performance work is not limited to Cython. C, C++, Rust, generated bindings, Cython glue, or replacement internal architectures are all acceptable when they keep the code clear and improve performance. Existing Cython/Python hot paths may be replaced when they block these goals.
+
+## Non-goals
+
+- Do not change `import candle as torch` semantics to a non-PyTorch lazy framework.
+- Do not introduce CPU fallback for NPU correctness or performance.
+- Do not preserve existing Cython structure for compatibility with old internals.
+- Do not expose graph/fusion APIs as a requirement for user code to get the default fast path.
+
+## Acceptance Gates
+
+### L0: Single-operator parity gate
+
+Every benchmarked NPU operator must be at least as fast as the corresponding torch_npu operator under the same shapes, dtype, synchronization mode, and warmup policy.
+
+Initial L0 coverage:
+
+- elementwise: add, sub, mul, div
+- activation: gelu, silu, sigmoid, tanh
+- normalization: rms_norm, layer_norm, group_norm
+- reduction: sum, mean, softmax, log_softmax
+- linear algebra: matmul, bmm, addmm
+- memory/layout: contiguous, clone, copy, view-safe reshape paths
+- indexing/data: embedding, gather/scatter paths used by transformer workloads
+- backward hot paths for the above where torch_npu exposes equivalent behavior
+
+Required output per op:
+
+- Candle median latency
+- torch_npu median latency
+- p10/p90 or min/max distribution
+- sync and no-sync/chained submission modes where meaningful
+- kernel count or ACLNN submit count
+- allocation count and workspace allocation count
+- ratio: Candle / torch_npu
+
+Gate: no L0 operator may remain slower than torch_npu without being marked as a blocking regression.
+
+### L1: Composite block superiority gate
+
+Composite static blocks must outperform torch_npu on equivalent PyTorch code.
+
+Initial L1 coverage:
+
+- FFN block: linear + activation + linear
+- attention block: qkv projection, attention score, softmax, value projection
+- transformer block: layer norm, attention, residual, FFN, residual
+- repeated transformer blocks
+- selected elementwise-heavy chains that expose host launch overhead
+
+Required output:
+
+- Candle eager latency
+- Candle captured/replayed latency when graph path applies
+- torch_npu latency
+- Candle eager / torch_npu ratio
+- Candle graph / torch_npu ratio
+- graph replay speedup over Candle eager
+- graph capture overhead and amortization count
+
+Gate: L1 captured/replayed path must be faster than torch_npu while preserving API-visible PyTorch semantics.
+
+### L2: End-to-end model superiority gate
+
+End-to-end model benchmarks must show Candle faster than torch_npu for forward, backward, and total iteration time.
+
+Initial L2 coverage:
+
+- MLP from `benchmarks/perf_candle_vs_torch_npu.py`
+- transformer block from `benchmarks/perf_candle_vs_torch_npu.py`
+- ResNet-style block from `benchmarks/perf_candle_vs_torch_npu.py`
+
+Required output:
+
+- forward latency
+- backward latency
+- total forward + backward latency
+- Candle eager and graph/fused path where applicable
+- torch_npu baseline
+- numerical parity checks at benchmark setup time
+
+Gate: composite/model Candle path must be faster than torch_npu. The stretch target remains 1.5x torch_npu performance on the transformer-oriented workloads, but the hard floor is strict superiority for composed workloads.
+
+## Architecture
+
+The Python API remains PyTorch-compatible and is not the performance core. Hot training-loop work should cross into native code quickly and stay there.
+
+```text
+Python torch-compatible API
+  -> thin dispatch/autograd boundary
+  -> native NPU performance core
+      -> single-op fast path
+      -> graph/fused composite path
+  -> ACLNN/ACLRT/HCCL runtime
+```
+
+The native performance core should be structured around explicit layers rather than Cython object dispatch:
+
+1. API boundary adapters
+2. Tensor/storage/device handles
+3. native dispatcher
+4. op descriptor/executor cache
+5. workspace and allocator pools
+6. graph capture/replay/fusion executor
+7. autograd scheduling and backward graph integration
+8. runtime FFI layer for ACLNN/ACLRT/HCCL
+
+Implementation language is chosen per layer:
+
+- C or generated C is preferred for the thinnest ACLNN/ACLRT FFI and ABI-stable shims.
+- C++ is preferred for dispatcher, graph executor, autograd engine, ownership, queues, and caches.
+- Rust is acceptable for IR/optimizer components if it improves safety without complicating Python/native integration.
+- Cython is acceptable as temporary glue, not as the long-term hot-path object scheduler.
+
+## Single-op Fast Path
+
+The single-op path exists to satisfy the L0 parity gate.
+
+```text
+Tensor op
+  -> native dispatcher
+  -> cached schema/device/dtype/shape decision
+  -> cached ACLNN descriptor/executor when safe
+  -> pooled output/storage/workspace allocation
+  -> ACLNN launch on current stream
+  -> minimal Tensor wrapper return
+```
+
+Key requirements:
+
+- Avoid Python allocation, Python tuple construction, and repeated dynamic lookup on hot paths.
+- Avoid stale pointer bugs in executor caches by keying reusable plans on stable shape/dtype/stride metadata while rebinding tensor addresses at launch time.
+- Reuse temporary workspace buffers across compatible calls.
+- Make allocator fast paths O(1) under steady state; defer expensive event draining outside the per-allocation critical path.
+- Preserve current-stream semantics and stream safety.
+- Keep native kernels as normal default paths, not optional flags.
+
+## Composite Graph Path
+
+The composite path exists to satisfy L1/L2 superiority gates.
+
+Candle already has low-level ACL graph capture/replay through CANN `aclmdlRI`. That mechanism records submitted work, but it does not optimize or fuse Candle operations. The redesign should build a higher-level execution layer above it.
+
+```text
+PyTorch-compatible eager calls
+  -> internal trace/capture of a static block
+  -> stable input/output buffer binding
+  -> graph replay plan
+  -> optional fusion or launch coalescing
+  -> default replay on subsequent compatible invocations
+```
+
+First target: static shapes and stable control flow. Dynamic shape support can be added later through multiple cached plans or runtime update APIs.
+
+Graph plans must track:
+
+- input tensor identities or storage slots
+- output slots
+- shapes, strides, dtype, device
+- stream and capture mode
+- mutation and aliasing constraints
+- workspace pool requirements
+- autograd participation and backward graph capture status
+
+The graph path must be internal. User code should not have to opt into non-PyTorch semantics to benefit from it.
+
+## Autograd Strategy
+
+The existing Cython autograd engine can remain as a correctness reference during migration, but it should not define the final performance architecture.
+
+Short term:
+
+- Count backward nodes, emitted NPU kernels, allocation count, and Python callback count in L2 benchmarks.
+- Remove proven backward recomputation on NPU hot paths, especially sigmoid/tanh/softmax/log_softmax and normalization backward where saved forward results or stats avoid extra kernels.
+- Capture forward + backward static blocks where possible.
+
+Medium term:
+
+- Move autograd scheduling, dependency counting, ready queues, and graph task execution into a native engine if Python callback overhead remains measurable after graph replay.
+- Keep Python-visible autograd behavior aligned with PyTorch: `grad_fn`, hooks, retain graph, create graph, anomaly behavior, saved tensor hooks, views, and in-place semantics.
+
+Native autograd is a performance tool, not an API change.
+
+## Benchmark Plan
+
+Phase 0 must land before major rewrites.
+
+1. Extend L0 op benchmarks with torch_npu baselines and JSON output.
+2. Extend pipeline/static block benchmarks with equivalent torch_npu implementations.
+3. Add graph/eager mode fields to benchmark output.
+4. Add instrumentation counters:
+   - ACLNN submit count
+   - graph replay count
+   - allocator malloc/free count
+   - workspace allocation count
+   - host sync count
+   - Python backward callback count where available
+5. Store benchmark artifacts in a stable machine-readable format so regressions can be diffed.
+
+Benchmarks are not only reporting tools. They are the acceptance gates for PRs that claim NPU performance improvements.
+
+## Migration Plan
+
+1. Establish benchmark gates and current ratios.
+2. Rank L0 regressions by model impact and absolute latency.
+3. Replace the slowest single-op paths with native fast paths until L0 parity is reached.
+4. Build graph/captured callable support for L1 static blocks.
+5. Integrate backward capture and remove backward recomputation on hot paths.
+6. Reassess whether a native C++ autograd engine is needed for remaining L2 gaps.
+7. Delete old Cython/Python hot paths after native replacements are proven by benchmarks and compatibility tests.
+
+## Compatibility and Correctness
+
+Every performance path must preserve PyTorch-visible behavior. Required checks:
+
+- existing CPU/contract tests when shared semantics change
+- NPU tests for touched ops
+- no CPU fallback contract tests
+- torch_npu numerical comparisons in benchmarks for representative inputs
+- compatibility tests for affected API areas when API semantics are touched
+
+Optimization must not weaken schema validation, device placement, stream semantics, or no-fallback guarantees.
+
+## Risks
+
+- Graph replay can accidentally assume static aliasing or mutation behavior that PyTorch allows to vary. Mitigation: conservative plan guards and fallback to NPU eager path, not CPU.
+- Executor caching can reuse stale tensor addresses. Mitigation: cache plans/descriptors separately from per-call addresses.
+- Native rewrites can fragment code. Mitigation: explicit layer boundaries and generated bindings for repetitive ACLNN surfaces.
+- Chasing single-op parity can distract from model superiority. Mitigation: rank L0 work by L1/L2 impact and keep graph path as the main model-speed strategy.

--- a/tests/cpu/test_npu_op_benchmark_report.py
+++ b/tests/cpu/test_npu_op_benchmark_report.py
@@ -1,0 +1,68 @@
+from benchmarks.op_benchmark_npu.report import generate_report, ratio_failures
+
+
+def test_generate_report_includes_distribution_columns():
+    candle = [{
+        "framework": "candle",
+        "op": "add",
+        "mode": "fwd",
+        "dtype": "fp16",
+        "scenario": "infer",
+        "median_ms": 2.0,
+        "p10_ms": 1.5,
+        "p90_ms": 2.5,
+        "status": "ok",
+        "median_ratio": 2.0,
+    }]
+    torch_ref = [{
+        "framework": "torch_npu",
+        "op": "add",
+        "mode": "fwd",
+        "dtype": "fp16",
+        "scenario": "infer",
+        "median_ms": 1.0,
+        "p10_ms": 0.8,
+        "p90_ms": 1.2,
+        "status": "ok",
+        "median_ratio": 1.0,
+    }]
+
+    report = generate_report(candle, torch_ref, ["add"], ["fp16"], ["infer"], ["fwd"])
+
+    assert "| Op | candle median | torch_npu median | ratio | candle p10/p90 | torch_npu p10/p90 | impact |" in report
+    assert "| add | 2.0000 | 1.0000 | 2.00x | 1.5000/2.5000 | 0.8000/1.2000 | 1.0000 |" in report
+
+
+def test_ratio_failures_reports_slow_op():
+    candle = [{
+        "framework": "candle",
+        "op": "add",
+        "mode": "fwd",
+        "dtype": "fp16",
+        "scenario": "infer",
+        "median_ms": 2.0,
+        "status": "ok",
+        "median_ratio": 2.0,
+    }]
+    torch_ref = [{
+        "framework": "torch_npu",
+        "op": "add",
+        "mode": "fwd",
+        "dtype": "fp16",
+        "scenario": "infer",
+        "median_ms": 1.0,
+        "status": "ok",
+        "median_ratio": 1.0,
+    }]
+
+    failures = ratio_failures(
+        candle,
+        torch_ref,
+        op_names=["add"],
+        dtype_keys=["fp16"],
+        scen_keys=["infer"],
+        mode_keys=["fwd"],
+        max_ratio=1.0,
+    )
+
+    assert failures == ["add/fwd/fp16/infer: candle median_ratio 2.00x > 1.00x"]

--- a/tests/cpu/test_npu_op_benchmark_report.py
+++ b/tests/cpu/test_npu_op_benchmark_report.py
@@ -1,4 +1,5 @@
 from benchmarks.op_benchmark_npu.report import generate_report, ratio_failures
+from benchmarks.op_benchmark_npu.run import _output_stream
 
 
 def test_generate_report_includes_distribution_columns():
@@ -64,5 +65,70 @@ def test_ratio_failures_reports_slow_op():
         mode_keys=["fwd"],
         max_ratio=1.0,
     )
-
     assert failures == ["add/fwd/fp16/infer: candle median_ratio 2.00x > 1.00x"]
+
+
+def test_generate_report_does_not_mutate_input_rows():
+    candle = [{
+        "framework": "candle",
+        "op": "add",
+        "mode": "fwd",
+        "dtype": "fp16",
+        "scenario": "infer",
+        "median_ms": 2.0,
+        "status": "ok",
+    }]
+    torch_ref = [{
+        "framework": "torch_npu",
+        "op": "add",
+        "mode": "fwd",
+        "dtype": "fp16",
+        "scenario": "infer",
+        "median_ms": 1.0,
+        "status": "ok",
+    }]
+
+    generate_report(candle, torch_ref, ["add"], ["fp16"], ["infer"], ["fwd"])
+
+    assert "median_ratio" not in candle[0]
+    assert "median_ratio" not in torch_ref[0]
+
+
+def test_ratio_failures_does_not_mutate_input_rows():
+    candle = [{
+        "framework": "candle",
+        "op": "add",
+        "mode": "fwd",
+        "dtype": "fp16",
+        "scenario": "infer",
+        "median_ms": 2.0,
+        "status": "ok",
+    }]
+    torch_ref = [{
+        "framework": "torch_npu",
+        "op": "add",
+        "mode": "fwd",
+        "dtype": "fp16",
+        "scenario": "infer",
+        "median_ms": 1.0,
+        "status": "ok",
+    }]
+
+    ratio_failures(
+        candle,
+        torch_ref,
+        op_names=["add"],
+        dtype_keys=["fp16"],
+        scen_keys=["infer"],
+        mode_keys=["fwd"],
+        max_ratio=1.0,
+    )
+
+    assert "median_ratio" not in candle[0]
+    assert "median_ratio" not in torch_ref[0]
+
+
+def test_output_stream_routes_human_output_to_stderr_for_json_stdout():
+    assert _output_stream("-") == "stderr"
+    assert _output_stream(None) == "stdout"
+    assert _output_stream("results.json") == "stdout"

--- a/tests/cpu/test_npu_op_benchmark_report.py
+++ b/tests/cpu/test_npu_op_benchmark_report.py
@@ -1,3 +1,10 @@
+import json
+import subprocess
+import sys
+
+import pytest
+
+from benchmarks.op_benchmark_npu import run as op_run
 from benchmarks.op_benchmark_npu.report import generate_report, ratio_failures
 from benchmarks.op_benchmark_npu.run import _output_stream
 
@@ -127,8 +134,94 @@ def test_ratio_failures_does_not_mutate_input_rows():
     assert "median_ratio" not in candle[0]
     assert "median_ratio" not in torch_ref[0]
 
-
 def test_output_stream_routes_human_output_to_stderr_for_json_stdout():
     assert _output_stream("-") == "stderr"
     assert _output_stream(None) == "stdout"
     assert _output_stream("results.json") == "stdout"
+
+
+
+def _op_args():
+    class Args:
+        warmup = 1
+        iters = 1
+        ops = "add"
+        scenario = "infer"
+        dtype = "fp16"
+        mode = "fwd"
+
+    return Args()
+
+
+def test_run_worker_returns_structured_failure_for_nonzero_exit(monkeypatch):
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 9, stdout="partial stdout", stderr="worker exploded")
+
+    monkeypatch.setattr(op_run.subprocess, "run", fake_run)
+
+    rows = op_run._run_worker("candle", _op_args())
+
+    assert rows == [
+        {
+            "framework": "candle",
+            "status": "error: worker exit 9",
+            "stderr": "worker exploded",
+            "stdout": "partial stdout",
+        }
+    ]
+
+
+def test_run_worker_returns_structured_failure_for_malformed_json(monkeypatch):
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 0, stdout="not-json", stderr="worker warning")
+
+    monkeypatch.setattr(op_run.subprocess, "run", fake_run)
+
+    rows = op_run._run_worker("torch", _op_args())
+
+    assert rows[0]["framework"] == "torch_npu"
+    assert rows[0]["status"].startswith("error: malformed worker JSON:")
+    assert rows[0]["stderr"] == "worker warning"
+    assert rows[0]["stdout"] == "not-json"
+
+
+def test_main_exits_nonzero_for_worker_failure_without_ratio_gate(capsys, monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "op_benchmark_npu.run",
+            "--ops",
+            "add",
+            "--scenario",
+            "infer",
+            "--dtype",
+            "fp16",
+            "--mode",
+            "fwd",
+            "--json-output",
+            "-",
+        ],
+    )
+    monkeypatch.setattr(
+        op_run,
+        "_run_worker",
+        lambda framework, args: [
+            {
+                "framework": "candle" if framework == "candle" else "torch_npu",
+                "op": "add",
+                "mode": "fwd",
+                "dtype": "fp16",
+                "scenario": "infer",
+                "median_ms": 0.0,
+                "status": "error: worker exit 4" if framework == "candle" else "ok",
+            }
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        op_run.main()
+
+    assert exc_info.value.code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["failures"] == ["add/fwd/fp16/infer/candle: error: worker exit 4"]

--- a/tests/cpu/test_npu_op_benchmark_report.py
+++ b/tests/cpu/test_npu_op_benchmark_report.py
@@ -155,20 +155,26 @@ def _op_args():
 
 def test_run_worker_returns_structured_failure_for_nonzero_exit(monkeypatch):
     def fake_run(*args, **kwargs):
-        return subprocess.CompletedProcess(args[0], 9, stdout="partial stdout", stderr="worker exploded")
+        return subprocess.CompletedProcess(args[0], 2, stdout="", stderr="boom")
 
     monkeypatch.setattr(op_run.subprocess, "run", fake_run)
 
     rows = op_run._run_worker("candle", _op_args())
 
-    assert rows == [
-        {
-            "framework": "candle",
-            "status": "error: worker exit 9",
-            "stderr": "worker exploded",
-            "stdout": "partial stdout",
-        }
-    ]
+    assert rows
+    for row in rows:
+        assert row["framework"] == "candle"
+        assert row["op"] == "add"
+        assert row["mode"] == "fwd"
+        assert row["dtype"] == "fp16"
+        assert row["scenario"] == "infer"
+        assert "worker exit 2" in row["status"]
+        assert row["mean_ms"] == 0.0
+        assert row["median_ms"] == 0.0
+        assert row["p10_ms"] == 0.0
+        assert row["p90_ms"] == 0.0
+
+    generate_report(rows, [], ["add"], ["fp16"], ["infer"], ["fwd"])
 
 
 def test_run_worker_returns_structured_failure_for_malformed_json(monkeypatch):

--- a/tests/cpu/test_npu_perf_gate.py
+++ b/tests/cpu/test_npu_perf_gate.py
@@ -1,7 +1,29 @@
+import os
+
 import pytest
 
 import benchmarks.npu_perf_gate as npu_perf_gate
 from benchmarks.npu_perf_gate import build_commands
+
+
+
+
+def test_l2_command_uses_absolute_script_path():
+    commands = build_commands(
+        output_dir="results/npu_perf_gate/test",
+        warmup=1,
+        iters=2,
+        dtype="fp16",
+        cases="xfmr",
+        pipeline_cases="A1,B1s",
+    )
+    l2_cmd = commands[2]
+    script_arg = next(
+        (arg for arg in l2_cmd if arg.endswith("benchmarks/perf_candle_vs_torch_npu.py")),
+        None,
+    )
+    assert script_arg is not None, "L2 command must reference perf_candle_vs_torch_npu.py"
+    assert os.path.isabs(script_arg), f"L2 script path must be absolute, got: {script_arg}"
 
 
 def test_build_commands_writes_l0_l1_l2_artifacts_under_output_dir():
@@ -17,7 +39,7 @@ def test_build_commands_writes_l0_l1_l2_artifacts_under_output_dir():
     assert commands[0][-5:] == ["--max-ratio", "1.0", "--json-output", "results/npu_perf_gate/test/l0_ops.json", "--fail-on-ratio"]
     assert "benchmarks.op_benchmark_npu.run" in commands[0]
     assert "benchmarks.pipeline_npu.run" in commands[1]
-    assert "benchmarks/perf_candle_vs_torch_npu.py" in commands[2]
+    assert any(arg.endswith("benchmarks/perf_candle_vs_torch_npu.py") for arg in commands[2])
     assert "results/npu_perf_gate/test/l1_pipeline.json" in commands[1]
     assert "results/npu_perf_gate/test/l2_models.json" in commands[2]
 

--- a/tests/cpu/test_npu_perf_gate.py
+++ b/tests/cpu/test_npu_perf_gate.py
@@ -1,3 +1,6 @@
+import pytest
+
+import benchmarks.npu_perf_gate as npu_perf_gate
 from benchmarks.npu_perf_gate import build_commands
 
 
@@ -17,3 +20,57 @@ def test_build_commands_writes_l0_l1_l2_artifacts_under_output_dir():
     assert "benchmarks/perf_candle_vs_torch_npu.py" in commands[2]
     assert "results/npu_perf_gate/test/l1_pipeline.json" in commands[1]
     assert "results/npu_perf_gate/test/l2_models.json" in commands[2]
+
+
+def test_main_runs_all_commands_and_exits_1_when_any_child_fails(monkeypatch, tmp_path):
+    commands = [["cmd0"], ["cmd1"], ["cmd2"]]
+    returncodes = [2, 0, 3]
+    seen_commands = []
+
+    class Result:
+        def __init__(self, returncode):
+            self.returncode = returncode
+
+    def fake_run(command, check):
+        assert check is False
+        seen_commands.append(command)
+        return Result(returncodes[len(seen_commands) - 1])
+
+    monkeypatch.setattr(npu_perf_gate, "build_commands", lambda **_: commands)
+    monkeypatch.setattr(npu_perf_gate.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        npu_perf_gate.sys,
+        "argv",
+        ["npu_perf_gate", "--output-dir", str(tmp_path)],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        npu_perf_gate.main()
+
+    assert exc_info.value.code == 1
+    assert seen_commands == commands
+
+
+def test_main_exits_cleanly_when_all_child_commands_pass(monkeypatch, tmp_path):
+    commands = [["cmd0"], ["cmd1"], ["cmd2"]]
+    seen_commands = []
+
+    class Result:
+        returncode = 0
+
+    def fake_run(command, check):
+        assert check is False
+        seen_commands.append(command)
+        return Result()
+
+    monkeypatch.setattr(npu_perf_gate, "build_commands", lambda **_: commands)
+    monkeypatch.setattr(npu_perf_gate.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        npu_perf_gate.sys,
+        "argv",
+        ["npu_perf_gate", "--output-dir", str(tmp_path)],
+    )
+
+    npu_perf_gate.main()
+
+    assert seen_commands == commands

--- a/tests/cpu/test_npu_perf_gate.py
+++ b/tests/cpu/test_npu_perf_gate.py
@@ -1,0 +1,19 @@
+from benchmarks.npu_perf_gate import build_commands
+
+
+def test_build_commands_writes_l0_l1_l2_artifacts_under_output_dir():
+    commands = build_commands(
+        output_dir="results/npu_perf_gate/test",
+        warmup=1,
+        iters=2,
+        dtype="fp16",
+        cases="xfmr",
+        pipeline_cases="A1,B1s",
+    )
+
+    assert commands[0][-5:] == ["--max-ratio", "1.0", "--json-output", "results/npu_perf_gate/test/l0_ops.json", "--fail-on-ratio"]
+    assert "benchmarks.op_benchmark_npu.run" in commands[0]
+    assert "benchmarks.pipeline_npu.run" in commands[1]
+    assert "benchmarks/perf_candle_vs_torch_npu.py" in commands[2]
+    assert "results/npu_perf_gate/test/l1_pipeline.json" in commands[1]
+    assert "results/npu_perf_gate/test/l2_models.json" in commands[2]

--- a/tests/cpu/test_npu_perf_gates.py
+++ b/tests/cpu/test_npu_perf_gates.py
@@ -1,0 +1,73 @@
+from benchmarks.npu_perf_gates import (
+    annotate_ratio_rows,
+    collect_ratio_failures,
+    summarize_samples,
+)
+
+
+def test_summarize_samples_reports_distribution_fields():
+    summary = summarize_samples([4.0, 1.0, 3.0, 2.0, 5.0])
+
+    assert summary == {
+        "sample_count": 5,
+        "mean_ms": 3.0,
+        "median_ms": 3.0,
+        "min_ms": 1.0,
+        "max_ms": 5.0,
+        "p10_ms": 1.0,
+        "p90_ms": 5.0,
+        "p95_ms": 5.0,
+    }
+
+
+def test_summarize_samples_empty_list_returns_zero_distribution():
+    summary = summarize_samples([])
+
+    assert summary == {
+        "sample_count": 0,
+        "mean_ms": 0.0,
+        "median_ms": 0.0,
+        "min_ms": 0.0,
+        "max_ms": 0.0,
+        "p10_ms": 0.0,
+        "p90_ms": 0.0,
+        "p95_ms": 0.0,
+    }
+
+
+def test_annotate_ratio_rows_adds_candle_ratio_against_torch_npu():
+    rows = [
+        {"framework": "torch_npu", "case": "add", "median_ms": 2.0, "status": "ok"},
+        {"framework": "candle", "case": "add", "median_ms": 3.0, "status": "ok"},
+    ]
+
+    annotate_ratio_rows(rows, key_fields=("case",), metric="median_ms")
+
+    candle = next(row for row in rows if row["framework"] == "candle")
+    torch_ref = next(row for row in rows if row["framework"] == "torch_npu")
+    assert candle["median_ratio"] == 1.5
+    assert torch_ref["median_ratio"] == 1.0
+
+
+def test_collect_ratio_failures_reports_missing_errors_and_slow_rows():
+    rows = [
+        {"framework": "torch_npu", "case": "add", "median_ms": 2.0, "status": "ok"},
+        {"framework": "candle", "case": "add", "median_ms": 3.0, "status": "ok", "median_ratio": 1.5},
+        {"framework": "candle", "case": "mul", "median_ms": 0.0, "status": "error: boom"},
+    ]
+
+    failures = collect_ratio_failures(
+        rows,
+        key_fields=("case",),
+        expected_keys=[("add",), ("mul",), ("div",)],
+        max_ratio=1.0,
+        ratio_field="median_ratio",
+    )
+
+    assert failures == [
+        "add: candle median_ratio 1.50x > 1.00x",
+        "mul/candle: error: boom",
+        "mul: missing torch_npu result",
+        "div: missing candle result",
+        "div: missing torch_npu result",
+    ]

--- a/tests/cpu/test_npu_perf_gates.py
+++ b/tests/cpu/test_npu_perf_gates.py
@@ -20,6 +20,15 @@ def test_summarize_samples_reports_distribution_fields():
     }
 
 
+def test_summarize_samples_even_count_uses_true_median_and_nearest_rank_percentiles():
+    summary = summarize_samples([1.0, 100.0])
+
+    assert summary["median_ms"] == 50.5
+    assert summary["p10_ms"] == 1.0
+    assert summary["p90_ms"] == 100.0
+    assert summary["p95_ms"] == 100.0
+
+
 def test_summarize_samples_empty_list_returns_zero_distribution():
     summary = summarize_samples([])
 
@@ -47,6 +56,42 @@ def test_annotate_ratio_rows_adds_candle_ratio_against_torch_npu():
     torch_ref = next(row for row in rows if row["framework"] == "torch_npu")
     assert candle["median_ratio"] == 1.5
     assert torch_ref["median_ratio"] == 1.0
+
+
+def test_collect_ratio_failures_inclusive_allows_equal_ratio():
+    rows = [
+        {"framework": "torch_npu", "case": "add", "median_ms": 1.0, "status": "ok"},
+        {"framework": "candle", "case": "add", "median_ms": 1.0, "status": "ok", "median_ratio": 1.0},
+    ]
+
+    failures = collect_ratio_failures(
+        rows,
+        key_fields=("case",),
+        expected_keys=[("add",)],
+        max_ratio=1.0,
+        ratio_field="median_ratio",
+        inclusive=True,
+    )
+
+    assert failures == []
+
+
+def test_collect_ratio_failures_strict_rejects_equal_ratio():
+    rows = [
+        {"framework": "torch_npu", "case": "add", "median_ms": 1.0, "status": "ok"},
+        {"framework": "candle", "case": "add", "median_ms": 1.0, "status": "ok", "median_ratio": 1.0},
+    ]
+
+    failures = collect_ratio_failures(
+        rows,
+        key_fields=("case",),
+        expected_keys=[("add",)],
+        max_ratio=1.0,
+        ratio_field="median_ratio",
+        inclusive=False,
+    )
+
+    assert failures == ["add: candle median_ratio 1.00x >= 1.00x"]
 
 
 def test_collect_ratio_failures_reports_missing_errors_and_slow_rows():

--- a/tests/cpu/test_perf_candle_vs_torch_npu_ratios.py
+++ b/tests/cpu/test_perf_candle_vs_torch_npu_ratios.py
@@ -1,4 +1,5 @@
-from benchmarks.perf_candle_vs_torch_npu import _annotate_ratios, _ratio_failures
+import benchmarks.perf_candle_vs_torch_npu as _bench_mod
+from benchmarks.perf_candle_vs_torch_npu import _annotate_ratios, _ratio_failures, _spawn_worker
 
 
 def test_annotate_ratios_adds_total_ratio():
@@ -57,3 +58,20 @@ def test_ratio_failures_checks_total_ratio():
     )
 
     assert failures == ["xfmr: total ratio 1.04x > 0.99x"]
+
+
+def test_spawn_worker_normalizes_error_json(monkeypatch):
+    monkeypatch.setattr(
+        _bench_mod.subprocess,
+        "check_output",
+        lambda *a, **kw: b'{"error": "NPU not available under candle"}\n',
+    )
+    row = _spawn_worker("candle", "xfmr", iters=1, warmup=1, dtype_name="float16")
+    assert row["framework"] == "candle"
+    assert row["case"] == "xfmr"
+    assert row["error"] == "NPU not available under candle"
+    # _annotate_ratios must not raise KeyError
+    _annotate_ratios([row])
+    # _ratio_failures reports the missing reference row without crashing
+    failures = _ratio_failures([row], ["xfmr"], 1.0, 1.0, 0.99)
+    assert failures == ["xfmr: missing candle or torch_npu result for ratio gate"]

--- a/tests/cpu/test_perf_candle_vs_torch_npu_ratios.py
+++ b/tests/cpu/test_perf_candle_vs_torch_npu_ratios.py
@@ -1,0 +1,59 @@
+from benchmarks.perf_candle_vs_torch_npu import _annotate_ratios, _ratio_failures
+
+
+def test_annotate_ratios_adds_total_ratio():
+    results = [
+        {
+            "framework": "torch_npu",
+            "case": "xfmr",
+            "fwd_ms_median": 2.0,
+            "bwd_ms_median": 3.0,
+            "total_ms_median": 5.0,
+        },
+        {
+            "framework": "candle",
+            "case": "xfmr",
+            "fwd_ms_median": 1.5,
+            "bwd_ms_median": 2.0,
+            "total_ms_median": 3.5,
+        },
+    ]
+
+    _annotate_ratios(results)
+
+    candle = next(row for row in results if row["framework"] == "candle")
+    assert candle["fwd_ratio"] == 0.75
+    assert candle["bwd_ratio"] == 2.0 / 3.0
+    assert candle["total_ratio"] == 0.7
+
+
+def test_ratio_failures_checks_total_ratio():
+    results = [
+        {
+            "framework": "torch_npu",
+            "case": "xfmr",
+            "fwd_ms_median": 2.0,
+            "bwd_ms_median": 3.0,
+            "total_ms_median": 5.0,
+        },
+        {
+            "framework": "candle",
+            "case": "xfmr",
+            "fwd_ms_median": 2.0,
+            "bwd_ms_median": 3.0,
+            "total_ms_median": 5.2,
+            "fwd_ratio": 1.0,
+            "bwd_ratio": 1.0,
+            "total_ratio": 1.04,
+        },
+    ]
+
+    failures = _ratio_failures(
+        results,
+        cases=["xfmr"],
+        max_fwd_ratio=1.0,
+        max_bwd_ratio=1.0,
+        max_total_ratio=0.99,
+    )
+
+    assert failures == ["xfmr: total ratio 1.04x > 0.99x"]

--- a/tests/cpu/test_perf_candle_vs_torch_npu_ratios.py
+++ b/tests/cpu/test_perf_candle_vs_torch_npu_ratios.py
@@ -1,3 +1,8 @@
+import json
+import sys
+
+import pytest
+
 import benchmarks.perf_candle_vs_torch_npu as _bench_mod
 from benchmarks.perf_candle_vs_torch_npu import _annotate_ratios, _ratio_failures, _spawn_worker
 
@@ -75,3 +80,131 @@ def test_spawn_worker_normalizes_error_json(monkeypatch):
     # _ratio_failures reports the missing reference row without crashing
     failures = _ratio_failures([row], ["xfmr"], 1.0, 1.0, 0.99)
     assert failures == ["xfmr: missing candle or torch_npu result for ratio gate"]
+
+def test_json_stdout_mode_routes_human_output_to_stderr(capsys, monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "perf_candle_vs_torch_npu.py",
+            "--cases",
+            "mlp",
+            "--iters",
+            "1",
+            "--warmup",
+            "0",
+            "--json-output",
+            "-",
+        ],
+    )
+    monkeypatch.setattr(
+        _bench_mod,
+        "_spawn_worker",
+        lambda framework, case, *args, **kwargs: {
+            "framework": framework,
+            "case": case,
+            "fwd_ms_median": 1.0,
+            "bwd_ms_median": 1.0,
+            "total_ms_median": 2.0,
+            "fwd_ms_min": 1.0,
+            "bwd_ms_min": 1.0,
+            "total_ms_min": 2.0,
+            "fwd_ms_p10": 1.0,
+            "bwd_ms_p10": 1.0,
+            "total_ms_p10": 2.0,
+            "fwd_ms_p90": 1.0,
+            "bwd_ms_p90": 1.0,
+            "total_ms_p90": 2.0,
+        },
+    )
+
+    _bench_mod.main()
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["cases"] == ["mlp"]
+    assert captured.err
+    assert "# Perf bench: candle vs torch_npu" in captured.err
+    assert "running..." in captured.err
+    assert "algo" in captured.err
+
+
+def test_spawn_worker_nonzero_exit_returns_error_row_with_tail(monkeypatch):
+    def raise_called_process_error(*args, **kwargs):
+        raise _bench_mod.subprocess.CalledProcessError(
+            3,
+            ["python", "worker"],
+            output=b"trace line\njson? nope\n",
+        )
+
+    monkeypatch.setattr(_bench_mod.subprocess, "check_output", raise_called_process_error)
+
+    row = _spawn_worker("candle", "xfmr", iters=1, warmup=1, dtype_name="float16")
+
+    assert row["framework"] == "candle"
+    assert row["case"] == "xfmr"
+    assert row["error"] == "worker exit 3"
+    assert row["tail"] == ["trace line", "json? nope"]
+
+
+def test_spawn_worker_malformed_json_returns_error_row(monkeypatch):
+    monkeypatch.setattr(
+        _bench_mod.subprocess,
+        "check_output",
+        lambda *a, **kw: b"worker started\n{bad json}\nnot-json\n",
+    )
+
+    row = _spawn_worker("candle", "xfmr", iters=1, warmup=1, dtype_name="float16")
+
+    assert row == {
+        "framework": "candle",
+        "case": "xfmr",
+        "error": "no json from worker",
+    }
+
+
+def test_main_exits_nonzero_when_worker_error_occurs_without_ratio_gate(capsys, monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "perf_candle_vs_torch_npu.py",
+            "--cases",
+            "mlp",
+            "--iters",
+            "1",
+            "--warmup",
+            "0",
+            "--json-output",
+            "-",
+        ],
+    )
+
+    def fake_spawn(framework, case, *args, **kwargs):
+        if framework == "candle":
+            return {"framework": framework, "case": case, "error": "worker exit 7"}
+        return {
+            "framework": framework,
+            "case": case,
+            "fwd_ms_median": 1.0,
+            "bwd_ms_median": 1.0,
+            "total_ms_median": 2.0,
+            "fwd_ms_min": 1.0,
+            "bwd_ms_min": 1.0,
+            "total_ms_min": 2.0,
+            "fwd_ms_p10": 1.0,
+            "bwd_ms_p10": 1.0,
+            "total_ms_p10": 2.0,
+            "fwd_ms_p90": 1.0,
+            "bwd_ms_p90": 1.0,
+            "total_ms_p90": 2.0,
+        }
+
+    monkeypatch.setattr(_bench_mod, "_spawn_worker", fake_spawn)
+
+    with pytest.raises(SystemExit) as exc_info:
+        _bench_mod.main()
+
+    assert exc_info.value.code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["failures"] == ["mlp/candle: worker exit 7"]

--- a/tests/cpu/test_pipeline_npu_framework_neutral.py
+++ b/tests/cpu/test_pipeline_npu_framework_neutral.py
@@ -1,0 +1,19 @@
+import candle
+import candle.nn.functional as F
+
+from benchmarks.pipeline_npu.cases import CASES
+
+
+def test_pipeline_case_builders_accept_framework_module():
+    for name in ["A1", "A2s", "D2"]:
+        case = CASES[name]
+        forward = case["builder"](candle, F, "cpu", candle.float32)
+        out = forward()
+        assert hasattr(out, "shape")
+
+
+def test_pipeline_cases_do_not_require_global_candle_module_argument():
+    case = CASES["A1"]
+    forward = case["builder"](candle, F, "cpu", candle.float32)
+    out = forward()
+    assert tuple(out.shape) == (1, 128, 1024)

--- a/tests/cpu/test_pipeline_npu_imports.py
+++ b/tests/cpu/test_pipeline_npu_imports.py
@@ -1,0 +1,27 @@
+"""Assert that importing benchmarks.pipeline_npu.bench does not import candle at module load time."""
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_bench_does_not_import_candle_at_module_level():
+    code = (
+        "import importlib, sys;"
+        "sys.path.insert(0, '');"
+        "importlib.import_module('benchmarks.pipeline_npu.bench');"
+        "assert 'candle' not in sys.modules, 'candle was imported at module level';"
+        "print('OK')"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        env={
+            **__import__("os").environ,
+            "PYTHONPATH": f"{_REPO_ROOT}{__import__('os').pathsep}{_REPO_ROOT / 'src'}",
+        },
+    )
+    assert result.returncode == 0, f"subprocess failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    assert "OK" in result.stdout

--- a/tests/cpu/test_pipeline_npu_report.py
+++ b/tests/cpu/test_pipeline_npu_report.py
@@ -132,6 +132,81 @@ def test_spawn_worker_malformed_json_raises(monkeypatch):
         warmup=0,
         iters=1,
     )
-
     with pytest.raises(RuntimeError, match="failed to parse candle worker JSON"):
         pipeline_run._spawn_worker("candle", args)
+
+
+
+def test_json_stdout_mode_emits_only_json_to_stdout_and_human_to_stderr(capsys, monkeypatch):
+    rows_by_framework = {
+        "candle": [
+            {"framework": "candle", "case_id": "A1", "mode": "eager", "median_ms": 8.0, "status": "ok"}
+        ],
+        "torch_npu": [
+            {"framework": "torch_npu", "case_id": "A1", "mode": "eager", "median_ms": 10.0, "status": "ok"}
+        ],
+    }
+    monkeypatch.setattr(pipeline_run, "_spawn_worker", lambda framework, args: rows_by_framework[framework])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "pipeline_npu.run",
+            "--cases",
+            "A1",
+            "--mode",
+            "eager",
+            "--warmup",
+            "2",
+            "--iters",
+            "3",
+            "--json-output",
+            "-",
+        ],
+    )
+
+    pipeline_run.main()
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["warmup"] == 2
+    assert payload["iters"] == 3
+    assert payload["cases"] == ["A1"]
+    assert payload["mode"] == "eager"
+    assert payload["device"] == "npu"
+    assert payload["max_ratio"] == 0.99
+    assert payload["frameworks"] == ["candle", "torch_npu"]
+    assert "case | framework | mode" in captured.err
+    assert "A1 | candle | eager" in captured.err
+
+
+def test_main_exits_nonzero_for_error_status_without_ratio_gate(capsys, monkeypatch):
+    rows_by_framework = {
+        "candle": [
+            {"framework": "candle", "case_id": "A1", "mode": "eager", "median_ms": 0.0, "status": "error: boom"}
+        ],
+        "torch_npu": [
+            {"framework": "torch_npu", "case_id": "A1", "mode": "eager", "median_ms": 10.0, "status": "ok"}
+        ],
+    }
+    monkeypatch.setattr(pipeline_run, "_spawn_worker", lambda framework, args: rows_by_framework[framework])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "pipeline_npu.run",
+            "--cases",
+            "A1",
+            "--mode",
+            "eager",
+            "--json-output",
+            "-",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        pipeline_run.main()
+
+    assert exc_info.value.code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["failures"] == ["A1/eager/candle: error: boom"]

--- a/tests/cpu/test_pipeline_npu_report.py
+++ b/tests/cpu/test_pipeline_npu_report.py
@@ -85,6 +85,8 @@ def test_spawn_worker_runs_from_repo_root_with_repo_and_src_on_pythonpath(monkey
     monkeypatch.setattr(subprocess, "run", fake_run)
     args = SimpleNamespace(
         python=sys.executable,
+        candle_python=None,
+        torch_npu_python=None,
         cases="A1",
         mode="eager",
         device="npu",
@@ -108,6 +110,8 @@ def test_spawn_worker_nonzero_exit_returns_structured_failure_rows(monkeypatch):
     monkeypatch.setattr(subprocess, "run", fake_run)
     args = SimpleNamespace(
         python=None,
+        candle_python=None,
+        torch_npu_python=None,
         cases="A1,A2s",
         mode="eager",
         device="npu",
@@ -142,6 +146,8 @@ def test_spawn_worker_malformed_json_returns_structured_failure_rows(monkeypatch
     monkeypatch.setattr(subprocess, "run", fake_run)
     args = SimpleNamespace(
         python=None,
+        candle_python=None,
+        torch_npu_python=None,
         cases="A1",
         mode="eager",
         device="npu",
@@ -156,52 +162,33 @@ def test_spawn_worker_malformed_json_returns_structured_failure_rows(monkeypatch
     assert rows[0]["case_id"] == "A1"
     assert rows[0]["status"].startswith("error:")
 
+def test_spawn_worker_uses_framework_specific_python_executable(monkeypatch):
+    commands = []
+
+    def fake_run(cmd, capture_output, text, env, check, cwd):
+        commands.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout=json.dumps([{"framework": cmd[4], "case_id": "A1"}]), stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    args = SimpleNamespace(
+        python="/envs/default/bin/python",
+        candle_python="/envs/candle/bin/python",
+        torch_npu_python="/envs/torch_npu/bin/python",
+        cases="A1",
+        mode="eager",
+        device="npu",
+        warmup=0,
+        iters=1,
+    )
+
+    pipeline_run._spawn_worker("candle", args)
+    pipeline_run._spawn_worker("torch_npu", args)
+
+    assert commands[0][0] == "/envs/candle/bin/python"
+    assert commands[1][0] == "/envs/torch_npu/bin/python"
 
 
 def test_json_stdout_mode_emits_only_json_to_stdout_and_human_to_stderr(capsys, monkeypatch):
-    rows_by_framework = {
-        "candle": [
-            {"framework": "candle", "case_id": "A1", "mode": "eager", "median_ms": 8.0, "status": "ok"}
-        ],
-        "torch_npu": [
-            {"framework": "torch_npu", "case_id": "A1", "mode": "eager", "median_ms": 10.0, "status": "ok"}
-        ],
-    }
-    monkeypatch.setattr(pipeline_run, "_spawn_worker", lambda framework, args: rows_by_framework[framework])
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "pipeline_npu.run",
-            "--cases",
-            "A1",
-            "--mode",
-            "eager",
-            "--warmup",
-            "2",
-            "--iters",
-            "3",
-            "--json-output",
-            "-",
-        ],
-    )
-
-    pipeline_run.main()
-
-    captured = capsys.readouterr()
-    payload = json.loads(captured.out)
-    assert payload["warmup"] == 2
-    assert payload["iters"] == 3
-    assert payload["cases"] == ["A1"]
-    assert payload["mode"] == "eager"
-    assert payload["device"] == "npu"
-    assert payload["max_ratio"] == 0.99
-    assert payload["frameworks"] == ["candle", "torch_npu"]
-    assert "case | framework | mode" in captured.err
-    assert "A1 | candle | eager" in captured.err
-
-
-def test_main_exits_nonzero_for_error_status_without_ratio_gate(capsys, monkeypatch):
     rows_by_framework = {
         "candle": [
             {"framework": "candle", "case_id": "A1", "mode": "eager", "median_ms": 0.0, "status": "error: boom"}

--- a/tests/cpu/test_pipeline_npu_report.py
+++ b/tests/cpu/test_pipeline_npu_report.py
@@ -23,6 +23,15 @@ def test_annotate_pipeline_ratios_adds_candle_ratio():
     assert candle["median_ratio"] == 0.8
 
 
+def test_pipeline_ratio_failures_require_candle_to_be_faster_than_torch_npu():
+    rows = [
+        {"framework": "torch_npu", "case_id": "A1", "mode": "eager", "median_ms": 10.0, "status": "ok", "median_ratio": 1.0},
+        {"framework": "candle", "case_id": "A1", "mode": "eager", "median_ms": 10.5, "status": "ok", "median_ratio": 1.05},
+    ]
+
+    failures = pipeline_ratio_failures(rows, case_ids=["A1"], mode="eager", max_ratio=0.99)
+
+    assert failures == ["A1/eager: candle median_ratio 1.05x > 0.99x"]
 
 
 def test_worker_unknown_case_emits_structured_error_row(capsys, monkeypatch):

--- a/tests/cpu/test_pipeline_npu_report.py
+++ b/tests/cpu/test_pipeline_npu_report.py
@@ -101,39 +101,60 @@ def test_spawn_worker_runs_from_repo_root_with_repo_and_src_on_pythonpath(monkey
     assert pythonpath[0:2] == [repo_root, os.path.join(repo_root, "src")]
 
 
-def test_spawn_worker_nonzero_exit_raises(monkeypatch):
+def test_spawn_worker_nonzero_exit_returns_structured_failure_rows(monkeypatch):
     def fake_run(cmd, capture_output, text, env, check, cwd):
         return subprocess.CompletedProcess(cmd, 2, stdout="", stderr="boom")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
     args = SimpleNamespace(
-        python=sys.executable,
-        cases="A1",
+        python=None,
+        cases="A1,A2s",
         mode="eager",
         device="npu",
-        warmup=0,
+        warmup=1,
         iters=1,
     )
 
-    with pytest.raises(RuntimeError, match="candle worker failed"):
-        pipeline_run._spawn_worker("candle", args)
+    rows = pipeline_run._spawn_worker("candle", args)
+
+    assert len(rows) == 2
+    for row, case_id in zip(rows, ["A1", "A2s"]):
+        assert row["framework"] == "candle"
+        assert row["case_id"] == case_id
+        assert row["mode"] == "eager"
+        assert row["mean_ms"] == 0.0
+        assert row["median_ms"] == 0.0
+        assert row["p95_ms"] == 0.0
+        assert row["op_count"] == 0
+        assert "worker exit 2" in row["status"]
+
+    annotate_pipeline_ratios(rows)
+    assert pipeline_run._status_failures(rows) == [
+        "A1/eager/candle: error: worker exit 2",
+        "A2s/eager/candle: error: worker exit 2",
+    ]
 
 
-def test_spawn_worker_malformed_json_raises(monkeypatch):
+def test_spawn_worker_malformed_json_returns_structured_failure_rows(monkeypatch):
     def fake_run(cmd, capture_output, text, env, check, cwd):
         return subprocess.CompletedProcess(cmd, 0, stdout="not-json", stderr="")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
     args = SimpleNamespace(
-        python=sys.executable,
+        python=None,
         cases="A1",
         mode="eager",
         device="npu",
         warmup=0,
         iters=1,
     )
-    with pytest.raises(RuntimeError, match="failed to parse candle worker JSON"):
-        pipeline_run._spawn_worker("candle", args)
+
+    rows = pipeline_run._spawn_worker("candle", args)
+
+    assert len(rows) == 1
+    assert rows[0]["framework"] == "candle"
+    assert rows[0]["case_id"] == "A1"
+    assert rows[0]["status"].startswith("error:")
 
 
 

--- a/tests/cpu/test_pipeline_npu_report.py
+++ b/tests/cpu/test_pipeline_npu_report.py
@@ -1,3 +1,13 @@
+import json
+import os
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from benchmarks.pipeline_npu import run as pipeline_run
+from benchmarks.pipeline_npu import worker as pipeline_worker
 from benchmarks.pipeline_npu.run import annotate_pipeline_ratios, pipeline_ratio_failures
 
 
@@ -13,12 +23,106 @@ def test_annotate_pipeline_ratios_adds_candle_ratio():
     assert candle["median_ratio"] == 0.8
 
 
-def test_pipeline_ratio_failures_require_candle_to_be_faster_than_torch_npu():
-    rows = [
-        {"framework": "torch_npu", "case_id": "A1", "mode": "eager", "median_ms": 10.0, "status": "ok", "median_ratio": 1.0},
-        {"framework": "candle", "case_id": "A1", "mode": "eager", "median_ms": 10.5, "status": "ok", "median_ratio": 1.05},
+
+
+def test_worker_unknown_case_emits_structured_error_row(capsys, monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "worker",
+            "--framework",
+            "candle",
+            "--cases",
+            "BAD",
+            "--mode",
+            "eager",
+            "--warmup",
+            "0",
+            "--iters",
+            "1",
+        ],
+    )
+
+    pipeline_worker.main()
+
+    rows = json.loads(capsys.readouterr().out)
+    assert rows == [
+        {
+            "framework": "candle",
+            "case_id": "BAD",
+            "mode": "eager",
+            "mean_ms": 0.0,
+            "median_ms": 0.0,
+            "p95_ms": 0.0,
+            "op_count": 0,
+            "status": "error: unknown case: BAD",
+        }
     ]
 
-    failures = pipeline_ratio_failures(rows, case_ids=["A1"], mode="eager", max_ratio=0.99)
 
-    assert failures == ["A1/eager: candle median_ratio 1.05x > 0.99x"]
+def test_spawn_worker_runs_from_repo_root_with_repo_and_src_on_pythonpath(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, capture_output, text, env, check, cwd):
+        captured["cmd"] = cmd
+        captured["capture_output"] = capture_output
+        captured["text"] = text
+        captured["env"] = env
+        captured["check"] = check
+        captured["cwd"] = cwd
+        return subprocess.CompletedProcess(cmd, 0, stdout=json.dumps([{"framework": "candle", "case_id": "A1"}]), stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    args = SimpleNamespace(
+        python=sys.executable,
+        cases="A1",
+        mode="eager",
+        device="npu",
+        warmup=0,
+        iters=1,
+    )
+
+    rows = pipeline_run._spawn_worker("candle", args)
+
+    repo_root = pipeline_run._repo_root()
+    pythonpath = captured["env"]["PYTHONPATH"].split(os.pathsep)
+    assert rows == [{"framework": "candle", "case_id": "A1"}]
+    assert captured["cwd"] == repo_root
+    assert pythonpath[0:2] == [repo_root, os.path.join(repo_root, "src")]
+
+
+def test_spawn_worker_nonzero_exit_raises(monkeypatch):
+    def fake_run(cmd, capture_output, text, env, check, cwd):
+        return subprocess.CompletedProcess(cmd, 2, stdout="", stderr="boom")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    args = SimpleNamespace(
+        python=sys.executable,
+        cases="A1",
+        mode="eager",
+        device="npu",
+        warmup=0,
+        iters=1,
+    )
+
+    with pytest.raises(RuntimeError, match="candle worker failed"):
+        pipeline_run._spawn_worker("candle", args)
+
+
+def test_spawn_worker_malformed_json_raises(monkeypatch):
+    def fake_run(cmd, capture_output, text, env, check, cwd):
+        return subprocess.CompletedProcess(cmd, 0, stdout="not-json", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    args = SimpleNamespace(
+        python=sys.executable,
+        cases="A1",
+        mode="eager",
+        device="npu",
+        warmup=0,
+        iters=1,
+    )
+
+    with pytest.raises(RuntimeError, match="failed to parse candle worker JSON"):
+        pipeline_run._spawn_worker("candle", args)

--- a/tests/cpu/test_pipeline_npu_report.py
+++ b/tests/cpu/test_pipeline_npu_report.py
@@ -1,0 +1,24 @@
+from benchmarks.pipeline_npu.run import annotate_pipeline_ratios, pipeline_ratio_failures
+
+
+def test_annotate_pipeline_ratios_adds_candle_ratio():
+    rows = [
+        {"framework": "torch_npu", "case_id": "A1", "mode": "eager", "median_ms": 10.0, "status": "ok"},
+        {"framework": "candle", "case_id": "A1", "mode": "eager", "median_ms": 8.0, "status": "ok"},
+    ]
+
+    annotate_pipeline_ratios(rows)
+
+    candle = next(row for row in rows if row["framework"] == "candle")
+    assert candle["median_ratio"] == 0.8
+
+
+def test_pipeline_ratio_failures_require_candle_to_be_faster_than_torch_npu():
+    rows = [
+        {"framework": "torch_npu", "case_id": "A1", "mode": "eager", "median_ms": 10.0, "status": "ok", "median_ratio": 1.0},
+        {"framework": "candle", "case_id": "A1", "mode": "eager", "median_ms": 10.5, "status": "ok", "median_ratio": 1.05},
+    ]
+
+    failures = pipeline_ratio_failures(rows, case_ids=["A1"], mode="eager", max_ratio=0.99)
+
+    assert failures == ["A1/eager: candle median_ratio 1.05x > 0.99x"]

--- a/tests/npu/test_pipeline_npu_bench_smoke.py
+++ b/tests/npu/test_pipeline_npu_bench_smoke.py
@@ -1,15 +1,18 @@
-import candle as torch
-
-from benchmarks.pipeline_npu.bench import run_case, CASES
+from benchmarks.pipeline_npu.bench import CASES, run_case
 
 
 def test_pipeline_bench_smoke_cpu():
     case = CASES["A1"]
-    result = run_case(case, device="cpu", pipeline=False, warmup=1, iters=1)
+    result = run_case(case, framework="candle", device="cpu", mode="eager", warmup=1, iters=1)
+    assert result["framework"] == "candle"
     assert result["case_id"] == "A1"
+    assert result["mode"] == "eager"
+    assert result["status"] == "ok"
     assert "mean_ms" in result
+    assert "median_ms" in result
     assert "p95_ms" in result
     assert isinstance(result["mean_ms"], float)
+    assert isinstance(result["median_ms"], float)
     assert isinstance(result["p95_ms"], float)
 
 


### PR DESCRIPTION
## Summary
- Add shared NPU benchmark summary/ratio helpers and single-op JSON ratio gates.
- Add torch_npu comparison orchestration for pipeline and end-to-end benchmarks, including structured worker failure reporting.
- Add Phase 0/Phase 1 NPU performance design docs and ignore generated performance-gate artifacts.

## Test Plan
- [x] source /usr/local/Ascend/cann-9.0.0/set_env.sh && source /home/jenkins/anaconda3/etc/profile.d/conda.sh && conda run -n candle311 python -m pytest tests/cpu/test_npu_perf_gates.py tests/cpu/test_npu_op_benchmark_report.py tests/cpu/test_npu_perf_gate.py tests/cpu/test_perf_candle_vs_torch_npu_ratios.py tests/cpu/test_pipeline_npu_framework_neutral.py tests/cpu/test_pipeline_npu_imports.py tests/cpu/test_pipeline_npu_report.py tests/npu/test_pipeline_npu_bench_smoke.py -q

🤖 Generated with [Claude Code](https://claude.com/claude-code)