### PR TITLE
fix(npu): keep cross entropy masks in logits dtype

### DIFF
--- a/src/candle/nn/functional.py
+++ b/src/candle/nn/functional.py
@@ -433,15 +433,14 @@ def cross_entropy(input, target, weight=None, size_average=None, ignore_index=-1
         from .._functional import sum as _sum, neg, mean
         from .._dispatch import dispatch
         from .._creation import tensor as _tensor
-        from .._dtype import float32
         C = input.shape[1]
         nll = nll_loss(log_probs, target, weight=weight, ignore_index=ignore_index,
                        reduction=reduction)
         smooth_loss = neg(dispatch("sum", None, log_probs, dim=1))
         smooth_loss = dispatch("div", None, smooth_loss,
-                               _tensor(float(C), device=input.device))
+                               _tensor(float(C), dtype=input.dtype, device=input.device))
         valid = dispatch("ne", None, target, ignore_index)
-        valid_float = valid.to(dtype=float32)
+        valid_float = valid.to(dtype=input.dtype)
         smooth_loss = dispatch("mul", None, smooth_loss, valid_float)
         if reduction == 'mean':
             valid_count = dispatch("sum", None, valid_float)
@@ -451,8 +450,8 @@ def cross_entropy(input, target, weight=None, size_average=None, ignore_index=-1
         elif reduction == 'sum':
             smooth_loss = dispatch("sum", None, smooth_loss)
         ls = label_smoothing
-        ls_t = _tensor(ls, device=input.device)
-        one_minus_ls = _tensor(1.0 - ls, device=input.device)
+        ls_t = _tensor(ls, dtype=input.dtype, device=input.device)
+        one_minus_ls = _tensor(1.0 - ls, dtype=input.dtype, device=input.device)
         return dispatch("add", None,
                          dispatch("mul", None, one_minus_ls, nll),
                          dispatch("mul", None, ls_t, smooth_loss))
@@ -526,7 +525,7 @@ def nll_loss(input, target, weight=None, size_average=None, ignore_index=-100,
              reduce=None, reduction='mean'):
     from .._functional import mean
     from .._dispatch import dispatch
-    from .._dtype import int64 as int64_dtype, float32
+    from .._dtype import int64 as int64_dtype
     from .._creation import tensor as _tensor
     batch_size = input.shape[0]
     if target.dtype != int64_dtype:
@@ -542,7 +541,7 @@ def nll_loss(input, target, weight=None, size_average=None, ignore_index=-100,
                         1, target_2d)
         w = w_2d.view((batch_size,))
         losses = dispatch("mul", None, losses, w)
-    valid_float = valid.to(dtype=float32)
+    valid_float = valid.to(dtype=input.dtype)
     losses = dispatch("mul", None, losses, valid_float)
     if reduction == 'none':
         return losses

--- a/tests/npu/test_cross_entropy_npu_dtype.py
+++ b/tests/npu/test_cross_entropy_npu_dtype.py
@@ -1,0 +1,31 @@
+"""Cross entropy L0 parity tests for NPU."""
+import numpy as np
+
+import candle as torch
+import candle.nn.functional as F
+
+
+def test_cross_entropy_fp16_logits_int64_targets_runs_on_npu():
+    """cross_entropy must accept fp16 logits and int64 targets on NPU."""
+    logits = torch.randn((2, 8), device="npu", dtype=torch.float16)
+    targets = torch.tensor([1, 6], device="npu", dtype=torch.int64)
+
+    loss = F.cross_entropy(logits, targets)
+
+    assert loss.device.type == "npu"
+    assert loss.shape == ()
+    assert loss.dtype == torch.float16
+    assert np.isfinite(loss.to("cpu").numpy()).all()
+
+
+def test_cross_entropy_label_smoothing_fp16_npu():
+    """label_smoothing branch must keep mask/scalars in logits dtype on NPU."""
+    logits = torch.randn((2, 8), device="npu", dtype=torch.float16)
+    targets = torch.tensor([0, 7], device="npu", dtype=torch.int64)
+
+    loss = F.cross_entropy(logits, targets, label_smoothing=0.1)
+
+    assert loss.device.type == "npu"
+    assert loss.shape == ()
+    assert loss.dtype == torch.float16
+    assert np.isfinite(loss.to("cpu").numpy()).all()


### PR DESCRIPTION
## Summary
- keep `nll_loss` ignore-index masks in the input/logits dtype before NPU binary ops
- create cross-entropy label-smoothing divisor and scalar tensors in the logits dtype/device
- add focused NPU coverage for fp16 logits with int64 targets, including label smoothing

## Test Plan
- `source /usr/local/Ascend/cann-9.0.0/set_env.sh && source /home/jenkins/anaconda3/etc/profile.d/conda.sh && PYTHONPATH="$PWD/src:$PWD${PYTHONPATH:+:$PYTHONPATH}" conda run -n candle311 python -m pytest tests/npu/test_cross_entropy_npu_dtype.py -v --tb=short`
- `CONDA_PREFIX_BASE=/home/jenkins/anaconda3 CANDLE_CONDA_ENV=candle311 TORCH_NPU_CONDA_ENV=torchnpu311 CANN_SET_ENV=/usr/local/Ascend/cann-9.0.0/set_env.sh CONDA_SH=/home/jenkins/anaconda3/etc/profile.d/conda.sh PYTHONPATH="$PWD/src:$PWD${PYTHONPATH:+:$PYTHONPATH}" python -m benchmarks.op_benchmark_npu.run --ops cross_entropy --dtype fp16 --scenario infer --mode fwd --warmup 3 --iters 10 --json-output /tmp/ce_check.json`
- `source /home/jenkins/anaconda3/etc/profile.d/conda.sh && conda run -n candle311 pylint src/candle/ --rcfile=.github/pylint.conf`
- `source /home/jenkins/anaconda3/etc/profile.d/conda.sh && conda run -n candle311 python -m pytest tests/cpu/ tests/contract/ -v --tb=short`

🤖 Generated with [Claude Code](https://claude.com/claude-code)