### PR TITLE
Optimize NPU biasless linear eager path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ required_extensions = [
 # Cross-platform extensions (Linux + macOS)
 # ---------------------------------------------------------------------------
 _system = platform.system()
+_has_npu_cython = _system == "Linux"
 cross_platform_extensions = []
 if _system in ("Linux", "Darwin"):
     cross_platform_extensions = [
@@ -225,6 +226,7 @@ ext_modules = cythonize(
         "boundscheck": False,
         "wraparound": False,
     },
+    compile_time_env={"HAS_NPU_CYTHON": _has_npu_cython},
     nthreads=os.cpu_count() or 1,
 )
 

--- a/src/candle/_C/_autograd_engine.pyx
+++ b/src/candle/_C/_autograd_engine.pyx
@@ -10,7 +10,8 @@ import warnings
 import weakref
 
 from candle.autograd.grad_mode import no_grad
-from candle._C._npu_ops cimport fast_add as _cy_fast_npu_add
+IF HAS_NPU_CYTHON:
+    from candle._C._npu_ops cimport fast_add as _cy_fast_npu_add
 
 
 cdef dict _implicit_scalar_grad_cache = {}
@@ -25,8 +26,15 @@ cdef inline void _ensure_dispatch_ref():
         _dispatch_fn = dispatch
 
 
+cdef object _non_npu_zero_stride_contiguous(object grad):
+    return None
+
+
 cdef inline void _ensure_npu_zero_stride_contiguous_ref():
     global _npu_zero_stride_contiguous_fn
+    IF not HAS_NPU_CYTHON:
+        _npu_zero_stride_contiguous_fn = _non_npu_zero_stride_contiguous
+        return
     if _npu_zero_stride_contiguous_fn is None:
         from candle._C._npu_ops import fast_zero_stride_contiguous
         _npu_zero_stride_contiguous_fn = fast_zero_stride_contiguous
@@ -39,12 +47,13 @@ cdef inline object _merge_backward_grads(object lhs, object rhs, bint create_gra
         and getattr(getattr(lhs, "device", None), "type", None) == "npu"
         and getattr(getattr(rhs, "device", None), "type", None) == "npu"
     ):
-        try:
-            result = _cy_fast_npu_add(lhs, rhs)
-        except (RuntimeError, TypeError, ValueError):
-            result = None
-        if result is not None:
-            return _mark_fresh_npu_owned_backward_grad(result)
+        IF HAS_NPU_CYTHON:
+            try:
+                result = _cy_fast_npu_add(lhs, rhs)
+            except (RuntimeError, TypeError, ValueError):
+                result = None
+            if result is not None:
+                return _mark_fresh_npu_owned_backward_grad(result)
     from candle._functional import add
     result = add(lhs, rhs)
     if not create_graph:

--- a/src/candle/_C/_functional_ops.pyx
+++ b/src/candle/_C/_functional_ops.pyx
@@ -430,6 +430,42 @@ cdef inline int _exact_npu_linear_hot_state(object input, object weight, object 
     return 2
 
 
+cdef inline int _exact_npu_linear_no_bias_hot_state(object input, object weight):
+    """Return 1 for inference, 2 for autograd, 0 for fallback."""
+    cdef bint grad_on
+    cdef bint requires_grad
+    cdef TensorImpl inp
+    cdef TensorImpl w
+    _ensure_base()
+    if not (isinstance(input, _BaseTensor) and isinstance(weight, _BaseTensor)):
+        return 0
+    if _check_value(input) or _check_value(weight):
+        return 0
+    inp = <TensorImpl>input
+    w = <TensorImpl>weight
+    if inp._device_type != 1 or w._device_type != 1:
+        return 0
+    if _functionalize_active_flag or _pipeline_active_flag or _npu_autocast_active_flag:
+        return 0
+    if inp._ndim < 2 or w._ndim != 2:
+        return 0
+    if inp._c_shape[inp._ndim - 1] != w._c_shape[1]:
+        return 0
+    if inp._device_index != w._device_index:
+        return 0
+    if inp._dtype_code != w._dtype_code:
+        return 0
+    if not _tensor_has_strict_contiguous_stride(inp):
+        return 0
+    grad_on = _grad_enabled_fast()
+    requires_grad = inp.requires_grad or w.requires_grad
+    if not grad_on or not requires_grad:
+        return 1
+    if _npu_profiler_active_flag:
+        return 0
+    return 2
+
+
 cdef inline int _exact_npu_layer_norm_hot_state(object input, object weight, object bias, object normalized_shape):
     """Return 1 for inference, 2 for autograd, 0 for fallback."""
     cdef bint grad_on
@@ -1581,6 +1617,193 @@ cdef class _NpuLinearBackward(_CyAutogradNode):
         return grad_input, grad_weight, grad_bias
 
 
+cdef class _NpuLinearNoBiasBackward(_CyAutogradNode):
+    cdef public object _input
+    cdef public object _weight
+    cdef public object _input_shape
+    cdef int64_t _saved_input_version
+    cdef int64_t _saved_weight_version
+    cdef bint _saved_input_released
+    cdef bint _saved_weight_released
+    cdef object _saved_input_obj
+    cdef object _saved_weight_obj
+
+    cdef void _init_fast(self, object input_, object weight):
+        cdef object saved_input
+        cdef object saved_weight
+        self.inputs = (input_, weight)
+        self._hooks = None
+        self._prehooks = None
+        self._metadata = None
+        self._name = "LinearBackward0"
+        self._anomaly_trace = None
+        self._anomaly_parent = None
+        self._next_functions_cache = (_npu_edge_for(<TensorImpl>input_), _npu_edge_for(<TensorImpl>weight))
+        self._input = input_
+        self._weight = weight
+        self._input_shape = (<TensorImpl>input_)._shape_tuple
+        self._saved_input_released = False
+        self._saved_weight_released = False
+        if _npu_has_saved_hooks():
+            saved_input = SavedTensor(input_)
+            saved_weight = SavedTensor(weight)
+            self._saved_input_obj = saved_input
+            self._saved_weight_obj = saved_weight
+            self._saved_input_version = 0
+            self._saved_weight_version = 0
+        else:
+            self._saved_input_obj = None
+            self._saved_weight_obj = None
+            self._saved_input_version = (<TensorImpl>input_)._version_value
+            self._saved_weight_version = (<TensorImpl>weight)._version_value
+        self._saved_tensors_list = _npu_empty_saved_tensors
+        self._saved_fields = _npu_empty_saved_fields
+
+    def __init__(self, input_, weight):
+        self._init_fast(input_, weight)
+
+    cpdef tuple _engine_next_functions(self):
+        return self._next_functions_cache
+
+    @property
+    def next_functions(self):
+        cached = _npu_materialize_leaf_edges(self.inputs, self._next_functions_cache)
+        self._next_functions_cache = cached
+        return cached
+
+    cpdef object _saved_proxy_tensor_py(self, int slot):
+        if slot == 0:
+            return self._input
+        return self._weight
+
+    cpdef bint _saved_proxy_released_py(self, int slot):
+        if slot == 0:
+            return self._saved_input_released
+        return self._saved_weight_released
+
+    cpdef void _saved_proxy_release_py(self, int slot):
+        if slot == 0:
+            self._saved_input_released = True
+        else:
+            self._saved_weight_released = True
+
+    cpdef object _saved_proxy_materialize_py(self, int slot):
+        if slot == 0:
+            return _npu_materialize_tensor_version(self._input, self._saved_input_version, self._saved_input_released)
+        return _npu_materialize_tensor_version(self._weight, self._saved_weight_version, self._saved_weight_released)
+
+    cdef object _raw_saved_input_proxy(self):
+        if self._saved_input_obj is None:
+            self._saved_input_obj = _npu_saved_tensor_proxy(self, 0)
+        return self._saved_input_obj
+
+    cdef object _raw_saved_weight_proxy(self):
+        if self._saved_weight_obj is None:
+            self._saved_weight_obj = _npu_saved_tensor_proxy(self, 1)
+        return self._saved_weight_obj
+
+    def saved_tensors(self):
+        cdef object input_saved
+        cdef object weight_saved
+        if self._saved_input_obj is not None:
+            input_saved = self._saved_input_obj.materialize()
+        else:
+            input_saved = self._saved_proxy_materialize_py(0)
+        if self._saved_weight_obj is not None:
+            weight_saved = self._saved_weight_obj.materialize()
+        else:
+            weight_saved = self._saved_proxy_materialize_py(1)
+        return (input_saved, weight_saved)
+
+    def release_saved_tensors(self):
+        if self._saved_input_obj is not None:
+            self._saved_input_obj.release()
+        else:
+            self._saved_input_released = True
+        if self._saved_weight_obj is not None:
+            self._saved_weight_obj.release()
+        else:
+            self._saved_weight_released = True
+
+    def __getattr__(self, name):
+        if name == "_raw_saved_input":
+            return self._raw_saved_input_proxy()
+        if name == "_raw_saved_weight":
+            return self._raw_saved_weight_proxy()
+        if name == "_saved_input":
+            if self._saved_input_obj is not None:
+                return self._saved_input_obj.materialize()
+            return self._saved_proxy_materialize_py(0)
+        if name == "_saved_weight":
+            if self._saved_weight_obj is not None:
+                return self._saved_weight_obj.materialize()
+            return self._saved_proxy_materialize_py(1)
+        if name == "_raw_saved_tensors":
+            return (self._raw_saved_input_proxy(), self._raw_saved_weight_proxy())
+        if name == "_saved_tensors":
+            return self.saved_tensors()
+        return _CyAutogradNode.__getattr__(self, name)
+
+    def backward(self, grad):
+        cdef object input_
+        cdef object weight
+        cdef object grad_input = None
+        cdef object grad_weight = None
+        cdef object grad_2d
+        cdef object input_2d
+        cdef object flat_shape
+        cdef object grad_input_shape
+        cdef object grad_t
+        if self._saved_input_obj is not None:
+            input_ = self._saved_input_obj.materialize()
+        else:
+            input_ = self._saved_proxy_materialize_py(0)
+        if self._saved_weight_obj is not None:
+            weight = self._saved_weight_obj.materialize()
+        else:
+            weight = self._saved_proxy_materialize_py(1)
+        _ensure_npu_refs()
+        _ensure_npu_autograd_refs()
+        if _npu_create_graph_fn():
+            _ensure_dispatch()
+            if getattr(input_, "requires_grad", False):
+                grad_input = _dispatch_fn("matmul", None, grad, weight)
+            if (<TensorImpl>grad)._ndim == 2:
+                grad_2d = grad
+                input_2d = input_
+            else:
+                flat_shape = ((<TensorImpl>grad)._c_numel // (<TensorImpl>grad)._c_shape[(<TensorImpl>grad)._ndim - 1], (<TensorImpl>grad)._c_shape[(<TensorImpl>grad)._ndim - 1])
+                grad_2d = _dispatch_fn("reshape", None, grad, flat_shape)
+                input_2d = _dispatch_fn("reshape", None, input_, ((<TensorImpl>input_)._c_numel // (<TensorImpl>input_)._c_shape[(<TensorImpl>input_)._ndim - 1], (<TensorImpl>input_)._c_shape[(<TensorImpl>input_)._ndim - 1]))
+            if getattr(weight, "requires_grad", False):
+                grad_t = _dispatch_fn("transpose", None, grad_2d, 0, 1)
+                grad_weight = _dispatch_fn("matmul", None, grad_t, input_2d)
+            return grad_input, grad_weight
+        if (<TensorImpl>grad)._ndim == 2:
+            grad_2d = grad
+            input_2d = input_
+            grad_input_shape = self._input_shape
+        else:
+            flat_shape = ((<TensorImpl>grad)._c_numel // (<TensorImpl>grad)._c_shape[(<TensorImpl>grad)._ndim - 1], (<TensorImpl>grad)._c_shape[(<TensorImpl>grad)._ndim - 1])
+            if grad.is_contiguous():
+                grad_2d = (<TensorImpl>grad).cy_view(flat_shape)
+            elif _tensor_has_all_zero_stride(<TensorImpl>grad):
+                grad_2d = (<TensorImpl>grad).cy_as_strided(flat_shape, (0, 0), (<TensorImpl>grad)._c_offset)
+            else:
+                _ensure_dispatch()
+                grad_2d = _dispatch_fn("reshape", None, grad, flat_shape)
+            input_2d = (<TensorImpl>input_).cy_view(((<TensorImpl>input_)._c_numel // (<TensorImpl>input_)._c_shape[(<TensorImpl>input_)._ndim - 1], (<TensorImpl>input_)._c_shape[(<TensorImpl>input_)._ndim - 1]))
+            grad_input_shape = self._input_shape
+        if getattr(input_, "requires_grad", False):
+            grad_input = _cy_fast_npu_matmul(grad_2d, weight)
+            if (<TensorImpl>grad_input)._shape_tuple != grad_input_shape:
+                grad_input = (<TensorImpl>grad_input).cy_view(grad_input_shape)
+            grad_input = _mark_npu_owned_backward_grad(grad_input)
+        if getattr(weight, "requires_grad", False):
+            grad_weight = _mark_npu_owned_backward_grad(_cy_fast_npu_mm_mat2_backward(input_2d, grad_2d, 1))
+        return grad_input, grad_weight
+
+
 cdef class _NpuLayerNormBackward(_CyAutogradNode):
     cdef public object _input
     cdef public object _weight
@@ -2420,6 +2643,15 @@ cdef inline object _attach_npu_linear_grad(object result, object input, object w
     return result
 
 
+cdef inline object _attach_npu_linear_no_bias_grad(object result, object input, object weight):
+    cdef TensorImpl out = <TensorImpl>result
+    cdef _NpuLinearNoBiasBackward grad_fn = _NpuLinearNoBiasBackward.__new__(_NpuLinearNoBiasBackward)
+    grad_fn._init_fast(input, weight)
+    out.grad_fn = grad_fn
+    out.requires_grad = True
+    return result
+
+
 cdef inline object _attach_npu_add_grad(object result, object a, object b):
     cdef TensorImpl out = <TensorImpl>result
     cdef _NpuAddBackward grad_fn = _NpuAddBackward.__new__(_NpuAddBackward)
@@ -2839,7 +3071,7 @@ def addmm(input, mat1, mat2, *, beta=1, alpha=1):
 
 
 def linear(input, weight, bias=None):
-    """Fast linear: fuse safe NPU weight.t() + addmm glue in Cython."""
+    """Fast linear: fuse safe NPU weight.t() + addmm/matmul glue in Cython."""
     cdef int state
     cdef object weight_t
     cdef object mat1
@@ -2848,26 +3080,48 @@ def linear(input, weight, bias=None):
     cdef TensorImpl inp
     cdef TensorImpl out
 
-    state = _exact_npu_linear_hot_state(input, weight, bias)
-    if state != 0:
-        inp = <TensorImpl>input
-        weight_t = (<TensorImpl>weight).cy_transpose(0, 1)
-        if inp._ndim == 2:
-            mat1 = input
-            out_shape = None
-        else:
-            mat1 = inp.cy_view((inp._c_numel // inp._c_shape[inp._ndim - 1], inp._c_shape[inp._ndim - 1]))
-            out_shape = inp._shape_tuple[:inp._ndim - 1] + ((<TensorImpl>weight)._c_shape[0],)
-        try:
-            result = _cy_fast_npu_addmm(bias, mat1, weight_t, 1, 1)
-        except ValueError:
-            result = None
-        if result is not None:
-            if out_shape is not None:
-                result = (<TensorImpl>result).cy_view(out_shape)
-            if state == 2:
-                return _attach_npu_linear_grad(result, input, weight, bias)
-            return result
+    if bias is None:
+        state = _exact_npu_linear_no_bias_hot_state(input, weight)
+        if state != 0:
+            inp = <TensorImpl>input
+            weight_t = (<TensorImpl>weight).cy_transpose(0, 1)
+            if inp._ndim == 2:
+                mat1 = input
+                out_shape = None
+            else:
+                mat1 = inp.cy_view((inp._c_numel // inp._c_shape[inp._ndim - 1], inp._c_shape[inp._ndim - 1]))
+                out_shape = inp._shape_tuple[:inp._ndim - 1] + ((<TensorImpl>weight)._c_shape[0],)
+            try:
+                result = _cy_fast_npu_matmul(mat1, weight_t)
+            except ValueError:
+                result = None
+            if result is not None:
+                if out_shape is not None:
+                    result = (<TensorImpl>result).cy_view(out_shape)
+                if state == 2:
+                    return _attach_npu_linear_no_bias_grad(result, input, weight)
+                return result
+    else:
+        state = _exact_npu_linear_hot_state(input, weight, bias)
+        if state != 0:
+            inp = <TensorImpl>input
+            weight_t = (<TensorImpl>weight).cy_transpose(0, 1)
+            if inp._ndim == 2:
+                mat1 = input
+                out_shape = None
+            else:
+                mat1 = inp.cy_view((inp._c_numel // inp._c_shape[inp._ndim - 1], inp._c_shape[inp._ndim - 1]))
+                out_shape = inp._shape_tuple[:inp._ndim - 1] + ((<TensorImpl>weight)._c_shape[0],)
+            try:
+                result = _cy_fast_npu_addmm(bias, mat1, weight_t, 1, 1)
+            except ValueError:
+                result = None
+            if result is not None:
+                if out_shape is not None:
+                    result = (<TensorImpl>result).cy_view(out_shape)
+                if state == 2:
+                    return _attach_npu_linear_grad(result, input, weight, bias)
+                return result
 
     from candle.nn import functional as _nn_functional
     return _nn_functional._py_linear(input, weight, bias)

--- a/src/candle/_C/_functional_ops.pyx
+++ b/src/candle/_C/_functional_ops.pyx
@@ -451,6 +451,8 @@ cdef inline int _exact_npu_linear_no_bias_hot_state(object input, object weight)
         return 0
     if inp._c_shape[inp._ndim - 1] != w._c_shape[1]:
         return 0
+    if inp._c_shape[inp._ndim - 1] == 0:
+        return 0
     if inp._device_index != w._device_index:
         return 0
     if inp._dtype_code != w._dtype_code:

--- a/src/candle/_C/_functional_ops.pyx
+++ b/src/candle/_C/_functional_ops.pyx
@@ -12,38 +12,70 @@ from candle.autograd.node import AccumulateGrad, SavedTensor, _SavedValue
 from candle._C._autograd_node cimport Node as _CyAutogradNode
 from candle._C._tensor_impl cimport TensorImpl, cy_make_tensor_from_storage
 from candle._C._grad_mode_state cimport get_enabled_fast as _grad_enabled_fast
-from candle._C._npu_ops cimport (
-    fast_add as _cy_fast_npu_add,
-    fast_add_exact as _cy_fast_npu_add_exact,
-    fast_add_scalar_exact as _cy_fast_npu_add_scalar_exact,
-    fast_sub_exact as _cy_fast_npu_sub_exact,
-    fast_div_exact as _cy_fast_npu_div_exact,
-    fast_mul as _cy_fast_npu_mul,
-    fast_mul_exact as _cy_fast_npu_mul_exact,
-    fast_mul_scalar_exact as _cy_fast_npu_mul_scalar_exact,
-    fast_sub_scalar_exact as _cy_fast_npu_sub_scalar_exact,
-    fast_div_scalar_exact as _cy_fast_npu_div_scalar_exact,
-    fast_matmul as _cy_fast_npu_matmul,
-    fast_matmul_exact as _cy_fast_npu_matmul_exact,
-    fast_addmm as _cy_fast_npu_addmm,
-    fast_layer_norm as _cy_fast_npu_layer_norm,
-    fast_layer_norm_backward as _cy_fast_npu_layer_norm_backward,
-    fast_sum as _cy_fast_npu_sum,
-    fast_mm_mat1_backward as _cy_fast_npu_mm_mat1_backward,
-    fast_mm_mat2_backward as _cy_fast_npu_mm_mat2_backward,
-    fast_gelu as _cy_fast_npu_gelu,
-    fast_gelu_exact as _cy_fast_npu_gelu_exact,
-    fast_silu as _cy_fast_npu_silu,
-    fast_silu_exact as _cy_fast_npu_silu_exact,
-    fast_rsqrt as _cy_fast_npu_rsqrt,
-    fast_gelu_backward as _cy_fast_npu_gelu_backward,
-    fast_silu_backward as _cy_fast_npu_silu_backward,
-    fast_sdpa_flash_attention as _cy_fast_sdpa_flash_attention,
-    fast_sdpa_flash_attention_backward as _cy_fast_sdpa_flash_attention_backward,
-    fast_sdpa_flash_attention_backward_packed_qkv as _cy_fast_sdpa_flash_attention_backward_packed_qkv,
-    fast_packed_qkv_projection_forward as _cy_fast_packed_qkv_projection_forward,
-    fast_packed_qkv_projection_backward as _cy_fast_packed_qkv_projection_backward,
-)
+IF HAS_NPU_CYTHON:
+    from candle._C._npu_ops cimport (
+        fast_add as _cy_fast_npu_add,
+        fast_add_exact as _cy_fast_npu_add_exact,
+        fast_add_scalar_exact as _cy_fast_npu_add_scalar_exact,
+        fast_sub_exact as _cy_fast_npu_sub_exact,
+        fast_div_exact as _cy_fast_npu_div_exact,
+        fast_mul as _cy_fast_npu_mul,
+        fast_mul_exact as _cy_fast_npu_mul_exact,
+        fast_mul_scalar_exact as _cy_fast_npu_mul_scalar_exact,
+        fast_sub_scalar_exact as _cy_fast_npu_sub_scalar_exact,
+        fast_div_scalar_exact as _cy_fast_npu_div_scalar_exact,
+        fast_matmul as _cy_fast_npu_matmul,
+        fast_matmul_exact as _cy_fast_npu_matmul_exact,
+        fast_addmm as _cy_fast_npu_addmm,
+        fast_layer_norm as _cy_fast_npu_layer_norm,
+        fast_layer_norm_backward as _cy_fast_npu_layer_norm_backward,
+        fast_sum as _cy_fast_npu_sum,
+        fast_mm_mat1_backward as _cy_fast_npu_mm_mat1_backward,
+        fast_mm_mat2_backward as _cy_fast_npu_mm_mat2_backward,
+        fast_gelu as _cy_fast_npu_gelu,
+        fast_gelu_exact as _cy_fast_npu_gelu_exact,
+        fast_silu as _cy_fast_npu_silu,
+        fast_silu_exact as _cy_fast_npu_silu_exact,
+        fast_rsqrt as _cy_fast_npu_rsqrt,
+        fast_gelu_backward as _cy_fast_npu_gelu_backward,
+        fast_silu_backward as _cy_fast_npu_silu_backward,
+        fast_sdpa_flash_attention as _cy_fast_sdpa_flash_attention,
+        fast_sdpa_flash_attention_backward as _cy_fast_sdpa_flash_attention_backward,
+        fast_sdpa_flash_attention_backward_packed_qkv as _cy_fast_sdpa_flash_attention_backward_packed_qkv,
+        fast_packed_qkv_projection_forward as _cy_fast_packed_qkv_projection_forward,
+        fast_packed_qkv_projection_backward as _cy_fast_packed_qkv_projection_backward,
+    )
+ELSE:
+    cdef object _cy_fast_npu_add = None
+    cdef object _cy_fast_npu_add_exact = None
+    cdef object _cy_fast_npu_add_scalar_exact = None
+    cdef object _cy_fast_npu_sub_exact = None
+    cdef object _cy_fast_npu_div_exact = None
+    cdef object _cy_fast_npu_mul = None
+    cdef object _cy_fast_npu_mul_exact = None
+    cdef object _cy_fast_npu_mul_scalar_exact = None
+    cdef object _cy_fast_npu_sub_scalar_exact = None
+    cdef object _cy_fast_npu_div_scalar_exact = None
+    cdef object _cy_fast_npu_matmul = None
+    cdef object _cy_fast_npu_matmul_exact = None
+    cdef object _cy_fast_npu_addmm = None
+    cdef object _cy_fast_npu_layer_norm = None
+    cdef object _cy_fast_npu_layer_norm_backward = None
+    cdef object _cy_fast_npu_sum = None
+    cdef object _cy_fast_npu_mm_mat1_backward = None
+    cdef object _cy_fast_npu_mm_mat2_backward = None
+    cdef object _cy_fast_npu_gelu = None
+    cdef object _cy_fast_npu_gelu_exact = None
+    cdef object _cy_fast_npu_silu = None
+    cdef object _cy_fast_npu_silu_exact = None
+    cdef object _cy_fast_npu_rsqrt = None
+    cdef object _cy_fast_npu_gelu_backward = None
+    cdef object _cy_fast_npu_silu_backward = None
+    cdef object _cy_fast_sdpa_flash_attention = None
+    cdef object _cy_fast_sdpa_flash_attention_backward = None
+    cdef object _cy_fast_sdpa_flash_attention_backward_packed_qkv = None
+    cdef object _cy_fast_packed_qkv_projection_forward = None
+    cdef object _cy_fast_packed_qkv_projection_backward = None
 
 # Cached reference to base Tensor class
 cdef object _BaseTensor = None
@@ -282,6 +314,8 @@ cdef inline bint _profiler_active():
 
 
 cdef inline bint _exact_base_npu_pair(object a, object b):
+    IF not HAS_NPU_CYTHON:
+        return False
     _ensure_base()
     return (
         type(a) is _BaseTensor
@@ -293,11 +327,15 @@ cdef inline bint _exact_base_npu_pair(object a, object b):
 
 
 cdef inline bint _exact_base_npu_unary(object a):
+    IF not HAS_NPU_CYTHON:
+        return False
     _ensure_base()
     return type(a) is _BaseTensor and (<TensorImpl>a)._device_type == 1
 
 
 cdef inline bint _exact_base_npu_tensor_scalar(object a, object value):
+    IF not HAS_NPU_CYTHON:
+        return False
     _ensure_base()
     return type(a) is _BaseTensor and (<TensorImpl>a)._device_type == 1 and isinstance(value, (int, float))
 
@@ -352,6 +390,8 @@ cdef inline tuple _contiguous_stride_tuple(object shape):
 
 cdef inline int _exact_npu_addmm_hot_state(object input, object mat1, object mat2, object beta, object alpha):
     """Return 1 for inference, 2 for autograd, 0 for fallback."""
+    IF not HAS_NPU_CYTHON:
+        return 0
     cdef bint grad_on
     cdef bint requires_grad
     cdef TensorImpl bias
@@ -392,6 +432,8 @@ cdef inline int _exact_npu_addmm_hot_state(object input, object mat1, object mat
 
 cdef inline int _exact_npu_linear_hot_state(object input, object weight, object bias):
     """Return 1 for inference, 2 for autograd, 0 for fallback."""
+    IF not HAS_NPU_CYTHON:
+        return 0
     cdef bint grad_on
     cdef bint requires_grad
     cdef TensorImpl inp
@@ -432,6 +474,8 @@ cdef inline int _exact_npu_linear_hot_state(object input, object weight, object 
 
 cdef inline int _exact_npu_linear_no_bias_hot_state(object input, object weight):
     """Return 1 for inference, 2 for autograd, 0 for fallback."""
+    IF not HAS_NPU_CYTHON:
+        return 0
     cdef bint grad_on
     cdef bint requires_grad
     cdef TensorImpl inp
@@ -470,6 +514,8 @@ cdef inline int _exact_npu_linear_no_bias_hot_state(object input, object weight)
 
 cdef inline int _exact_npu_layer_norm_hot_state(object input, object weight, object bias, object normalized_shape):
     """Return 1 for inference, 2 for autograd, 0 for fallback."""
+    IF not HAS_NPU_CYTHON:
+        return 0
     cdef bint grad_on
     cdef bint requires_grad
     cdef TensorImpl inp
@@ -564,6 +610,8 @@ cdef inline int _exact_npu_unary_hot_state(object a):
 
 cdef inline bint _is_npu_tensor_pair(object a, object b):
     """True only when both operands are tensors on the NPU device."""
+    IF not HAS_NPU_CYTHON:
+        return False
     if isinstance(a, TensorImpl) and isinstance(b, TensorImpl):
         return (<TensorImpl>a)._device_type == 1 and (<TensorImpl>b)._device_type == 1
     cdef object a_dev = getattr(a, "device", None)
@@ -575,6 +623,8 @@ cdef inline bint _is_npu_tensor_pair(object a, object b):
 
 cdef inline bint _npu_pair_ready(object a, object b):
     """True if both operands are NPU tensors and global fast-path guards allow bypass."""
+    IF not HAS_NPU_CYTHON:
+        return False
     cdef object b_dev
     if isinstance(a, TensorImpl) and isinstance(b, TensorImpl):
         if (<TensorImpl>a)._device_type != 1 or (<TensorImpl>b)._device_type != 1:
@@ -594,6 +644,8 @@ cdef inline bint _npu_pair_ready(object a, object b):
 
 cdef inline bint _npu_unary_ready(object a):
     """True if a single tensor is NPU and global fast-path guards allow bypass."""
+    IF not HAS_NPU_CYTHON:
+        return False
     cdef object dev
     if isinstance(a, TensorImpl):
         if (<TensorImpl>a)._device_type != 1:
@@ -2453,6 +2505,8 @@ def npu_flash_sdpa(query, key, value, scale_factor, attn_mask=None):
     cdef object out
     cdef object softmax_max
     cdef object softmax_sum
+    IF not HAS_NPU_CYTHON:
+        return None
     if not isinstance(query, TensorImpl) or not isinstance(key, TensorImpl) or not isinstance(value, TensorImpl):
         return None
     if attn_mask is not None and not isinstance(attn_mask, TensorImpl):

--- a/src/candle/_C/_mps_helpers.pyx
+++ b/src/candle/_C/_mps_helpers.pyx
@@ -96,6 +96,14 @@ cdef inline void _ensure_runtime():
     _get_dispatcher_fn = get_dispatcher
 
 
+cdef inline object _storage_untyped(object storage):
+    """Return the untyped storage for Python and Cython storage wrappers."""
+    cdef object untyped = getattr(storage, "_untyped", None)
+    if untyped is not None:
+        return untyped
+    return getattr(storage, "_untyped_storage", None)
+
+
 # ---------------------------------------------------------------------------
 # C-level guard (inlined, not exposed to Python)
 # ---------------------------------------------------------------------------
@@ -107,9 +115,9 @@ cdef inline bint _can_use_gpu_c(object t):
     if t.numel() <= 0:
         return False
     cdef object storage = t._storage
-    if not hasattr(storage, '_untyped'):
+    cdef object untyped = _storage_untyped(storage)
+    if untyped is None:
         return False
-    cdef object untyped = storage._untyped
     if not hasattr(untyped, '_metal_buffer'):
         return False
     return untyped._metal_buffer is not None
@@ -147,7 +155,7 @@ cpdef int itemsize(object dtype):
 
 cpdef object get_metal_buf(object t):
     """Return the raw Metal buffer from tensor *t*."""
-    return t._storage._untyped._metal_buffer
+    return _storage_untyped(t._storage)._metal_buffer
 
 
 cpdef object alloc_output_buf(int numel, object dtype):
@@ -177,16 +185,12 @@ cpdef object from_metal_buffer(object metal_buf_obj, object shape, object stride
         numel = 1
 
     cdef object untyped = _MPSUntypedStorage_cls(metal_buf_obj, nbytes, device=device)
-    cdef long ptr = _buffer_contents_fn(metal_buf_obj)
-    cdef object np_dtype = _NP_DTYPE.get(dtype, np.float32)
-    cdef object data = np.frombuffer(
-        (ctypes.c_uint8 * nbytes).from_address(ptr),
-        dtype=np_dtype,
-        count=numel,
+    cdef object typed_storage = _TypedStorage_cls(
+        wrap_storage=untyped,
+        dtype=dtype,
+        _internal=True,
     )
-    cdef object typed_storage = _TypedStorage_cls(untyped, dtype, numel, data=data)
-    from candle._C._tensor_impl import cy_make_tensor_from_storage
-    return cy_make_tensor_from_storage(typed_storage, shape_t, stride_t, 0, False)
+    return _Tensor_cls(typed_storage, shape_t, stride_t, 0, False)
 
 
 cdef inline object _read_scalar_c(object t):
@@ -194,7 +198,7 @@ cdef inline object _read_scalar_c(object t):
     _ensure_dtypes()
     _ensure_runtime()
     cdef int nb   = itemsize(t.dtype)
-    cdef long ptr = _buffer_contents_fn(t._storage._untyped._metal_buffer)
+    cdef long ptr = _buffer_contents_fn(_storage_untyped(t._storage)._metal_buffer)
     cdef bytes raw = bytes((ctypes.c_char * nb).from_address(ptr))
     return struct.unpack(_FMT[t.dtype], raw)[0]
 
@@ -219,7 +223,7 @@ cpdef object dispatch_unary_gpu(object a, str kernel_base):
     cdef str sfx        = _SUFFIX[a.dtype]
     cdef int numel      = a.numel()
     cdef object out_buf = alloc_output_buf(numel, a.dtype)
-    cdef object mb      = a._storage._untyped._metal_buffer
+    cdef object mb      = _storage_untyped(a._storage)._metal_buffer
 
     if a.is_contiguous():
         d.dispatch_unary(f"{kernel_base}_{sfx}", mb, out_buf, numel)
@@ -242,7 +246,7 @@ cpdef object dispatch_unary_predicate_gpu(object a, str kernel_base):
     cdef str sfx        = _SUFFIX[a.dtype]
     cdef int numel      = a.numel()
     cdef object out_buf = alloc_output_buf(numel, _bool_dtype)
-    cdef object mb      = a._storage._untyped._metal_buffer
+    cdef object mb      = _storage_untyped(a._storage)._metal_buffer
 
     if a.is_contiguous():
         d.dispatch_unary(f"{kernel_base}_{sfx}", mb, out_buf, numel)
@@ -273,7 +277,7 @@ cpdef object dispatch_binary_gpu(object a, object b, str kernel_base):
     cdef str sfx        = _SUFFIX[a.dtype]
     cdef int numel      = a.numel()
     cdef object out_buf = alloc_output_buf(numel, a.dtype)
-    cdef object mb_a    = a._storage._untyped._metal_buffer
+    cdef object mb_a    = _storage_untyped(a._storage)._metal_buffer
     cdef str fmt        = _FMT[a.dtype]
     cdef object mb_b
     cdef object raw_val
@@ -282,7 +286,7 @@ cpdef object dispatch_binary_gpu(object a, object b, str kernel_base):
     if (isinstance(b, _Tensor_cls)
             and _can_use_gpu_c(b)
             and a.shape == b.shape):
-        mb_b = b._storage._untyped._metal_buffer
+        mb_b = _storage_untyped(b._storage)._metal_buffer
         if a.is_contiguous() and b.is_contiguous():
             d.dispatch_binary(f"{kernel_base}_{sfx}", mb_a, mb_b, out_buf, numel)
         else:

--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -868,7 +868,11 @@ def fast_binary_op(a, b, fn, str name):
     if name == "eq" or name == "ne" or name == "lt" or name == "le" or name == "gt" or name == "ge":
         from candle._dtype import bool as _bool_dtype
         out_dtype = _bool_dtype
-    cdef int64_t alloc_size = n * c_dtype_itemsize(out_dtype)
+    cdef int64_t alloc_elems = n
+    cdef int64_t alloc_size
+    if alloc_elems == 0:
+        alloc_elems = 1
+    alloc_size = alloc_elems * c_dtype_itemsize(out_dtype)
     if dev_idx == 0:
         _ensure_allocator_dev0()
         out_ptr = _fast_allocator_dev0.malloc(alloc_size, stream=stream.stream)
@@ -876,6 +880,9 @@ def fast_binary_op(a, b, fn, str name):
         # Multi-device fallback: still avoids the two lazy imports inside
         # _alloc_device by going directly to get_allocator().
         out_ptr = _get_allocator_fn_ref(dev_idx).malloc(alloc_size, stream=stream.stream)
+
+    if n == 0:
+        return _cy_make_npu_tensor(out_ptr, alloc_elems, out_dtype, _device_obj_fast(a), out_shape, out_stride)
 
     # 7. Get data pointers without Python storage() calls on the hot path
     cdef uintptr_t a_ptr

--- a/src/candle/_C/_tensor_api.pyx
+++ b/src/candle/_C/_tensor_api.pyx
@@ -957,9 +957,24 @@ def tensor_to(self, *args, **kwargs):
     return result
 
 
-def tensor_backward(self, gradient=None, retain_graph=False, create_graph=False, inputs=None):
+def tensor_backward(self, gradient=None, retain_graph=None, create_graph=False, inputs=None):
+    _ensure_base()
+    if not _is_tensor_without_torch_function_override(self):
+        return type(self).__torch_function__(
+            tensor_backward,
+            {type(self)},
+            (self,),
+            {
+                "gradient": gradient,
+                "retain_graph": retain_graph,
+                "create_graph": create_graph,
+                "inputs": inputs,
+            },
+        )
     _flush_pending(self)
     _ensure_backward_ref()
+    if retain_graph is None:
+        retain_graph = create_graph
     _backward_fn(
         self,
         gradient,

--- a/src/candle/_C/_tensor_api.pyx
+++ b/src/candle/_C/_tensor_api.pyx
@@ -8,6 +8,7 @@ while preserving the existing Python fallback behavior in ``candle._tensor``.
 
 import numpy as np
 
+cimport cython
 from libc.stdint cimport int64_t, uintptr_t, uint64_t
 from candle._C._tensor_impl cimport TensorImpl
 from candle._C._aclrt_ffi cimport memcpy_d2d as _cy_memcpy_d2d
@@ -792,6 +793,7 @@ def tensor_detach_(self):
     return self
 
 
+@cython.auto_pickle(False)
 cdef class _NpuToCopyBackward(_CyAutogradNode):
     cdef public object _src_dtype
 
@@ -1058,6 +1060,7 @@ cdef inline object _propagate_npu_owned_backward_grad(object source, object resu
     return result
 
 
+@cython.auto_pickle(False)
 cdef class _NpuReshapeBackward(_CyAutogradNode):
     cdef public object _self_shape
 
@@ -1104,6 +1107,7 @@ cdef inline object _attach_reshape_grad(object result, object self_):
     return result
 
 
+@cython.auto_pickle(False)
 cdef class _NpuTransposeIntBackward(_CyAutogradNode):
     cdef public object _self
     cdef public object _dim0
@@ -3054,6 +3058,7 @@ cdef inline bint _npu_scalar_reflected_fast_ok(object self, object other):
     return True
 
 
+@cython.auto_pickle(False)
 cdef class _NpuReflectedScalarSubBackward(_CyAutogradNode):
     cdef public object _self
 
@@ -3088,6 +3093,7 @@ cdef class _NpuReflectedScalarSubBackward(_CyAutogradNode):
         return (_mark_npu_owned_backward_grad(out),)
 
 
+@cython.auto_pickle(False)
 cdef class _NpuReflectedScalarDivBackward(_CyAutogradNode):
     cdef public object _self
     cdef public object _value
@@ -3290,6 +3296,7 @@ def tensor_xor(self, other):
 # ── reduction ops ─────────────────────────────────────────────────────────────
 
 
+@cython.auto_pickle(False)
 cdef class _NpuSumBackward(_CyAutogradNode):
     cdef public object _self
     cdef public object _self_shape

--- a/src/candle/_C/_tensor_api.pyx
+++ b/src/candle/_C/_tensor_api.pyx
@@ -11,20 +11,21 @@ import numpy as np
 cimport cython
 from libc.stdint cimport int64_t, uintptr_t, uint64_t
 from candle._C._tensor_impl cimport TensorImpl
-from candle._C._aclrt_ffi cimport memcpy_d2d as _cy_memcpy_d2d
+IF HAS_NPU_CYTHON:
+    from candle._C._aclrt_ffi cimport memcpy_d2d as _cy_memcpy_d2d
+    from candle._C._npu_ops cimport (
+        fast_sum as _cy_fast_npu_sum,
+        fast_add_exact as _cy_fast_npu_add_exact,
+        fast_sub_exact as _cy_fast_npu_sub_exact,
+        fast_mul_exact as _cy_fast_npu_mul_exact,
+        fast_mul_scalar_exact as _cy_fast_npu_mul_scalar_exact,
+        fast_div_exact as _cy_fast_npu_div_exact,
+        fast_rsub_scalar_exact as _cy_fast_npu_rsub_scalar_exact,
+        fast_rdiv_scalar_exact as _cy_fast_npu_rdiv_scalar_exact,
+        fast_cast as _cy_fast_npu_cast,
+    )
 from candle._C._autograd_node cimport Node as _CyAutogradNode
 from candle._C._grad_mode_state cimport get_enabled_fast as _grad_enabled_fast
-from candle._C._npu_ops cimport (
-    fast_sum as _cy_fast_npu_sum,
-    fast_add_exact as _cy_fast_npu_add_exact,
-    fast_sub_exact as _cy_fast_npu_sub_exact,
-    fast_mul_exact as _cy_fast_npu_mul_exact,
-    fast_mul_scalar_exact as _cy_fast_npu_mul_scalar_exact,
-    fast_div_exact as _cy_fast_npu_div_exact,
-    fast_rsub_scalar_exact as _cy_fast_npu_rsub_scalar_exact,
-    fast_rdiv_scalar_exact as _cy_fast_npu_rdiv_scalar_exact,
-    fast_cast as _cy_fast_npu_cast,
-)
 
 
 def _bf16_to_f32_local(arr):
@@ -485,8 +486,9 @@ cdef inline object _annotate_reshape_view(object source, object view, object sha
 
 
 cpdef object tensor_add(object self, object other):
-    if _can_use_npu_tensor_binary_direct(self, other):
-        return _cy_fast_npu_add_exact(<TensorImpl>self, <TensorImpl>other)
+    IF HAS_NPU_CYTHON:
+        if _can_use_npu_tensor_binary_direct(self, other):
+            return _cy_fast_npu_add_exact(<TensorImpl>self, <TensorImpl>other)
     _ensure_functional_refs()
     return _add_fn(self, other)
 
@@ -613,15 +615,17 @@ def tensor_is_pinned(self):
     return self._storage.is_pinned()
 
 cpdef object tensor_sub(object self, object other):
-    if _can_use_npu_tensor_binary_direct(self, other):
-        return _cy_fast_npu_sub_exact(<TensorImpl>self, <TensorImpl>other)
+    IF HAS_NPU_CYTHON:
+        if _can_use_npu_tensor_binary_direct(self, other):
+            return _cy_fast_npu_sub_exact(<TensorImpl>self, <TensorImpl>other)
     _ensure_functional_add_sub_ref()
     return _functional_sub_fn(self, other)
 
 
 cpdef object tensor_mul(object self, object other):
-    if _can_use_npu_tensor_binary_direct(self, other):
-        return _cy_fast_npu_mul_exact(<TensorImpl>self, <TensorImpl>other)
+    IF HAS_NPU_CYTHON:
+        if _can_use_npu_tensor_binary_direct(self, other):
+            return _cy_fast_npu_mul_exact(<TensorImpl>self, <TensorImpl>other)
     _ensure_functional_refs()
     return _mul_fn(self, other)
 
@@ -721,7 +725,10 @@ def tensor_clone(self, *, memory_format=None):
                         alloc_nbytes, stream=stream.stream)
                     src_ptr = <uintptr_t>src_impl._storage._untyped._device_ptr
                     if nbytes != 0:
-                        _cy_memcpy_d2d(dst_ptr, nbytes, src_ptr, <uintptr_t>int(stream.stream), True)
+                        IF HAS_NPU_CYTHON:
+                            _cy_memcpy_d2d(dst_ptr, nbytes, src_ptr, <uintptr_t>int(stream.stream), True)
+                        ELSE:
+                            raise RuntimeError("NPU clone fast path requires NPU Cython support")
                     storage = _npu_typed_storage_from_ptr_fn(
                         dst_ptr, src_impl._c_numel, src_impl._dtype_obj, device=src_impl._device_obj)
                     _ensure_tensor_factory_ref()
@@ -823,10 +830,11 @@ cdef class _NpuToCopyBackward(_CyAutogradNode):
         except ImportError:
             pass
         result = None
-        try:
-            result = _cy_fast_npu_cast(grad, self._src_dtype)
-        except ValueError:
-            result = None
+        IF HAS_NPU_CYTHON:
+            try:
+                result = _cy_fast_npu_cast(grad, self._src_dtype)
+            except ValueError:
+                result = None
         if result is None:
             _ensure_functional_refs()
             result = _to_dispatch_fn(grad, grad.device, dtype=self._src_dtype)
@@ -919,9 +927,12 @@ def tensor_to(self, *args, **kwargs):
         and dtype != self.dtype
         and _can_use_npu_to_dtype_fast_path(self, dtype)
     ):
-        try:
-            fast_cast_result = _cy_fast_npu_cast(self, dtype)
-        except ValueError:
+        IF HAS_NPU_CYTHON:
+            try:
+                fast_cast_result = _cy_fast_npu_cast(self, dtype)
+            except ValueError:
+                fast_cast_result = None
+        ELSE:
             fast_cast_result = None
         if fast_cast_result is not None:
             if _grad_enabled_fast() and (<TensorImpl>self).requires_grad:
@@ -3089,7 +3100,11 @@ cdef class _NpuReflectedScalarSubBackward(_CyAutogradNode):
                 return (_dispatch_fn("neg", grad.device.type, grad),)
         except ImportError:
             pass
-        out = _cy_fast_npu_mul_scalar_exact(<TensorImpl>grad, -1.0)
+        IF HAS_NPU_CYTHON:
+            out = _cy_fast_npu_mul_scalar_exact(<TensorImpl>grad, -1.0)
+            return (_mark_npu_owned_backward_grad(out),)
+        _ensure_dispatch_ref()
+        out = _dispatch_fn("neg", grad.device.type, grad)
         return (_mark_npu_owned_backward_grad(out),)
 
 
@@ -3151,9 +3166,14 @@ cdef class _NpuReflectedScalarDivBackward(_CyAutogradNode):
                 return (_dispatch_fn("mul", x.device.type, ratio, -self._value),)
         except ImportError:
             pass
-        denom = _cy_fast_npu_mul_exact(<TensorImpl>x, <TensorImpl>x)
-        ratio = _cy_fast_npu_div_exact(<TensorImpl>grad, <TensorImpl>denom)
-        out = _cy_fast_npu_mul_scalar_exact(<TensorImpl>ratio, -self._value)
+        IF HAS_NPU_CYTHON:
+            denom = _cy_fast_npu_mul_exact(<TensorImpl>x, <TensorImpl>x)
+            ratio = _cy_fast_npu_div_exact(<TensorImpl>grad, <TensorImpl>denom)
+            out = _cy_fast_npu_mul_scalar_exact(<TensorImpl>ratio, -self._value)
+            return (_mark_npu_owned_backward_grad(out),)
+        denom = _dispatch_fn("mul", x.device.type, x, x)
+        ratio = _dispatch_fn("true_divide", x.device.type, grad, denom)
+        out = _dispatch_fn("mul", x.device.type, ratio, -self._value)
         return (_mark_npu_owned_backward_grad(out),)
 
 
@@ -3177,11 +3197,12 @@ cdef inline object _attach_npu_reflected_scalar_div_grad(object result, object s
 
 def tensor_rsub(self, other):
     """other - self  (reflected sub)"""
-    if _npu_scalar_reflected_fast_ok(self, other):
-        result = _cy_fast_npu_rsub_scalar_exact(<TensorImpl>self, other)
-        if _grad_enabled_fast() and (<TensorImpl>self).requires_grad:
-            return _attach_npu_reflected_scalar_sub_grad(result, self)
-        return result
+    IF HAS_NPU_CYTHON:
+        if _npu_scalar_reflected_fast_ok(self, other):
+            result = _cy_fast_npu_rsub_scalar_exact(<TensorImpl>self, other)
+            if _grad_enabled_fast() and (<TensorImpl>self).requires_grad:
+                return _attach_npu_reflected_scalar_sub_grad(result, self)
+            return result
     _ensure_dispatch_ref()
     neg_self = _dispatch_fn("neg", self.device.type, self)
     return _dispatch_fn("add", self.device.type, neg_self, other)
@@ -3193,18 +3214,20 @@ def tensor_rmul(self, other):
 
 
 cpdef object tensor_truediv(object self, object other):
-    if _can_use_npu_tensor_binary_direct(self, other):
-        return _cy_fast_npu_div_exact(<TensorImpl>self, <TensorImpl>other)
+    IF HAS_NPU_CYTHON:
+        if _can_use_npu_tensor_binary_direct(self, other):
+            return _cy_fast_npu_div_exact(<TensorImpl>self, <TensorImpl>other)
     _ensure_functional_refs()
     return _div_fn(self, other)
 
 
 def tensor_rtruediv(self, other):
-    if _npu_scalar_reflected_fast_ok(self, other):
-        result = _cy_fast_npu_rdiv_scalar_exact(<TensorImpl>self, other)
-        if _grad_enabled_fast() and (<TensorImpl>self).requires_grad:
-            return _attach_npu_reflected_scalar_div_grad(result, self, other)
-        return result
+    IF HAS_NPU_CYTHON:
+        if _npu_scalar_reflected_fast_ok(self, other):
+            result = _cy_fast_npu_rdiv_scalar_exact(<TensorImpl>self, other)
+            if _grad_enabled_fast() and (<TensorImpl>self).requires_grad:
+                return _attach_npu_reflected_scalar_div_grad(result, self, other)
+            return result
     _ensure_dispatch_ref()
     return _dispatch_fn("true_divide", self.device.type, other, self)
 
@@ -3402,9 +3425,12 @@ cdef inline object _attach_npu_sum_grad(object result, object self_, object dim,
 def tensor_sum_method(self, dim=None, keepdim=False, *, dtype=None):
     cdef object result
     if _can_use_npu_sum_fast_path(self, dtype):
-        try:
-            result = _cy_fast_npu_sum(self, dim, keepdim)
-        except ValueError:
+        IF HAS_NPU_CYTHON:
+            try:
+                result = _cy_fast_npu_sum(self, dim, keepdim)
+            except ValueError:
+                result = None
+        ELSE:
             result = None
         if result is not None:
             if _grad_enabled_fast() and (<TensorImpl>self).requires_grad:

--- a/src/candle/_C/_tensor_impl.pyx
+++ b/src/candle/_C/_tensor_impl.pyx
@@ -9,16 +9,17 @@ VersionCounter is inlined as a C int64.
 
 from libc.stdint cimport int64_t
 from candle._C._grad_mode_state cimport get_enabled_fast as _grad_enabled_fast
-from candle._C._npu_ops cimport (
-    fast_add_exact as _slot_fast_npu_add_exact,
-    fast_add_scalar_exact as _slot_fast_npu_add_scalar_exact,
-    fast_sub_exact as _slot_fast_npu_sub_exact,
-    fast_sub_scalar_exact as _slot_fast_npu_sub_scalar_exact,
-    fast_mul_exact as _slot_fast_npu_mul_exact,
-    fast_mul_scalar_exact as _slot_fast_npu_mul_scalar_exact,
-    fast_div_exact as _slot_fast_npu_div_exact,
-    fast_div_scalar_exact as _slot_fast_npu_div_scalar_exact,
-)
+IF HAS_NPU_CYTHON:
+    from candle._C._npu_ops cimport (
+        fast_add_exact as _slot_fast_npu_add_exact,
+        fast_add_scalar_exact as _slot_fast_npu_add_scalar_exact,
+        fast_sub_exact as _slot_fast_npu_sub_exact,
+        fast_sub_scalar_exact as _slot_fast_npu_sub_scalar_exact,
+        fast_mul_exact as _slot_fast_npu_mul_exact,
+        fast_mul_scalar_exact as _slot_fast_npu_mul_scalar_exact,
+        fast_div_exact as _slot_fast_npu_div_exact,
+        fast_div_scalar_exact as _slot_fast_npu_div_scalar_exact,
+    )
 from candle._C._tensor_api cimport (
     _npu_functionalize_active_flag,
     _npu_pipeline_active_flag,
@@ -137,31 +138,35 @@ cdef class TensorImpl:
     # ---------------------------------------------------------------
 
     def __add__(self, other):
-        if _can_use_npu_binary_slot_direct(self, other):
-            return _slot_fast_npu_add_exact(self, <TensorImpl>other)
-        if _can_use_npu_scalar_slot_direct(self, other):
-            return _slot_fast_npu_add_scalar_exact(self, other)
+        IF HAS_NPU_CYTHON:
+            if _can_use_npu_binary_slot_direct(self, other):
+                return _slot_fast_npu_add_exact(self, <TensorImpl>other)
+            if _can_use_npu_scalar_slot_direct(self, other):
+                return _slot_fast_npu_add_scalar_exact(self, other)
         return _slot_tensor_add(self, other)
 
     def __sub__(self, other):
-        if _can_use_npu_binary_slot_direct(self, other):
-            return _slot_fast_npu_sub_exact(self, <TensorImpl>other)
-        if _can_use_npu_scalar_slot_direct(self, other):
-            return _slot_fast_npu_sub_scalar_exact(self, other)
+        IF HAS_NPU_CYTHON:
+            if _can_use_npu_binary_slot_direct(self, other):
+                return _slot_fast_npu_sub_exact(self, <TensorImpl>other)
+            if _can_use_npu_scalar_slot_direct(self, other):
+                return _slot_fast_npu_sub_scalar_exact(self, other)
         return _slot_tensor_sub(self, other)
 
     def __mul__(self, other):
-        if _can_use_npu_binary_slot_direct(self, other):
-            return _slot_fast_npu_mul_exact(self, <TensorImpl>other)
-        if _can_use_npu_scalar_slot_direct(self, other):
-            return _slot_fast_npu_mul_scalar_exact(self, other)
+        IF HAS_NPU_CYTHON:
+            if _can_use_npu_binary_slot_direct(self, other):
+                return _slot_fast_npu_mul_exact(self, <TensorImpl>other)
+            if _can_use_npu_scalar_slot_direct(self, other):
+                return _slot_fast_npu_mul_scalar_exact(self, other)
         return _slot_tensor_mul(self, other)
 
     def __truediv__(self, other):
-        if _can_use_npu_binary_slot_direct(self, other):
-            return _slot_fast_npu_div_exact(self, <TensorImpl>other)
-        if _can_use_npu_scalar_slot_direct(self, other):
-            return _slot_fast_npu_div_scalar_exact(self, other)
+        IF HAS_NPU_CYTHON:
+            if _can_use_npu_binary_slot_direct(self, other):
+                return _slot_fast_npu_div_exact(self, <TensorImpl>other)
+            if _can_use_npu_scalar_slot_direct(self, other):
+                return _slot_fast_npu_div_scalar_exact(self, other)
         return _slot_tensor_truediv(self, other)
 
     def __itruediv__(self, other):

--- a/src/candle/__init__.py
+++ b/src/candle/__init__.py
@@ -81,6 +81,12 @@ from . import _VF
 from . import _tensor_str
 from ._tensor import Tensor
 
+try:
+    from ._C import _tensor_api as _tensor_api
+    Tensor.backward = _tensor_api.tensor_backward
+except (ImportError, AttributeError):
+    pass
+
 # Torch-level numeric constants
 import builtins as _builtins
 inf = _builtins.float("inf")

--- a/src/candle/_backends/common/matmul_backward.py
+++ b/src/candle/_backends/common/matmul_backward.py
@@ -25,15 +25,19 @@ def _scale_if_needed(result, alpha):
 
 def mm_mat1_backward(grad, mat2, mat1_shape, mat1_strides=None, mat1_layout=None, alpha=1):
     """Gradient for mat1 in addmm/mm: grad @ mat2.T."""
-    del mat1_shape, mat1_strides, mat1_layout
+    del mat1_strides, mat1_layout
     from ..._dispatch import dispatch
+    if len(grad.shape) == 1 and len(mat1_shape) == 2 and mat1_shape[0] == 1:
+        grad = dispatch("reshape", grad.device.type, grad, (1, grad.shape[0]))
     mat2_t = dispatch("transpose", mat2.device.type, mat2, 0, 1)
     return _scale_if_needed(dispatch("matmul", grad.device.type, grad, mat2_t), alpha)
 
 
 def mm_mat2_backward(grad, mat1, mat2_shape, mat2_strides=None, mat2_layout=None, alpha=1):
     """Gradient for mat2 in addmm/mm: mat1.T @ grad."""
-    del mat2_shape, mat2_strides, mat2_layout
+    del mat2_strides, mat2_layout
     from ..._dispatch import dispatch
+    if len(grad.shape) == 1 and len(mat2_shape) == 2 and len(mat1.shape) == 2 and mat1.shape[0] == 1:
+        grad = dispatch("reshape", grad.device.type, grad, (1, grad.shape[0]))
     mat1_t = dispatch("transpose", mat1.device.type, mat1, 0, 1)
     return _scale_if_needed(dispatch("matmul", grad.device.type, mat1_t, grad), alpha)

--- a/src/candle/_backends/npu/creation.py
+++ b/src/candle/_backends/npu/creation.py
@@ -24,6 +24,25 @@ def _reject_unsupported_memory_format(memory_format):
     raise TypeError(f"unsupported memory_format {memory_format}")
 
 
+_NPU_IN_GRAPH_CAPTURE = None
+
+
+def _npu_in_graph_capture():
+    global _NPU_IN_GRAPH_CAPTURE  # pylint: disable=global-statement
+    if _NPU_IN_GRAPH_CAPTURE is None:
+        from ... import npu as _npu
+        _NPU_IN_GRAPH_CAPTURE = _npu._is_in_graph_capture  # pylint: disable=protected-access
+    return _NPU_IN_GRAPH_CAPTURE()
+
+
+def _try_graph_capture_scalar_tensor(arr, dtype, device, runtime, stream):
+    if arr.shape != () or not _npu_in_graph_capture():
+        return None
+    ptr = npu_runtime._alloc_device(max(arr.itemsize, 1), runtime=runtime)
+    aclnn.inplace_fill_scalar(ptr, arr.shape, (), dtype, arr.item(), runtime, stream=stream.stream)
+    return npu_typed_storage_from_ptr(ptr, 1, dtype, device=device)
+
+
 def _require_inplace_one_zero():
     if not aclnn.ones_zero_symbols_ok():
         raise RuntimeError("aclnnInplaceOne/Zero not available")
@@ -37,8 +56,10 @@ def tensor_create(data, dtype=None, device=None, requires_grad=False, memory_for
         ptr = npu_runtime._alloc_device(1, runtime=runtime)
         storage = npu_typed_storage_from_ptr(ptr, 0, dtype, device=device)
     else:
-        ptr, _ = npu_runtime._copy_cpu_to_npu(arr, runtime=runtime)
-        storage = npu_typed_storage_from_ptr(ptr, arr.size, dtype, device=device)
+        storage = _try_graph_capture_scalar_tensor(arr, dtype, device, runtime, stream)
+        if storage is None:
+            ptr, _ = npu_runtime._copy_cpu_to_npu(arr, runtime=runtime)
+            storage = npu_typed_storage_from_ptr(ptr, arr.size, dtype, device=device)
     stride = tuple(np.array(arr.strides) // arr.itemsize)
     return _wrap_tensor(storage, arr.shape, stride, requires_grad)
 
@@ -521,8 +542,10 @@ def tensor_create(data, dtype=None, device=None, requires_grad=False, memory_for
         ptr = npu_runtime._alloc_device(1, runtime=runtime)
         storage = npu_typed_storage_from_ptr(ptr, 0, dtype, device=device)
     else:
-        ptr, _ = npu_runtime._copy_cpu_to_npu(arr, runtime=runtime)
-        storage = npu_typed_storage_from_ptr(ptr, arr.size, dtype, device=device)
+        storage = _try_graph_capture_scalar_tensor(arr, dtype, device, runtime, stream)
+        if storage is None:
+            ptr, _ = npu_runtime._copy_cpu_to_npu(arr, runtime=runtime)
+            storage = npu_typed_storage_from_ptr(ptr, arr.size, dtype, device=device)
     stride = tuple(np.array(arr.strides) // arr.itemsize)
     return _wrap_tensor(storage, arr.shape, stride, requires_grad)
 

--- a/src/candle/_backends/npu/ops/_helpers.py
+++ b/src/candle/_backends/npu/ops/_helpers.py
@@ -22,6 +22,17 @@ except ImportError:
     _fast_cast_impl = None
 
 
+_NPU_IN_GRAPH_CAPTURE = None
+
+
+def _npu_in_graph_capture():
+    global _NPU_IN_GRAPH_CAPTURE  # pylint: disable=global-statement
+    if _NPU_IN_GRAPH_CAPTURE is None:
+        from .... import npu as _npu
+        _NPU_IN_GRAPH_CAPTURE = _npu._is_in_graph_capture  # pylint: disable=protected-access
+    return _NPU_IN_GRAPH_CAPTURE()
+
+
 def _unwrap_storage(tensor):
     if tensor.storage().device.type != "npu":
         raise ValueError("Expected NPU storage for NPU op")
@@ -366,8 +377,22 @@ def _scalar_to_npu_tensor(scalar, ref_tensor):
     stream = npu_state.current_stream((ref_tensor.device.index or 0))
     out_shape = ref_tensor.shape
     out_stride = npu_runtime._contiguous_stride(out_shape)
-    out_size = _numel(out_shape) * _dtype_itemsize(ref_tensor.dtype)
+    out_numel = _numel(out_shape)
+    out_size = out_numel * _dtype_itemsize(ref_tensor.dtype)
     out_ptr = npu_runtime._alloc_device(out_size, runtime=runtime)
+    if _npu_in_graph_capture():
+        if out_numel:
+            aclnn.inplace_fill_scalar(
+                out_ptr,
+                out_shape,
+                out_stride,
+                ref_tensor.dtype,
+                scalar,
+                runtime,
+                stream=stream.stream,
+            )
+        out_storage = npu_typed_storage_from_ptr(out_ptr, out_numel, ref_tensor.dtype, device=ref_tensor.device)
+        return _wrap_tensor(out_storage, out_shape, out_stride)
     # Fill on host then memcpy H2D to avoid aclnn scalar ops.
     from .. import acl_loader
     import ctypes
@@ -411,7 +436,7 @@ def _scalar_to_npu_tensor(scalar, ref_tensor):
         npu_runtime.memcpy_h2d(out_ptr, int(out_size), host_ptr, runtime=runtime)
     finally:
         acl.rt.free_host(host_ptr)
-    out_storage = npu_typed_storage_from_ptr(out_ptr, _numel(out_shape), ref_tensor.dtype, device=ref_tensor.device)
+    out_storage = npu_typed_storage_from_ptr(out_ptr, out_numel, ref_tensor.dtype, device=ref_tensor.device)
     return _wrap_tensor(out_storage, out_shape, out_stride)
 
 

--- a/src/candle/_backends/npu/ops/_helpers.py
+++ b/src/candle/_backends/npu/ops/_helpers.py
@@ -378,7 +378,8 @@ def _scalar_to_npu_tensor(scalar, ref_tensor):
     out_shape = ref_tensor.shape
     out_stride = npu_runtime._contiguous_stride(out_shape)
     out_numel = _numel(out_shape)
-    out_size = out_numel * _dtype_itemsize(ref_tensor.dtype)
+    itemsize = _dtype_itemsize(ref_tensor.dtype)
+    out_size = max(out_numel * itemsize, itemsize, 1)
     out_ptr = npu_runtime._alloc_device(out_size, runtime=runtime)
     if _npu_in_graph_capture():
         if out_numel:
@@ -391,7 +392,7 @@ def _scalar_to_npu_tensor(scalar, ref_tensor):
                 runtime,
                 stream=stream.stream,
             )
-        out_storage = npu_typed_storage_from_ptr(out_ptr, out_numel, ref_tensor.dtype, device=ref_tensor.device)
+        out_storage = npu_typed_storage_from_ptr(out_ptr, max(out_numel, 1), ref_tensor.dtype, device=ref_tensor.device)
         return _wrap_tensor(out_storage, out_shape, out_stride)
     # Fill on host then memcpy H2D to avoid aclnn scalar ops.
     from .. import acl_loader
@@ -403,7 +404,6 @@ def _scalar_to_npu_tensor(scalar, ref_tensor):
         raise RuntimeError(f"acl.rt.malloc_host failed: {ret}")
     try:
         host_buf = (ctypes.c_uint8 * int(out_size)).from_address(int(host_ptr))
-        itemsize = _dtype_itemsize(ref_tensor.dtype)
         dtype_name = getattr(ref_tensor.dtype, "name", None) or str(ref_tensor.dtype).split(".")[-1]
         if dtype_name == "float16":
             from ..aclnn import _float_to_float16_bits
@@ -436,7 +436,7 @@ def _scalar_to_npu_tensor(scalar, ref_tensor):
         npu_runtime.memcpy_h2d(out_ptr, int(out_size), host_ptr, runtime=runtime)
     finally:
         acl.rt.free_host(host_ptr)
-    out_storage = npu_typed_storage_from_ptr(out_ptr, out_numel, ref_tensor.dtype, device=ref_tensor.device)
+    out_storage = npu_typed_storage_from_ptr(out_ptr, max(out_numel, 1), ref_tensor.dtype, device=ref_tensor.device)
     return _wrap_tensor(out_storage, out_shape, out_stride)
 
 

--- a/src/candle/_backends/npu/ops/comparison.py
+++ b/src/candle/_backends/npu/ops/comparison.py
@@ -66,6 +66,7 @@ except ImportError:
     _fast_bitwise_and_inplace_impl = None  # type: ignore[assignment]
     _fast_bitwise_or_inplace_impl = None  # type: ignore[assignment]
     _fast_bitwise_xor_inplace_impl = None  # type: ignore[assignment]
+    _fast_bitwise_not_inplace_impl = None  # type: ignore[assignment]
     _HAS_FAST_LOGICAL_NOT = False
     _HAS_FAST_BITWISE_NOT = False
     _HAS_FAST_ISCLOSE = False
@@ -86,6 +87,7 @@ except ImportError:
     _HAS_FAST_BITWISE_AND_INPLACE = False
     _HAS_FAST_BITWISE_OR_INPLACE = False
     _HAS_FAST_BITWISE_XOR_INPLACE = False
+    _HAS_FAST_BITWISE_NOT_INPLACE = False
 
 from ._helpers import (
     _unwrap_storage, _wrap_tensor,

--- a/src/candle/_backends/npu/ops/linalg.py
+++ b/src/candle/_backends/npu/ops/linalg.py
@@ -69,6 +69,19 @@ def matmul(a, b, out=None):
     if a.dtype != b.dtype:
         raise ValueError("NPU matmul requires matching dtypes")
 
+    user_out_shape = _matmul_out_shape(tuple(a.shape), tuple(b.shape))
+    a_dim = len(a.shape)
+    b_dim = len(b.shape)
+    if a_dim == 1:
+        contract_dim = int(a.shape[0])
+    elif b_dim == 1:
+        contract_dim = int(b.shape[0])
+    else:
+        contract_dim = int(a.shape[-1])
+    if contract_dim == 0 or _numel(user_out_shape) == 0:
+        from ..creation import zeros_create
+        return _return(zeros_create(user_out_shape, dtype=a.dtype, device=a.device))
+
     # 310B aclnnMatmul only supports float16; cast float32 inputs and cast result back.
     # TODO: re-enable float32 native path when CANN fixes float32 support on 310B.
     from ...._dtype import float16 as float16_dtype
@@ -104,7 +117,6 @@ def matmul(a, b, out=None):
     #   (A) (*, M, K) @ (K, N): collapse left to 2-D.
     #   (B) (b1,...,bn, M, K) @ (b1,...,bn, K, N), ndim >= 4, contiguous
     #       and matching leading dims (no broadcast): collapse to 3-D BMM.
-    user_out_shape = _matmul_out_shape(tuple(a.shape), tuple(b.shape))
     if a.dim() >= 3 and b.dim() == 2 and a.is_contiguous():
         a = a.reshape(-1, a.shape[-1])
     elif (

--- a/src/candle/_backends/npu/ops/reduce.py
+++ b/src/candle/_backends/npu/ops/reduce.py
@@ -1103,17 +1103,18 @@ def cummin_op(a, dim):
 
 
 def _argsort_310b_fallback(a, dim, descending):
-    from ..creation import zeros_create
+    from ..creation import empty_create
     from . import scatter, where
     from .comparison import eq, gt, lt
     from .math import add, isnan, sub
     from .shape import _slice_along_dim
 
     dim_size = int(a.shape[dim])
-    out = zeros_create(tuple(a.shape), dtype=int64_dtype, device=a.device)
+    out = empty_create(tuple(a.shape), dtype=int64_dtype, device=a.device)
     if dim_size == 0:
         return out
 
+    out = sub(out, out)
     nan_mask = isnan(a) if a.dtype.is_floating_point else None
     nan_count = count_nonzero(nan_mask, dim=dim, keepdim=True) if nan_mask is not None else None
     cmp_op = gt if bool(descending) else lt
@@ -1127,7 +1128,7 @@ def _argsort_310b_fallback(a, dim, descending):
         if nan_mask is not None:
             prev_nan = _slice_along_dim(nan_mask, 0, i, dim) if i > 0 else None
             if prev_nan is None:
-                nan_before = zeros_create(rank.shape, dtype=int64_dtype, device=a.device)
+                nan_before = sub(rank, rank)
             else:
                 nan_before = count_nonzero(prev_nan, dim=dim, keepdim=True)
             if bool(descending):

--- a/src/candle/_backends/npu/ops/reduce.py
+++ b/src/candle/_backends/npu/ops/reduce.py
@@ -1102,26 +1102,50 @@ def cummin_op(a, dim):
     return values, indices
 
 
-def _topk_310b_fill_value(dtype, largest):
-    name = getattr(dtype, "name", None) or str(dtype).split(".")[-1]
-    if name in ("float16", "float32", "float64", "bfloat16"):
-        return -float("inf") if largest else float("inf")
-    if name == "int8":
-        return -128 if largest else 127
-    if name == "uint8":
-        return 0 if largest else 255
-    if name == "int16":
-        return -32768 if largest else 32767
-    if name == "int32":
-        return -2147483648 if largest else 2147483647
-    if name == "int64":
-        return -9223372036854775808 if largest else 9223372036854775807
-    raise RuntimeError(f"NPU topk 310B fallback does not support dtype {dtype}")
+def _argsort_310b_fallback(a, dim, descending):
+    from ..creation import zeros_create
+    from . import scatter, where
+    from .comparison import eq, gt, lt
+    from .math import add, isnan, sub
+    from .shape import _slice_along_dim
+
+    dim_size = int(a.shape[dim])
+    out = zeros_create(tuple(a.shape), dtype=int64_dtype, device=a.device)
+    if dim_size == 0:
+        return out
+
+    nan_mask = isnan(a) if a.dtype.is_floating_point else None
+    nan_count = count_nonzero(nan_mask, dim=dim, keepdim=True) if nan_mask is not None else None
+    cmp_op = gt if bool(descending) else lt
+    for i in range(dim_size):
+        val = _slice_along_dim(a, i, i + 1, dim)
+        rank = count_nonzero(cmp_op(a, val), dim=dim, keepdim=True)
+        if i > 0:
+            prev = _slice_along_dim(a, 0, i, dim)
+            equal_before = count_nonzero(eq(prev, val), dim=dim, keepdim=True)
+            rank = add(rank, equal_before)
+        if nan_mask is not None:
+            prev_nan = _slice_along_dim(nan_mask, 0, i, dim) if i > 0 else None
+            if prev_nan is None:
+                nan_before = zeros_create(rank.shape, dtype=int64_dtype, device=a.device)
+            else:
+                nan_before = count_nonzero(prev_nan, dim=dim, keepdim=True)
+            if bool(descending):
+                nan_rank = nan_before
+                rank = add(rank, nan_count)
+            else:
+                non_nan_count = sub(_scalar_to_npu_tensor(dim_size, nan_count), nan_count)
+                nan_rank = add(non_nan_count, nan_before)
+            rank = where(isnan(val), nan_rank, rank)
+        out = scatter(out, dim, rank, _scalar_to_npu_tensor(i, out))
+    return out
 
 
 def _topk_310b_fallback(a, k, dim, largest, sorted_flag):
+    del sorted_flag  # rank-based fallback already produces sorted values
     from ..creation import empty_create
-    from . import cat, scatter
+    from . import gather
+    from .shape import _slice_along_dim
 
     out_shape = list(a.shape)
     out_shape[dim] = int(k)
@@ -1132,31 +1156,10 @@ def _topk_310b_fallback(a, k, dim, largest, sorted_flag):
         indices = empty_create(out_shape, dtype=int64_dtype, device=a.device)
         return values, indices
 
-    work = a
-    values_parts = []
-    indices_parts = []
-    fill_value = _topk_310b_fill_value(a.dtype, largest)
-
-    for _ in range(int(k)):
-        if largest:
-            idx = argmax(work, dim=dim, keepdim=True)
-            val = amax(work, dim=dim, keepdim=True)
-        else:
-            idx = argmin(work, dim=dim, keepdim=True)
-            val = amin(work, dim=dim, keepdim=True)
-        values_parts.append(val)
-        indices_parts.append(idx)
-        work = scatter(work, dim, idx, fill_value)
-
-    if len(values_parts) == 1:
-        values = values_parts[0]
-        indices = indices_parts[0]
-    else:
-        values = cat(values_parts, dim=dim)
-        indices = cat(indices_parts, dim=dim)
-
-    if not bool(sorted_flag):
-        return values, indices
+    indices = _argsort_310b_fallback(a, dim=dim, descending=bool(largest))
+    values = gather(a, dim, indices)
+    values = _slice_along_dim(values, 0, int(k), dim)
+    indices = _slice_along_dim(indices, 0, int(k), dim)
     return values, indices
 
 
@@ -1164,8 +1167,7 @@ def argsort(a, dim=-1, descending=False, stable=False):
     dim = _normalize_dim(dim, a.dim())
 
     if _use_soc_fallback("argsort"):
-        _, indices = _topk_310b_fallback(a, k=a.shape[dim], dim=dim, largest=bool(descending), sorted_flag=True)
-        return indices
+        return _argsort_310b_fallback(a, dim=dim, descending=bool(descending))
 
     # aclnnArgsort/aclnnSort can poison subsequent topk in current runtime.
     # Use topk(k=full_dim) for stable=False to keep behavior and runtime stability.
@@ -1200,7 +1202,9 @@ def sort(a, dim=-1, descending=False, stable=False):
     dim = _normalize_dim(dim, a.dim())
 
     if _use_soc_fallback("sort"):
-        return _topk_310b_fallback(a, k=a.shape[dim], dim=dim, largest=bool(descending), sorted_flag=True)
+        from . import gather
+        indices = _argsort_310b_fallback(a, dim=dim, descending=bool(descending))
+        return gather(a, dim, indices), indices
 
     # Keep runtime stable for default unstable sort path.
     if not stable:

--- a/src/candle/_backends/npu/ops/shape.py
+++ b/src/candle/_backends/npu/ops/shape.py
@@ -2512,6 +2512,11 @@ def gather(a, dim, index):
             raise ValueError("index shape mismatch")
     if not _npu_in_graph_capture():
         _validate_index_bounds(index, a.shape[dim], allow_negative=False, name="gather")
+    # Graph capture cannot perform PyTorch-style host-synchronous bounds checks:
+    # it would require D2H reads/synchronization that aclgraph rejects. Native
+    # torch_npu/ACLNN also does not raise invalid-index errors inside capture, so
+    # captured gather preserves valid-index semantics and defers invalid-index
+    # behavior to the device kernel instead of silently moving validation to CPU.
 
     if _use_soc_fallback("gather"):
         return _gather_310b_fallback(a, dim, index)
@@ -2550,6 +2555,9 @@ def index_select(a, dim, index):
         raise ValueError("index must be 1D")
     dim_size = a.shape[dim]
     if _npu_in_graph_capture():
+        # Avoid D2H validation during graph capture. Native ACLNN gather accepts
+        # negative indices with PyTorch-compatible wraparound for index_select's
+        # expanded gather form, so valid negative-index semantics still hold.
         return _index_select_known_nonnegative(a, dim, index, validate=False)
     _validate_index_bounds(index, dim_size, allow_negative=True, name="index_select")
     norm_index = _normalize_negative_indices(index, dim_size)

--- a/src/candle/_backends/npu/ops/shape.py
+++ b/src/candle/_backends/npu/ops/shape.py
@@ -656,7 +656,7 @@ def _npu_aclnn_slice(tensor, dim, start, stop, step):
 def _npu_assign_to_view(view, value):
     """Write *value* into a view tensor (which shares storage with the original).
 
-    For contiguous views, use D2D memcpy.  Otherwise, use aclnnInplaceCopy.
+    For contiguous views, use D2D memcpy outside graph capture. Otherwise, use aclnnInplaceCopy.
     """
     runtime = npu_runtime.get_runtime((view.device.index or 0))
     stream = npu_state.current_stream((view.device.index or 0))
@@ -679,7 +679,21 @@ def _npu_assign_to_view(view, value):
                 npu_runtime.memcpy_h2d(dst_ptr, copy_size, src_ptr, runtime=runtime)
             else:
                 src_ptr = _npu_data_ptr(value)
-                npu_runtime.memcpy_d2d(dst_ptr, copy_size, src_ptr, runtime=runtime)
+                if _npu_in_graph_capture():
+                    aclnn.inplace_copy(
+                        dst_ptr,
+                        src_ptr,
+                        view.shape,
+                        view.stride,
+                        view.dtype,
+                        value.shape,
+                        value.stride,
+                        value.dtype,
+                        runtime,
+                        stream=stream.stream,
+                    )
+                else:
+                    npu_runtime.memcpy_d2d(dst_ptr, copy_size, src_ptr, runtime=runtime)
         else:
             # Non-contiguous: use aclnnInplaceCopy
             dst_ptr = _npu_data_ptr(view)
@@ -2496,7 +2510,8 @@ def gather(a, dim, index):
     for i, size in enumerate(index.shape):
         if i != dim and size != a.shape[i]:
             raise ValueError("index shape mismatch")
-    _validate_index_bounds(index, a.shape[dim], allow_negative=False, name="gather")
+    if not _npu_in_graph_capture():
+        _validate_index_bounds(index, a.shape[dim], allow_negative=False, name="gather")
 
     if _use_soc_fallback("gather"):
         return _gather_310b_fallback(a, dim, index)

--- a/src/candle/_vmap.py
+++ b/src/candle/_vmap.py
@@ -50,8 +50,75 @@ def _mapped_size(args, in_dims):
     return size, tuple(normalized)
 
 
+def _out_dim_for_index(out_dims, index, count):
+    if isinstance(out_dims, (tuple, list)):
+        if len(out_dims) != count:
+            raise ValueError(
+                f"vmap out_dims must have one entry per output; got {len(out_dims)} "
+                f"entries for {count} outputs"
+            )
+        return out_dims[index]
+    return out_dims
+
+
+def _validate_output_structure(outputs, first):
+    for output in outputs[1:]:
+        if isinstance(first, tuple):
+            if not isinstance(output, tuple) or len(output) != len(first):
+                raise RuntimeError("vmap output structure must be the same for every mapped element")
+        elif isinstance(first, list):
+            if not isinstance(output, list) or len(output) != len(first):
+                raise RuntimeError("vmap output structure must be the same for every mapped element")
+        elif type(output) is not type(first):
+            raise RuntimeError("vmap output structure must be the same for every mapped element")
+
+
+def _empty_tensor_slice(arg, dim):
+    from ._creation import empty  # pylint: disable=import-outside-toplevel
+
+    shape = tuple(arg.shape[:dim]) + tuple(arg.shape[dim + 1:])
+    return empty(
+        shape,
+        dtype=arg.dtype,
+        device=arg.device,
+        requires_grad=getattr(arg, "requires_grad", False),
+    )
+
+
+def _empty_stacked_output(example, out_dims):
+    if isinstance(example, Tensor):
+        from ._creation import empty  # pylint: disable=import-outside-toplevel
+
+        shape = list(example.shape)
+        rank = len(shape) + 1
+        out_dim = out_dims
+        if out_dim < 0:
+            out_dim += rank
+        if out_dim < 0 or out_dim > rank:
+            raise ValueError(f"vmap out_dim {out_dims} is out of bounds for output with {rank} dims")
+        shape.insert(out_dim, 0)
+        return empty(
+            tuple(shape),
+            dtype=example.dtype,
+            device=example.device,
+            requires_grad=getattr(example, "requires_grad", False),
+        )
+    if isinstance(example, tuple):
+        return tuple(
+            _empty_stacked_output(item, _out_dim_for_index(out_dims, index, len(example)))
+            for index, item in enumerate(example)
+        )
+    if isinstance(example, list):
+        return [
+            _empty_stacked_output(item, _out_dim_for_index(out_dims, index, len(example)))
+            for index, item in enumerate(example)
+        ]
+    return []
+
+
 def _stack_outputs(outputs, out_dims):
     first = outputs[0]
+    _validate_output_structure(outputs, first)
     if isinstance(first, Tensor):
         result = stack(outputs, dim=0)
         if out_dims != 0:
@@ -59,12 +126,18 @@ def _stack_outputs(outputs, out_dims):
         return result
     if isinstance(first, tuple):
         return tuple(
-            _stack_outputs([output[index] for output in outputs], out_dims)
+            _stack_outputs(
+                [output[index] for output in outputs],
+                _out_dim_for_index(out_dims, index, len(first)),
+            )
             for index in _builtins.range(len(first))
         )
     if isinstance(first, list):
         return [
-            _stack_outputs([output[index] for output in outputs], out_dims)
+            _stack_outputs(
+                [output[index] for output in outputs],
+                _out_dim_for_index(out_dims, index, len(first)),
+            )
             for index in _builtins.range(len(first))
         ]
     return outputs
@@ -87,6 +160,14 @@ def vmap(func, in_dims=0, out_dims=0, randomness="error", *, chunk_size=None):
         dims = _normalize_in_dims(in_dims, len(args))
         size, normalized_dims = _mapped_size(args, dims)
         outputs = []
+        if size == 0:
+            sliced_args = []
+            for arg, dim in zip(args, normalized_dims):
+                if dim is None:
+                    sliced_args.append(arg)
+                else:
+                    sliced_args.append(_empty_tensor_slice(arg, dim))
+            return _empty_stacked_output(func(*sliced_args, **kwargs), out_dims)
         for index in _builtins.range(size):
             sliced_args = []
             for arg, dim in zip(args, normalized_dims):

--- a/src/candle/library.py
+++ b/src/candle/library.py
@@ -64,11 +64,20 @@ class Library:
             @lib.impl("my_add", dispatch_key="CPU")
             def my_add_cpu(x, y): ...
 
+            @lib.impl("my_add", "CPU")
+            def my_add_cpu(x, y): ...
+
         Args:
             name: Operator name (qualified or bare).
-            fn: Kernel function.  If None, returns a decorator.
+            fn: Kernel function, or dispatch key in decorator shorthand.
+                If None, returns a decorator.
             dispatch_key: Dispatch key string (e.g. "CPU", "NPU", "Meta").
         """
+        if isinstance(fn, (str, DispatchKey)):
+            if dispatch_key != "CompositeImplicitAutograd":
+                raise TypeError("dispatch key specified both positionally and by keyword")
+            dispatch_key = fn
+            fn = None
         qualname = self._qualname(name)
         if self._dispatch_key is not None and dispatch_key == "CompositeImplicitAutograd":
             dispatch_key = self._dispatch_key

--- a/src/candle/nn/module.py
+++ b/src/candle/nn/module.py
@@ -168,11 +168,21 @@ class Module:
         return self.to(device='cpu')
 
     def cuda(self, device=None):
-        target = 'cuda' if device is None else f'cuda:{device}'
+        if device is None:
+            target = 'cuda'
+        elif hasattr(device, 'type'):
+            target = device
+        else:
+            target = f'cuda:{device}'
         return self.to(device=target)
 
     def npu(self, device=None):
-        target = 'npu' if device is None else f'npu:{device}'
+        if device is None:
+            target = 'npu'
+        elif hasattr(device, 'type'):
+            target = device
+        else:
+            target = f'npu:{device}'
         return self.to(device=target)
 
     def float(self):

--- a/src/candle/ops.py
+++ b/src/candle/ops.py
@@ -18,6 +18,12 @@ class _Op:
         self._schema = _OpSchema(qualname, overload_name) if qualname else None
 
     def __call__(self, *args, **kwargs):
+        if self._qualname is not None:
+            from ._dispatch import dispatch  # pylint: disable=import-outside-toplevel
+            from ._dispatch.registry import registry  # pylint: disable=import-outside-toplevel
+
+            if registry.has(self._qualname):
+                return dispatch(self._qualname, None, *args, **kwargs)
         return self._return_value
 
     @property

--- a/tests/cpu/test_autograd_api.py
+++ b/tests/cpu/test_autograd_api.py
@@ -1,5 +1,13 @@
+import inspect
+
 import pytest
 import candle as torch
+
+
+def test_tensor_backward_retain_graph_default_matches_torch_api():
+    signature = inspect.signature(torch.Tensor.backward)
+
+    assert signature.parameters["retain_graph"].default is None
 
 
 def test_backward_requires_grad_for_non_scalar():

--- a/tests/cpu/test_grad_mode_tls.py
+++ b/tests/cpu/test_grad_mode_tls.py
@@ -16,12 +16,35 @@ def test_grad_mode_state_lives_in_compiled_c_boundary():
     assert torch.inference_mode.__module__ == "candle._C._grad_mode_state"
 
 
+def _cython_source_path_for_extension_path(path):
+    """Return the .pyx path for a compiled extension path on any CI platform."""
+    for suffix in importlib.machinery.EXTENSION_SUFFIXES:
+        if path.endswith(suffix):
+            base = path[: -len(suffix)]
+            marker_index = base.find(".cpython-")
+            if marker_index != -1:
+                base = base[:marker_index]
+            return base + ".pyx"
+    if path.endswith(".so"):
+        base = path[: -len(".so")]
+        marker_index = base.find(".cpython-")
+        if marker_index != -1:
+            base = base[:marker_index]
+        return base + ".pyx"
+    return path
+
+
+def test_grad_mode_source_lookup_handles_platform_extension_suffixes():
+    assert _cython_source_path_for_extension_path(
+        "/tmp/_grad_mode_state.cpython-311-x86_64-linux-gnu.so"
+    ) == "/tmp/_grad_mode_state.pyx"
+    assert _cython_source_path_for_extension_path(
+        "/tmp/_grad_mode_state.cpython-311-aarch64-linux-gnu.so"
+    ) == "/tmp/_grad_mode_state.pyx"
+
+
 def test_grad_mode_default_check_is_c_thread_local_fast_path():
-    src = _grad_mode_state.__loader__.path
-    for suffix in (".cpython-311-aarch64-linux-gnu.so", ".so"):
-        if src.endswith(suffix):
-            src = src[: -len(suffix)] + ".pyx"
-            break
+    src = _cython_source_path_for_extension_path(_grad_mode_state.__loader__.path)
     with open(src, encoding="utf-8") as handle:
         content = handle.read()
     # Default-on grad mode must be a C thread-local read, not a

--- a/tests/cpu/test_torch_function.py
+++ b/tests/cpu/test_torch_function.py
@@ -83,6 +83,17 @@ def test_torch_function_blocking():
         assert "BlockingTensor" in str(e)
 
 
+def test_tensor_backward_intercepts_torch_function():
+    TrackedTensor.reset()
+    base = torch.tensor(2.0, requires_grad=True)
+    tracked = TrackedTensor(base)
+
+    tracked.backward()
+
+    assert any("backward" in name for name in TrackedTensor._ops_called)
+    assert base.grad is not None
+
+
 def test_plain_tensors_skip_torch_function():
     a = torch.randn(3)
     b = torch.randn(3)

--- a/tests/npu/common/test_ops.py
+++ b/tests/npu/common/test_ops.py
@@ -972,6 +972,132 @@ def test_npu_add_scalar_inplace_captures_without_host_scalar_copy(monkeypatch):
 
 
 
+def test_npu_scalar_tensor_creation_captures_without_host_copy(monkeypatch):
+    """NPU scalar tensor creation should be graph-capturable without H2D copy."""
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+
+    import candle._backends.npu.creation as npu_creation
+
+    calls = {"h2d": 0}
+    original_copy_cpu_to_npu = npu_creation.npu_runtime._copy_cpu_to_npu
+
+    def forbidden_copy_cpu_to_npu(*args, **kwargs):
+        calls["h2d"] += 1
+        raise AssertionError("graph-captured scalar tensor creation must not use raw H2D copy")
+
+    monkeypatch.setattr(npu_creation.npu_runtime, "_copy_cpu_to_npu", forbidden_copy_cpu_to_npu)
+
+    graph = torch.npu.NPUGraph()
+    with torch.npu.graph(graph):
+        out = torch.tensor(float("-inf"), device="npu", dtype=torch.float32)
+    graph.replay()
+    torch.npu.synchronize()
+    monkeypatch.setattr(npu_creation.npu_runtime, "_copy_cpu_to_npu", original_copy_cpu_to_npu)
+
+    assert calls == {"h2d": 0}
+    assert out.device.type == "npu"
+    assert out.shape == ()
+    assert np.isneginf(out.to("cpu").item())
+
+
+
+def test_npu_scalar_to_tensor_helper_captures_without_host_copy(monkeypatch):
+    """NPU tensor/scalar comparison should be graph-capturable without H2D scalar expansion."""
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+
+    import candle._backends.npu.ops._helpers as npu_helpers
+
+    calls = {"h2d": 0}
+    original_memcpy_h2d = npu_helpers.npu_runtime.memcpy_h2d
+
+    def forbidden_memcpy_h2d(*args, **kwargs):
+        calls["h2d"] += 1
+        raise AssertionError("graph-captured scalar expansion must not use raw H2D copy")
+
+    monkeypatch.setattr(npu_helpers.npu_runtime, "memcpy_h2d", forbidden_memcpy_h2d)
+
+    mask = torch.ones((4, 4), device="npu", dtype=torch.bool).tril()
+    graph = torch.npu.NPUGraph()
+    with torch.npu.graph(graph):
+        out = mask == False  # noqa: E712
+    graph.replay()
+    torch.npu.synchronize()
+    monkeypatch.setattr(npu_helpers.npu_runtime, "memcpy_h2d", original_memcpy_h2d)
+
+    assert calls == {"h2d": 0}
+    expected = np.triu(np.ones((4, 4), dtype=bool), k=1)
+    np.testing.assert_array_equal(out.to("cpu").numpy(), expected)
+
+
+
+def test_npu_contiguous_setitem_captures_without_raw_d2d(monkeypatch):
+    """NPU setitem into a contiguous view should be graph-capturable without raw D2D memcpy."""
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+
+    import candle._backends.npu.ops.shape as npu_shape
+
+    calls = {"memcpy_d2d": 0}
+    original_memcpy_d2d = npu_shape.npu_runtime.memcpy_d2d
+
+    def forbidden_memcpy_d2d(*args, **kwargs):
+        calls["memcpy_d2d"] += 1
+        raise AssertionError("graph-captured setitem view copy must not use raw D2D memcpy")
+
+    x = torch.zeros((4,), device="npu", dtype=torch.float32)
+    value = torch.tensor(np.array([3.0, 4.0], dtype=np.float32), device="npu")
+    monkeypatch.setattr(npu_shape.npu_runtime, "memcpy_d2d", forbidden_memcpy_d2d)
+
+    graph = torch.npu.NPUGraph()
+    with torch.npu.graph(graph):
+        x[:2] = value
+    graph.replay()
+    torch.npu.synchronize()
+    monkeypatch.setattr(npu_shape.npu_runtime, "memcpy_d2d", original_memcpy_d2d)
+
+    assert calls == {"memcpy_d2d": 0}
+    np.testing.assert_allclose(x.to("cpu").numpy(), np.array([3.0, 4.0, 0.0, 0.0], dtype=np.float32))
+
+
+
+def test_npu_gather_captures_without_host_index_bounds_read(monkeypatch):
+    """NPU gather should be graph-capturable without synchronizing index bounds to host."""
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+
+    import candle._backends.npu.ops.shape as npu_shape
+
+    calls = {"index_read": 0, "scalar_read": 0}
+
+    def forbidden_index_read(*args, **kwargs):
+        calls["index_read"] += 1
+        raise AssertionError("gather capture path must not read indices on host")
+
+    def forbidden_scalar_read(*args, **kwargs):
+        calls["scalar_read"] += 1
+        raise AssertionError("gather capture path must not read validation scalars on host")
+
+    monkeypatch.setattr(npu_shape, "_read_index_tensor_to_cpu", forbidden_index_read)
+    monkeypatch.setattr(npu_shape, "_read_bool_scalar", forbidden_scalar_read)
+
+    x = torch.tensor(np.arange(12, dtype=np.float32).reshape(3, 4), device="npu")
+    index = torch.tensor([[0, 1], [2, 3], [1, 0]], device="npu", dtype=torch.int64)
+
+    graph = torch.npu.NPUGraph()
+    with torch.npu.graph(graph):
+        out = torch.gather(x, dim=1, index=index)
+    graph.replay()
+    torch.npu.synchronize()
+
+    assert calls == {"index_read": 0, "scalar_read": 0}
+    expected = np.take_along_axis(np.arange(12, dtype=np.float32).reshape(3, 4),
+                                  np.array([[0, 1], [2, 3], [1, 0]], dtype=np.int64), axis=1)
+    np.testing.assert_allclose(out.to("cpu").numpy(), expected)
+
+
+
 def test_npu_index_select_known_nonnegative_captures_without_host_index_read(monkeypatch):
     """NPU x[:, idx] should capture without reading known nonnegative indices on host."""
     if not torch.npu.is_available():

--- a/tests/npu/common/test_ops.py
+++ b/tests/npu/common/test_ops.py
@@ -1032,6 +1032,38 @@ def test_npu_scalar_to_tensor_helper_captures_without_host_copy(monkeypatch):
 
 
 
+def test_npu_empty_scalar_to_tensor_helper_captures_without_zero_byte_alloc(monkeypatch):
+    """Empty NPU tensor/scalar comparison should not request a zero-byte device allocation."""
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+
+    import candle._backends.npu.ops._helpers as npu_helpers
+
+    calls = {"zero_alloc": 0}
+    original_alloc_device = npu_helpers.npu_runtime._alloc_device
+
+    def checked_alloc_device(size, *args, **kwargs):
+        if int(size) == 0:
+            calls["zero_alloc"] += 1
+            raise AssertionError("empty scalar expansion must allocate at least one byte")
+        return original_alloc_device(size, *args, **kwargs)
+
+    monkeypatch.setattr(npu_helpers.npu_runtime, "_alloc_device", checked_alloc_device)
+
+    mask = torch.empty((0,), device="npu", dtype=torch.bool)
+    graph = torch.npu.NPUGraph()
+    with torch.npu.graph(graph):
+        out = mask == False  # noqa: E712
+    graph.replay()
+    torch.npu.synchronize()
+    monkeypatch.setattr(npu_helpers.npu_runtime, "_alloc_device", original_alloc_device)
+
+    assert calls == {"zero_alloc": 0}
+    assert out.device.type == "npu"
+    assert out.shape == (0,)
+
+
+
 def test_npu_contiguous_setitem_captures_without_raw_d2d(monkeypatch):
     """NPU setitem into a contiguous view should be graph-capturable without raw D2D memcpy."""
     if not torch.npu.is_available():
@@ -1129,6 +1161,24 @@ def test_npu_index_select_known_nonnegative_captures_without_host_index_read(mon
 
     assert calls == {"index_read": 0, "scalar_read": 0}
     np.testing.assert_allclose(out.to("cpu").numpy(), np.array([[0, 2], [4, 6], [8, 10]], dtype=np.float32))
+
+
+
+def test_npu_index_select_negative_indices_capture_normalizes_on_device():
+    """NPU index_select should preserve negative-index semantics during graph capture."""
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+
+    x = torch.tensor([10.0, 20.0, 30.0], device="npu", dtype=torch.float32)
+    idx = torch.tensor([-1, 0], device="npu", dtype=torch.int64)
+
+    graph = torch.npu.NPUGraph()
+    with torch.npu.graph(graph):
+        out = torch.index_select(x, 0, idx)
+    graph.replay()
+    torch.npu.synchronize()
+
+    np.testing.assert_allclose(out.to("cpu").numpy(), np.array([30.0, 10.0], dtype=np.float32))
 
 
 

--- a/tests/npu/cython/test_fast_add_hot_path.py
+++ b/tests/npu/cython/test_fast_add_hot_path.py
@@ -2579,6 +2579,24 @@ def test_npu_linear_without_bias_skips_generated_matmul_backward(npu_device, mon
 
 
 
+def test_npu_linear_without_bias_zero_in_features_does_not_divide_by_zero(npu_device):
+    """Zero-width biasless NPU linear should fall through instead of dividing by input.shape[-1]."""
+    import numpy as np
+    import candle as torch
+    import candle.nn.functional as F
+
+    x = torch.empty((2, 3, 0), device=npu_device, dtype=torch.float16)
+    weight = torch.empty((4, 0), device=npu_device, dtype=torch.float16)
+
+    out = F.linear(x, weight, None)
+    torch.npu.synchronize()
+
+    assert out.device.type == "npu"
+    assert out.shape == (2, 3, 4)
+    np.testing.assert_allclose(out.to("cpu").numpy(), np.zeros((2, 3, 4), dtype=np.float16))
+
+
+
 def test_npu_addmm_autograd_skips_python_dispatch(npu_device, monkeypatch):
     """NPU addmm training hot path should attach autograd without Python dispatch."""
     import candle as torch

--- a/tests/npu/cython/test_fast_add_hot_path.py
+++ b/tests/npu/cython/test_fast_add_hot_path.py
@@ -293,6 +293,14 @@ def test_autograd_backward_skips_unrequested_grads_map_accumulation():
     assert "self.grads_map[tensor]" in grads_map_branch
 
 
+def test_public_tensor_backward_is_cython_hot_wrapper():
+    """Qwen2 eager train steps should not enter the Python Tensor.backward wrapper."""
+    import candle as torch
+    from candle._C import _tensor_api as tensor_api
+
+    assert torch.Tensor.backward is tensor_api.tensor_backward
+
+
 def test_autograd_backward_grad_merge_uses_cython_fast_add():
     """Common NPU backward grad merges should avoid the Python functional add wrapper."""
     src = (_REPO_ROOT / "src/candle/_C/_autograd_engine.pyx").read_text(encoding="utf-8")
@@ -2510,6 +2518,64 @@ def test_npu_linear_cython_hot_path_skips_python_weight_t(npu_device, monkeypatc
     assert x.grad is not None and x.grad.device.type == "npu"
     assert weight.grad is not None and weight.grad.device.type == "npu"
     assert bias.grad is not None and bias.grad.device.type == "npu"
+
+
+
+def test_npu_linear_without_bias_skips_python_linear_glue(npu_device, monkeypatch):
+    """Biasless NPU F.linear should use a Cython hot path, not Python _py_linear."""
+    import numpy as np
+    import candle as torch
+    import candle.nn.functional as F
+
+    x = torch.randn(4, 8, device=npu_device, dtype=torch.float16, requires_grad=True)
+    weight = torch.randn(6, 8, device=npu_device, dtype=torch.float16, requires_grad=True)
+    torch.npu.synchronize()
+    x_np = x.to("cpu").numpy().astype(np.float32)
+    weight_np = weight.to("cpu").numpy().astype(np.float32)
+    expected_out = x_np @ weight_np.T
+    expected_x_grad = np.ones((4, 6), dtype=np.float32) @ weight_np
+    expected_weight_grad = np.ones((6, 4), dtype=np.float32) @ x_np
+
+    def fail_py_linear(*args, **kwargs):
+        raise AssertionError("biasless NPU F.linear should bypass Python _py_linear glue")
+
+    monkeypatch.setattr(F, "_py_linear", fail_py_linear)
+
+    out = F.linear(x, weight, None)
+    out.sum().backward()
+    torch.npu.synchronize()
+
+    assert out.device.type == "npu"
+    assert x.grad is not None and x.grad.device.type == "npu"
+    assert weight.grad is not None and weight.grad.device.type == "npu"
+    np.testing.assert_allclose(out.to("cpu").numpy(), expected_out, rtol=2e-2, atol=2e-2)
+    np.testing.assert_allclose(x.grad.to("cpu").numpy(), expected_x_grad, rtol=2e-2, atol=2e-2)
+    np.testing.assert_allclose(weight.grad.to("cpu").numpy(), expected_weight_grad, rtol=2e-2, atol=2e-2)
+
+
+
+def test_npu_linear_without_bias_skips_generated_matmul_backward(npu_device, monkeypatch):
+    """Biasless NPU F.linear backward should attach a Cython node, not generated matmul backward."""
+    import candle as torch
+    import candle.nn.functional as F
+    import candle._generated.functions as functions_mod
+
+    x = torch.randn(4, 8, device=npu_device, dtype=torch.float16, requires_grad=True)
+    weight = torch.randn(6, 8, device=npu_device, dtype=torch.float16, requires_grad=True)
+    torch.npu.synchronize()
+
+    def fail_matmul_backward(*args, **kwargs):
+        raise AssertionError("biasless NPU F.linear backward should bypass generated MatmulBackward0 helper")
+
+    monkeypatch.setattr(functions_mod, "_matmul_backward_helper", fail_matmul_backward)
+
+    out = F.linear(x, weight, None)
+    out.sum().backward()
+    torch.npu.synchronize()
+
+    assert out.device.type == "npu"
+    assert x.grad is not None and x.grad.device.type == "npu"
+    assert weight.grad is not None and weight.grad.device.type == "npu"
 
 
 


### PR DESCRIPTION
## Summary
- preserve NPU graph-capture support for scalar tensor creation, scalar expansion, contiguous setitem, and gather without forbidden host copies/reads
- route biasless NPU `F.linear` through a Cython forward/backward eager path to avoid Python `_py_linear` glue and generated matmul backward helper
- fix review edge cases for `Tensor.backward` API semantics, zero-width NPU linear, empty scalar expansion allocation, and zero-numel binary outputs
- include generic CPU compatibility fixes surfaced by the required validation gate (`torch.library`, `torch.ops`, module device helpers, and vmap parity)

## Validation
- `python setup.py build_ext --inplace`
- `python -m pytest tests/cpu/ tests/contract/ -v --tb=short` → 3576 passed, 30 skipped, 36 warnings
- `python -m pytest tests/npu/ -v --tb=short` → 585 passed, 25 skipped, 5 warnings
- `python -m pylint src/candle/ --rcfile=.github/pylint.conf` → 10.00/10
- `git diff --check`

## Benchmark
- `benchmarks/hf_qwen2_parity.py --framework all --mode train-step --device npu --dtype float16 --iters 20 --warmup 5 --timeout 240`
- Candle: 78.00 ms median train-step; torch_npu: 14.88 ms median train-step (Candle remains ~5.24x slower, next eager batch should continue from dispatch/autograd overhead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)