### PR TITLE
perf(npu): optimize backward redispatch with Cython fast paths

### DIFF
--- a/src/candle/_C/_dispatcher_core.pyx
+++ b/src/candle/_C/_dispatcher_core.pyx
@@ -10,6 +10,14 @@ function boundaries on the hot path.
 
 from libc.stdint cimport int64_t, uint32_t
 from candle._C._tensor_impl cimport TensorImpl
+IF HAS_NPU_CYTHON:
+    from candle._C._npu_ops cimport (
+        fast_add_exact as _redispatch_fast_npu_add_exact,
+        fast_sub_exact as _redispatch_fast_npu_sub_exact,
+        fast_mul_exact as _redispatch_fast_npu_mul_exact,
+        fast_div_exact as _redispatch_fast_npu_div_exact,
+        fast_neg as _redispatch_fast_npu_neg,
+    )
 import os
 import inspect
 
@@ -891,9 +899,77 @@ def cy_dispatch_with_keyset_fast(str name, object keyset, object dispatch_device
     The keyset is pre-built by the caller; _dispatch_core applies TLS masks
     and skips keyset construction.
     """
+    cdef object fast_result
+    cdef object fast_keyset
     _ensure_imports()
     _ensure_dispatch_helpers()
+    if keyset is not None and not _is_profiler_enabled_fn():
+        fast_keyset = _apply_tls_masks_inline(keyset)
+        fast_result = _try_fast_npu_backward_redispatch(name, fast_keyset, args, kwargs)
+        if fast_result is not None:
+            return fast_result
     return _dispatch_core(name, dispatch_device, args, kwargs, keyset, None)
+
+
+# ---------------------------------------------------------------------------
+# NPU backward redispatch fast path
+# ---------------------------------------------------------------------------
+
+cdef inline object _try_fast_npu_backward_redispatch(str name, object keyset,
+                                                     tuple args, dict kwargs) except *:
+    """Bypass registry/schema/Python wrappers for raw exact-base NPU backward ops.
+
+    This is only entered from redispatch with a pre-stripped backend keyset. Public
+    dispatch still uses normal schema validation and autograd handling. Covered
+    cases are exact same-shape NPU Tensor operands used by backward formulas.
+    """
+    cdef unsigned int m
+    cdef int nargs
+    cdef object a
+    cdef object b
+    IF not HAS_NPU_CYTHON:
+        return None
+    if keyset is None:
+        return None
+    if kwargs:
+        return None
+    if hasattr(keyset, "mask"):
+        m = <unsigned int>int(keyset.mask)
+    else:
+        m = <unsigned int>int(keyset)
+    if m != _KEY_NPU:
+        return None
+    nargs = len(args)
+    if name == "neg":
+        if nargs != 1:
+            return None
+        a = args[0]
+        if type(a) is not _BaseTensor:
+            return None
+        if (<TensorImpl>a)._device_type != 1:
+            return None
+        return _redispatch_fast_npu_neg(a)
+    if not (name == "mul" or name == "div" or name == "true_divide" or name == "add" or name == "sub"):
+        return None
+    if nargs != 2:
+        return None
+    a = args[0]
+    b = args[1]
+    if type(a) is not _BaseTensor or type(b) is not _BaseTensor:
+        return None
+    if (<TensorImpl>a)._device_type != 1 or (<TensorImpl>b)._device_type != 1:
+        return None
+    if (<TensorImpl>a)._device_index != (<TensorImpl>b)._device_index:
+        return None
+    if (<TensorImpl>a)._shape_tuple != (<TensorImpl>b)._shape_tuple:
+        return None
+    if name == "mul":
+        return _redispatch_fast_npu_mul_exact(<TensorImpl>a, <TensorImpl>b)
+    if name == "div" or name == "true_divide":
+        return _redispatch_fast_npu_div_exact(<TensorImpl>a, <TensorImpl>b)
+    if name == "add":
+        return _redispatch_fast_npu_add_exact(<TensorImpl>a, <TensorImpl>b)
+    return _redispatch_fast_npu_sub_exact(<TensorImpl>a, <TensorImpl>b)
 
 
 # ---------------------------------------------------------------------------

--- a/src/candle/_C/_npu_ops.pxd
+++ b/src/candle/_C/_npu_ops.pxd
@@ -44,6 +44,7 @@ cpdef object fast_rsqrt(object a)
 cpdef object fast_cast(object a, object dst_dtype)
 cpdef object fast_gelu_backward(object grad, object saved_input)
 cpdef object fast_silu_backward(object grad, object saved_input)
+cpdef object fast_neg(object a)
 cpdef object fast_copy_small_inner_contiguous_view(object view)
 cpdef object fast_cat_small_last_dim(object tensors, int64_t dim, object out_shape, object out_stride,
                                      int64_t out_ptr, object first)

--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -7096,7 +7096,7 @@ def _npu_contiguous_copy(a):
     return contiguous(a)
 
 
-def fast_neg(a):
+cpdef object fast_neg(object a):
     """Optimized out-of-place neg(a) that calls _ffi.unary_op directly."""
     _ensure_npu_imports()
     _ensure_ffi_neg()

--- a/tests/npu/cython/test_fast_backward_hot_path.py
+++ b/tests/npu/cython/test_fast_backward_hot_path.py
@@ -1,0 +1,143 @@
+import re
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _read(relpath):
+    return (_REPO_ROOT / relpath).read_text(encoding="utf-8")
+
+
+def test_backward_redispatch_fast_path_is_cython_only():
+    """Hot NPU backward redispatch ops should route directly to Cython kernels."""
+    src = _read("src/candle/_C/_dispatcher_core.pyx")
+    assert "from candle._C._npu_ops cimport" in src
+    for symbol in (
+        "fast_add_exact as _redispatch_fast_npu_add_exact",
+        "fast_sub_exact as _redispatch_fast_npu_sub_exact",
+        "fast_mul_exact as _redispatch_fast_npu_mul_exact",
+        "fast_div_exact as _redispatch_fast_npu_div_exact",
+        "fast_neg as _redispatch_fast_npu_neg",
+    ):
+        assert symbol in src
+
+    assert "cdef inline object _try_fast_npu_backward_redispatch" in src
+    fast_path = re.search(
+        r"cdef inline object _try_fast_npu_backward_redispatch\(.*?\) except \*:(?P<body>.*?)\n\n\n#",
+        src,
+        flags=re.DOTALL,
+    )
+    assert fast_path is not None
+    body = fast_path.group("body")
+    for call in (
+        "_redispatch_fast_npu_mul_exact(<TensorImpl>a, <TensorImpl>b)",
+        "_redispatch_fast_npu_div_exact(<TensorImpl>a, <TensorImpl>b)",
+        "_redispatch_fast_npu_add_exact(<TensorImpl>a, <TensorImpl>b)",
+        "_redispatch_fast_npu_sub_exact(<TensorImpl>a, <TensorImpl>b)",
+        "_redispatch_fast_npu_neg(a)",
+    ):
+        assert call in body
+    assert "_registry" not in body
+    assert "schema_obj" not in body
+    assert ".bind(" not in body
+
+
+def test_backward_redispatch_fast_path_has_raw_exact_npu_guards():
+    """The Cython bypass is only valid for raw same-device exact-base NPU redispatch."""
+    src = _read("src/candle/_C/_dispatcher_core.pyx")
+    fast_path = re.search(
+        r"cdef inline object _try_fast_npu_backward_redispatch\(.*?\) except \*:(?P<body>.*?)\n\n\n#",
+        src,
+        flags=re.DOTALL,
+    )
+    assert fast_path is not None
+    body = fast_path.group("body")
+
+    assert "if keyset is None:" in body
+    assert "if kwargs:" in body
+    assert "m != _KEY_NPU" in body
+    assert "name == \"true_divide\"" in body
+    assert "type(a) is not _BaseTensor" in body
+    assert "type(b) is not _BaseTensor" in body
+    assert "(<TensorImpl>a)._device_type != 1" in body
+    assert "(<TensorImpl>b)._device_type != 1" in body
+    assert "(<TensorImpl>a)._device_index != (<TensorImpl>b)._device_index" in body
+    assert "(<TensorImpl>a)._shape_tuple != (<TensorImpl>b)._shape_tuple" in body
+
+
+def test_fast_neg_is_cpdef_for_cython_redispatch_cimport():
+    """Unary neg must be cimportable by the dispatcher Cython fast path."""
+    pxd = _read("src/candle/_C/_npu_ops.pxd")
+    pyx = _read("src/candle/_C/_npu_ops.pyx")
+    assert "cpdef object fast_neg(object a)" in pxd
+    assert "cpdef object fast_neg(object a):" in pyx
+
+
+def test_backward_redispatch_public_python_remains_thin():
+    """Do not add a parallel Python hot helper; redispatch should stay a thin Cython entry."""
+    src = _read("src/candle/_dispatch/dispatcher.py")
+    match = re.search(r"def redispatch\(name, keyset, \*args, \*\*kwargs\):(?P<body>.*?)\n\n", src, re.DOTALL)
+    assert match is not None
+    body = match.group("body")
+    assert "dispatch_with_keyset(name, keyset, None, *args, **kwargs)" in body
+    assert "fast_npu" not in body
+    assert "_C._npu_ops" not in body
+
+
+def test_npu_backward_redispatch_mul_bypasses_python_backend(npu_device, monkeypatch):
+    """Generated/backward redispatch mul should not call the Python NPU backend wrapper."""
+    import numpy as np
+    import candle as torch
+    from candle._dispatch.keys import DispatchKey
+    from candle._dispatch.registry import registry
+
+    calls = {"mul": 0}
+
+    def fail_python_mul(*args, **kwargs):
+        calls["mul"] += 1
+        raise AssertionError("NPU backward redispatch mul should use the Cython exact kernel")
+
+    monkeypatch.setitem(registry.get("mul").kernels, DispatchKey.NPU, fail_python_mul)
+
+    x = torch.tensor([1.0, 2.0, 3.0, 4.0], device=npu_device, dtype=torch.float32, requires_grad=True)
+    y = torch.tensor([5.0, 6.0, 7.0, 8.0], device=npu_device, dtype=torch.float32, requires_grad=True)
+    out = (x * y).sum()
+    out.backward()
+    torch.npu.synchronize()
+
+    assert calls["mul"] == 0
+    np.testing.assert_allclose(x.grad.to("cpu").numpy(), [5.0, 6.0, 7.0, 8.0], rtol=1e-6, atol=1e-6)
+    np.testing.assert_allclose(y.grad.to("cpu").numpy(), [1.0, 2.0, 3.0, 4.0], rtol=1e-6, atol=1e-6)
+
+
+def test_npu_backward_redispatch_div_neg_bypasses_python_backend(npu_device, monkeypatch):
+    """Div backward uses div/mul/neg redispatch; covered exact ops should stay in Cython."""
+    import numpy as np
+    import candle as torch
+    from candle._dispatch.keys import DispatchKey
+    from candle._dispatch.registry import registry
+
+    calls = {"div": 0, "mul": 0, "neg": 0}
+
+    def fail(name):
+        def inner(*args, **kwargs):
+            calls[name] += 1
+            raise AssertionError(f"NPU backward redispatch {name} should use Cython exact kernel")
+        return inner
+
+    monkeypatch.setitem(registry.get("div").kernels, DispatchKey.NPU, fail("div"))
+    monkeypatch.setitem(registry.get("mul").kernels, DispatchKey.NPU, fail("mul"))
+    monkeypatch.setitem(registry.get("neg").kernels, DispatchKey.NPU, fail("neg"))
+
+    x_values = np.array([4.0, 9.0, 16.0, 25.0], dtype=np.float32)
+    y_values = np.array([2.0, 3.0, 4.0, 5.0], dtype=np.float32)
+    x = torch.tensor(x_values, device=npu_device, dtype=torch.float32, requires_grad=True)
+    y = torch.tensor(y_values, device=npu_device, dtype=torch.float32, requires_grad=True)
+    out = (x / y).sum()
+    out.backward()
+    torch.npu.synchronize()
+
+    assert calls == {"div": 0, "mul": 0, "neg": 0}
+    np.testing.assert_allclose(x.grad.to("cpu").numpy(), 1.0 / y_values, rtol=1e-6, atol=1e-6)
+    np.testing.assert_allclose(y.grad.to("cpu").numpy(), -x_values / (y_values * y_values), rtol=1e-6, atol=1e-6)


### PR DESCRIPTION
Adds Cython fast paths for high-frequency backward redispatch ops (mul, div, add, sub, neg) to bypass Python dispatch + schema validation overhead.

## Benchmark (Qwen2 tiny, 910B3, fp16, 50 iters)

**Before (25bbb46):** total 83.7ms, backward 55.08ms, gap 5.8×
**After (f1dbcb4):** total 78.19ms, backward 46.33ms, gap 5.15×

**Improvement:** 6.6% total speedup, 16% backward speedup

## Implementation

- Extends `_try_fast_npu_backward_redispatch` in `_C/_dispatcher_core.pyx` to bypass Python backend + schema for exact same-device same-shape NPU binary/unary ops
- Exact guards: base `_BaseTensor`, NPU device_type=1, same device_index, same shape
- Covered ops: mul, div (true_divide), add, sub, neg
- Runtime tests confirm Python NPU backend kernels are not called (monkeypatched to fail)

## Test coverage

- 6 tests in `tests/npu/cython/test_fast_backward_hot_path.py`
- Full NPU suite: 227/227 passed
- CPU + contract: 176/176 passed

## Next steps

Remaining backward redispatch overhead (~30ms/step) dominated by:
- reshape (51 calls/step, view metadata)
- zeros (42 calls/step, creation)
- setitem (39 calls/step, scatter)

These require different fast-path patterns and will be addressed in follow-up PRs.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)