### PR TITLE
perf(npu): enable training-mode forward fast paths for sub/div

### DIFF
--- a/src/candle/_C/_functional_ops.pxd
+++ b/src/candle/_C/_functional_ops.pxd
@@ -8,3 +8,5 @@ Exposes autograd attach functions for use in other Cython modules
 # Autograd attach functions for training-mode fast paths
 cpdef object attach_npu_add_grad(object result, object a, object b)
 cpdef object attach_npu_mul_grad(object result, object a, object b)
+cpdef object attach_npu_sub_grad(object result, object a, object b)
+cpdef object attach_npu_div_grad(object result, object a, object b)

--- a/src/candle/_C/_functional_ops.pyx
+++ b/src/candle/_C/_functional_ops.pyx
@@ -1293,6 +1293,222 @@ cdef class _NpuMulBackward(_CyAutogradNode):
         return grad_self, grad_other
 
 
+cdef class _NpuSubBackward(_CyAutogradNode):
+    cdef public object _self
+    cdef public object _other
+
+    cdef void _init_fast(self, object self_, object other):
+        # Manual field init. Sub backward is simple: grad_self = grad, grad_other = -grad.
+        self.inputs = (self_, other)
+        self._saved_tensors_list = _npu_empty_saved_tensors
+        self._saved_fields = _npu_empty_saved_fields
+        self._hooks = None
+        self._prehooks = None
+        self._metadata = None
+        self._name = "SubBackward0"
+        self._anomaly_trace = None
+        self._anomaly_parent = None
+        self._next_functions_cache = _npu_binary_edges_if_needed(self_, other)
+        self._self = self_
+        self._other = other
+
+    def __init__(self, self_, other):
+        self._init_fast(self_, other)
+
+    @property
+    def next_functions(self):
+        cached = _npu_get_binary_edges(self._self, self._other, self._next_functions_cache)
+        self._next_functions_cache = cached
+        return cached
+
+    def backward(self, grad):
+        grad_self = grad if (<TensorImpl>self._self).requires_grad else None
+        grad_other = None
+        if (<TensorImpl>self._other).requires_grad:
+            _ensure_npu_refs()
+            _ensure_npu_autograd_refs()
+            if _npu_create_graph_fn():
+                # Keep the gradient differentiable under create_graph.
+                grad_other = _npu_dispatch_mul_fn("mul", None, grad, -1)
+            else:
+                grad_other = _mark_npu_owned_backward_grad(_cy_fast_npu_mul_scalar_exact(<TensorImpl>grad, -1))
+        return grad_self, grad_other
+
+
+cdef class _NpuDivBackward(_CyAutogradNode):
+    cdef public object _self
+    cdef public object _other
+    cdef int64_t _saved_self_version
+    cdef int64_t _saved_other_version
+    cdef bint _saved_self_released
+    cdef bint _saved_other_released
+    cdef object _saved_self_obj
+    cdef object _saved_other_obj
+
+    cdef void _init_fast(self, object self_, object other):
+        # Div backward needs saved tensors: grad_self = grad / other, grad_other = -grad * self / (other^2).
+        cdef object saved_self
+        cdef object saved_other
+        self.inputs = (self_, other)
+        self._hooks = None
+        self._prehooks = None
+        self._metadata = None
+        self._name = "DivBackward0"
+        self._anomaly_trace = None
+        self._anomaly_parent = None
+        self._next_functions_cache = _npu_binary_edges_if_needed(self_, other)
+        self._self = self_
+        self._other = other
+        self._saved_self_released = False
+        self._saved_other_released = False
+        if _npu_has_saved_hooks():
+            saved_self = SavedTensor(self_)
+            if self_ is other:
+                saved_other = saved_self
+            else:
+                saved_other = SavedTensor(other)
+            self._saved_self_obj = saved_self
+            self._saved_other_obj = saved_other
+            self._saved_self_version = 0
+            self._saved_other_version = 0
+        else:
+            self._saved_self_obj = None
+            self._saved_other_obj = None
+            self._saved_self_version = (<TensorImpl>self_)._version_value
+            self._saved_other_version = self._saved_self_version if self_ is other else (<TensorImpl>other)._version_value
+        self._saved_tensors_list = _npu_empty_saved_tensors
+        self._saved_fields = _npu_empty_saved_fields
+
+    def __init__(self, self_, other):
+        self._init_fast(self_, other)
+
+    @property
+    def next_functions(self):
+        cached = _npu_get_binary_edges(self._self, self._other, self._next_functions_cache)
+        self._next_functions_cache = cached
+        return cached
+
+    cpdef object _saved_proxy_tensor_py(self, int slot):
+        if slot == 0:
+            return self._self
+        return self._other
+
+    cpdef bint _saved_proxy_released_py(self, int slot):
+        if slot == 0:
+            return self._saved_self_released
+        return self._saved_other_released
+
+    cpdef void _saved_proxy_release_py(self, int slot):
+        if slot == 0:
+            self._saved_self_released = True
+        else:
+            self._saved_other_released = True
+
+    cpdef object _saved_proxy_materialize_py(self, int slot):
+        if slot == 0:
+            return _npu_materialize_tensor_version(self._self, self._saved_self_version, self._saved_self_released)
+        return _npu_materialize_tensor_version(self._other, self._saved_other_version, self._saved_other_released)
+
+    cdef object _raw_saved_self_proxy(self):
+        if self._saved_self_obj is None:
+            self._saved_self_obj = _npu_saved_tensor_proxy(self, 0)
+        return self._saved_self_obj
+
+    cdef object _raw_saved_other_proxy(self):
+        if self._saved_other_obj is None:
+            if self._self is self._other:
+                self._saved_other_obj = self._raw_saved_self_proxy()
+            else:
+                self._saved_other_obj = _npu_saved_tensor_proxy(self, 1)
+        return self._saved_other_obj
+
+    def saved_tensors(self):
+        cdef object self_saved
+        cdef object other_saved
+        if self._saved_self_obj is not None:
+            self_saved = self._saved_self_obj.materialize()
+        else:
+            self_saved = self._saved_proxy_materialize_py(0)
+        if self._saved_other_obj is not None:
+            other_saved = self._saved_other_obj.materialize()
+        elif self._self is self._other and self._saved_self_obj is not None:
+            other_saved = self._saved_self_obj.materialize()
+        else:
+            other_saved = self._saved_proxy_materialize_py(1)
+        return (self_saved, other_saved)
+
+    def release_saved_tensors(self):
+        if self._saved_self_obj is not None:
+            self._saved_self_obj.release()
+        else:
+            self._saved_self_released = True
+        if self._self is self._other or self._saved_other_obj is self._saved_self_obj:
+            self._saved_other_released = True
+            return
+        if self._saved_other_obj is not None:
+            self._saved_other_obj.release()
+        else:
+            self._saved_other_released = True
+
+    def __getattr__(self, name):
+        if name == "_raw_saved_self":
+            return self._raw_saved_self_proxy()
+        if name == "_raw_saved_other":
+            return self._raw_saved_other_proxy()
+        if name == "_saved_self":
+            if self._saved_self_obj is not None:
+                return self._saved_self_obj.materialize()
+            return self._saved_proxy_materialize_py(0)
+        if name == "_saved_other":
+            if self._saved_other_obj is not None:
+                return self._saved_other_obj.materialize()
+            if self._self is self._other and self._saved_self_obj is not None:
+                return self._saved_self_obj.materialize()
+            return self._saved_proxy_materialize_py(1)
+        if name == "_raw_saved_tensors":
+            return (self._raw_saved_self_proxy(), self._raw_saved_other_proxy())
+        if name == "_saved_tensors":
+            return self.saved_tensors()
+        return _CyAutogradNode.__getattr__(self, name)
+
+    def backward(self, grad):
+        grad_self = None
+        grad_other = None
+        if self._saved_self_obj is not None:
+            self_ = self._saved_self_obj.materialize()
+        else:
+            self_ = self._saved_proxy_materialize_py(0)
+        if self._saved_other_obj is not None:
+            other = self._saved_other_obj.materialize()
+        elif self._self is self._other and self._saved_self_obj is not None:
+            other = self._saved_self_obj.materialize()
+        else:
+            other = self._saved_proxy_materialize_py(1)
+        _ensure_npu_refs()
+        _ensure_npu_autograd_refs()
+        # grad_self = grad / other
+        # grad_other = -grad * self / (other^2)
+        if _npu_create_graph_fn():
+            # Under create_graph the gradient itself must be differentiable,
+            # so route through the dispatched (graph-building) ops.
+            if getattr(self_, "requires_grad", False):
+                grad_self = _npu_dispatch_mul_fn("true_divide", None, grad, other)
+            if getattr(other, "requires_grad", False):
+                # grad_other = -grad * self / other^2
+                tmp = _npu_dispatch_mul_fn("mul", None, grad, self_)
+                tmp = _npu_dispatch_mul_fn("true_divide", None, tmp, _npu_dispatch_mul_fn("mul", None, other, other))
+                grad_other = _npu_dispatch_mul_fn("mul", None, tmp, -1)
+            return grad_self, grad_other
+        if getattr(self_, "requires_grad", False):
+            grad_self = _mark_npu_owned_backward_grad(_cy_fast_npu_div_exact(<TensorImpl>grad, <TensorImpl>other))
+        if getattr(other, "requires_grad", False):
+            # grad_other = -grad * self / (other^2)
+            other_sq = _cy_fast_npu_mul(other, other)
+            tmp = _cy_fast_npu_div_exact(<TensorImpl>_cy_fast_npu_mul(grad, self_), <TensorImpl>other_sq)
+            grad_other = _mark_npu_owned_backward_grad(_cy_fast_npu_mul_scalar_exact(<TensorImpl>tmp, -1))
+        return grad_self, grad_other
+
+
 cdef class _NpuAddmmBackward(_CyAutogradNode):
     cdef public object _self
     cdef public object _mat1
@@ -2728,6 +2944,26 @@ cpdef object attach_npu_mul_grad(object result, object a, object b):
     return result
 
 
+cpdef object attach_npu_sub_grad(object result, object a, object b):
+    """Attach NPU sub backward node. Exposed for training-mode forward fast paths."""
+    cdef TensorImpl out = <TensorImpl>result
+    cdef _NpuSubBackward grad_fn = _NpuSubBackward.__new__(_NpuSubBackward)
+    grad_fn._init_fast(a, b)
+    out.grad_fn = grad_fn
+    out.requires_grad = True
+    return result
+
+
+cpdef object attach_npu_div_grad(object result, object a, object b):
+    """Attach NPU div backward node. Exposed for training-mode forward fast paths."""
+    cdef TensorImpl out = <TensorImpl>result
+    cdef _NpuDivBackward grad_fn = _NpuDivBackward.__new__(_NpuDivBackward)
+    grad_fn._init_fast(a, b)
+    out.grad_fn = grad_fn
+    out.requires_grad = True
+    return result
+
+
 cdef inline object _attach_npu_scalar_pass_grad(object result, object a, object name):
     cdef TensorImpl out = <TensorImpl>result
     cdef _NpuScalarPassBackward grad_fn = _NpuScalarPassBackward.__new__(_NpuScalarPassBackward)
@@ -2990,6 +3226,8 @@ def sub(a, b, *, alpha=1):
             npu_state = _exact_npu_binary_hot_state(a, b)
             if npu_state == 1 and not _npu_profiler_active_flag:
                 return _cy_fast_npu_sub_exact(<TensorImpl>a, <TensorImpl>b)
+            if npu_state == 2:
+                return attach_npu_sub_grad(_cy_fast_npu_sub_exact(<TensorImpl>a, <TensorImpl>b), a, b)
         if _exact_base_npu_tensor_scalar(a, b):
             npu_state = _exact_npu_scalar_hot_state(a)
             if npu_state == 1 and not _npu_profiler_active_flag:
@@ -3027,6 +3265,8 @@ def div(a, b, *, rounding_mode=None):
             npu_state = _exact_npu_binary_hot_state(a, b)
             if npu_state == 1 and not _npu_profiler_active_flag:
                 return _cy_fast_npu_div_exact(<TensorImpl>a, <TensorImpl>b)
+            if npu_state == 2:
+                return attach_npu_div_grad(_cy_fast_npu_div_exact(<TensorImpl>a, <TensorImpl>b), a, b)
         if _exact_base_npu_tensor_scalar(a, b):
             npu_state = _exact_npu_scalar_hot_state(a)
             if npu_state == 1 and not _npu_profiler_active_flag:

--- a/src/candle/_C/_tensor_impl.pyx
+++ b/src/candle/_C/_tensor_impl.pyx
@@ -23,6 +23,8 @@ IF HAS_NPU_CYTHON:
     from candle._C._functional_ops cimport (
         attach_npu_add_grad,
         attach_npu_mul_grad,
+        attach_npu_sub_grad,
+        attach_npu_div_grad,
     )
 from candle._C._tensor_api cimport (
     _npu_functionalize_active_flag,
@@ -186,6 +188,9 @@ cdef class TensorImpl:
         IF HAS_NPU_CYTHON:
             if _can_use_npu_binary_slot_direct(self, other):
                 return _slot_fast_npu_sub_exact(self, <TensorImpl>other)
+            if _can_use_npu_binary_slot_train(self, other):
+                result = _slot_fast_npu_sub_exact(self, <TensorImpl>other)
+                return attach_npu_sub_grad(result, self, other)
             if _can_use_npu_scalar_slot_direct(self, other):
                 return _slot_fast_npu_sub_scalar_exact(self, other)
         return _slot_tensor_sub(self, other)
@@ -205,6 +210,9 @@ cdef class TensorImpl:
         IF HAS_NPU_CYTHON:
             if _can_use_npu_binary_slot_direct(self, other):
                 return _slot_fast_npu_div_exact(self, <TensorImpl>other)
+            if _can_use_npu_binary_slot_train(self, other):
+                result = _slot_fast_npu_div_exact(self, <TensorImpl>other)
+                return attach_npu_div_grad(result, self, other)
             if _can_use_npu_scalar_slot_direct(self, other):
                 return _slot_fast_npu_div_scalar_exact(self, other)
         return _slot_tensor_truediv(self, other)

--- a/tests/npu/cython/test_training_forward_sub_div_fast_path.py
+++ b/tests/npu/cython/test_training_forward_sub_div_fast_path.py
@@ -1,0 +1,210 @@
+"""Test training-mode forward fast paths for NPU sub/div operators.
+
+Training-mode forward sub/div ops (requires_grad=True) should stay in Cython and
+attach autograd nodes directly, rather than falling back to Python dispatch.
+
+This tests the implementation in _tensor_impl.pyx __sub__/__truediv__ slots with
+the _can_use_npu_binary_slot_train guard plus the attach_npu_sub_grad/
+attach_npu_div_grad autograd attach functions in _functional_ops.pyx.
+"""
+import numpy as np
+import pytest
+
+
+def test_npu_sub_training_mode_stays_in_cython(npu_device, monkeypatch):
+    """Training-mode sub should use Cython fast path, not Python dispatch."""
+    import candle as torch
+    from candle._dispatch.registry import registry
+    from candle._dispatch.keys import DispatchKey
+
+    calls = {"python_sub": 0}
+
+    def fail_python_sub(*args, **kwargs):
+        calls["python_sub"] += 1
+        raise AssertionError("Training-mode sub should use Cython fast path, not Python dispatch")
+
+    monkeypatch.setitem(registry.get("sub").kernels, DispatchKey.NPU, fail_python_sub)
+
+    x = torch.tensor([5.0, 8.0, 11.0], device=npu_device, dtype=torch.float32, requires_grad=True)
+    y = torch.tensor([2.0, 3.0, 4.0], device=npu_device, dtype=torch.float32, requires_grad=True)
+    z = x - y
+
+    assert z.requires_grad
+    assert z.grad_fn is not None
+    assert "Sub" in str(type(z.grad_fn))
+
+    loss = z.sum()
+    loss.backward()
+
+    # d(x - y)/dx = 1, d(x - y)/dy = -1
+    np.testing.assert_allclose(x.grad.cpu().numpy(), [1.0, 1.0, 1.0], rtol=1e-6)
+    np.testing.assert_allclose(y.grad.cpu().numpy(), [-1.0, -1.0, -1.0], rtol=1e-6)
+
+    assert calls["python_sub"] == 0, "Training-mode sub went through Python dispatch"
+
+
+def test_npu_div_training_mode_stays_in_cython(npu_device, monkeypatch):
+    """Training-mode div should use Cython fast path, not Python dispatch."""
+    import candle as torch
+    from candle._dispatch.registry import registry
+    from candle._dispatch.keys import DispatchKey
+
+    calls = {"python_div": 0}
+
+    def fail_python_div(*args, **kwargs):
+        calls["python_div"] += 1
+        raise AssertionError("Training-mode div should use Cython fast path, not Python dispatch")
+
+    # true_divide is the registered op name for tensor-tensor division
+    monkeypatch.setitem(registry.get("true_divide").kernels, DispatchKey.NPU, fail_python_div)
+
+    x = torch.tensor([4.0, 6.0, 8.0], device=npu_device, dtype=torch.float32, requires_grad=True)
+    y = torch.tensor([2.0, 2.0, 4.0], device=npu_device, dtype=torch.float32, requires_grad=True)
+    z = x / y
+
+    assert z.requires_grad
+    assert z.grad_fn is not None
+    assert "Div" in str(type(z.grad_fn))
+
+    loss = z.sum()
+    loss.backward()
+
+    # d(x / y)/dx = 1/y ; d(x / y)/dy = -x/y^2
+    np.testing.assert_allclose(x.grad.cpu().numpy(), [0.5, 0.5, 0.25], rtol=1e-6)
+    np.testing.assert_allclose(y.grad.cpu().numpy(), [-1.0, -1.5, -0.5], rtol=1e-6)
+
+    assert calls["python_div"] == 0, "Training-mode div went through Python dispatch"
+
+
+def test_npu_training_forward_sub_div_correctness_matches_inference(npu_device):
+    """Training-mode sub/div forward results should match inference mode."""
+    import candle as torch
+
+    x_vals = np.random.randn(4, 4).astype(np.float32)
+    y_vals = (np.random.randn(4, 4) + 3.0).astype(np.float32)  # avoid div by ~0
+
+    with torch.no_grad():
+        x_inf = torch.tensor(x_vals, device=npu_device, dtype=torch.float32)
+        y_inf = torch.tensor(y_vals, device=npu_device, dtype=torch.float32)
+        z_inf_sub = x_inf - y_inf
+        z_inf_div = x_inf / y_inf
+
+    x_train = torch.tensor(x_vals, device=npu_device, dtype=torch.float32, requires_grad=True)
+    y_train = torch.tensor(y_vals, device=npu_device, dtype=torch.float32, requires_grad=True)
+    z_train_sub = x_train - y_train
+    z_train_div = x_train / y_train
+
+    np.testing.assert_allclose(z_train_sub.detach().cpu().numpy(), z_inf_sub.cpu().numpy(), rtol=1e-6)
+    np.testing.assert_allclose(z_train_div.detach().cpu().numpy(), z_inf_div.cpu().numpy(), rtol=1e-5)
+
+
+def test_npu_training_forward_sub_div_mixed_requires_grad(npu_device):
+    """Sub/div fast path should work when only one operand requires grad."""
+    import candle as torch
+
+    # Only x requires grad
+    x = torch.tensor([6.0, 9.0], device=npu_device, dtype=torch.float32, requires_grad=True)
+    y = torch.tensor([2.0, 3.0], device=npu_device, dtype=torch.float32, requires_grad=False)
+
+    z_sub = x - y
+    assert z_sub.requires_grad and z_sub.grad_fn is not None
+    z_sub.sum().backward()
+    np.testing.assert_allclose(x.grad.cpu().numpy(), [1.0, 1.0], rtol=1e-6)
+    assert y.grad is None
+
+    x2 = torch.tensor([6.0, 9.0], device=npu_device, dtype=torch.float32, requires_grad=True)
+    z_div = x2 / y
+    assert z_div.requires_grad and z_div.grad_fn is not None
+    z_div.sum().backward()
+    np.testing.assert_allclose(x2.grad.cpu().numpy(), [0.5, 1.0 / 3.0], rtol=1e-6)
+    assert y.grad is None
+
+    # Only y requires grad
+    a = torch.tensor([6.0, 9.0], device=npu_device, dtype=torch.float32, requires_grad=False)
+    b = torch.tensor([2.0, 3.0], device=npu_device, dtype=torch.float32, requires_grad=True)
+
+    z_sub2 = a - b
+    assert z_sub2.requires_grad and z_sub2.grad_fn is not None
+    z_sub2.sum().backward()
+    np.testing.assert_allclose(b.grad.cpu().numpy(), [-1.0, -1.0], rtol=1e-6)
+
+    b2 = torch.tensor([2.0, 3.0], device=npu_device, dtype=torch.float32, requires_grad=True)
+    z_div2 = a / b2
+    assert z_div2.requires_grad and z_div2.grad_fn is not None
+    z_div2.sum().backward()
+    # d(a / b)/db = -a/b^2 = [-6/4, -9/9] = [-1.5, -1.0]
+    np.testing.assert_allclose(b2.grad.cpu().numpy(), [-1.5, -1.0], rtol=1e-6)
+
+
+def test_npu_inference_mode_sub_div_still_fast(npu_device, monkeypatch):
+    """Inference mode sub/div should still use the inference-only fast path."""
+    import candle as torch
+    from candle._dispatch.registry import registry
+    from candle._dispatch.keys import DispatchKey
+
+    calls = {"python": 0}
+
+    def fail_python(*args, **kwargs):
+        calls["python"] += 1
+        raise AssertionError("Inference-mode sub/div should use Cython fast path")
+
+    monkeypatch.setitem(registry.get("sub").kernels, DispatchKey.NPU, fail_python)
+    monkeypatch.setitem(registry.get("true_divide").kernels, DispatchKey.NPU, fail_python)
+
+    with torch.no_grad():
+        x = torch.tensor([4.0, 6.0], device=npu_device, dtype=torch.float32)
+        y = torch.tensor([2.0, 3.0], device=npu_device, dtype=torch.float32)
+        z_sub = x - y
+        z_div = x / y
+
+    assert not z_sub.requires_grad and z_sub.grad_fn is None
+    assert not z_div.requires_grad and z_div.grad_fn is None
+    np.testing.assert_allclose(z_sub.cpu().numpy(), [2.0, 3.0], rtol=1e-6)
+    np.testing.assert_allclose(z_div.cpu().numpy(), [2.0, 2.0], rtol=1e-6)
+
+    assert calls["python"] == 0
+
+
+def test_npu_div_backward_create_graph(npu_device):
+    """Div backward under create_graph should build a differentiable graph (second-order)."""
+    import candle as torch
+    import candle.autograd as ag
+
+    x = torch.tensor([4.0], device=npu_device, dtype=torch.float32, requires_grad=True)
+    y = torch.tensor([2.0], device=npu_device, dtype=torch.float32, requires_grad=True)
+    z = x / y
+
+    g = ag.grad(z, [x, y], grad_outputs=torch.ones_like(z), create_graph=True)
+    # dz/dx = 1/y = 0.5 ; dz/dy = -x/y^2 = -1.0
+    np.testing.assert_allclose(g[0].detach().cpu().numpy(), [0.5], rtol=1e-6)
+    np.testing.assert_allclose(g[1].detach().cpu().numpy(), [-1.0], rtol=1e-6)
+
+    # First-order grads must remain differentiable.
+    assert g[0].grad_fn is not None
+    assert g[1].grad_fn is not None
+
+    # Second-order: d/dx(dz/dy) = d/dx(-x/y^2) = -1/y^2 = -0.25
+    g2 = ag.grad(g[1], [x], grad_outputs=torch.ones_like(g[1]), retain_graph=True)
+    np.testing.assert_allclose(g2[0].detach().cpu().numpy(), [-0.25], rtol=1e-6)
+
+
+def test_npu_sub_backward_create_graph(npu_device):
+    """Sub backward under create_graph should produce correct gradients.
+
+    The gradient of subtraction is constant (+1 / -1), so like PyTorch the
+    resulting gradient tensors carry no grad_fn — but the call must succeed
+    under create_graph and yield correct values without raising.
+    """
+    import candle as torch
+    import candle.autograd as ag
+
+    x = torch.tensor([5.0], device=npu_device, dtype=torch.float32, requires_grad=True)
+    y = torch.tensor([2.0], device=npu_device, dtype=torch.float32, requires_grad=True)
+    z = x - y
+
+    g = ag.grad(z, [x, y], grad_outputs=torch.ones_like(z), create_graph=True)
+    # dz/dx = 1 ; dz/dy = -1
+    np.testing.assert_allclose(g[0].detach().cpu().numpy(), [1.0], rtol=1e-6)
+    np.testing.assert_allclose(g[1].detach().cpu().numpy(), [-1.0], rtol=1e-6)
+
+


### PR DESCRIPTION
## Summary

Extends the PR #564 training-mode forward fast-path pattern (add/mul) to tensor-tensor **sub** and **div**. Previously, `sub`/`div` with `requires_grad=True` fell back to Python dispatch on NPU even though inference-mode sub/div and training-mode add/mul already stayed in Cython. This closes that gap so all four binary ops share the same fast slot in training mode.

## Changes

- Add `_NpuSubBackward` and `_NpuDivBackward` Cython autograd nodes in `_functional_ops.pyx`, mirroring `_NpuAddBackward`/`_NpuMulBackward`:
  - Sub backward is constant: `grad_self = grad`, `grad_other = -grad`.
  - Div backward saves both operands and computes `grad/other` and `-grad*self/other²`, with a `create_graph` branch routing through dispatched ops to keep gradients differentiable for second-order autograd.
- Export `attach_npu_sub_grad`/`attach_npu_div_grad` as `cpdef` and declare them in `_functional_ops.pxd` for cimport.
- Wire the training-mode fast path into the `__sub__`/`__truediv__` `TensorImpl` slots (via the existing `_can_use_npu_binary_slot_train` guard) and the `sub()`/`div()` functional entry points (the `npu_state == 2` branch).
- Add `tests/npu/cython/test_training_forward_sub_div_fast_path.py` (7 tests): Cython routing (asserts no Python NPU-kernel fallback via registry monkeypatch), forward correctness vs inference, mixed `requires_grad`, inference-mode preservation, and first/second-order `create_graph` gradients matching PyTorch.

## Scope note

Profiling the tiny-Qwen2 train step confirms tensor-tensor sub/div is **not** on its hot path (the hot backward nodes are Getitem/Pow/Mean/View, and division there is scalar). So this is a generic correctness + latency win for training workloads that use tensor-tensor sub/div under autograd — not a Qwen2 benchmark mover. It keeps the binary-op training fast-path family complete and consistent.

## Validation

- 7/7 new sub/div training fast-path tests pass
- 369 NPU cython + common ops tests pass
- 602 full NPU suite pass (25 skipped)
- 3577 CPU + contract tests pass (30 skipped)
- pylint 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)