### PR TITLE
perf(npu): route dispatched scalar div/sub/pow through cached-scalar kernel

### DIFF
--- a/src/candle/_C/_npu_ops.pyx
+++ b/src/candle/_C/_npu_ops.pyx
@@ -5727,6 +5727,15 @@ def fast_pow(a, b):
 
 
 def fast_pow_tensor_scalar(a, exponent):
+    # Outside graph capture, reuse the persistent cached 0-d scalar tensor (same
+    # (device, dtype, value) materialized once) and broadcast it through the
+    # tensor-tensor Pow kernel, instead of materializing a fresh full-shape
+    # scalar tensor (host malloc + byte-pack + H2D memcpy) on every call.
+    # During capture, keep the explicit per-call materialization so no new
+    # cached-fill H2D traffic is recorded into the graph.
+    if isinstance(a, TensorImpl) and (<TensorImpl>a)._device_type == 1 \
+            and not _npu_in_graph_capture():
+        return fast_pow(a, _get_cached_scalar_tensor(<TensorImpl>a, exponent))
     return fast_pow(a, _npu_scalar_like(exponent, a))
 
 

--- a/src/candle/_backends/npu/ops/math.py
+++ b/src/candle/_backends/npu/ops/math.py
@@ -41,6 +41,7 @@ try:
         fast_erf as _fast_erf_impl,
         fast_erf_inplace as _fast_erf_inplace_impl,
         fast_div as _fast_div_impl,
+        fast_div_scalar_exact as _fast_div_scalar_impl,
         fast_div_inplace as _fast_div_inplace_impl,
         fast_erfc as _fast_erfc_impl,
         fast_erfc_inplace as _fast_erfc_inplace_impl,
@@ -94,6 +95,7 @@ try:
         fast_square as _fast_square_impl,
         fast_square_inplace as _fast_square_inplace_impl,
         fast_sub as _fast_sub_impl,
+        fast_sub_scalar_exact as _fast_sub_scalar_impl,
         fast_sub_inplace as _fast_sub_inplace_impl,
         fast_tan as _fast_tan_impl,
         fast_tan_inplace as _fast_tan_inplace_impl,
@@ -206,6 +208,8 @@ except ImportError:
     _fast_acos_impl = None  # type: ignore[assignment]
     _fast_mul_impl = None  # type: ignore[assignment]
     _fast_mul_scalar_impl = None  # type: ignore[assignment]
+    _fast_div_scalar_impl = None  # type: ignore[assignment]
+    _fast_sub_scalar_impl = None  # type: ignore[assignment]
     _fast_add_scalar_impl = None  # type: ignore[assignment]
     _fast_add_scalar_inplace_impl = None  # type: ignore[assignment]
     _HAS_FAST_ADD = False
@@ -321,6 +325,8 @@ def mul(a, b):
 
 def sub(a, b):
     if isinstance(b, (int, float)):
+        if _fast_sub_scalar_impl is not None:
+            return _fast_sub_scalar_impl(a, b)
         b = _scalar_to_npu_tensor(b, a)
     if _HAS_FAST_SUB:
         return _fast_sub_impl(a, b)
@@ -329,6 +335,8 @@ def sub(a, b):
 
 def div(a, b):
     if isinstance(b, (int, float)):
+        if _fast_div_scalar_impl is not None:
+            return _fast_div_scalar_impl(a, b)
         b = _scalar_to_npu_tensor(b, a)
     if _HAS_FAST_DIV:
         return _fast_div_impl(a, b)

--- a/tests/npu/cython/test_dispatched_scalar_fast_path.py
+++ b/tests/npu/cython/test_dispatched_scalar_fast_path.py
@@ -1,0 +1,120 @@
+"""RED tests: dispatched NPU scalar div/sub/pow must use the cached-scalar
+Cython fast path, not the slow per-call _scalar_to_npu_tensor host-malloc +
+byte-pack + H2D-memcpy materialization.
+
+Backward helpers (e.g. MeanBackward0 -> div by numel, PowTensorScalarBackward0
+-> pow(x, 1.0)) call these ops via redispatch with a Python scalar operand.
+Each such call currently materializes a *full-shape* scalar tensor on device.
+add/mul already avoid this via cached 0-d scalar kernels; div/sub/pow should
+match. These tests assert the slow helper is NOT used and results stay correct.
+"""
+import numpy as np
+import pytest
+
+
+def _patch_scalar_counters(monkeypatch):
+    """Patch every module binding of _scalar_to_npu_tensor with a counter.
+
+    math.py binds the helper into its own namespace at import (used by div/sub);
+    _npu_scalar_like (used by pow) imports it from _helpers at call time. Patch
+    both so any slow-path use is detected regardless of which op triggers it.
+    """
+    import candle._backends.npu.ops.math as math_mod
+    import candle._backends.npu.ops._helpers as helpers_mod
+
+    calls = {"n": 0}
+
+    def make_counter(orig):
+        def counter(scalar, ref):
+            calls["n"] += 1
+            return orig(scalar, ref)
+        return counter
+
+    monkeypatch.setattr(math_mod, "_scalar_to_npu_tensor",
+                        make_counter(math_mod._scalar_to_npu_tensor))
+    monkeypatch.setattr(helpers_mod, "_scalar_to_npu_tensor",
+                        make_counter(helpers_mod._scalar_to_npu_tensor))
+    return calls
+
+
+def test_dispatched_div_scalar_avoids_slow_helper(npu_device, monkeypatch):
+    """div(tensor, python_scalar) must not materialize a full-shape scalar tensor."""
+    import candle._backends.npu.ops.math as math_mod
+    import candle as torch
+
+    calls = _patch_scalar_counters(monkeypatch)
+
+    x = torch.tensor([4.0, 6.0, 8.0], device=npu_device, dtype=torch.float32)
+    out = math_mod.div(x, 2.0)
+
+    np.testing.assert_allclose(out.cpu().numpy(), [2.0, 3.0, 4.0], rtol=1e-6)
+    assert calls["n"] == 0, "div(tensor, scalar) used the slow _scalar_to_npu_tensor path"
+
+
+def test_dispatched_sub_scalar_avoids_slow_helper(npu_device, monkeypatch):
+    """sub(tensor, python_scalar) must not materialize a full-shape scalar tensor."""
+    import candle._backends.npu.ops.math as math_mod
+    import candle as torch
+
+    calls = _patch_scalar_counters(monkeypatch)
+
+    x = torch.tensor([4.0, 6.0, 8.0], device=npu_device, dtype=torch.float32)
+    out = math_mod.sub(x, 1.0)
+
+    np.testing.assert_allclose(out.cpu().numpy(), [3.0, 5.0, 7.0], rtol=1e-6)
+    assert calls["n"] == 0, "sub(tensor, scalar) used the slow _scalar_to_npu_tensor path"
+
+
+def test_dispatched_pow_scalar_avoids_slow_helper(npu_device, monkeypatch):
+    """pow(tensor, python_scalar) must not materialize a full-shape scalar tensor.
+
+    Uses exponent 3.0 (not 2.0, which has its own mul(a, a) shortcut) and 1.0
+    (the exact exponent PowTensorScalarBackward0 produces for the x**2 backward).
+    """
+    import candle._backends.npu.ops.math as math_mod
+    import candle as torch
+
+    calls = _patch_scalar_counters(monkeypatch)
+
+    x = torch.tensor([2.0, 3.0, 4.0], device=npu_device, dtype=torch.float32)
+    out3 = math_mod.pow(x, 3.0)
+    np.testing.assert_allclose(out3.cpu().numpy(), [8.0, 27.0, 64.0], rtol=1e-5)
+
+    out1 = math_mod.pow(x, 1.0)
+    np.testing.assert_allclose(out1.cpu().numpy(), [2.0, 3.0, 4.0], rtol=1e-6)
+
+    assert calls["n"] == 0, "pow(tensor, scalar) used the slow _scalar_to_npu_tensor path"
+
+
+def test_dispatched_scalar_ops_match_inference_dtypes(npu_device):
+    """fp16/fp32 dispatched div/sub/pow scalar results stay numerically correct."""
+    import candle._backends.npu.ops.math as math_mod
+    import candle as torch
+
+    for dtype, rtol in ((torch.float32, 1e-6), (torch.float16, 3e-3)):
+        x = torch.tensor([4.0, 6.0, 8.0], device=npu_device, dtype=dtype)
+        np.testing.assert_allclose(
+            math_mod.div(x, 2.0).cpu().float().numpy(), [2.0, 3.0, 4.0], rtol=rtol)
+        np.testing.assert_allclose(
+            math_mod.sub(x, 1.0).cpu().float().numpy(), [3.0, 5.0, 7.0], rtol=rtol)
+        np.testing.assert_allclose(
+            math_mod.pow(x, 3.0).cpu().float().numpy(), [64.0, 216.0, 512.0], rtol=rtol)
+
+
+def test_rmsnorm_backward_scalar_path_correct(npu_device):
+    """End-to-end: mean/pow backward (RMSNorm-shaped) gradients stay correct.
+
+    Exercises MeanBackward0 (div by numel) and PowTensorScalarBackward0
+    (pow(x, 1.0)) through the dispatched scalar fast path during .backward().
+    """
+    import candle as torch
+
+    x = torch.tensor([[1.0, 2.0, 3.0, 4.0]], device=npu_device,
+                     dtype=torch.float32, requires_grad=True)
+    # variance = mean(x^2, -1, keepdim) ; loss = variance.sum()
+    var = x.pow(2).mean(-1, keepdim=True)
+    var.sum().backward()
+
+    # d/dx mean(x^2)/1 over last dim of size n: 2x/n  (n=4)
+    expected = (2.0 * np.array([[1.0, 2.0, 3.0, 4.0]])) / 4.0
+    np.testing.assert_allclose(x.grad.cpu().numpy(), expected, rtol=1e-5)


### PR DESCRIPTION
## Summary

Dispatched NPU `div(tensor, scalar)`, `sub(tensor, scalar)`, and `pow(tensor, scalar)` materialized a fresh **full-shape** scalar tensor on every call via `_scalar_to_npu_tensor` (host malloc + byte-pack + H2D memcpy). `add`/`mul` already avoid this by reusing the persistent **cached 0-d scalar tensor** and the tensor-tensor exact kernels. This PR makes `div`/`sub`/`pow` do the same.

## Why

Profiling the tiny-Qwen2 train step (910B3, fp16, backward-only cProfile) showed `_scalar_to_npu_tensor` as the **#2 backward `tottime` row** (~0.013s, 50 calls/iter):
- 25 from `MeanBackward0` (RMSNorm `mean` → div by `numel`)
- 25 from `PowTensorScalarBackward0` (RMSNorm `x²` backward → `pow(x, 1.0)`)

Each call did a per-call host malloc + dtype byte-pack + H2D memcpy to fill a full-shape scalar tensor.

## Change

- `math.py`: `div`/`sub` scalar operands now route through the existing `fast_div_scalar_exact` / `fast_sub_scalar_exact` Cython kernels (cached 0-d scalar + tensor-tensor exact kernel) before falling back to `_scalar_to_npu_tensor`.
- `_npu_ops.pyx`: `fast_pow_tensor_scalar` reuses the cached 0-d scalar tensor outside graph capture; the per-call materialization is preserved **during capture** so no new cached-fill H2D traffic is recorded into the graph.
- The slow `_scalar_to_npu_tensor` path is **preserved as a guarded fallback** (kernel entry point not deleted).

## Impact (tiny-Qwen2, 910B3, fp16, backward-only profile)

- `_scalar_to_npu_tensor` **removed entirely** from backward hot rows.
- Backward function calls: **63692 → 58858** (−4834/iter).
- Backward host profile time: **−9%** (0.173s → 0.157s over 5 iters).
- Wall-clock backward median: ~38.6ms → ~37.0ms.

## Correctness

Behavior-preserving: the cached scalar carries the **same dtype as `a`** (matching the previous full-shape materialization) and broadcasts via the same tensor-tensor kernels.

- Qwen2 full-model parity unchanged: logits `max_abs_diff 0.0`, `max_rel_diff 0.0`, `failures: []`.

## Tests

- 5 new tests in `tests/npu/cython/test_dispatched_scalar_fast_path.py` (RED→green): assert dispatched `div`/`sub`/`pow` scalar ops do **not** hit `_scalar_to_npu_tensor`, plus fp16/fp32 correctness and an end-to-end RMSNorm-shaped backward.

## Validation

- Full NPU suite: **608 passed, 25 skipped**
- CPU + contract: **3577 passed, 30 skipped**
- pylint: **10.00/10**

🤖 Generated with [Claude Code](https://claude.com/claude-code)