### PR TITLE
Optimize NPU FSDP2 Transformer training

### DIFF
--- a/benchmarks/perf_fsdp2_transformer_candle_vs_torch_npu.py
+++ b/benchmarks/perf_fsdp2_transformer_candle_vs_torch_npu.py
@@ -1,0 +1,788 @@
+#!/usr/bin/env python3
+"""Two-card Transformer FSDP2 NPU perf comparison: Candle vs torch_npu."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from benchmarks.npu_perf_gates import summarize_samples
+
+
+@dataclass(frozen=True)
+class FSDP2TransformerCase:
+    """Shape/configuration for a Transformer FSDP2 benchmark case."""
+
+    layers: int
+    batch_per_rank: int
+    seq: int
+    hidden: int
+    heads: int
+    mlp_ratio: int = 4
+
+
+CASES = {
+    "xfmr_fsdp2_small": FSDP2TransformerCase(
+        layers=1,
+        batch_per_rank=2,
+        seq=128,
+        hidden=512,
+        heads=8,
+    ),
+    "xfmr_fsdp2_medium": FSDP2TransformerCase(
+        layers=4,
+        batch_per_rank=1,
+        seq=256,
+        hidden=1024,
+        heads=16,
+    ),
+}
+
+
+def _build_transformer_model(torch, cfg):
+    """Build the shared Transformer stack used by Candle and torch_npu."""
+    nn = torch.nn
+    functional = torch.nn.functional
+
+    class TransformerBlock(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.norm1 = nn.LayerNorm(cfg.hidden)
+            self.attn = nn.MultiheadAttention(
+                cfg.hidden,
+                cfg.heads,
+                batch_first=True,
+                dropout=0.0,
+            )
+            self.norm2 = nn.LayerNorm(cfg.hidden)
+            self.ff1 = nn.Linear(cfg.hidden, cfg.mlp_ratio * cfg.hidden)
+            self.ff2 = nn.Linear(cfg.mlp_ratio * cfg.hidden, cfg.hidden)
+
+        def forward(self, x):
+            y = self.norm1(x)
+            attn_out, _ = self.attn(y, y, y, need_weights=False)
+            x = x + attn_out
+            z = self.norm2(x)
+            z = functional.gelu(self.ff1(z))
+            return x + self.ff2(z)
+
+    class TransformerStack(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.blocks = nn.ModuleList([TransformerBlock() for _ in range(cfg.layers)])
+            self.final_norm = nn.LayerNorm(cfg.hidden)
+
+        def forward(self, x):
+            for block in self.blocks:
+                x = block(x)
+            return self.final_norm(x)
+
+    return TransformerStack()
+
+
+def _iter_fsdp_transformer_modules(model):
+    """Yield modules in bottom-up FSDP wrapping order."""
+    for block in model.blocks:
+        yield block.norm1
+        yield block.attn
+        yield block.norm2
+        yield block.ff1
+        yield block.ff2
+        yield block
+    yield model.final_norm
+    yield model
+
+
+def _sync_candle(torch, dist):
+    if hasattr(torch, "npu") and hasattr(torch.npu, "synchronize"):
+        torch.npu.synchronize()
+    dist.barrier()
+
+
+def _sync_torch_npu(torch, dist):
+    torch.npu.synchronize()
+    dist.barrier()
+
+
+def _run_timed_steps(torch, dist, model, x, optimizer, *, iters, warmup, sync_all,
+                     profile_reset=None, profile_summary=None):
+    """Run warmup and timed training steps, returning per-rank samples."""
+    # Initial runtime/cache warmup outside the requested warmup count.
+    out = model(x)
+    loss = out.sum()
+    loss.backward()
+    optimizer.step()
+    optimizer.zero_grad(set_to_none=True)
+    sync_all(torch, dist)
+
+    for _ in range(warmup):
+        out = model(x)
+        loss = out.sum()
+        loss.backward()
+        optimizer.step()
+        optimizer.zero_grad(set_to_none=True)
+    sync_all(torch, dist)
+    if profile_reset is not None:
+        profile_reset(True)
+
+    fwd_samples = []
+    bwd_samples = []
+    optim_samples = []
+    total_samples = []
+    for _ in range(iters):
+        sync_all(torch, dist)
+        t0 = time.perf_counter()
+        out = model(x)
+        loss = out.sum()
+        if hasattr(torch, "npu") and hasattr(torch.npu, "synchronize"):
+            torch.npu.synchronize()
+        t1 = time.perf_counter()
+        loss.backward()
+        if hasattr(torch, "npu") and hasattr(torch.npu, "synchronize"):
+            torch.npu.synchronize()
+        t2 = time.perf_counter()
+        optimizer.step()
+        optimizer.zero_grad(set_to_none=True)
+        if hasattr(torch, "npu") and hasattr(torch.npu, "synchronize"):
+            torch.npu.synchronize()
+        t3 = time.perf_counter()
+        dist.barrier()
+
+        fwd_samples.append((t1 - t0) * 1000.0)
+        bwd_samples.append((t2 - t1) * 1000.0)
+        optim_samples.append((t3 - t2) * 1000.0)
+        total_samples.append((t3 - t0) * 1000.0)
+
+    result = {
+        "fwd_ms_samples": fwd_samples,
+        "bwd_ms_samples": bwd_samples,
+        "optim_ms_samples": optim_samples,
+        "total_ms_samples": total_samples,
+    }
+    if profile_summary is not None:
+        result["profile"] = profile_summary()
+    if profile_reset is not None:
+        profile_reset(False)
+    return result
+
+
+def _write_worker_result(out_dir, rank, payload):
+    Path(out_dir).mkdir(parents=True, exist_ok=True)
+    path = Path(out_dir) / f"rank{rank}.json"
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _run_candle_worker(args):
+    import candle as torch  # pylint: disable=import-outside-toplevel
+    import candle.distributed as dist  # pylint: disable=import-outside-toplevel
+    from candle.distributed._composable.fsdp import fully_shard  # pylint: disable=import-outside-toplevel
+    from candle.distributed.device_mesh import DeviceMesh  # pylint: disable=import-outside-toplevel
+
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    device = torch.Device(f"npu:{rank}")
+    cfg = CASES[args.case]
+
+    try:
+        dist.init_process_group(backend="hccl", device_id=device)
+        torch.manual_seed(args.seed)
+        dtype = getattr(torch, args.dtype)
+        model = _build_transformer_model(torch, cfg).to(device).to(dtype)
+        mesh = DeviceMesh("npu", (world_size,))
+        for module in _iter_fsdp_transformer_modules(model):
+            fully_shard(module, mesh=mesh)
+        optimizer = torch.optim.SGD(model.parameters(), lr=args.lr)
+        x = torch.randn(
+            cfg.batch_per_rank,
+            cfg.seq,
+            cfg.hidden,
+            device=device,
+            dtype=dtype,
+            requires_grad=True,
+        )
+        profile_reset = None
+        profile_summary = None
+        if args.profile_candle:
+            from candle.distributed._composable.fsdp import _profile  # pylint: disable=import-outside-toplevel
+            profile_reset = _profile.reset
+            profile_summary = _profile.summary
+        samples = _run_timed_steps(
+            torch,
+            dist,
+            model,
+            x,
+            optimizer,
+            iters=args.iters,
+            warmup=args.warmup,
+            sync_all=_sync_candle,
+            profile_reset=profile_reset,
+            profile_summary=profile_summary,
+        )
+        payload = {
+            "rank": rank,
+            "framework": "candle",
+            "case": args.case,
+            "world_size": world_size,
+            "global_batch": cfg.batch_per_rank * world_size,
+            "batch_per_rank": cfg.batch_per_rank,
+            "dtype": args.dtype,
+            "config": asdict(cfg),
+            **samples,
+        }
+        _write_worker_result(args.out_dir, rank, payload)
+        dist.destroy_process_group()
+    except Exception as exc:  # pragma: no cover - diagnostics for benchmark workers
+        _write_worker_result(
+            args.out_dir,
+            rank,
+            {"rank": rank, "framework": "candle", "case": args.case, "error": repr(exc)},
+        )
+        try:
+            if dist.is_initialized():
+                dist.destroy_process_group()
+        except Exception:  # pylint: disable=broad-except
+            pass
+        raise
+
+
+def _run_torch_npu_worker(args):
+    import torch  # pylint: disable=import-outside-toplevel
+    import torch_npu  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import,import-error
+    import torch.distributed as dist  # pylint: disable=import-outside-toplevel
+    from torch.distributed._composable.fsdp import fully_shard  # pylint: disable=import-outside-toplevel
+    from torch.distributed.device_mesh import init_device_mesh  # pylint: disable=import-outside-toplevel
+
+    rank = int(os.environ.get("RANK", "0"))
+    local_rank = int(os.environ.get("LOCAL_RANK", rank))
+    world_size = int(os.environ["WORLD_SIZE"])
+    cfg = CASES[args.case]
+
+    try:
+        torch.npu.set_device(local_rank)
+        dist.init_process_group(backend="hccl")
+        torch.manual_seed(args.seed)
+        device = torch.device(f"npu:{local_rank}")
+        dtype = getattr(torch, args.dtype)
+        model = _build_transformer_model(torch, cfg).to(device=device, dtype=dtype)
+        mesh = init_device_mesh("npu", (world_size,))
+        for module in _iter_fsdp_transformer_modules(model):
+            fully_shard(module, mesh=mesh)
+        optimizer = torch.optim.SGD(model.parameters(), lr=args.lr)
+        x = torch.randn(
+            cfg.batch_per_rank,
+            cfg.seq,
+            cfg.hidden,
+            device=device,
+            dtype=dtype,
+            requires_grad=True,
+        )
+        samples = _run_timed_steps(
+            torch,
+            dist,
+            model,
+            x,
+            optimizer,
+            iters=args.iters,
+            warmup=args.warmup,
+            sync_all=_sync_torch_npu,
+        )
+        payload = {
+            "rank": rank,
+            "framework": "torch_npu",
+            "case": args.case,
+            "world_size": world_size,
+            "global_batch": cfg.batch_per_rank * world_size,
+            "batch_per_rank": cfg.batch_per_rank,
+            "dtype": args.dtype,
+            "config": asdict(cfg),
+            **samples,
+        }
+        _write_worker_result(args.out_dir, rank, payload)
+        dist.destroy_process_group()
+    except Exception as exc:  # pragma: no cover - diagnostics for benchmark workers
+        _write_worker_result(
+            args.out_dir,
+            rank,
+            {"rank": rank, "framework": "torch_npu", "case": args.case, "error": repr(exc)},
+        )
+        try:
+            if dist.is_initialized():
+                dist.destroy_process_group()
+        except Exception:  # pylint: disable=broad-except
+            pass
+        raise
+
+
+def _max_by_iteration(rank_results, sample_key):
+    sample_lists = [row[sample_key] for row in rank_results]
+    return [max(values) for values in zip(*sample_lists)]
+
+
+def _copy_summary_fields(result, prefix, samples):
+    summary = summarize_samples(samples)
+    for key, value in summary.items():
+        if key.endswith("_ms"):
+            result[f"{prefix}_ms_{key[:-3]}"] = value
+        else:
+            result[f"{prefix}_{key}"] = value
+    result[f"{prefix}_ms_samples"] = samples
+
+
+def _aggregate_profile_summaries(rank_results):
+    """Aggregate per-rank FSDP profile summaries by phase."""
+    phase_names = sorted(
+        {
+            phase
+            for row in rank_results
+            for phase in row.get("profile", {})
+        }
+    )
+    if not phase_names:
+        return None
+    aggregated = {}
+    for phase in phase_names:
+        counts = []
+        totals = []
+        avgs = []
+        for row in rank_results:
+            event = row.get("profile", {}).get(phase, {})
+            count = event.get("count", 0)
+            total_ms = event.get("total_ms", 0.0)
+            avg_ms = event.get("avg_ms", total_ms / count if count else 0.0)
+            counts.append(count)
+            totals.append(total_ms)
+            avgs.append(avg_ms)
+        aggregated[phase] = {
+            "count_by_rank": counts,
+            "count_max": max(counts) if counts else 0,
+            "total_ms_by_rank": totals,
+            "total_ms_max": max(totals) if totals else 0.0,
+            "avg_ms_by_rank": avgs,
+            "avg_ms_max": max(avgs) if avgs else 0.0,
+        }
+    return aggregated
+
+
+def _aggregate_rank_results(framework, case, rank_results):
+    """Aggregate per-rank worker JSON into one framework/case result row."""
+    if not rank_results:
+        return {"framework": framework, "case": case, "error": "no rank results"}
+    errors = [row for row in rank_results if "error" in row]
+    if errors:
+        return {
+            "framework": framework,
+            "case": case,
+            "error": "; ".join(f"rank {row.get('rank')}: {row['error']}" for row in errors),
+            "rank_results": rank_results,
+        }
+
+    rank_results = sorted(rank_results, key=lambda row: row["rank"])
+    fwd_samples = _max_by_iteration(rank_results, "fwd_ms_samples")
+    bwd_samples = _max_by_iteration(rank_results, "bwd_ms_samples")
+    optim_samples = _max_by_iteration(rank_results, "optim_ms_samples")
+    total_samples = _max_by_iteration(rank_results, "total_ms_samples")
+
+    first = rank_results[0]
+    result = {
+        "framework": framework,
+        "case": case,
+        "world_size": first["world_size"],
+        "global_batch": first["global_batch"],
+        "batch_per_rank": first["batch_per_rank"],
+        "dtype": first.get("dtype"),
+        "config": first.get("config"),
+        "rank_results": rank_results,
+    }
+    _copy_summary_fields(result, "fwd", fwd_samples)
+    _copy_summary_fields(result, "bwd", bwd_samples)
+    _copy_summary_fields(result, "optim", optim_samples)
+    _copy_summary_fields(result, "total", total_samples)
+    profile = _aggregate_profile_summaries(rank_results)
+    if profile is not None:
+        result["profile"] = profile
+    total_ms = result["total_ms_median"]
+    result["samples_per_second"] = (
+        float(result["global_batch"]) / (float(total_ms) / 1000.0)
+        if total_ms else 0.0
+    )
+    return result
+
+
+def _base_worker_args(args, framework, case, out_dir):
+    worker_args = [
+        os.path.abspath(__file__),
+        "--worker",
+        "--framework", framework,
+        "--case", case,
+        "--iters", str(args.iters),
+        "--warmup", str(args.warmup),
+        "--dtype", args.dtype,
+        "--lr", str(args.lr),
+        "--seed", str(args.seed),
+        "--out-dir", out_dir,
+    ]
+    if framework == "candle" and getattr(args, "profile_candle", False):
+        worker_args.append("--profile-candle")
+    return worker_args
+
+
+def _torch_npu_launch_command(python_exe, script_path, *, world_size, worker_args):
+    return [
+        python_exe,
+        "-m",
+        "torch.distributed.run",
+        "--standalone",
+        f"--nproc_per_node={world_size}",
+        script_path,
+        *worker_args,
+    ]
+
+
+def _run_processes(procs, *, timeout):
+    outputs = []
+    for proc in procs:
+        out, _ = proc.communicate(timeout=timeout)
+        outputs.append(out.decode("utf-8", errors="replace"))
+    return outputs
+
+
+def _read_rank_results(out_dir, world_size):
+    results = []
+    for rank in range(world_size):
+        path = Path(out_dir) / f"rank{rank}.json"
+        if path.exists():
+            results.append(json.loads(path.read_text(encoding="utf-8")))
+        else:
+            results.append({"rank": rank, "error": f"missing rank output: {path}"})
+    return results
+
+
+def _spawn_candle(case, args, out_dir):
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+
+    base_env = os.environ.copy()
+    base_env["MASTER_ADDR"] = "127.0.0.1"
+    base_env["MASTER_PORT"] = str(port)
+    base_env["WORLD_SIZE"] = str(args.world_size)
+    src_dir = os.path.join(_REPO_ROOT, "src")
+    base_env["CANDLE_SRC"] = src_dir
+    old_pythonpath = base_env.get("PYTHONPATH")
+    base_env["PYTHONPATH"] = (
+        src_dir if not old_pythonpath else os.pathsep.join((src_dir, old_pythonpath))
+    )
+
+    procs = []
+    for rank in range(args.world_size):
+        env = dict(base_env, RANK=str(rank), LOCAL_RANK=str(rank))
+        cmd = [args.candle_python or sys.executable, *_base_worker_args(args, "candle", case, out_dir)]
+        procs.append(
+            subprocess.Popen(
+                cmd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+        )
+
+    outputs = []
+    try:
+        outputs = _run_processes(procs, timeout=args.timeout)
+    finally:
+        for proc in procs:
+            if proc.poll() is None:
+                proc.kill()
+
+    rank_results = _read_rank_results(out_dir, args.world_size)
+    for rank, proc in enumerate(procs):
+        if proc.returncode != 0 and "error" not in rank_results[rank]:
+            rank_results[rank]["error"] = f"worker exit {proc.returncode}"
+            rank_results[rank]["tail"] = outputs[rank].splitlines()[-16:]
+    return _aggregate_rank_results("candle", case, rank_results)
+
+
+def _spawn_torch_npu(case, args, out_dir):
+    script_path = os.path.abspath(__file__)
+    worker_args = _base_worker_args(args, "torch_npu", case, out_dir)[1:]
+    cmd = _torch_npu_launch_command(
+        args.torch_npu_python or sys.executable,
+        script_path,
+        world_size=args.world_size,
+        worker_args=worker_args,
+    )
+    env = os.environ.copy()
+    # Keep the benchmark repository importable without forcing Candle's src path
+    # into the torch_npu worker environment.
+    old_pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = _REPO_ROOT if not old_pythonpath else os.pathsep.join((_REPO_ROOT, old_pythonpath))
+    try:
+        completed = subprocess.run(
+            cmd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=args.timeout,
+            check=False,
+        )
+        output = completed.stdout.decode("utf-8", errors="replace")
+    except subprocess.TimeoutExpired:
+        return {"framework": "torch_npu", "case": case, "error": "timeout"}
+
+    rank_results = _read_rank_results(out_dir, args.world_size)
+    if completed.returncode != 0:
+        for row in rank_results:
+            row.setdefault("error", f"torch.distributed.run exit {completed.returncode}")
+            row.setdefault("tail", output.splitlines()[-24:])
+    return _aggregate_rank_results("torch_npu", case, rank_results)
+
+
+def _spawn_framework(framework, case, args):
+    with tempfile.TemporaryDirectory(prefix=f"fsdp2_{framework}_{case}_") as tmpdir:
+        if framework == "candle":
+            return _spawn_candle(case, args, tmpdir)
+        if framework == "torch_npu":
+            return _spawn_torch_npu(case, args, tmpdir)
+    raise ValueError(f"unknown framework: {framework}")
+
+
+def _index_results(results):
+    by_case = {}
+    for row in results:
+        by_case.setdefault(row["case"], {})[row["framework"]] = row
+    return by_case
+
+
+def _annotate_ratios(results):
+    by_case = _index_results(results)
+    for by_framework in by_case.values():
+        candle = by_framework.get("candle")
+        torch_ref = by_framework.get("torch_npu")
+        if candle is None or torch_ref is None:
+            continue
+        if "error" in candle or "error" in torch_ref:
+            continue
+        metric_pairs = (
+            ("fwd_ms_median", "fwd_ratio"),
+            ("bwd_ms_median", "bwd_ratio"),
+            ("optim_ms_median", "optim_ratio"),
+            ("total_ms_median", "total_ratio"),
+        )
+        for metric, ratio_name in metric_pairs:
+            ref_value = torch_ref.get(metric)
+            candle_value = candle.get(metric)
+            if ref_value and candle_value is not None:
+                candle[ratio_name] = candle_value / ref_value
+        ref_tput = torch_ref.get("samples_per_second")
+        candle_tput = candle.get("samples_per_second")
+        if ref_tput and candle_tput is not None:
+            candle["throughput_ratio"] = candle_tput / ref_tput
+
+
+def _ratio_failures(results, cases, max_total_ratio):
+    failures = []
+    by_case = _index_results(results)
+    for case in cases:
+        by_framework = by_case.get(case, {})
+        candle = by_framework.get("candle")
+        torch_ref = by_framework.get("torch_npu")
+        if candle is None or torch_ref is None:
+            failures.append(f"{case}: missing candle or torch_npu result")
+            continue
+        if "error" in candle:
+            failures.append(f"{case}/candle: {candle['error']}")
+            continue
+        if "error" in torch_ref:
+            failures.append(f"{case}/torch_npu: {torch_ref['error']}")
+            continue
+        total_ratio = candle.get("total_ratio")
+        if total_ratio is None:
+            failures.append(f"{case}: missing candle/torch_npu total ratio")
+        elif total_ratio > max_total_ratio:
+            failures.append(
+                f"{case}: total ratio {total_ratio:.2f}x > {max_total_ratio:.2f}x"
+            )
+    return failures
+
+
+def _fmt_ms(value):
+    if value is None:
+        return "-"
+    return f"{value:.2f}"
+
+
+def _fmt_ratio(row, framework):
+    if framework == "torch_npu":
+        return "1.00x"
+    if "total_ratio" not in row:
+        return "-"
+    return (
+        f"f {row.get('fwd_ratio', 0.0):.2f}x / "
+        f"b {row.get('bwd_ratio', 0.0):.2f}x / "
+        f"o {row.get('optim_ratio', 0.0):.2f}x / "
+        f"t {row['total_ratio']:.2f}x"
+    )
+
+
+def _print_table(results, frameworks, stream=None):
+    stream = stream or sys.stdout
+    by_case = _index_results(results)
+    header = ["algo", "fwd ms", "bwd ms", "optim ms", "total ms", "samples/s", "ratio"]
+    print(" | ".join(f"{item:>20}" for item in header), file=stream)
+    print("-+-".join("-" * 20 for _ in header), file=stream)
+    for case, by_framework in by_case.items():
+        for framework in frameworks:
+            row = by_framework.get(framework)
+            algo = f"{case}/{framework}"
+            if row is None or "error" in row:
+                values = [algo, "err", "err", "err", "err", "err", "-"]
+            else:
+                values = [
+                    algo,
+                    _fmt_ms(row.get("fwd_ms_median")),
+                    _fmt_ms(row.get("bwd_ms_median")),
+                    _fmt_ms(row.get("optim_ms_median")),
+                    _fmt_ms(row.get("total_ms_median")),
+                    f"{row.get('samples_per_second', 0.0):.2f}",
+                    _fmt_ratio(row, framework),
+                ]
+            print(" | ".join(f"{item:>20}" for item in values), file=stream)
+    for row in results:
+        if "error" in row:
+            print(f"\n[{row['framework']} / {row['case']}] ERROR: {row['error']}", file=stream)
+            for rank_row in row.get("rank_results", []):
+                tail = rank_row.get("tail")
+                if tail:
+                    print(f"  rank {rank_row.get('rank')} tail:", file=stream)
+                    for line in tail:
+                        print(f"    | {line}", file=stream)
+
+
+def _write_json_output(path, payload):
+    text = json.dumps(payload, indent=2, sort_keys=True)
+    if path == "-":
+        print(text)
+        return
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(text)
+        handle.write("\n")
+
+
+def _parse_cases(value):
+    cases = [case.strip() for case in value.split(",") if case.strip()]
+    unknown = [case for case in cases if case not in CASES]
+    if unknown:
+        raise SystemExit(f"unknown cases: {unknown}; known: {list(CASES)}")
+    return cases
+
+
+def _build_parser():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--framework", default="all", choices=("all", "candle", "torch_npu"))
+    parser.add_argument("--case", default=None, help="single case for worker mode")
+    parser.add_argument("--cases", default=",".join(CASES.keys()))
+    parser.add_argument("--world-size", type=int, default=2)
+    parser.add_argument("--iters", type=int, default=20)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--dtype", default="float16")
+    parser.add_argument("--lr", type=float, default=0.001)
+    parser.add_argument("--seed", type=int, default=20260608)
+    parser.add_argument("--timeout", type=int, default=1200)
+    parser.add_argument("--out-dir", default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--candle-python", default=None)
+    parser.add_argument("--torch-npu-python", default=None)
+    parser.add_argument("--json-output", default=None)
+    parser.add_argument("--profile-candle", action="store_true")
+    parser.add_argument("--fail-on-ratio", action="store_true")
+    parser.add_argument("--max-total-ratio", type=float, default=1.0)
+    return parser
+
+
+def main():
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    if args.world_size <= 0:
+        parser.error("--world-size must be > 0")
+    if args.iters <= 0:
+        parser.error("--iters must be > 0")
+    if args.warmup < 0:
+        parser.error("--warmup must be >= 0")
+    if args.max_total_ratio <= 0:
+        parser.error("--max-total-ratio must be > 0")
+
+    if args.worker:
+        if args.case not in CASES:
+            parser.error("--case must name a known case in worker mode")
+        if not args.out_dir:
+            parser.error("--out-dir is required in worker mode")
+        if args.framework == "candle":
+            _run_candle_worker(args)
+        elif args.framework == "torch_npu":
+            _run_torch_npu_worker(args)
+        else:
+            parser.error("worker mode requires --framework candle|torch_npu")
+        return
+
+    cases = _parse_cases(args.cases)
+    frameworks = ["candle", "torch_npu"] if args.framework == "all" else [args.framework]
+    human_stream = sys.stderr if args.json_output == "-" else sys.stdout
+    print(
+        "# FSDP2 Transformer bench: candle vs torch_npu "
+        f"(world_size={args.world_size}, iters={args.iters}, warmup={args.warmup}, "
+        f"dtype={args.dtype})",
+        file=human_stream,
+    )
+    print(f"# Cases: {cases}", file=human_stream)
+
+    results = []
+    for case in cases:
+        for framework in frameworks:
+            print(f"  [{framework} / {case}] running...", flush=True, file=human_stream)
+            results.append(_spawn_framework(framework, case, args))
+
+    _annotate_ratios(results)
+    failures = []
+    if args.fail_on_ratio:
+        failures.extend(_ratio_failures(results, cases, args.max_total_ratio))
+
+    print(file=human_stream)
+    _print_table(results, frameworks, stream=human_stream)
+    if failures:
+        print("\n# Gate failures", file=human_stream)
+        for failure in failures:
+            print(f"- {failure}", file=human_stream)
+
+    payload = {
+        "cases": cases,
+        "frameworks": frameworks,
+        "world_size": args.world_size,
+        "iters": args.iters,
+        "warmup": args.warmup,
+        "dtype": args.dtype,
+        "lr": args.lr,
+        "max_total_ratio": args.max_total_ratio,
+        "failures": failures,
+        "results": results,
+    }
+    if args.json_output:
+        _write_json_output(args.json_output, payload)
+    if failures:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -4228,6 +4228,102 @@ def fast_sub_inplace(a, b):
     return a
 
 
+def fast_sgd_step(a, grad, lr):
+    """In-place SGD update: a -= lr * grad using aclnnSub alpha scalar."""
+    _ensure_npu_imports()
+    _ensure_ffi_binary()
+    _ensure_ffi_scalar_helpers()
+
+    cdef int dev_idx
+    _validate_npu_binary(a, grad, "sgd_step", &dev_idx)
+
+    a_dtype = a.dtype
+    runtime = _get_runtime_fast(dev_idx)
+    stream = _get_stream_fast(dev_idx)
+
+    py_a_shape = (<TensorImpl>a)._shape_tuple if isinstance(a, TensorImpl) else a.shape
+    py_g_shape = (<TensorImpl>grad)._shape_tuple if isinstance(grad, TensorImpl) else grad.shape
+    py_a_stride = (<TensorImpl>a)._stride_tuple if isinstance(a, TensorImpl) else a.stride
+    py_g_stride = (<TensorImpl>grad)._stride_tuple if isinstance(grad, TensorImpl) else grad.stride
+    cdef int a_ndim = len(py_a_shape)
+    cdef int g_ndim = len(py_g_shape)
+    if a_ndim > MAX_NDIM or g_ndim > MAX_NDIM:
+        raise ValueError(f"ndim exceeds MAX_NDIM ({MAX_NDIM})")
+
+    cdef int64_t[MAX_NDIM] a_shape_buf, g_shape_buf, out_shape_buf
+    _fill_shape(py_a_shape, a_shape_buf, a_ndim)
+    _fill_shape(py_g_shape, g_shape_buf, g_ndim)
+    cdef int out_ndim
+    with nogil:
+        out_ndim = c_broadcast_shape(
+            a_shape_buf, a_ndim, g_shape_buf, g_ndim, out_shape_buf)
+    if out_ndim != a_ndim:
+        raise ValueError("NPU sgd_step requires grad broadcastable to param shape")
+    cdef int i
+    for i in range(out_ndim):
+        if out_shape_buf[i] != a_shape_buf[i]:
+            raise ValueError("NPU sgd_step requires grad broadcastable to param shape")
+
+    cdef int dtype_code = _dtype_to_acl_code(a_dtype)
+    cdef uintptr_t a_ptr
+    cdef uintptr_t g_ptr
+    if isinstance(a, TensorImpl):
+        a_ptr = <uintptr_t>(<TensorImpl>a)._storage._untyped._device_ptr
+    else:
+        a_ptr = <uintptr_t>a.storage().data_ptr()
+    if isinstance(grad, TensorImpl):
+        g_ptr = <uintptr_t>(<TensorImpl>grad)._storage._untyped._device_ptr
+    else:
+        g_ptr = <uintptr_t>grad.storage().data_ptr()
+
+    cdef object scalar_handle_obj = _create_scalar_fn(_scalar_bytes_fn(float(lr), a_dtype), dtype_code)
+    cdef uintptr_t alpha_scalar = <uintptr_t>scalar_handle_obj
+    cdef uintptr_t stream_raw = int(stream.stream)
+    cdef object ws_size = 0
+    cdef object executor = 0
+    try:
+        ws_size, executor = _ffi_binary_op_with_alpha(
+            _sub_getws_ptr, _sub_exec_ptr,
+            py_a_shape, py_a_stride,
+            py_g_shape, py_g_stride,
+            py_a_shape, py_a_stride,
+            dtype_code, 2,
+            a_ptr, g_ptr, a_ptr,
+            alpha_scalar,
+            stream_raw)
+
+        if ws_size:
+            workspace_ptr, ret = _acl_rt_malloc_fn(ws_size, 0)
+            if ret != 0:
+                raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+            try:
+                ret = _ffi_execute(
+                    _sub_exec_ptr, int(workspace_ptr), ws_size,
+                    executor, stream_raw)
+                if ret != 0:
+                    raise RuntimeError(f"aclnnSub execute failed: {ret}")
+            finally:
+                runtime.defer_raw_free(workspace_ptr)
+
+        _defer_executor_fn(executor)
+    finally:
+        _destroy_scalar_fn(int(alpha_scalar))
+    return a
+
+
+
+def fast_sgd_step_many(params, grads, lr):
+    """Batch in-place SGD updates for a parameter group."""
+    cdef Py_ssize_t n = len(params)
+    if n != len(grads):
+        raise ValueError("params and grads must have the same length")
+    cdef Py_ssize_t i
+    for i in range(n):
+        fast_sgd_step(params[i], grads[i], lr)
+    return None
+
+
+
 def fast_mul_inplace(a, b):
     """In-place mul_(a, b) that calls _ffi.binary_op_no_alpha with output aliased to a."""
     _ensure_npu_imports()

--- a/src/candle/_backends/npu/__init__.py
+++ b/src/candle/_backends/npu/__init__.py
@@ -385,6 +385,7 @@ from .ops import (
     adaptive_max_pool1d_op,
     # Phase 4: optimizer composites
     _sgd_step_op,
+    _sgd_step_many_op,
     _adagrad_step_op,
     _rmsprop_step_op,
     _adadelta_step_op,
@@ -914,6 +915,7 @@ registry.register("adaptive_max_pool1d", "npu", adaptive_max_pool1d_op)
 
 # Phase 4: Optimizer composites
 registry.register("_sgd_step", "npu", _sgd_step_op)
+registry.register("_sgd_step_many", "npu", _sgd_step_many_op)
 registry.register("_adagrad_step", "npu", _adagrad_step_op)
 registry.register("_rmsprop_step", "npu", _rmsprop_step_op)
 registry.register("_adadelta_step", "npu", _adadelta_step_op)

--- a/src/candle/_backends/npu/ops/__init__.py
+++ b/src/candle/_backends/npu/ops/__init__.py
@@ -148,7 +148,7 @@ from .special import (
 )
 
 from .optim import (
-    _adam_step_op, _sgd_step_op,
+    _adam_step_op, _sgd_step_op, _sgd_step_many_op,
     _adagrad_step_op, _rmsprop_step_op, _adadelta_step_op,
     _adamax_step_op, _asgd_step_op, _nadam_step_op,
     _radam_step_op, _rprop_step_op, _sparse_adam_step_op,

--- a/src/candle/_backends/npu/ops/optim.py
+++ b/src/candle/_backends/npu/ops/optim.py
@@ -11,11 +11,17 @@ from .reduce import maximum, minimum
 try:
     from candle._C._npu_ops import (
         fast_adam_step as _fast_adam_step_impl,
+        fast_sgd_step as _fast_sgd_step_impl,
+        fast_sgd_step_many as _fast_sgd_step_many_impl,
     )  # pylint: disable=import-error,no-name-in-module
     _HAS_FAST_ADAM_STEP = True
+    _HAS_FAST_SGD_STEP = True
 except ImportError:
     _fast_adam_step_impl = None  # type: ignore[assignment]
+    _fast_sgd_step_impl = None  # type: ignore[assignment]
+    _fast_sgd_step_many_impl = None  # type: ignore[assignment]
     _HAS_FAST_ADAM_STEP = False
+    _HAS_FAST_SGD_STEP = False
 
 
 def _adam_step_op(param, grad, exp_avg, exp_avg_sq, max_exp_avg_sq,
@@ -40,22 +46,30 @@ def _sgd_step_op(param, grad, buf, lr, momentum, dampening, weight_decay,
     """SGD step as composite of NPU arithmetic ops."""
     g = neg(grad) if maximize else grad
     if weight_decay != 0:
-        wd_t = _scalar_to_npu_tensor(weight_decay, param)
-        g = add(g, mul(wd_t, param))
+        g = add(g, mul(param, weight_decay))
     if momentum != 0:
-        mom_t = _scalar_to_npu_tensor(momentum, buf)
-        damp_t = _scalar_to_npu_tensor(1.0 - dampening, buf)
         # buf = momentum * buf + (1-dampening) * g
-        new_buf = add(mul(mom_t, buf), mul(damp_t, g))
+        new_buf = add(mul(buf, momentum), mul(g, 1.0 - dampening))
         copy_(buf, new_buf)
         if nesterov:
-            g = add(g, mul(mom_t, buf))
+            g = add(g, mul(buf, momentum))
         else:
             g = buf
-    lr_t = _scalar_to_npu_tensor(lr, param)
-    new_param = sub(param, mul(lr_t, g))
-    copy_(param, new_param)
+    if _HAS_FAST_SGD_STEP:
+        return _fast_sgd_step_impl(param, g, float(lr))
+    update = mul(g, lr)
+    copy_(param, sub(param, update))
     return param
+
+
+def _sgd_step_many_op(params, grads, lr):
+    """Batched no-momentum SGD step for NPU parameter groups."""
+    if _fast_sgd_step_many_impl is not None:
+        _fast_sgd_step_many_impl(params, grads, float(lr))
+        return None
+    for param, grad in zip(params, grads):
+        _sgd_step_op(param, grad, None, lr, 0.0, 0.0, 0.0, False, False)
+    return None
 
 
 def _adagrad_step_op(param, grad, state_sum, step, lr, lr_decay,

--- a/src/candle/_dispatch/schemas.py
+++ b/src/candle/_dispatch/schemas.py
@@ -679,6 +679,7 @@ def register_schemas():  # pylint: disable=too-many-statements
 
     # Optimizer step ops (fused per-parameter kernels)
     registry.register_schema("_sgd_step", "_sgd_step(Tensor param, Tensor grad, Any buf, float lr, float momentum, float dampening, float weight_decay, bool nesterov, bool maximize) -> Tensor")
+    registry.register_schema("_sgd_step_many", "_sgd_step_many(Tensor[] params, Tensor[] grads, float lr) -> Any")
     registry.register_schema("_adam_step", "_adam_step(Tensor param, Tensor grad, Tensor exp_avg, Tensor exp_avg_sq, Any max_exp_avg_sq, int step, float lr, float beta1, float beta2, float eps, float weight_decay, bool amsgrad, bool maximize) -> Tensor")
     registry.register_schema("_adamw_step", "_adamw_step(Tensor param, Tensor grad, Tensor exp_avg, Tensor exp_avg_sq, Any max_exp_avg_sq, int step, float lr, float beta1, float beta2, float eps, float weight_decay, bool amsgrad, bool maximize) -> Tensor")
     registry.register_schema("_adagrad_step", "_adagrad_step(Tensor param, Tensor grad, Tensor state_sum, int step, float lr, float lr_decay, float weight_decay, float eps, bool maximize) -> Tensor")

--- a/src/candle/distributed/_composable/fsdp/_fsdp_param.py
+++ b/src/candle/distributed/_composable/fsdp/_fsdp_param.py
@@ -3,6 +3,7 @@ from enum import Enum, auto
 from ....distributed.tensor.dtensor import DTensor
 from ....distributed.tensor.placement import Shard
 from .... import distributed as dist
+from . import _profile
 
 try:
     from ....distributed._fsdp_fastpath import (
@@ -112,7 +113,8 @@ class FSDPParam:
                 device=local_tensor.device,
             )
             pg = self._mesh_info.shard_process_group
-            dist.all_gather_into_tensor(output, local_tensor, group=pg)
+            with _profile.record("fsdp.all_gather"):
+                dist.all_gather_into_tensor(output, local_tensor, group=pg)
             # Strip padding to restore original shape
             if self._padded_dim_size > 0:
                 from ...._functional import narrow
@@ -212,7 +214,8 @@ class FSDPParam:
             *shard_shape, dtype=grad.dtype, device=grad.device
         )
         pg = self._mesh_info.shard_process_group
-        dist.reduce_scatter_tensor(reduced_grad, grad, group=pg)
+        with _profile.record("fsdp.reduce_scatter_collective"):
+            dist.reduce_scatter_tensor(reduced_grad, grad, group=pg)
         # Cast reduced gradient back to param storage dtype for optimizer
         shard_dtype = self._sharded_param.to_local().dtype
         if reduced_grad.dtype != shard_dtype:

--- a/src/candle/distributed/_composable/fsdp/_fsdp_param_group.py
+++ b/src/candle/distributed/_composable/fsdp/_fsdp_param_group.py
@@ -1,5 +1,6 @@
 """FSDPParamGroup -- batched communication for parameter groups."""
 from .... import distributed as dist
+from . import _profile
 
 try:
     from ....distributed._fsdp_fastpath import (
@@ -11,6 +12,18 @@ try:
     _HAVE_FASTPATH = True
 except ImportError:  # pragma: no cover
     _HAVE_FASTPATH = False
+
+
+def _should_use_flat_buffer(world_size, param_count, device):
+    """Return whether flat-buffer unshard is ready for this device."""
+    device_type = getattr(device, "type", None)
+    return world_size > 1 and param_count > 1 and device_type != "npu"
+
+
+def _should_use_flat_reduce_scatter(use_flat_buffer, device):
+    """Return whether flat reduce-scatter is ready for this device."""
+    device_type = getattr(device, "type", None)
+    return use_flat_buffer and device_type != "npu"
 
 
 class FSDPParamGroup:
@@ -29,7 +42,19 @@ class FSDPParamGroup:
         self._is_unsharded = False
 
         world_size = mesh_info.shard_mesh_size
-        self._use_flat_buffer = world_size > 1 and len(fsdp_params) > 1
+        first_device = fsdp_params[0]._sharded_param.to_local().device
+        self._use_flat_buffer = _should_use_flat_buffer(
+            world_size, len(fsdp_params), first_device
+        )
+        # NPU flat reduce-scatter currently requires Python/on-device slice
+        # packing into the rank-strided flat buffer. For Transformer-sized
+        # groups that packing is much slower than issuing per-parameter NPU
+        # reduce-scatter collectives, so keep flat all-gather enabled but use
+        # the generic per-parameter gradient reduction path on NPU until the
+        # flat gradient pack path is implemented as a native device kernel.
+        self._use_flat_reduce_scatter = _should_use_flat_reduce_scatter(
+            self._use_flat_buffer, first_device
+        )
 
         # Build owner map: param_name -> group_index (0 for all params in this
         # single group).  Uses Cython fastpath when available.
@@ -96,20 +121,21 @@ class FSDPParamGroup:
         The fallback slice-assignment path is preserved for environments
         where the extension has not been compiled.
         """
-        if _HAVE_FASTPATH and getattr(self._flat_shard.device, "type", None) == "cpu":
-            shards = [
-                list(fp._sharded_param.to_local().reshape(-1))
-                for fp in self.fsdp_params
-            ]
-            flat_list = list(self._flat_shard)
-            _cy_pack_shards(shards, flat_list, self._shard_offsets)
-            # Write the updated list back into the tensor
-            for i, val in enumerate(flat_list):
-                self._flat_shard[i] = val
-        else:
-            for fp, (start, end) in zip(self.fsdp_params, self._shard_offsets):
-                local = fp._sharded_param.to_local()
-                self._flat_shard[start:end] = local.reshape(-1)
+        with _profile.record("fsdp.flat_pack"):
+            if _HAVE_FASTPATH and getattr(self._flat_shard.device, "type", None) == "cpu":
+                shards = [
+                    list(fp._sharded_param.to_local().reshape(-1))
+                    for fp in self.fsdp_params
+                ]
+                flat_list = list(self._flat_shard)
+                _cy_pack_shards(shards, flat_list, self._shard_offsets)
+                # Write the updated list back into the tensor
+                for i, val in enumerate(flat_list):
+                    self._flat_shard[i] = val
+            else:
+                for fp, (start, end) in zip(self.fsdp_params, self._shard_offsets):
+                    local = fp._sharded_param.to_local()
+                    self._flat_shard[start:end] = local.reshape(-1)
 
     def _copy_flat_to_shard_grads(self, flat_src):
         """Write gradient data from *flat_src* back to each param shard's grad.
@@ -123,29 +149,30 @@ class FSDPParamGroup:
         The fallback slice-reshape path is preserved for environments where
         the extension has not been compiled.
         """
-        if _HAVE_FASTPATH and getattr(flat_src.device, "type", None) == "cpu":
-            from ...._creation import zeros
-            # Convert flat_src tensor to list for the Cython helper
-            flat_list = list(flat_src)
-            # Pre-allocate mutable shard lists
-            shard_lists = [
-                [0.0] * (end - start)
-                for start, end in self._shard_offsets
-            ]
-            _cy_unpack_shards(flat_list, shard_lists, self._shard_offsets)
-            for fp, shard_list, shape in zip(
-                self.fsdp_params, shard_lists, self._shard_shapes
-            ):
-                flat_g = zeros(len(shard_list), dtype=flat_src.dtype,
-                               device=flat_src.device)
-                for i, val in enumerate(shard_list):
-                    flat_g[i] = val
-                fp._sharded_param.to_local().grad = flat_g.reshape(*shape)
-        else:
-            for i, fp in enumerate(self.fsdp_params):
-                start, end = self._shard_offsets[i]
-                shape = self._shard_shapes[i]
-                fp._sharded_param.to_local().grad = flat_src[start:end].reshape(*shape)
+        with _profile.record("fsdp.flat_unpack"):
+            if _HAVE_FASTPATH and getattr(flat_src.device, "type", None) == "cpu":
+                from ...._creation import zeros
+                # Convert flat_src tensor to list for the Cython helper
+                flat_list = list(flat_src)
+                # Pre-allocate mutable shard lists
+                shard_lists = [
+                    [0.0] * (end - start)
+                    for start, end in self._shard_offsets
+                ]
+                _cy_unpack_shards(flat_list, shard_lists, self._shard_offsets)
+                for fp, shard_list, shape in zip(
+                    self.fsdp_params, shard_lists, self._shard_shapes
+                ):
+                    flat_g = zeros(len(shard_list), dtype=flat_src.dtype,
+                                   device=flat_src.device)
+                    for i, val in enumerate(shard_list):
+                        flat_g[i] = val
+                    fp._sharded_param.to_local().grad = flat_g.reshape(*shape)
+            else:
+                for i, fp in enumerate(self.fsdp_params):
+                    start, end = self._shard_offsets[i]
+                    shape = self._shard_shapes[i]
+                    fp._sharded_param.to_local().grad = flat_src[start:end].reshape(*shape)
 
     # ------------------------------------------------------------------
     # Batched shard lifecycle
@@ -155,59 +182,64 @@ class FSDPParamGroup:
         """Unshard all parameters in the group."""
         if self._is_unsharded:
             return
-        if self._use_flat_buffer:
-            self._unshard_flat()
-        else:
-            for p in self.fsdp_params:
-                p.unshard()
+        with _profile.record("fsdp.unshard"):
+            if self._use_flat_buffer:
+                self._unshard_flat()
+            else:
+                for p in self.fsdp_params:
+                    p.unshard()
         self._is_unsharded = True
 
     def _unshard_flat(self):
         """Single all-gather on the flat buffer, then scatter to params."""
         self._copy_shards_to_flat()
         pg = self.mesh_info.shard_process_group
-        dist.all_gather_into_tensor(self._flat_full, self._flat_shard, group=pg)
+        with _profile.record("fsdp.all_gather"):
+            dist.all_gather_into_tensor(self._flat_full, self._flat_shard, group=pg)
 
         # Scatter gathered data back to individual params
         world_size = self.mesh_info.shard_mesh_size
-        for i, fp in enumerate(self.fsdp_params):
-            start, end = self._shard_offsets[i]
-            numel = end - start
-            # Reconstruct full param: gather chunks from each rank's region
-            chunks = []
-            for rank in range(world_size):
-                rank_offset = rank * self._total_shard_numel
-                chunk = self._flat_full[rank_offset + start:rank_offset + end]
-                chunks.append(chunk)
-            from ...._functional import cat, narrow
-            full_flat = cat(chunks, dim=0)
-            # Reshape to full param shape
-            full_shape = list(fp._orig_shape)
-            full_param = full_flat.reshape(*full_shape)
-            # Strip padding if needed
-            if fp._padded_dim_size > 0:
-                orig_dim = fp._orig_shape[fp._shard_dim]
-                full_param = narrow(full_param, fp._shard_dim, 0, orig_dim)
-            full_param.requires_grad = fp._sharded_param.requires_grad
-            fp._unsharded_param = full_param
-            fp._set_param_on_module(full_param)
-            fp._sharded_state = fp._sharded_state.__class__.UNSHARDED
+        with _profile.record("fsdp.unshard_reconstruct"):
+            for i, fp in enumerate(self.fsdp_params):
+                start, end = self._shard_offsets[i]
+                numel = end - start
+                # Reconstruct full param: gather chunks from each rank's region
+                chunks = []
+                for rank in range(world_size):
+                    rank_offset = rank * self._total_shard_numel
+                    chunk = self._flat_full[rank_offset + start:rank_offset + end]
+                    chunks.append(chunk)
+                from ...._functional import cat, narrow
+                full_flat = cat(chunks, dim=0)
+                # Reshape to full param shape
+                full_shape = list(fp._orig_shape)
+                full_param = full_flat.reshape(*full_shape)
+                # Strip padding if needed
+                if fp._padded_dim_size > 0:
+                    orig_dim = fp._orig_shape[fp._shard_dim]
+                    full_param = narrow(full_param, fp._shard_dim, 0, orig_dim)
+                full_param.requires_grad = fp._sharded_param.requires_grad
+                fp._unsharded_param = full_param
+                fp._set_param_on_module(full_param)
+                fp._sharded_state = fp._sharded_state.__class__.UNSHARDED
 
     def reshard(self):
         """Reshard all parameters in the group."""
         if not self._is_unsharded:
             return
-        for p in self.fsdp_params:
-            p.reshard()
+        with _profile.record("fsdp.reshard"):
+            for p in self.fsdp_params:
+                p.reshard()
         self._is_unsharded = False
 
     def reduce_scatter_grads(self):
         """Reduce-scatter gradients for all parameters in the group."""
-        if self._use_flat_buffer:
-            self._reduce_scatter_flat()
-        else:
-            for p in self.fsdp_params:
-                p.reduce_scatter_grad()
+        with _profile.record("fsdp.grad_reduce_scatter"):
+            if self._use_flat_reduce_scatter:
+                self._reduce_scatter_flat()
+            else:
+                for p in self.fsdp_params:
+                    p.reduce_scatter_grad()
 
     def _reduce_scatter_flat(self):
         """Single reduce-scatter on flat gradient buffer."""
@@ -248,7 +280,8 @@ class FSDPParamGroup:
             dtype=self._flat_shard.dtype,
             device=self._flat_shard.device,
         )
-        dist.reduce_scatter_tensor(reduced_flat, self._flat_full, group=pg)
+        with _profile.record("fsdp.flat_reduce_scatter_collective"):
+            dist.reduce_scatter_tensor(reduced_flat, self._flat_full, group=pg)
 
         # Scatter reduced shards back to params via Cython unpack or fallback
         self._copy_flat_to_shard_grads(reduced_flat)

--- a/src/candle/distributed/_composable/fsdp/_fsdp_state.py
+++ b/src/candle/distributed/_composable/fsdp/_fsdp_state.py
@@ -1,5 +1,6 @@
 """FSDPState -- hook orchestration for FSDP2."""
 from ....distributed.tensor.dtensor import DTensor
+from . import _profile
 
 try:
     from ....distributed._fsdp_fastpath import (
@@ -51,15 +52,18 @@ class FSDPState:
             self._lazy_init_root()
         # Clear stale backward hook handles from previous iteration
         self._pre_backward_hook_handles.clear()
-        self.param_group.pre_forward()
+        with _profile.record("fsdp.pre_forward"):
+            self.param_group.pre_forward()
         return args, kwargs
 
     def _post_forward(self, module, args, output):
         """Post-forward: register backward hooks + reshard + output cast."""
-        self._register_pre_backward_hooks(output)
-        self._register_post_backward_hooks()
+        with _profile.record("fsdp.hook_setup"):
+            self._register_pre_backward_hooks(output)
+            self._register_post_backward_hooks()
         if self.reshard_after_forward:
-            self.param_group.post_forward()
+            with _profile.record("fsdp.post_forward_reshard"):
+                self.param_group.post_forward()
         # Mixed precision: cast output to output_dtype
         if (self._mp_policy is not None
                 and self._mp_policy.output_dtype is not None):
@@ -132,7 +136,10 @@ class FSDPState:
         """Reduce-scatter captured gradients and reshard."""
         if self._sync_gradients:
             for fsdp_param, grad in self._pending_grads.values():
-                fsdp_param.reduce_scatter_grad(grad)
+                unsharded = fsdp_param._unsharded_param
+                if unsharded is not None:
+                    unsharded.grad = grad
+            self.param_group.reduce_scatter_grads()
         else:
             # no_sync mode: accumulate grads on unsharded params directly
             for fsdp_param, grad in self._pending_grads.values():

--- a/src/candle/distributed/_composable/fsdp/_profile.py
+++ b/src/candle/distributed/_composable/fsdp/_profile.py
@@ -1,0 +1,53 @@
+"""Lightweight FSDP phase profiling helpers.
+
+The profiler is intentionally opt-in and records host wall-clock time around
+existing FSDP phases. It does not change collective semantics or tensor device
+placement.
+"""
+import time
+from contextlib import contextmanager
+
+_ENABLED = False
+_EVENTS = {}
+
+
+def reset(enabled=False):
+    """Enable/disable profiling and clear accumulated events."""
+    global _ENABLED, _EVENTS
+    _ENABLED = bool(enabled)
+    _EVENTS = {}
+
+
+def enabled():
+    """Return whether FSDP phase profiling is active."""
+    return _ENABLED
+
+
+@contextmanager
+def record(name):
+    """Record elapsed host time for one named FSDP phase when enabled."""
+    if not _ENABLED:
+        yield
+        return
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+        event = _EVENTS.setdefault(name, {"count": 0, "total_ms": 0.0})
+        event["count"] += 1
+        event["total_ms"] += elapsed_ms
+
+
+def summary():
+    """Return a JSON-serializable summary of recorded FSDP phase timings."""
+    result = {}
+    for name, event in sorted(_EVENTS.items()):
+        count = event["count"]
+        total_ms = event["total_ms"]
+        result[name] = {
+            "count": count,
+            "total_ms": total_ms,
+            "avg_ms": total_ms / count if count else 0.0,
+        }
+    return result

--- a/src/candle/distributed/tensor/dtensor.py
+++ b/src/candle/distributed/tensor/dtensor.py
@@ -290,7 +290,7 @@ class DTensor(Tensor):
 
     # Optimizer step ops that should operate directly on local shards
     _SHARD_PASSTHROUGH_OPS = frozenset({
-        "_sgd_step", "_adam_step", "_adamw_step",
+        "_sgd_step", "_sgd_step_many", "_adam_step", "_adamw_step",
     })
 
     @classmethod

--- a/src/candle/optim/sgd.py
+++ b/src/candle/optim/sgd.py
@@ -84,10 +84,21 @@ class SGD(Optimizer):
             lr = group["lr"]
             maximize = group["maximize"]
 
-            for p in group["params"]:
-                if p.grad is None:
-                    continue
+            active_params = [p for p in group["params"] if p.grad is not None]
+            if (
+                    active_params
+                    and momentum == 0
+                    and weight_decay == 0
+                    and not nesterov
+                    and not maximize
+                    and _all_same_device(active_params, "npu")):
+                dispatch(
+                    "_sgd_step_many", None,
+                    active_params, [p.grad for p in active_params], lr,
+                )
+                continue
 
+            for p in active_params:
                 param_id = id(p)
 
                 if momentum != 0:
@@ -108,3 +119,19 @@ class SGD(Optimizer):
 
         self._call_step_post_hooks()
         return loss
+
+
+def _all_same_device(params, device_type):
+    if not params:
+        return False
+    first_device = params[0].device
+    if getattr(first_device, "type", None) != device_type:
+        return False
+    first_index = getattr(first_device, "index", None)
+    for param in params[1:]:
+        device = param.device
+        if getattr(device, "type", None) != device_type:
+            return False
+        if getattr(device, "index", None) != first_index:
+            return False
+    return True

--- a/tests/contract/test_autograd_audit_inventory.py
+++ b/tests/contract/test_autograd_audit_inventory.py
@@ -24,6 +24,7 @@ OPTIMIZER_STEP_OPS = {
     "_rmsprop_step",
     "_rprop_step",
     "_sgd_step",
+    "_sgd_step_many",
     "_sparse_adam_step",
 }
 
@@ -257,7 +258,7 @@ def test_schema_ops_without_autograd_registration_are_categorized():
     actual_missing = _schema_ops() - _autograd_registered_ops()
     assert sorted(actual_missing - expected_missing) == []
     assert sorted(expected_missing - actual_missing) == []
-    assert len(actual_missing) == 119
+    assert len(actual_missing) == 120
 
 
 def test_derivatives_not_implemented_inventory_is_classified():

--- a/tests/contract/test_mechanism_audit_pr1.py
+++ b/tests/contract/test_mechanism_audit_pr1.py
@@ -175,11 +175,11 @@ def test_npu_forward_ops_autograd_coverage_categorization_snapshot():
     assert (generated_only & both) == set()
     assert (handwritten_only & both) == set()
 
-    assert len(forward) == 461
+    assert len(forward) == 462
     assert len(generated_only) == 246
     assert len(handwritten_only) == 34
     assert len(both) == 55
-    assert len(missing) == 126
+    assert len(missing) == 127
 
 
 # ---------------------------------------------------------------------------

--- a/tests/contract/test_npu_mechanism_audit.py
+++ b/tests/contract/test_npu_mechanism_audit.py
@@ -1716,6 +1716,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
         "_rmsprop_step",
         "_rprop_step",
         "_sgd_step",
+        "_sgd_step_many",
         "_sparse_adam_step",
         "abs_",
         "acos_",
@@ -1834,7 +1835,7 @@ def test_npu_forward_autograd_registration_inventory_is_explicit():
     }
 
     assert missing_autograd == expected_missing
-    assert len(forward_ops) == 461
+    assert len(forward_ops) == 462
     assert len(autograd_ops & forward_ops) == 335
 
 

--- a/tests/cpu/test_dtensor.py
+++ b/tests/cpu/test_dtensor.py
@@ -78,3 +78,33 @@ def test_dtensor_sharded_blocks_compute():
         assert False, "Should have raised RuntimeError"
     except RuntimeError as e:
         assert "sharded" in str(e).lower() or "not supported" in str(e).lower()
+
+
+def test_dtensor_sgd_step_many_passthrough_unwraps_local_shards():
+    """Batched optimizer steps should operate on local shards like _sgd_step."""
+    from candle._dispatch.dispatcher import dispatch
+    from candle._dispatch.registry import registry
+
+    local_param = torch.ones(4)
+    local_grad = torch.ones(4)
+    spec = _make_spec((Shard(0),), global_shape=(8,))
+    dt = DTensor(local_param, spec)
+    captured = {}
+
+    def kernel(params, grads, lr):
+        captured["params"] = params
+        captured["grads"] = grads
+        captured["lr"] = lr
+        return None
+
+    snapshot = registry.snapshot()
+    try:
+        registry.register("_sgd_step_many", "cpu", kernel)
+        dispatch("_sgd_step_many", None, [dt], [local_grad], 0.1)
+    finally:
+        registry.restore(snapshot)
+
+    assert captured["params"] == [local_param]
+    assert captured["grads"] == [local_grad]
+    assert captured["lr"] == 0.1
+    assert not isinstance(captured["params"][0], DTensor)

--- a/tests/cpu/test_perf_fsdp2_transformer_benchmark.py
+++ b/tests/cpu/test_perf_fsdp2_transformer_benchmark.py
@@ -1,0 +1,269 @@
+"""Static/unit tests for the two-card FSDP2 Transformer benchmark."""
+
+import inspect
+import json
+import sys
+from types import SimpleNamespace
+
+import benchmarks.perf_fsdp2_transformer_candle_vs_torch_npu as _bench_mod
+
+
+def test_transformer_fsdp2_cases_are_registered():
+    assert "xfmr_fsdp2_small" in _bench_mod.CASES
+    assert "xfmr_fsdp2_medium" in _bench_mod.CASES
+
+    small = _bench_mod.CASES["xfmr_fsdp2_small"]
+    assert small.layers >= 1
+    assert small.batch_per_rank == 2
+    assert small.seq == 128
+    assert small.hidden == 512
+    assert small.heads == 8
+
+    medium = _bench_mod.CASES["xfmr_fsdp2_medium"]
+    assert medium.layers >= small.layers
+    assert medium.seq >= small.seq
+    assert medium.hidden >= small.hidden
+
+
+def test_transformer_model_uses_mha_sdpa_path():
+    source = inspect.getsource(_bench_mod._build_transformer_model)
+
+    assert "MultiheadAttention" in source
+    assert "batch_first=True" in source
+    assert "dropout=0.0" in source
+    assert "need_weights=False" in source
+    assert "functional.gelu" in source
+
+
+def test_candle_worker_uses_composable_fsdp_and_valid_mesh():
+    source = inspect.getsource(_bench_mod._run_candle_worker)
+
+    assert "from candle.distributed._composable.fsdp import fully_shard" in source
+    assert "from candle.distributed.device_mesh import DeviceMesh" in source
+    assert 'DeviceMesh("npu", (world_size,))' in source
+    assert "list(range(world_size))" not in source
+
+
+def test_torch_npu_worker_uses_torch_fsdp2_and_device_mesh():
+    source = inspect.getsource(_bench_mod._run_torch_npu_worker)
+
+    assert "import torch_npu" in source
+    assert "from torch.distributed._composable.fsdp import fully_shard" in source
+    assert "from torch.distributed.device_mesh import init_device_mesh" in source
+    assert 'init_device_mesh("npu", (world_size,))' in source
+    assert "torch.npu.set_device" in source
+
+
+def test_torch_npu_launch_uses_configured_python_distributed_run():
+    cmd = _bench_mod._torch_npu_launch_command(
+        "/path/to/python",
+        "/repo/bench.py",
+        world_size=2,
+        worker_args=["--worker", "--framework", "torch_npu"],
+    )
+
+    assert cmd[:3] == ["/path/to/python", "-m", "torch.distributed.run"]
+    assert "--standalone" in cmd
+    assert "--nproc_per_node=2" in cmd
+    assert "/repo/bench.py" in cmd
+    assert cmd[-3:] == ["--worker", "--framework", "torch_npu"]
+
+
+def test_profile_candle_flag_is_forwarded_to_candle_workers_only():
+    args = SimpleNamespace(
+        iters=1,
+        warmup=0,
+        dtype="float16",
+        lr=0.001,
+        seed=123,
+        profile_candle=True,
+    )
+
+    candle_args = _bench_mod._base_worker_args(args, "candle", "xfmr_fsdp2_small", "/tmp/out")
+    torch_args = _bench_mod._base_worker_args(args, "torch_npu", "xfmr_fsdp2_small", "/tmp/out")
+
+    assert "--profile-candle" in candle_args
+    assert "--profile-candle" not in torch_args
+
+
+def test_aggregate_results_include_fsdp2_metrics_and_ratios():
+    candle = _bench_mod._aggregate_rank_results(
+        "candle",
+        "xfmr_fsdp2_small",
+        [
+            {
+                "rank": 0,
+                "world_size": 2,
+                "batch_per_rank": 2,
+                "global_batch": 4,
+                "fwd_ms_samples": [2.0, 2.0],
+                "bwd_ms_samples": [3.0, 3.0],
+                "optim_ms_samples": [1.0, 1.0],
+                "total_ms_samples": [6.0, 6.0],
+            },
+            {
+                "rank": 1,
+                "world_size": 2,
+                "batch_per_rank": 2,
+                "global_batch": 4,
+                "fwd_ms_samples": [2.5, 2.5],
+                "bwd_ms_samples": [3.5, 3.5],
+                "optim_ms_samples": [1.0, 1.0],
+                "total_ms_samples": [7.0, 7.0],
+            },
+        ],
+    )
+    torch_ref = dict(candle)
+    torch_ref.update(
+        framework="torch_npu",
+        fwd_ms_median=5.0,
+        bwd_ms_median=7.0,
+        optim_ms_median=2.0,
+        total_ms_median=14.0,
+        samples_per_second=4.0 / 0.014,
+    )
+
+    _bench_mod._annotate_ratios([candle, torch_ref])
+
+    assert candle["fwd_ms_median"] == 2.5
+    assert candle["bwd_ms_median"] == 3.5
+    assert candle["optim_ms_median"] == 1.0
+    assert candle["total_ms_median"] == 7.0
+    assert candle["samples_per_second"] == 4.0 / 0.007
+    assert candle["fwd_ratio"] == 0.5
+    assert candle["bwd_ratio"] == 0.5
+    assert candle["optim_ratio"] == 0.5
+    assert candle["total_ratio"] == 0.5
+    assert candle["throughput_ratio"] == 2.0
+
+
+def test_fsdp_post_backward_uses_grouped_reduce_scatter_path():
+    source = _bench_mod.Path(_bench_mod._REPO_ROOT).joinpath(
+        "src/candle/distributed/_composable/fsdp/_fsdp_state.py"
+    ).read_text(encoding="utf-8")
+    body = source.split("def _post_backward_all", 1)[1].split("def _lazy_init_root", 1)[0]
+
+    assert "param_group.reduce_scatter_grads()" in body
+    assert "fsdp_param.reduce_scatter_grad(grad)" not in body
+
+
+def test_aggregate_results_preserves_candle_profile_summary():
+    result = _bench_mod._aggregate_rank_results(
+        "candle",
+        "xfmr_fsdp2_small",
+        [
+            {
+                "rank": 0,
+                "world_size": 2,
+                "batch_per_rank": 2,
+                "global_batch": 4,
+                "fwd_ms_samples": [2.0],
+                "bwd_ms_samples": [3.0],
+                "optim_ms_samples": [1.0],
+                "total_ms_samples": [6.0],
+                "profile": {"fsdp.unshard": {"count": 2, "total_ms": 4.0}},
+            },
+            {
+                "rank": 1,
+                "world_size": 2,
+                "batch_per_rank": 2,
+                "global_batch": 4,
+                "fwd_ms_samples": [2.5],
+                "bwd_ms_samples": [3.5],
+                "optim_ms_samples": [1.0],
+                "total_ms_samples": [7.0],
+                "profile": {"fsdp.unshard": {"count": 2, "total_ms": 6.0}},
+            },
+        ],
+    )
+
+    assert result["profile"]["fsdp.unshard"]["count_max"] == 2
+    assert result["profile"]["fsdp.unshard"]["total_ms_max"] == 6.0
+    assert result["profile"]["fsdp.unshard"]["total_ms_by_rank"] == [4.0, 6.0]
+
+
+def test_npu_flat_unshard_stays_disabled_until_native_pack_exists():
+    from candle.distributed._composable.fsdp._fsdp_param_group import (
+        _should_use_flat_buffer,
+    )
+
+    class Device:
+        def __init__(self, device_type):
+            self.type = device_type
+
+    assert not _should_use_flat_buffer(2, 2, Device("npu"))
+    assert _should_use_flat_buffer(2, 2, Device("cpu"))
+    assert not _should_use_flat_buffer(1, 2, Device("cpu"))
+    assert not _should_use_flat_buffer(2, 1, Device("cpu"))
+
+
+def test_npu_flat_reduce_scatter_stays_disabled_until_native_pack_exists():
+    from candle.distributed._composable.fsdp._fsdp_param_group import (
+        _should_use_flat_reduce_scatter,
+    )
+
+    class Device:
+        def __init__(self, device_type):
+            self.type = device_type
+
+    assert not _should_use_flat_reduce_scatter(True, Device("npu"))
+    assert _should_use_flat_reduce_scatter(True, Device("cpu"))
+    assert not _should_use_flat_reduce_scatter(False, Device("npu"))
+
+
+def test_npu_sgd_step_uses_scalar_lr_without_full_tensor_fill():
+    source = _bench_mod.Path(_bench_mod._REPO_ROOT).joinpath(
+        "src/candle/_backends/npu/ops/optim.py"
+    ).read_text(encoding="utf-8")
+    body = source.split("def _sgd_step_op", 1)[1].split("def _adagrad_step_op", 1)[0]
+
+    assert "fast_sgd_step" in body
+    assert "_scalar_to_npu_tensor(lr, param)" not in body
+
+
+def test_main_json_stdout_payload_has_expected_fields(capsys, monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "perf_fsdp2_transformer_candle_vs_torch_npu.py",
+            "--cases",
+            "xfmr_fsdp2_small",
+            "--iters",
+            "1",
+            "--warmup",
+            "0",
+            "--world-size",
+            "2",
+            "--json-output",
+            "-",
+        ],
+    )
+
+    def fake_spawn(framework, case, args):
+        del args
+        return {
+            "framework": framework,
+            "case": case,
+            "world_size": 2,
+            "global_batch": 4,
+            "batch_per_rank": 2,
+            "fwd_ms_median": 1.0,
+            "bwd_ms_median": 2.0,
+            "optim_ms_median": 0.5,
+            "total_ms_median": 3.5,
+            "samples_per_second": 4.0 / 0.0035,
+        }
+
+    monkeypatch.setattr(_bench_mod, "_spawn_framework", fake_spawn)
+
+    _bench_mod.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["cases"] == ["xfmr_fsdp2_small"]
+    assert payload["world_size"] == 2
+    assert payload["iters"] == 1
+    assert payload["warmup"] == 0
+    assert payload["results"][0]["framework"] == "candle"
+    assert payload["results"][0]["batch_per_rank"] == 2
+    assert "samples_per_second" in payload["results"][0]

--- a/tests/distributed/test_fsdp_npu_integration.py
+++ b/tests/distributed/test_fsdp_npu_integration.py
@@ -174,7 +174,7 @@ try:
     torch.manual_seed(42)
     model = nn.Linear(16, 8).to(device)
 
-    mesh = DeviceMesh("npu", list(range(world_size)))
+    mesh = DeviceMesh("npu", (world_size,))
     fully_shard(model, mesh=mesh)
 
     opt = torch.optim.SGD(model.parameters(), lr=0.01)
@@ -240,7 +240,7 @@ try:
 
     torch.manual_seed(42)
     model = nn.Linear(8, 4).to(device)
-    mesh = DeviceMesh("npu", list(range(world_size)))
+    mesh = DeviceMesh("npu", (world_size,))
     fully_shard(model, mesh=mesh)
 
     local_w = (
@@ -312,7 +312,7 @@ try:
 
     torch.manual_seed(42)
     model = nn.Linear(8, 4).to(device)
-    mesh = DeviceMesh("npu", list(range(world_size)))
+    mesh = DeviceMesh("npu", (world_size,))
     fully_shard(model, mesh=mesh)
 
     # Record sharded weight shape before summoning
@@ -387,7 +387,7 @@ try:
 
     torch.manual_seed(42)
     model = nn.Linear(8, 4).to(device)
-    mesh = DeviceMesh("npu", list(range(world_size)))
+    mesh = DeviceMesh("npu", (world_size,))
     # reshard_after_forward=False: keep full params between fwd and bwd
     fully_shard(model, mesh=mesh, reshard_after_forward=False)
 


### PR DESCRIPTION
## Summary
- Add a two-card FSDP2 Transformer benchmark comparing Candle against torch_npu
- Add opt-in FSDP phase profiling to identify unshard/reduce-scatter bottlenecks
- Optimize NPU SGD with scalar alpha updates and a batched no-momentum parameter-group path
- Guard NPU flat-buffer FSDP paths until native pack/reconstruct kernels exist, using the faster generic per-parameter NPU path
- Fix FSDP NPU mesh construction in integration tests and update audit inventories for the new internal optimizer op

## Performance
- small Transformer: Candle 29.25ms vs torch_npu 33.80ms total step time (0.87x)
- medium Transformer: Candle 115.57ms vs torch_npu 123.89ms total step time (0.93x)

## Validation
- CPU + contract: 3522 passed, 30 skipped
- NPU + distributed: 530 passed, 29 skipped
- pylint: 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)